### PR TITLE
61: Initial activity search support

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -55,7 +55,9 @@
   },
   "devDependencies": {
     "@capacitor/cli": "2.4.0",
+    "@ionic/cli": "^6.11.9",
     "@ionic/lab": "3.2.7",
+    "@types/geojson": "^7946.0.3",
     "@types/jest": "^24.0.25",
     "@types/node": "^12.12.24",
     "@types/pouchdb": "^6.4.0",

--- a/app/src/components/photo/PhotoContainer.tsx
+++ b/app/src/components/photo/PhotoContainer.tsx
@@ -9,7 +9,7 @@ import {
   ActivityStatus,
 } from 'constants/activities'
 
-interface Photo {
+export interface Photo {
   filepath: string;
   webviewPath?: string;
   base64?: string;

--- a/app/src/hooks/useInvasivesApi.ts
+++ b/app/src/hooks/useInvasivesApi.ts
@@ -1,11 +1,17 @@
-import { useContext, useMemo } from 'react';
-import axios from 'axios';
 import { useKeycloak } from '@react-keycloak/web';
+import axios from 'axios';
 import { DatabaseContext } from 'contexts/DatabaseContext';
+import { IActivitySearchCriteria, ICreateActivity } from 'interfaces/useInvasivesApi-interfaces';
+import { useContext, useMemo } from 'react';
 
 const API_URL = 'https://api-mobile-dev-invasivesbc.pathfinder.gov.bc.ca';
 // const API_URL = 'http://localhost:3002';
 
+/**
+ * Returns an instance of axios with baseURL and authorization headers set.
+ *
+ * @return {*}
+ */
 const useApi = () => {
   const { keycloak } = useKeycloak();
   const instance = useMemo(() => {
@@ -21,10 +27,27 @@ const useApi = () => {
   return instance;
 };
 
+/**
+ * Returns a set of supported api methods.
+ *
+ * @return {object} object whose properties are supported api methods.
+ */
 export const useInvasivesApi = () => {
   const api = useApi();
 
   const databaseContext = useContext(DatabaseContext);
+
+  /**
+   * Fetch activities by search criteria.
+   *
+   * @param {activitiesSearchCriteria} activitiesSearchCriteria
+   * @return {*}  {Promise<any>}
+   */
+  const getActivities = async (activitiesSearchCriteria: IActivitySearchCriteria): Promise<any> => {
+    const { data } = await api.post(`/api/activity/`, activitiesSearchCriteria);
+
+    return data;
+  };
 
   /**
    * Fetch a signle activity by its id.
@@ -41,17 +64,17 @@ export const useInvasivesApi = () => {
   /**
    * Create a new activity record.
    *
-   * @param {*} activity
+   * @param {ICreateActivity} activity
    * @return {*}  {Promise<any>}
    */
-  const createActivity = async (activity: any): Promise<any> => {
+  const createActivity = async (activity: ICreateActivity): Promise<any> => {
     const { data } = await api.post('/api/activity', activity);
 
     return data;
   };
 
   /**
-   * Fetch the api yaml spec.
+   * Fetch the api json-schema spec.
    *
    * @return {*}  {Promise<any>}
    */
@@ -62,7 +85,7 @@ export const useInvasivesApi = () => {
   };
 
   /**
-   * Fetch the api spec and save it in the local database.
+   * Fetch the api json-schema spec and save it in the local database.
    * If the request fails (due to lack of internet connection, etc), then return the cached copy of the api spec.
    *
    * @return {*}  {Promise<any>}
@@ -82,7 +105,9 @@ export const useInvasivesApi = () => {
       return data;
     }
   };
+
   return {
+    getActivities,
     getActivityById,
     createActivity,
     getApiSpec,

--- a/app/src/interfaces/useInvasivesApi-interfaces.ts
+++ b/app/src/interfaces/useInvasivesApi-interfaces.ts
@@ -1,0 +1,82 @@
+import { ActivityParentType, ActivityType } from 'constants/activities';
+import { Feature } from 'geojson';
+import { Photo } from 'components/photo/PhotoContainer';
+
+/**
+ * Activity search filter criteria.
+ *
+ * @export
+ * @interface IActivitySearchCriteria
+ */
+export interface IActivitySearchCriteria {
+  /**
+   * The page of results to return. Starts at 0.
+   *
+   * @type {number}
+   * @memberof IActivitySearchCriteria
+   */
+  page?: number;
+  /**
+   * The number of results to return.
+   *@
+   * @type {number}
+   * @memberof IActivitySearchCriteria
+   */
+  limit?: number;
+  /**
+   * Activity type filter.
+   *
+   * @type {string}
+   * @memberof IActivitySearchCriteria
+   */
+  activity_type?: string;
+  /**
+   * Activity sub type filter.
+   *
+   * @type {string}
+   * @memberof IActivitySearchCriteria
+   */
+  activity_subtype?: string;
+  /**
+   * Date start filter. Defaults time to start of day.
+   *
+   * @type {Date}
+   * @memberof IActivitySearchCriteria
+   */
+  date_range_start?: Date;
+  /**
+   * Date end filter. Defaults time to end of day.
+   *
+   * @type {Date}
+   * @memberof IActivitySearchCriteria
+   */
+  date_range_end?: Date;
+  /**
+   * True if the respons should include associated media, false otherwise.
+   *
+   * @type {boolean}
+   * @memberof IActivitySearchCriteria
+   */
+  include_media?: boolean;
+  /**
+   * GeoJSON bounding box.
+   *
+   * @type {GeoJSON.BBox}
+   * @memberof IActivitySearchCriteria
+   */
+  bbox?: GeoJSON.BBox;
+}
+
+/**
+ * Create activity endpoint post body.
+ *
+ * @export
+ * @interface ICreateActivity
+ */
+export interface ICreateActivity {
+  activity_type: ActivityParentType;
+  activity_subtype: ActivityType;
+  geometry: Feature[];
+  media: Photo[];
+  form_data: any;
+}


### PR DESCRIPTION
- Add api method to fetch activities based on a search criteria object.
- Added interface for the search criteria
- Added interface for the sync object

Note: bbox and include_media search criteria aren't hooked up (see: https://github.com/bcgov/lucy-web/pull/941)