### PR TITLE
Add notification util

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -14,6 +14,7 @@
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.2.1",
     "@material-ui/styles": "^4.10.0",
+    "@material-ui/lab": "latest",
     "@react-keycloak/web": "^2.1.0",
     "@rjsf/core": "~2.4.0",
     "@rjsf/material-ui": "~2.4.0",

--- a/app/src/components/activities-list/ActivitiesList.tsx
+++ b/app/src/components/activities-list/ActivitiesList.tsx
@@ -20,7 +20,7 @@ import moment from 'moment';
 import React, { useContext, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Subscription } from 'rxjs';
-import { addNewError, triggerError } from 'utils/NotificationUtils';
+import { triggerError } from 'utils/NotificationUtils';
 import { v4 as uuidv4 } from 'uuid';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -75,8 +75,6 @@ const ActivityList: React.FC<IActivityList> = (props) => {
   const databaseContext = useContext(DatabaseContext);
 
   const [docs, setDocs] = useState<any[]>([]);
-
-
 
   const updateActivityList = async () => {
     const activityDocs = await databaseContext.database.find({
@@ -135,8 +133,7 @@ const ActivityList: React.FC<IActivityList> = (props) => {
     history.push(`/home/activity`);
   };
 
-    const api = useInvasivesApi();
-
+  const api = useInvasivesApi();
 
   return (
     <List className={classes.activityList}>
@@ -165,7 +162,6 @@ const ActivityList: React.FC<IActivityList> = (props) => {
 
 const ActivitiesList: React.FC = (props) => {
   const databaseContext = useContext(DatabaseContext);
-
 
   const addNewActivity = async (activityType: ActivityType) => {
     await databaseContext.database.put({

--- a/app/src/components/activities-list/ActivitiesList.tsx
+++ b/app/src/components/activities-list/ActivitiesList.tsx
@@ -20,6 +20,7 @@ import moment from 'moment';
 import React, { useContext, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Subscription } from 'rxjs';
+import { addNewError, triggerError } from 'utils/NotificationUtils';
 import { v4 as uuidv4 } from 'uuid';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -165,24 +166,6 @@ const ActivityList: React.FC<IActivityList> = (props) => {
 const ActivitiesList: React.FC = (props) => {
   const databaseContext = useContext(DatabaseContext);
 
-  const addNewError = async () => {
-    await databaseContext.database.put({
-      _id: uuidv4(),
-      docType: "error",
-      errorText: "Some error text",
-      errorAcknowledged: false,
-      dateCreated: new Date()
-    });
-    console.log('added a new error')
-  }
-
-  const triggerError = async() => {
-    try {
-      throw Error("crash the app!")
-    } catch (error) {
-      addNewError()
-    }
-  }
 
   const addNewActivity = async (activityType: ActivityType) => {
     await databaseContext.database.put({
@@ -214,8 +197,14 @@ const ActivitiesList: React.FC = (props) => {
         <ActivityList type={ActivityType.TREATMENT} />
       </div>
       <div>
-        <Button variant="contained" startIcon={<Add />} onClick={() => triggerError()}>
+        <Button variant="contained" startIcon={<Add />} onClick={() => addNewActivity(ActivityType.MONITORING)}>
           Add New Monitoring
+        </Button>
+        <ActivityList type={ActivityType.MONITORING} />
+      </div>
+      <div>
+        <Button variant="contained" startIcon={<Add />} onClick={() => triggerError(databaseContext)}>
+          Simulate Error
         </Button>
         <ActivityList type={ActivityType.MONITORING} />
       </div>

--- a/app/src/components/activities-list/ActivitiesList.tsx
+++ b/app/src/components/activities-list/ActivitiesList.tsx
@@ -75,6 +75,8 @@ const ActivityList: React.FC<IActivityList> = (props) => {
 
   const [docs, setDocs] = useState<any[]>([]);
 
+
+
   const updateActivityList = async () => {
     const activityDocs = await databaseContext.database.find({
       selector: { type: props.type }
@@ -167,6 +169,8 @@ const ActivitiesList: React.FC = (props) => {
     await databaseContext.database.put({
       _id: uuidv4(),
       docType: "error",
+      errorText: "Some error text",
+      errorAcknowledged: false,
       dateCreated: new Date()
     });
     console.log('added a new error')

--- a/app/src/components/activities-list/ActivitiesList.tsx
+++ b/app/src/components/activities-list/ActivitiesList.tsx
@@ -12,6 +12,7 @@ import {
   Theme
 } from '@material-ui/core';
 import { Add, DeleteForever } from '@material-ui/icons';
+import { useInvasivesApi } from 'api/api';
 import { ActivityType, ActivityTypeIcon } from 'constants/activities';
 import { MediumDateFormat } from 'constants/misc';
 import { DatabaseContext } from 'contexts/DatabaseContext';
@@ -131,6 +132,9 @@ const ActivityList: React.FC<IActivityList> = (props) => {
     history.push(`/home/activity`);
   };
 
+    const api = useInvasivesApi();
+
+
   return (
     <List className={classes.activityList}>
       {docs.map((doc) => {
@@ -158,6 +162,23 @@ const ActivityList: React.FC<IActivityList> = (props) => {
 
 const ActivitiesList: React.FC = (props) => {
   const databaseContext = useContext(DatabaseContext);
+
+  const addNewError = async () => {
+    await databaseContext.database.put({
+      _id: uuidv4(),
+      docType: "error",
+      dateCreated: new Date()
+    });
+    console.log('added a new error')
+  }
+
+  const triggerError = async() => {
+    try {
+      throw Error("crash the app!")
+    } catch (error) {
+      addNewError()
+    }
+  }
 
   const addNewActivity = async (activityType: ActivityType) => {
     await databaseContext.database.put({
@@ -189,7 +210,7 @@ const ActivitiesList: React.FC = (props) => {
         <ActivityList type={ActivityType.TREATMENT} />
       </div>
       <div>
-        <Button variant="contained" startIcon={<Add />} onClick={() => addNewActivity(ActivityType.MONITORING)}>
+        <Button variant="contained" startIcon={<Add />} onClick={() => triggerError()}>
           Add New Monitoring
         </Button>
         <ActivityList type={ActivityType.MONITORING} />

--- a/app/src/contexts/DatabaseContext.tsx
+++ b/app/src/contexts/DatabaseContext.tsx
@@ -4,7 +4,7 @@ import PouchDBUpsert from 'pouchdb-upsert';
 import React, { useEffect, useState } from 'react';
 import { Subject } from 'rxjs';
 
-interface IDatabaseContext<T> {
+export interface IDatabaseContext<T> {
   database: PouchDB.Database<T>;
   changes: Subject<PouchDB.Core.ChangesResponseChange<T>>;
 }

--- a/app/src/features/home/HomeLayout.tsx
+++ b/app/src/features/home/HomeLayout.tsx
@@ -1,10 +1,10 @@
-import { Collapse, IconButton, makeStyles, Snackbar, Theme, withWidth } from '@material-ui/core';
+import { Collapse, IconButton, makeStyles, Theme } from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
+import { Alert } from '@material-ui/lab';
 import TabsContainer from 'components/tabs/TabsContainer';
 import { DatabaseContext } from 'contexts/DatabaseContext';
 import React, { useContext, useEffect, useState } from 'react';
 import { Subscription } from 'rxjs';
-import CloseIcon from '@material-ui/icons/Close';
-import { Alert } from '@material-ui/lab';
 
 const useStyles = makeStyles((theme: Theme) => ({
   homeLayoutRoot: {
@@ -28,13 +28,13 @@ const HomeLayout = (props: any) => {
   const classes = useStyles();
   const databaseContext = useContext(DatabaseContext);
 
-  const [isOpen, setIsOpen] = useState(false)
-  const [error, setError] = useState(null)
+  const [isOpen, setIsOpen] = useState(false);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     const updateComponent = (): Subscription => {
       if (!databaseContext.database) {
-        console.log('db not ready')
+        console.log('db not ready');
         // database not ready
         return;
       }
@@ -69,31 +69,29 @@ const HomeLayout = (props: any) => {
   }, [databaseContext]);
 
   const addToErrorsOnPage = async () => {
-    console.log('add errors to page')
-
+    console.log('add errors to page');
 
     //console.dir(databaseContext.database.allDocs())
 
     const errors = await databaseContext.database.find({
-      selector: { docType: "error", errorAcknowledged: false }
+      selector: { docType: 'error', errorAcknowledged: false }
     });
-    console.dir(errors)
+    console.dir(errors);
 
     if (errors.docs.length > 0) {
-      setError(errors.docs[0])
-      setIsOpen(true)
-      console.log('it happened')
+      setError(errors.docs[0]);
+      setIsOpen(true);
+      console.log('it happened');
     }
-
   };
 
-
   const acknowledgeError = (docId: string) => {
-    databaseContext.database.upsert(docId, (doc) => { return { ...doc, errorAcknowledged: true } })
+    databaseContext.database.upsert(docId, (doc) => {
+      return { ...doc, errorAcknowledged: true };
+    });
     setIsOpen(false);
-    console.log('acknowledged error')
-  }
-
+    console.log('acknowledged error');
+  };
 
   /*useEffect(() => {
     const isDBOK = () => {
@@ -119,13 +117,11 @@ const HomeLayout = (props: any) => {
               color="inherit"
               size="small"
               onClick={() => {
-                acknowledgeError(error._id)
-              }}
-            >
+                acknowledgeError(error._id);
+              }}>
               <CloseIcon fontSize="inherit" />
             </IconButton>
-          }
-        >
+          }>
           {error == null ? null : error.errorText}
         </Alert>
       </Collapse>

--- a/app/src/utils/NotificationUtils.tsx
+++ b/app/src/utils/NotificationUtils.tsx
@@ -1,24 +1,21 @@
-import { DatabaseContext, IDatabaseContext } from "contexts/DatabaseContext";
-import { useContext } from "react";
+import { IDatabaseContext } from 'contexts/DatabaseContext';
 import { v4 as uuidv4 } from 'uuid';
-
-
 
 export const addNewError = async (databaseContext: IDatabaseContext<any>) => {
   await databaseContext.database.put({
     _id: uuidv4(),
-    docType: "error",
-    errorText: "Some error text",
+    docType: 'error',
+    errorText: 'Some error text',
     errorAcknowledged: false,
     dateCreated: new Date()
   });
-  console.log('added a new error')
-}
+  console.log('added a new error');
+};
 
 export const triggerError = async (databaseContext: IDatabaseContext<any>) => {
   try {
-    throw Error("crash the app!")
+    throw Error('crash the app!');
   } catch (error) {
-    addNewError(databaseContext)
+    addNewError(databaseContext);
   }
-}
+};

--- a/app/src/utils/NotificationUtils.tsx
+++ b/app/src/utils/NotificationUtils.tsx
@@ -1,0 +1,24 @@
+import { DatabaseContext, IDatabaseContext } from "contexts/DatabaseContext";
+import { useContext } from "react";
+import { v4 as uuidv4 } from 'uuid';
+
+
+
+export const addNewError = async (databaseContext: IDatabaseContext<any>) => {
+  await databaseContext.database.put({
+    _id: uuidv4(),
+    docType: "error",
+    errorText: "Some error text",
+    errorAcknowledged: false,
+    dateCreated: new Date()
+  });
+  console.log('added a new error')
+}
+
+export const triggerError = async (databaseContext: IDatabaseContext<any>) => {
+  try {
+    throw Error("crash the app!")
+  } catch (error) {
+    addNewError(databaseContext)
+  }
+}


### PR DESCRIPTION
* utils/notificationUtil, has example of adding an error that will both be presented to user and logged to db.
* errors need to be acknowledged by user or otherwise will persist over a power out / restart
* can also display non errors (success, warnings, etc) by following the template

Need to have a database context to use it.  Put a 'simulate error button' on activity page so people can try.

