### PR TITLE
fix kml

### DIFF
--- a/app/src/components/map-buddy-components/KMLUpload.tsx
+++ b/app/src/components/map-buddy-components/KMLUpload.tsx
@@ -21,9 +21,9 @@ export const KMLUpload: React.FC<any> = (props) => {
 
     if (geoFromDOM) {
       console.log('saving geo feat collection');
-      databaseContext.database.upsert('theShapeAsGeoFeatureCollection', (shapeLastTime) => {
-        return geoFromDOM;
-      });
+      await databaseContext.database.upsert('trip', (tripDoc) => {
+        return { ...tripDoc, geometry: geoFromDOM };
+      })
     }
   };
 


### PR DESCRIPTION

- [x] id of uploaded kml geo lines up with trip record
- [ ] geo(s) from upload are visible without refreshing the page

For now, the first geo in the collection uploaded will be used in the search.  If
you upload one polygon, that will be the search boundary.
