### PR TITLE
108: View Reference Activities + Other Changes

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -96,7 +96,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "start:ionic": "ionic serve",
-    "start:ionic:reload": "ionic serve -l",
+    "start:ionic:reload": "ionic serve",
     "build-prod": "react-scripts build --prod",
     "deploy_start": "node server",
     "eject": "react-scripts eject",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2,6 +2,7 @@ import { DeviceInfo } from '@capacitor/core';
 import { IonReactRouter } from '@ionic/react-router';
 import { CircularProgress, createMuiTheme, makeStyles, ThemeProvider } from '@material-ui/core';
 import { KeycloakProvider } from '@react-keycloak/web';
+import { DatabaseChangesContextProvider } from 'contexts/DatabaseChangesContext';
 import Keycloak, { KeycloakConfig, KeycloakInstance } from 'keycloak-js';
 import React from 'react';
 import AppRouter from './AppRouter';
@@ -104,12 +105,16 @@ const App: React.FC<IAppProps> = (props) => {
                   return (
                     <DatabaseContextProvider>
                       <DatabaseContext.Consumer>
-                        {(context: IDatabaseContext<any>) => {
-                          if (!context.database || !context.changes) {
+                        {(databaseContext: IDatabaseContext) => {
+                          if (!databaseContext.database) {
                             // database not ready, delay loading app
                             return <CircularProgress />;
                           }
-                          return <AppRouter />;
+                          return (
+                            <DatabaseChangesContextProvider>
+                              <AppRouter />
+                            </DatabaseChangesContextProvider>
+                          );
                         }}
                       </DatabaseContext.Consumer>
                     </DatabaseContextProvider>

--- a/app/src/components/activities-list/ReferenceActivitiesList.tsx
+++ b/app/src/components/activities-list/ReferenceActivitiesList.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  Button,
   Divider,
   Grid,
   List,
@@ -147,18 +146,6 @@ const ReferenceActivitiesList: React.FC = (props) => {
   const classes = useStyles();
 
   const databaseContext = useContext(DatabaseContext);
-
-  const tempAddReference = () => {
-    databaseContext.database.put({
-      _id: '1234123123123123',
-      docType: DocType.REFERENCE_ACTIVITY,
-      activityType: 'Observation',
-      activitySubtype: 'plant observation',
-      dateCreated: new Date(),
-      dateUpated: null,
-      formData: null
-    });
-  };
 
   return (
     <>

--- a/app/src/components/activities-list/ReferenceActivitiesList.tsx
+++ b/app/src/components/activities-list/ReferenceActivitiesList.tsx
@@ -1,0 +1,180 @@
+import {
+  Box,
+  Button,
+  Divider,
+  Grid,
+  List,
+  ListItem,
+  ListItemIcon,
+  makeStyles,
+  Paper,
+  SvgIcon,
+  Theme,
+  Typography
+} from '@material-ui/core';
+import { ActivityTypeIcon } from 'constants/activities';
+import { DocType } from 'constants/database';
+import { MediumDateFormat } from 'constants/misc';
+import { DatabaseChangesContext } from 'contexts/DatabaseChangesContext';
+import { DatabaseContext } from 'contexts/DatabaseContext';
+import moment from 'moment';
+import React, { useContext, useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  activitiesContent: {},
+  activityList: {},
+  activitiyListItem: {
+    display: 'flex',
+    flexDirection: 'row',
+    marginTop: '0.5rem',
+    marginBottom: '0.5rem',
+    border: '1px solid',
+    borderColor: theme.palette.grey[300],
+    borderRadius: '6px'
+  },
+  activityListItem_Grid: {
+    flexDirection: 'row',
+    [theme.breakpoints.down('sm')]: {
+      flexDirection: 'column'
+    }
+  },
+  activitiyListItem_Typography: {
+    [theme.breakpoints.down('sm')]: {
+      display: 'inline',
+      marginRight: '1rem'
+    }
+  },
+  actionsBar: {
+    display: 'flex',
+    flexDirection: 'row-reverse',
+    marginBottom: '2rem'
+  }
+}));
+
+interface IReferenceActivityListItem {
+  disable?: boolean;
+  activity: any;
+}
+
+const ReferenceActivityListItem: React.FC<IReferenceActivityListItem> = (props) => {
+  const classes = useStyles();
+
+  return (
+    <Grid className={classes.activityListItem_Grid} container spacing={2}>
+      <Divider flexItem={true} orientation="vertical" />
+      <Grid item md={2}>
+        <Box overflow="hidden" textOverflow="ellipsis" title={props.activity.activitySubtype.split('_')[2]}>
+          <Typography className={classes.activitiyListItem_Typography}>Type</Typography>
+          {props.activity.activitySubtype}
+        </Box>
+      </Grid>
+      <Divider flexItem={true} orientation="vertical" />
+      <Grid item md={2}>
+        <Box overflow="hidden" textOverflow="ellipsis" title={props.activity.activityType.split('_')[2]}>
+          <Typography className={classes.activitiyListItem_Typography}>Type</Typography>
+          {props.activity.activityType}
+        </Box>
+      </Grid>
+      <Divider flexItem={true} orientation="vertical" />
+      <Grid item md={2}>
+        <Typography className={classes.activitiyListItem_Typography}>Created</Typography>
+        {moment(props.activity.dateCreated).format(MediumDateFormat)}
+      </Grid>
+      <Divider flexItem={true} orientation="vertical" />
+      <Grid item md={2}>
+        <Typography className={classes.activitiyListItem_Typography}>Last Updated</Typography>
+        {(props.activity.dateUpdated && moment(props.activity.dateUpdated).format(MediumDateFormat)) || 'n/a'}
+      </Grid>
+    </Grid>
+  );
+};
+
+interface IReferenceActivityList {
+  disable?: boolean;
+}
+
+// TODO change any to a type that defines the overall items being displayed
+const ReferenceActivityList: React.FC<IReferenceActivityList> = (props) => {
+  const classes = useStyles();
+
+  const history = useHistory();
+
+  const databaseContext = useContext(DatabaseContext);
+  const databaseChangesContext = useContext(DatabaseChangesContext);
+
+  const [docs, setDocs] = useState<any[]>([]);
+
+  const updateActivityList = async () => {
+    const activityResult = await databaseContext.database.find({
+      selector: { docType: DocType.REFERENCE_ACTIVITY }
+    });
+
+    setDocs([...activityResult.docs]);
+  };
+
+  useEffect(() => {
+    const updateComponent = () => {
+      updateActivityList();
+    };
+
+    updateComponent();
+  }, [databaseChangesContext]);
+
+  const navigateToActivityPage = async (doc: any) => {
+    history.push(`/home/references/activity/${doc._id}`);
+  };
+
+  return (
+    <List className={classes.activityList}>
+      {docs.map((doc) => {
+        return (
+          <Paper elevation={1} key={doc._id}>
+            <ListItem button className={classes.activitiyListItem} onClick={() => navigateToActivityPage(doc)}>
+              <ListItemIcon>
+                <SvgIcon fontSize="large" component={ActivityTypeIcon[doc.activityType]} />
+              </ListItemIcon>
+              <ReferenceActivityListItem disable={props.disable} activity={doc} />
+            </ListItem>
+          </Paper>
+        );
+      })}
+    </List>
+  );
+};
+
+const ReferenceActivitiesList: React.FC = (props) => {
+  const classes = useStyles();
+
+  const databaseContext = useContext(DatabaseContext);
+
+  const tempAddReference = () => {
+    databaseContext.database.put({
+      _id: '1234123123123123',
+      docType: DocType.REFERENCE_ACTIVITY,
+      activityType: 'Observation',
+      activitySubtype: 'plant observation',
+      dateCreated: new Date(),
+      dateUpated: null,
+      formData: null
+    });
+  };
+
+  return (
+    <>
+      <div>
+        <div className={classes.actionsBar}></div>
+        <div className={classes.activitiesContent}>
+          <div>
+            <Typography variant="h5">Reference Activities</Typography>
+          </div>
+          <div>
+            <ReferenceActivityList disable={true} />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ReferenceActivitiesList;

--- a/app/src/components/activities-search-controls/ActivitiesFilter.tsx
+++ b/app/src/components/activities-search-controls/ActivitiesFilter.tsx
@@ -79,7 +79,7 @@ export const ActivityDataFilter: React.FC<any> = (props) => {
     };
 
     getActivityData();
-  }, [databaseContext]);
+  }, [databaseChangesContext]);
 
   if (!doc) {
     return <CircularProgress />;

--- a/app/src/components/activity/ActivityComponent.tsx
+++ b/app/src/components/activity/ActivityComponent.tsx
@@ -1,0 +1,44 @@
+import { Accordion, AccordionDetails, AccordionSummary, Typography } from '@material-ui/core';
+import { ExpandMore } from '@material-ui/icons';
+import FormContainer from 'components/form/FormContainer';
+import MapContainer, { IMapContainerProps } from 'components/map/MapContainer';
+import PhotoContainer from 'components/photo/PhotoContainer';
+import React from 'react';
+
+export interface IActivityComponentProps extends IMapContainerProps {
+  classes?: any;
+  activity: any;
+}
+
+const ActivityComponent: React.FC<IActivityComponentProps> = (props) => {
+  return (
+    <>
+      <Accordion defaultExpanded={true}>
+        <AccordionSummary expandIcon={<ExpandMore />} aria-controls="panel-map-content" id="panel-map-header">
+          <Typography className={props.classes.heading}>Map</Typography>
+        </AccordionSummary>
+        <AccordionDetails className={props.classes.mapContainer}>
+          <MapContainer {...props} />
+        </AccordionDetails>
+      </Accordion>
+      <Accordion>
+        <AccordionSummary expandIcon={<ExpandMore />} aria-controls="panel-form-content" id="panel-form-header">
+          <Typography className={props.classes.heading}>Form</Typography>
+        </AccordionSummary>
+        <AccordionDetails className={props.classes.formContainer}>
+          <FormContainer {...props} />
+        </AccordionDetails>
+      </Accordion>
+      <Accordion>
+        <AccordionSummary expandIcon={<ExpandMore />} aria-controls="panel-photo-content" id="panel-photo-header">
+          <Typography className={props.classes.heading}>Photos</Typography>
+        </AccordionSummary>
+        <AccordionDetails className={props.classes.photoContainer}>
+          <PhotoContainer {...props} />
+        </AccordionDetails>
+      </Accordion>
+    </>
+  );
+};
+
+export default ActivityComponent;

--- a/app/src/components/database/ManageDatabaseComponent.tsx
+++ b/app/src/components/database/ManageDatabaseComponent.tsx
@@ -3,11 +3,11 @@ import { DeleteForever } from '@material-ui/icons';
 import { DatabaseContext } from 'contexts/DatabaseContext';
 import React, { useContext } from 'react';
 
-interface IManageDatabaseContainerProps {
+interface IManageDatabaseComponentProps {
   classes?: any;
 }
 
-const ManageDatabaseContainer: React.FC<IManageDatabaseContainerProps> = (props) => {
+const ManageDatabaseComponent: React.FC<IManageDatabaseComponentProps> = (props) => {
   const databaseContext = useContext(DatabaseContext);
 
   const wipeLocalDatabase = async () => {
@@ -26,13 +26,17 @@ const ManageDatabaseContainer: React.FC<IManageDatabaseContainerProps> = (props)
     await Promise.all(promises);
   };
 
+  const resetDatabase = async () => {
+    await databaseContext.resetDatabase();
+  };
+
   return (
     <div>
-      <Button variant="contained" startIcon={<DeleteForever />} onClick={() => wipeLocalDatabase()}>
+      <Button variant="contained" startIcon={<DeleteForever />} onClick={() => resetDatabase()}>
         Wipe Local Data
       </Button>
     </div>
   );
 };
 
-export default ManageDatabaseContainer;
+export default ManageDatabaseComponent;

--- a/app/src/components/database/ManageDatabaseComponent.tsx
+++ b/app/src/components/database/ManageDatabaseComponent.tsx
@@ -10,22 +10,6 @@ interface IManageDatabaseComponentProps {
 const ManageDatabaseComponent: React.FC<IManageDatabaseComponentProps> = (props) => {
   const databaseContext = useContext(DatabaseContext);
 
-  const wipeLocalDatabase = async () => {
-    const docs = await databaseContext.database.allDocs();
-
-    if (!docs) {
-      return;
-    }
-
-    const promises = [];
-
-    docs.rows.map((row) => {
-      promises.push(databaseContext.database.remove(row.id, row.value.rev));
-    });
-
-    await Promise.all(promises);
-  };
-
   const resetDatabase = async () => {
     await databaseContext.resetDatabase();
   };

--- a/app/src/components/form/FormContainer.tsx
+++ b/app/src/components/form/FormContainer.tsx
@@ -75,8 +75,8 @@ const FormContainer: React.FC<IFormContainerProps> = (props) => {
       const response = await invasivesApi.getCachedApiSpec();
 
       setSchemas({
-        schema: { ...response.components.schemas[props.activity.activityType], components: response.components },
-        uiSchema: RootUISchemas[props.activity.activityType]
+        schema: { ...response.components.schemas[props.activity.activitySubtype], components: response.components },
+        uiSchema: RootUISchemas[props.activity.activitySubtype]
       });
     };
 

--- a/app/src/components/photo/PhotoContainer.tsx
+++ b/app/src/components/photo/PhotoContainer.tsx
@@ -24,15 +24,15 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
   const [photos, setPhotos] = useState<Photo[]>([]);
   const databaseContext = useContext(DatabaseContext);
 
-  const initPhotos = async function (activityDoc: any) {
-    const dbDoc = await databaseContext.database.get(activityDoc._id);
+  const initPhotos = async function () {
+    const dbDoc = await databaseContext.database.get(props.activity._id);
     const dbPhotos = dbDoc.photos || [];
     setPhotos(dbPhotos);
   };
 
-  const updateDB = async function (activityDoc: any) {
-    await databaseContext.database.upsert(activityDoc._id, (doc) => {
-      return { ...doc, photos: photos, status: ActivityStatus.EDITED, dateUpdated: new Date() };
+  const updateDB = async function () {
+    await databaseContext.database.upsert(props.activity._id, (dbDoc) => {
+      return { ...dbDoc, photos: photos, status: ActivityStatus.EDITED, dateUpdated: new Date() };
     });
   };
 
@@ -63,15 +63,15 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
   };
 
   useEffect(() => {
-    if (props) {
-      initPhotos(props.activity);
+    if (photos && photos.length) {
+      return;
     }
-  }, [props]);
+
+    initPhotos();
+  }, []);
 
   useEffect(() => {
-    if (props) {
-      updateDB(props.activity);
-    }
+    updateDB();
   }, [photos]);
 
   // Grid with overlays: https://material-ui.com/components/grid-list/

--- a/app/src/components/point-of-interest-search/PointOfInterestFilter.tsx
+++ b/app/src/components/point-of-interest-search/PointOfInterestFilter.tsx
@@ -77,7 +77,7 @@ export const PointOfInterestDataFilter: React.FC<any> = (props) => {
     };
 
     getPointOfInterestData();
-  }, [databaseContext]);
+  }, [databaseChangesContext]);
 
   if (!doc) {
     return <CircularProgress />;

--- a/app/src/components/tabs/TabsContainer.tsx
+++ b/app/src/components/tabs/TabsContainer.tsx
@@ -1,5 +1,5 @@
-import { AppBar, makeStyles, Tab, Tabs, Theme } from '@material-ui/core';
-import { Assignment, Explore, HomeWork, Map } from '@material-ui/icons';
+import { AppBar, Tab, Tabs } from '@material-ui/core';
+import { Assignment, Bookmarks, Explore, HomeWork, Map } from '@material-ui/icons';
 import React, { useCallback, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 
@@ -17,17 +17,24 @@ interface IBaseProps {
 const TabsContainer: React.FC<IBaseProps> = (props) => {
   const history = useHistory();
 
+  const urlContainsPath = (path: string): string => {
+    return (history.location.pathname.includes(path) && history.location.pathname) || null;
+  };
+
   const getActiveTab = useCallback(
     (activeTab: number): number => {
       switch (history.location.pathname) {
-        case '/home/plan':
+        case urlContainsPath('/home/plan'):
           return 0;
-        case '/home/activities':
+        case urlContainsPath('/home/references'):
+        case urlContainsPath('/home/references/activity/'):
           return 1;
-        case '/home/map':
+        case urlContainsPath('/home/activities'):
           return 2;
-        case '/home/activity':
+        case urlContainsPath('/home/map'):
           return 3;
+        case urlContainsPath('/home/activity'):
+          return 4;
         default:
           return activeTab;
       }
@@ -51,17 +58,23 @@ const TabsContainer: React.FC<IBaseProps> = (props) => {
         <Tabs value={activeTab} onChange={handleChange} variant="scrollable" scrollButtons="on">
           <Tab label="Plan My Trip" icon={<Explore />} onClick={() => history.push('/home/plan')} {...a11yProps(0)} />
           <Tab
+            label="References"
+            icon={<Bookmarks />}
+            onClick={() => history.push('/home/references')}
+            {...a11yProps(1)}
+          />
+          <Tab
             label="My Activities"
             icon={<HomeWork />}
             onClick={() => history.push('/home/activities')}
-            {...a11yProps(1)}
+            {...a11yProps(2)}
           />
-          <Tab label="Map" icon={<Map />} onClick={() => history.push('/home/map')} {...a11yProps(2)} />
+          <Tab label="Map" icon={<Map />} onClick={() => history.push('/home/map')} {...a11yProps(3)} />
           <Tab
             label="Current Activity"
             icon={<Assignment />}
             onClick={() => history.push('/home/activity')}
-            {...a11yProps(3)}
+            {...a11yProps(4)}
           />
         </Tabs>
       </AppBar>

--- a/app/src/constants/activities.ts
+++ b/app/src/constants/activities.ts
@@ -1,12 +1,12 @@
 import { SvgIconComponent, Assignment, Build, Visibility } from '@material-ui/icons';
 
-export enum ActivityParentType {
+export enum ActivityType {
   Observation = 'Observation',
   Treatment = 'Treatment',
   Monitoring = 'Monitoring'
 }
 
-export enum ActivityType {
+export enum ActivitySubtype {
   Observation_PlantTerrestial = 'Activity_Observation_PlantTerrestial',
   Observation_PlantAquatic = 'Activity_Observation_PlantAquatic',
   Observation_AnimalTerrestrial = 'Activity_Observation_AnimalTerrestrial',
@@ -28,10 +28,10 @@ export enum ActivityType {
   Monitoring_BiologicalTerrestrialAnimal = 'Activity_Monitoring_BiologicalTerrestrialAnimal'
 }
 
-export const ActivityParentTypeIcon: { [key: string]: SvgIconComponent } = {
-  [ActivityParentType.Observation]: Assignment,
-  [ActivityParentType.Treatment]: Build,
-  [ActivityParentType.Monitoring]: Visibility
+export const ActivityTypeIcon: { [key: string]: SvgIconComponent } = {
+  [ActivityType.Observation]: Assignment,
+  [ActivityType.Treatment]: Build,
+  [ActivityType.Monitoring]: Visibility
 };
 
 export enum ActivityStatus {

--- a/app/src/constants/database.ts
+++ b/app/src/constants/database.ts
@@ -1,5 +1,6 @@
 export enum DocType {
   APPSTATE = 'appstate',
   ACTIVITY = 'activity',
+  REFERENCE_ACTIVITY = 'reference_activity',
   NOTIFICATION = 'notification'
 }

--- a/app/src/contexts/DatabaseChangesContext.tsx
+++ b/app/src/contexts/DatabaseChangesContext.tsx
@@ -19,7 +19,7 @@ export const DatabaseChangesContextProvider: React.FC = (props) => {
 
   const setupDatabase = async () => {
     if (!changesListener) {
-      const changesListener = databaseContext.database
+      const listener = databaseContext.database
         .changes({ live: true, since: 'now' })
         .on('change', (change) => {
           setDatabaseChanges(change);
@@ -27,7 +27,7 @@ export const DatabaseChangesContextProvider: React.FC = (props) => {
         .on('complete', (final) => () => setDatabaseChanges(final))
         .on('error', (error) => () => setDatabaseChanges(error));
 
-      setChangesListener(changesListener);
+      setChangesListener(listener);
     }
   };
 

--- a/app/src/contexts/DatabaseChangesContext.tsx
+++ b/app/src/contexts/DatabaseChangesContext.tsx
@@ -1,0 +1,50 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { DatabaseContext } from './DatabaseContext';
+
+export type IDatabaseChanges = PouchDB.Core.ChangesResponseChange<any> | PouchDB.Core.ChangesResponse<any> | any;
+
+export const DatabaseChangesContext = React.createContext<IDatabaseChanges>(null);
+
+/**
+ * Provides access to a database changes object, which contains information about the most recent database updates.
+ *
+ * @param {*} props
+ * @return {*}
+ */
+export const DatabaseChangesContextProvider: React.FC = (props) => {
+  const databaseContext = useContext(DatabaseContext);
+
+  const [databaseChanges, setDatabaseChanges] = useState<IDatabaseChanges>(null);
+  const [changesListener, setChangesListener] = useState<PouchDB.Core.Changes<any>>(null);
+
+  const setupDatabase = async () => {
+    if (!changesListener) {
+      const changesListener = databaseContext.database
+        .changes({ live: true, since: 'now' })
+        .on('change', (change) => {
+          setDatabaseChanges(change);
+        })
+        .on('complete', (final) => () => setDatabaseChanges(final))
+        .on('error', (error) => () => setDatabaseChanges(error));
+
+      setChangesListener(changesListener);
+    }
+  };
+
+  const cleanupDatabase = async () => {
+    if (changesListener) {
+      changesListener.cancel();
+    }
+  };
+
+  // TODO Update [] dependencies to properly run cleanup (if keycloak expires?)
+  useEffect(() => {
+    setupDatabase();
+
+    return async () => {
+      await cleanupDatabase();
+    };
+  }, []);
+
+  return <DatabaseChangesContext.Provider value={databaseChanges}>{props.children}</DatabaseChangesContext.Provider>;
+};

--- a/app/src/contexts/DatabaseContext.tsx
+++ b/app/src/contexts/DatabaseContext.tsx
@@ -2,78 +2,99 @@ import PouchDB from 'pouchdb-core';
 import PouchDBFind from 'pouchdb-find';
 import PouchDBUpsert from 'pouchdb-upsert';
 import React, { useEffect, useState } from 'react';
-import { Subject } from 'rxjs';
 
-export interface IDatabaseContext<T> {
-  database: PouchDB.Database<T>;
-  changes: Subject<PouchDB.Core.ChangesResponseChange<T>>;
-}
+export type IDatabaseContext = {
+  database: PouchDB.Database<any>;
+  resetDatabase: () => void;
+};
 
-export const DatabaseContext = React.createContext<IDatabaseContext<any>>({ database: null, changes: null });
+export const DatabaseContext = React.createContext<IDatabaseContext>({ database: null, resetDatabase: () => {} });
 
+/**
+ * Provides access to the database and to related functions to manipulate the database instance.
+ *
+ * @param {*} props
+ */
 export const DatabaseContextProvider: React.FC = (props) => {
-  const [databaseContext, setDatabaseContext] = useState<IDatabaseContext<any>>({ database: null, changes: null });
-  const [changesListener, setChangesListener] = useState<PouchDB.Core.Changes<any>>(null);
+  const [databaseContext, setDatabaseContext] = useState<IDatabaseContext>({ database: null, resetDatabase: () => {} });
 
-  const setupDatabase = async () => {
-    let db = databaseContext.database;
-    let dbChanges = databaseContext.changes;
+  /**
+   * Create the database using mobile plugins/settings.
+   */
+  const createMobileDatabase = (): PouchDB.Database<any> => {
+    PouchDB.plugin(require('pouchdb-adapter-cordova-sqlite')); // adds mobile adapter
 
-    if (!db) {
-      PouchDB.plugin(PouchDBFind); // adds find query support
-      PouchDB.plugin(PouchDBUpsert); // adds upsert query support
-
-      if (window['cordova']) {
-        PouchDB.plugin(require('pouchdb-adapter-cordova-sqlite')); // adds mobile adapter
-        db = new PouchDB('invasivesbc', {
-          adapter: 'cordova-sqlite',
-          // See https://www.npmjs.com/package/cordova-sqlite-storage for details on the below options
-          iosDatabaseLocation: 'default',
-          androidDatabaseProvider: 'system'
-        } as any);
-      } else {
-        PouchDB.plugin(require('pouchdb-adapter-idb').default); // add sbrowser adapter
-        db = new PouchDB('invasivesbc', { adapter: 'idb' });
-      }
-    }
-
-    if (!dbChanges) {
-      dbChanges = new Subject<any>();
-
-      // add changes listenter to db that emits the changes obj to anyone subscribed to the subject
-      const changes = db
-        .changes({ live: true, since: 'now' })
-        .on('change', (change) => dbChanges.next(change))
-        .on('complete', () => () => dbChanges.complete())
-        .on('error', () => () => dbChanges.complete());
-
-      // sotre changes reference for use in cleanup
-      setChangesListener(changes);
-    }
-
-    setDatabaseContext({ database: db, changes: dbChanges });
+    return new PouchDB('invasivesbc', {
+      adapter: 'cordova-sqlite',
+      // See https://www.npmjs.com/package/cordova-sqlite-storage for details on the below options
+      iosDatabaseLocation: 'default',
+      androidDatabaseProvider: 'system'
+    } as any);
   };
 
+  /**
+   * Create the database using standard (non-mobile) plugins/settings.
+   */
+  const createDatabase = (): PouchDB.Database<any> => {
+    PouchDB.plugin(require('pouchdb-adapter-idb').default); // add sbrowser adapter
+
+    return new PouchDB('invasivesbc', { adapter: 'idb' });
+  };
+
+  /**
+   * Create the database.
+   */
+  const setupDatabase = async () => {
+    let db = databaseContext.database;
+
+    if (db) {
+      return;
+    }
+
+    PouchDB.plugin(PouchDBFind); // adds find query support
+    PouchDB.plugin(PouchDBUpsert); // adds upsert query support
+
+    if (window['cordova']) {
+      db = createMobileDatabase();
+    } else {
+      db = createDatabase();
+    }
+
+    setDatabaseContext({ database: db, resetDatabase: () => resetDatabase(db) });
+  };
+
+  /**
+   * Destroy and re-create the database.
+   */
+  const resetDatabase = async (db) => {
+    if (!db) {
+      return;
+    }
+
+    await db.destroy();
+    await setupDatabase();
+  };
+
+  /**
+   * Close the database.
+   *
+   * Note: This only closes any active connections/listeners, and does not destory the actual database or its content.
+   */
   const cleanupDatabase = async () => {
     let db = databaseContext.database;
 
-    if (changesListener) {
-      // cancel changes listener
-      changesListener.cancel();
+    if (!db) {
+      return;
     }
 
-    if (db) {
-      // close db
-      db.close();
-    }
+    await db.close();
   };
 
-  // TODO Update [] dependencies to properly run cleanup (if keycloak expires?)
   useEffect(() => {
     setupDatabase();
 
-    return () => {
-      cleanupDatabase();
+    return async () => {
+      await cleanupDatabase();
     };
   }, []);
 

--- a/app/src/features/home/HomeRouter.tsx
+++ b/app/src/features/home/HomeRouter.tsx
@@ -6,6 +6,9 @@ import PrivateRoute from 'utils/PrivateRoute';
 import ActivityPage from './activity/ActivityPage';
 import HomeLayout from './HomeLayout';
 import PlanPage from './plan/PlanPage';
+import ReferencesPage from './references/ReferencesPage';
+import ReferencesActivityPage from './references/ReferencesActivityPage';
+import AppRoute from 'utils/AppRoute';
 
 interface IHomeRouterProps {
   classes: any;
@@ -15,10 +18,31 @@ const HomeRouter: React.FC<IHomeRouterProps> = (props) => {
   return (
     <Switch>
       <Redirect exact from="/home" to="/home/activities" />
-      <PrivateRoute layout={HomeLayout} path="/home/plan" component={PlanPage} componentProps={props} />
-      <PrivateRoute layout={HomeLayout} path="/home/activities" component={ActivitiesPage} componentProps={props} />
-      <PrivateRoute layout={HomeLayout} path="/home/map" component={MapPage} componentProps={props} />
-      <PrivateRoute layout={HomeLayout} path="/home/activity" component={ActivityPage} componentProps={props} />
+      <PrivateRoute exact layout={HomeLayout} path="/home/plan" component={PlanPage} componentProps={props} />
+      <PrivateRoute
+        exact
+        layout={HomeLayout}
+        path="/home/references"
+        component={ReferencesPage}
+        componentProps={props}
+      />
+      <PrivateRoute
+        layout={HomeLayout}
+        path="/home/references/activity/:id?"
+        component={ReferencesActivityPage}
+        componentProps={props}
+      />
+      <PrivateRoute
+        exact
+        layout={HomeLayout}
+        path="/home/activities"
+        component={ActivitiesPage}
+        componentProps={props}
+      />
+      <PrivateRoute exact layout={HomeLayout} path="/home/map" component={MapPage} componentProps={props} />
+      <PrivateRoute exact layout={HomeLayout} path="/home/activity" component={ActivityPage} componentProps={props} />
+      {/*  Catch any unknown routes, and re-direct to the not found page */}
+      <AppRoute title="*" path="/home/*" component={() => <Redirect to="/page-not-found" />} />
     </Switch>
   );
 };

--- a/app/src/features/home/activity/ActivityPage.tsx
+++ b/app/src/features/home/activity/ActivityPage.tsx
@@ -1,4 +1,3 @@
-import * as L from 'leaflet';
 import { CircularProgress, Container, makeStyles } from '@material-ui/core';
 import ActivityComponent from 'components/activity/ActivityComponent';
 import { DatabaseContext } from 'contexts/DatabaseContext';

--- a/app/src/features/home/map/MapPage.tsx
+++ b/app/src/features/home/map/MapPage.tsx
@@ -1,7 +1,8 @@
 import clsx from 'clsx';
 import { Container, makeStyles, Theme } from '@material-ui/core';
-import React from 'react';
+import React, { useState } from 'react';
 import MapContainer from 'components/map/MapContainer';
+import { Feature } from 'geojson';
 
 const useStyles = makeStyles((theme: Theme) => ({
   mapContainer: {
@@ -20,9 +21,17 @@ interface IMapProps {
 const MapPage: React.FC<IMapProps> = (props) => {
   const classes = useStyles();
 
+  const [geometry, setGeometry] = useState<Feature[]>([]);
+  const [extent, setExtent] = useState(null);
+
   return (
     <Container className={clsx(classes.mapContainer)} maxWidth={false} disableGutters={true}>
-      <MapContainer classes={classes} />
+      <MapContainer
+        classes={classes}
+        mapId={'mainMap'}
+        geometryState={{ geometry, setGeometry }}
+        extentState={{ extent, setExtent }}
+      />
     </Container>
   );
 };

--- a/app/src/features/home/plan/PlanPage.tsx
+++ b/app/src/features/home/plan/PlanPage.tsx
@@ -9,7 +9,7 @@ import {
   LinearProgress,
   Typography
 } from '@material-ui/core';
-import ManageDatabaseContainer from 'components/database/ClearDatabase';
+import ManageDatabaseComponent from 'components/database/ManageDatabaseComponent';
 import MapContainer from 'components/map/MapContainer';
 import { DatabaseContext } from 'contexts/DatabaseContext';
 import React, { useContext, useEffect, useState } from 'react';
@@ -91,6 +91,10 @@ const PlanPage: React.FC<IPlanPageProps> = (props) => {
   const [geoFeatCollection, setGeoFeatCollection] = useState(null);
 
   const databaseContext = useContext(DatabaseContext);
+
+  const [geometry, setGeometry] = useState(null);
+  const [extent, setExtent] = useState(null);
+
   const getGeos = () => {
     databaseContext.database
       .find({
@@ -115,7 +119,7 @@ const PlanPage: React.FC<IPlanPageProps> = (props) => {
   const classes = useStyles();
   return (
     <Container className={props.classes.container}>
-      <ManageDatabaseContainer />
+      <ManageDatabaseComponent />
       <Grid container spacing={3} className={classes.tripGrid}>
         <Grid item xs={12} sm={12}>
           <Paper className={classes.paper}>
@@ -170,7 +174,13 @@ const PlanPage: React.FC<IPlanPageProps> = (props) => {
         </Grid>
         <Grid item xs={12} sm={6} className={classes.mapGridItem}>
           <Paper className={classes.paper} elevation={5}>
-            <MapContainer {...props} geoFeatCollection={geoFeatCollection} classes={classes} />
+            <MapContainer
+              {...props}
+              classes={classes}
+              mapId={'TODO_this_needs_to_be_a_globally_uniqe_id_per_map_instance'}
+              geometryState={{ geometry, setGeometry }}
+              extentState={{ extent, setExtent }}
+            />
           </Paper>
         </Grid>
       </Grid>

--- a/app/src/features/home/references/ReferencesActivityPage.tsx
+++ b/app/src/features/home/references/ReferencesActivityPage.tsx
@@ -1,4 +1,3 @@
-import * as L from 'leaflet';
 import { CircularProgress, Container, makeStyles } from '@material-ui/core';
 import ActivityComponent from 'components/activity/ActivityComponent';
 import { DatabaseChangesContext } from 'contexts/DatabaseChangesContext';

--- a/app/src/features/home/references/ReferencesActivityPage.tsx
+++ b/app/src/features/home/references/ReferencesActivityPage.tsx
@@ -1,0 +1,72 @@
+import * as L from 'leaflet';
+import { CircularProgress, Container, makeStyles } from '@material-ui/core';
+import ActivityComponent from 'components/activity/ActivityComponent';
+import { DatabaseChangesContext } from 'contexts/DatabaseChangesContext';
+import { DatabaseContext } from 'contexts/DatabaseContext';
+import React, { useContext, useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { Feature } from 'geojson';
+
+const useStyles = makeStyles((theme) => ({
+  heading: {
+    fontSize: theme.typography.pxToRem(18),
+    fontWeight: theme.typography.fontWeightRegular
+  },
+  mapContainer: {
+    height: '600px'
+  },
+  map: {
+    height: '100%',
+    width: '100%'
+  },
+  formContainer: {},
+  photoContainer: {}
+}));
+
+interface IReferencesActivityPage {
+  classes?: any;
+  match?: any;
+}
+
+const ReferencesActivityPage: React.FC<IReferencesActivityPage> = (props) => {
+  const urlParams = useParams();
+
+  const classes = useStyles();
+
+  const databaseContext = useContext(DatabaseContext);
+  const databaseChangesContext = useContext(DatabaseChangesContext);
+
+  const [geometry, setGeometry] = useState<Feature[]>([]);
+  const [extent, setExtent] = useState(null);
+
+  const [doc, setDoc] = useState(null);
+
+  useEffect(() => {
+    const getActivityData = async () => {
+      const activityResult = await databaseContext.database.find({ selector: { _id: urlParams['id'] } });
+
+      setGeometry(activityResult.docs[0].geometry);
+      setDoc(activityResult.docs[0]);
+    };
+
+    getActivityData();
+  }, [databaseChangesContext]);
+
+  if (!doc) {
+    return <CircularProgress />;
+  }
+
+  return (
+    <Container className={props.classes.container}>
+      <ActivityComponent
+        classes={classes}
+        activity={doc}
+        mapId={doc._id}
+        geometryState={{ geometry, setGeometry }}
+        extentState={{ extent, setExtent }}
+      />
+    </Container>
+  );
+};
+
+export default ReferencesActivityPage;

--- a/app/src/features/home/references/ReferencesPage.tsx
+++ b/app/src/features/home/references/ReferencesPage.tsx
@@ -1,0 +1,17 @@
+import { Container } from '@material-ui/core';
+import ReferenceActivitiesList from 'components/activities-list/ReferenceActivitiesList';
+import React from 'react';
+
+interface IReferenceActivitiesPage {
+  classes?: any;
+}
+
+const ReferenceActivitiesPage: React.FC<IReferenceActivitiesPage> = (props) => {
+  return (
+    <Container className={props.classes.container}>
+      <ReferenceActivitiesList />
+    </Container>
+  );
+};
+
+export default ReferenceActivitiesPage;

--- a/app/src/features/home/references/ReferencesPage.tsx
+++ b/app/src/features/home/references/ReferencesPage.tsx
@@ -2,11 +2,11 @@ import { Container } from '@material-ui/core';
 import ReferenceActivitiesList from 'components/activities-list/ReferenceActivitiesList';
 import React from 'react';
 
-interface IReferenceActivitiesPage {
+interface IReferencesPagePage {
   classes?: any;
 }
 
-const ReferenceActivitiesPage: React.FC<IReferenceActivitiesPage> = (props) => {
+const ReferencesPage: React.FC<IReferencesPagePage> = (props) => {
   return (
     <Container className={props.classes.container}>
       <ReferenceActivitiesList />
@@ -14,4 +14,4 @@ const ReferenceActivitiesPage: React.FC<IReferenceActivitiesPage> = (props) => {
   );
 };
 
-export default ReferenceActivitiesPage;
+export default ReferencesPage;

--- a/app/src/interfaces/useInvasivesApi-interfaces.ts
+++ b/app/src/interfaces/useInvasivesApi-interfaces.ts
@@ -1,6 +1,5 @@
-import { ActivityParentType, ActivityType } from 'constants/activities';
-import { Feature } from 'geojson';
-import { Photo } from 'components/photo/PhotoContainer';
+import { ActivityType, ActivitySubtype } from 'constants/activities';
+import { Feature, Polygon } from 'geojson';
 
 /**
  * Activity search filter criteria.
@@ -54,10 +53,10 @@ export interface IActivitySearchCriteria {
   /**
    * GeoJSON polygon to search in.
    *
-   * @type {GeoJSON.Polygon}
+   * @type {Polygon}
    * @memberof IActivitySearchCriteria
    */
-  search_polygon?: GeoJSON.Polygon;
+  search_polygon?: Polygon;
 }
 
 /**
@@ -67,8 +66,8 @@ export interface IActivitySearchCriteria {
  * @interface ICreateActivity
  */
 export interface ICreateActivity {
-  activity_type: ActivityParentType;
-  activity_subtype: ActivityType;
+  activity_type: ActivityType;
+  activity_subtype: ActivitySubtype;
   geometry: Feature[];
   media: IMedia[];
   form_data: any;

--- a/app/src/pages/misc/AccessDenied.tsx
+++ b/app/src/pages/misc/AccessDenied.tsx
@@ -9,7 +9,7 @@ const AccessDenied = () => {
         <Grid item>
           <h1>Access Denied</h1>
           <h2>You do not have permission to view this page</h2>
-          <Link to="/activities">Go back to the activities page</Link>
+          <Link to="/home/activities">Go back to the activities page</Link>
         </Grid>
       </Grid>
     </Container>

--- a/app/src/pages/misc/NotFoundPage.tsx
+++ b/app/src/pages/misc/NotFoundPage.tsx
@@ -8,7 +8,7 @@ export const NotFoundPage = () => {
       <Grid container direction="row">
         <Grid item>
           <h1>Page not found</h1>
-          <Link to="/activities">Go back to the activities page</Link>
+          <Link to="/home/activities">Go back to the activities page</Link>
         </Grid>
       </Grid>
     </Container>

--- a/app/src/utils/NotificationUtils.tsx
+++ b/app/src/utils/NotificationUtils.tsx
@@ -2,7 +2,7 @@ import { DocType } from 'constants/database';
 import { IDatabaseContext } from 'contexts/DatabaseContext';
 import { v4 as uuidv4 } from 'uuid';
 
-export const notifyError = async (databaseContext: IDatabaseContext<any>, message: string) => {
+export const notifyError = async (databaseContext: IDatabaseContext, message: string) => {
   await databaseContext.database.put({
     _id: uuidv4(),
     docType: DocType.NOTIFICATION,
@@ -13,7 +13,7 @@ export const notifyError = async (databaseContext: IDatabaseContext<any>, messag
   });
 };
 
-export const notifySuccess = async (databaseContext: IDatabaseContext<any>, message: string) => {
+export const notifySuccess = async (databaseContext: IDatabaseContext, message: string) => {
   await databaseContext.database.put({
     _id: uuidv4(),
     docType: DocType.NOTIFICATION,
@@ -24,7 +24,7 @@ export const notifySuccess = async (databaseContext: IDatabaseContext<any>, mess
   });
 };
 
-export const notifyWarning = async (databaseContext: IDatabaseContext<any>, message: string) => {
+export const notifyWarning = async (databaseContext: IDatabaseContext, message: string) => {
   await databaseContext.database.put({
     _id: uuidv4(),
     docType: DocType.NOTIFICATION,
@@ -33,12 +33,4 @@ export const notifyWarning = async (databaseContext: IDatabaseContext<any>, mess
     acknowledged: false,
     dateCreated: new Date()
   });
-};
-// just for testing
-export const triggerError = async (databaseContext: IDatabaseContext<any>) => {
-  try {
-    throw Error('crash the app!');
-  } catch (error) {
-    notifyError(databaseContext, 'oh no');
-  }
 };

--- a/app/src/utils/PrivateRoute.tsx
+++ b/app/src/utils/PrivateRoute.tsx
@@ -13,7 +13,6 @@ interface IPrivateRouteProps extends RouteProps {
  * @param props - Properties to pass { component, role, claim }
  */
 const PrivateRoute: React.FC<IPrivateRouteProps> = (props) => {
-  const location = useLocation();
   const keycloak = useKeycloakWrapper();
 
   let { component: Component, layout: Layout, ...rest } = props;

--- a/app/src/utils/PrivateRoute.tsx
+++ b/app/src/utils/PrivateRoute.tsx
@@ -1,6 +1,6 @@
 import useKeycloakWrapper from 'hooks/useKeycloakWrapper';
 import React from 'react';
-import { Redirect, Route, RouteProps, useLocation } from 'react-router-dom';
+import { Route, RouteProps } from 'react-router-dom';
 
 interface IPrivateRouteProps extends RouteProps {
   component: React.ComponentType<any>;


### PR DESCRIPTION
- Fixed my weird naming for type (ActivityParentType, ActivityType) => (ActivityType, ActivitySubtype) which is more appropriate.
- Added page to display reference activities and page to render the activity (the same as the current activity page for now)
  - This list page looks for activities with a `docType` of reference activity (see constants)
- Updated database context
  - It now has a resetDatabase function (that only gets called by the Wipe Local Data button on the plan page) that deletes the current database, and replaces it with a new empty one. Seems to work fien, but havent done a ton of testing on this yet.
- Added DatabaseChangesContext
  - You can now use a useEffect on `DatabaseChangesContext` to trigger when any records in database change
- Updated MapContainer state/hook behaviour
  - The MapContainer now takes in some state objects, which the parent must provide.  This means that the map doesn't need to care about what is being rendered (activityPage, planPage, etc), as the parent just needs to supply the initial geometry array and extent, and can then setup their own useEffects to trigger functionality on geometry/extent changes, as they see fit.
  - See `ActivityPage.tsx` for an example.
  - All of the other leaflet controls/functionality is unchanged.
- Minor update to PhotoContainer state/hook behaviour
  - I think as a result of my database context changes, there was a useEffect infinite-loop happening.  Minor change to fix this.
- Fix 'not found' page routing
  - Wasn't setup before, even though the page (very basic page) existed already.
- Misc Cleanup