### PR TITLE
62: Edit single Activity + Misc Updates

### DIFF
--- a/app/src/components/activities-list/ReferenceActivitiesList.tsx
+++ b/app/src/components/activities-list/ReferenceActivitiesList.tsx
@@ -47,7 +47,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 interface IReferenceActivityListItem {
-  disable?: boolean;
+  isDisabled?: boolean;
   activity: any;
 }
 
@@ -85,7 +85,7 @@ const ReferenceActivityListItem: React.FC<IReferenceActivityListItem> = (props) 
 };
 
 interface IReferenceActivityList {
-  disable?: boolean;
+  isDisabled?: boolean;
 }
 
 // TODO change any to a type that defines the overall items being displayed
@@ -128,7 +128,7 @@ const ReferenceActivityList: React.FC<IReferenceActivityList> = (props) => {
               <ListItemIcon>
                 <SvgIcon fontSize="large" component={ActivityTypeIcon[doc.activityType]} />
               </ListItemIcon>
-              <ReferenceActivityListItem disable={props.disable} activity={doc} />
+              <ReferenceActivityListItem isDisabled={props.isDisabled} activity={doc} />
             </ListItem>
           </Paper>
         );
@@ -147,7 +147,7 @@ const ReferenceActivitiesList: React.FC = (props) => {
           <Typography variant="h4">Reference Activities</Typography>
         </div>
         <div>
-          <ReferenceActivityList disable={true} />
+          <ReferenceActivityList isDisabled={true} />
         </div>
       </div>
     </>

--- a/app/src/components/activity/ActivityComponent.tsx
+++ b/app/src/components/activity/ActivityComponent.tsx
@@ -1,11 +1,11 @@
 import { Accordion, AccordionDetails, AccordionSummary, Typography } from '@material-ui/core';
 import { ExpandMore } from '@material-ui/icons';
-import FormContainer from 'components/form/FormContainer';
+import FormContainer, { IFormContainerProps } from 'components/form/FormContainer';
 import MapContainer, { IMapContainerProps } from 'components/map/MapContainer';
-import PhotoContainer from 'components/photo/PhotoContainer';
+import PhotoContainer, { IPhotoContainerProps } from 'components/photo/PhotoContainer';
 import React from 'react';
 
-export interface IActivityComponentProps extends IMapContainerProps {
+export interface IActivityComponentProps extends IMapContainerProps, IFormContainerProps, IPhotoContainerProps {
   classes?: any;
   activity: any;
 }

--- a/app/src/components/form/FormContainer.tsx
+++ b/app/src/components/form/FormContainer.tsx
@@ -1,74 +1,44 @@
-import { Button, CircularProgress, Grid, Theme, Typography } from '@material-ui/core';
-import { makeStyles } from '@material-ui/styles';
+import { Box, CircularProgress, Typography } from '@material-ui/core';
+import { IChangeEvent, ISubmitEvent } from '@rjsf/core';
 import Form from '@rjsf/material-ui';
+import { ActivitySyncStatus } from 'constants/activities';
 import { useInvasivesApi } from 'hooks/useInvasivesApi';
-import { DatabaseContext } from 'contexts/DatabaseContext';
 import { JSONSchema7 } from 'json-schema';
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import RootUISchemas from 'rjsf/RootUISchemas';
-import { ActivityStatus, ActivitySyncStatus } from 'constants/activities';
+import FormControlsComponent, { IFormControlsComponentProps } from './FormControlsComponent';
 
 // Custom themed `Form` component, using @rjsf/material-ui as default base theme
 // const Form = withTheme({ ...rjsfMaterialTheme });
 
-const useStyles = makeStyles((theme: Theme) => ({
-  formControlsTop: {
-    marginBottom: '1rem'
-  },
-  formControlsBottom: {
-    marginTop: '1rem'
-  }
-}));
-
-interface IFormControlProps {
-  classes?: { root?: any };
-  disabled?: boolean;
-  formRef: { submit: Function };
-  activity: any;
-}
-
-const FormControls: React.FC<IFormControlProps> = (props) => {
-  const save = async (formData: any) => {
-    props.formRef.submit();
-  };
-
-  const isDisabled = props.disabled || false;
-
-  return (
-    <>
-      <Grid container spacing={3} className={props.classes.root}>
-        <Grid container item spacing={3}>
-          <Grid item>
-            <Button disabled={isDisabled} size="small" variant="contained" color="primary" onClick={save}>
-              Save
-            </Button>
-          </Grid>
-        </Grid>
-      </Grid>
-    </>
-  );
-};
-
-interface IFormContainerProps {
+export interface IFormContainerProps extends IFormControlsComponentProps {
   classes?: any;
   activity: any;
+  isReadOnly?: boolean;
+  /**
+   * A function executed everytime the form changes.
+   *
+   * Note: This will fire frequently, so consider wrapping it in a debounce function (see utils.ts > debounced).
+   */
+  onFormChange?: (event: IChangeEvent<any>, formRef: any) => any;
+  /**
+   * A function executed when the form submit hook fires, and form validation errors are found.
+   */
+  onFormSubmitError?: (errors: any[], formRef: any) => any;
+  /**
+   * A function executed everytime the form submit hook fires.
+   *
+   * Note: Form validation rules will run, and must succeed, before this will be called.
+   */
+  onFormSubmitSuccess?: (event: ISubmitEvent<any>, formRef: any) => any;
 }
 
 const FormContainer: React.FC<IFormContainerProps> = (props) => {
-  const classes = useStyles();
-
   const invasivesApi = useInvasivesApi();
-  const databaseContext = useContext(DatabaseContext);
 
   const [schemas, setSchemas] = useState<{ schema: any; uiSchema: any }>({ schema: null, uiSchema: null });
 
   const [formRef, setFormRef] = useState(null);
-
-  const submitHandler = async (event: any) => {
-    await databaseContext.database.upsert(props.activity._id, (activity) => {
-      return { ...activity, formData: event.formData, status: ActivityStatus.EDITED, dateUpdated: new Date() };
-    });
-  };
 
   useEffect(() => {
     const getApiSpec = async () => {
@@ -83,24 +53,20 @@ const FormContainer: React.FC<IFormContainerProps> = (props) => {
     getApiSpec();
   }, []);
 
-  useEffect(() => {});
-
   if (!schemas.schema || !schemas.uiSchema) {
     return <CircularProgress />;
   }
 
-  const isDisabled = props.activity?.sync?.status === ActivitySyncStatus.SYNC_SUCCESSFUL || false;
+  const isDisabled = props.isReadOnly || props.activity?.sync?.status === ActivitySyncStatus.SYNC_SUCCESSFUL || false;
 
   return (
-    <div>
-      <FormControls
-        activity={props.activity}
-        formRef={formRef}
-        disabled={isDisabled}
-        classes={{ root: classes.formControlsTop }}
-      />
+    <Box>
+      <Box mb={3}>
+        <FormControlsComponent onSubmit={() => formRef.submit()} isDisabled={isDisabled} />
+      </Box>
 
       <Form
+        key={props.activity?._id}
         disabled={isDisabled}
         formData={props.activity?.formData || null}
         schema={schemas.schema as JSONSchema7}
@@ -111,25 +77,51 @@ const FormContainer: React.FC<IFormContainerProps> = (props) => {
           return (
             <div>
               <Typography color="error" variant="h5">
-                The form contains one or more errors
+                The form contains one or more errors!
+              </Typography>
+              <Typography color="error" variant="h6">
+                Incorrect fields are highlighted below.
               </Typography>
             </div>
           );
         }}
-        onSubmit={submitHandler}
+        onChange={(event) => {
+          if (!props.onFormChange) {
+            return;
+          }
+
+          props.onFormChange(event, formRef);
+        }}
+        onError={(error) => {
+          if (!props.onFormSubmitError) {
+            return;
+          }
+
+          props.onFormSubmitError(error, formRef);
+        }}
+        onSubmit={(event) => {
+          if (!props.onFormSubmitSuccess) {
+            return;
+          }
+
+          props.onFormSubmitSuccess(event, formRef);
+        }}
         // `ref` does exist, but currently is missing from the `index.d.ts` types file.
         // @ts-ignore: No overload matches this call ts(2769)
-        ref={(form) => setFormRef(form)}>
+        ref={(form) => {
+          if (!form) {
+            return;
+          }
+
+          setFormRef(form);
+        }}>
         <React.Fragment />
       </Form>
 
-      <FormControls
-        activity={props.activity}
-        formRef={formRef}
-        disabled={isDisabled}
-        classes={{ root: classes.formControlsBottom }}
-      />
-    </div>
+      <Box mt={3}>
+        <FormControlsComponent onSubmit={() => formRef.submit()} isDisabled={isDisabled} />
+      </Box>
+    </Box>
   );
 };
 

--- a/app/src/components/form/FormControlsComponent.tsx
+++ b/app/src/components/form/FormControlsComponent.tsx
@@ -1,0 +1,38 @@
+import { Button, Grid } from '@material-ui/core';
+import React from 'react';
+
+export interface IFormControlsComponentProps {
+  classes?: any;
+  isDisabled?: boolean;
+  onSubmit?: Function;
+}
+
+const FormControlsComponent: React.FC<IFormControlsComponentProps> = (props) => {
+  const isDisabled = props.isDisabled || false;
+
+  return (
+    <>
+      <Grid container spacing={3}>
+        <Grid container item spacing={3}>
+          <Grid item>
+            <Button
+              disabled={isDisabled}
+              variant="contained"
+              color="primary"
+              onClick={() => {
+                if (!props.onSubmit) {
+                  return;
+                }
+
+                props.onSubmit();
+              }}>
+              Check Form For Errors
+            </Button>
+          </Grid>
+        </Grid>
+      </Grid>
+    </>
+  );
+};
+
+export default FormControlsComponent;

--- a/app/src/components/photo/PhotoContainer.tsx
+++ b/app/src/components/photo/PhotoContainer.tsx
@@ -1,42 +1,25 @@
-import { CardMedia, Fab, Grid, Paper, SvgIcon } from '@material-ui/core';
-import { AddAPhoto, DeleteForever } from '@material-ui/icons';
-import { useCamera } from '@ionic/react-hooks/camera';
 import { CameraResultType, CameraSource } from '@capacitor/core';
-import { DatabaseContext } from 'contexts/DatabaseContext';
-import React, { useState, useContext, useEffect } from 'react';
+import { useCamera } from '@ionic/react-hooks/camera';
+import { Box, Button, Card, CardActions, CardMedia, CircularProgress, Grid, IconButton } from '@material-ui/core';
+import { AddAPhoto, DeleteForever } from '@material-ui/icons';
+import React from 'react';
 
-import { ActivityStatus } from 'constants/activities';
-
-export interface Photo {
+export interface IPhoto {
   filepath: string;
   webviewPath?: string;
   base64?: string;
   dataUrl?: string;
 }
 
-interface IPhotoContainerProps {
+export interface IPhotoContainerProps {
   classes?: any;
-  activity?: any;
+  photoState: { photos: IPhoto[]; setPhotos: (photo: IPhoto[]) => void };
 }
 
 const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
   const { getPhoto } = useCamera();
-  const [photos, setPhotos] = useState<Photo[]>([]);
-  const databaseContext = useContext(DatabaseContext);
 
-  const initPhotos = async function () {
-    const dbDoc = await databaseContext.database.get(props.activity._id);
-    const dbPhotos = dbDoc.photos || [];
-    setPhotos(dbPhotos);
-  };
-
-  const updateDB = async function () {
-    await databaseContext.database.upsert(props.activity._id, (dbDoc) => {
-      return { ...dbDoc, photos: photos, status: ActivityStatus.EDITED, dateUpdated: new Date() };
-    });
-  };
-
-  const takePhoto = async (doc: any) => {
+  const takePhoto = async () => {
     const cameraPhoto = await getPhoto({
       resultType: CameraResultType.DataUrl,
       source: CameraSource.Camera,
@@ -49,63 +32,60 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
       dataUrl: cameraPhoto.dataUrl
     };
 
-    const newPhotos = [photo, ...photos];
-    setPhotos(newPhotos);
+    props.photoState.setPhotos([...props.photoState.photos, photo]);
   };
 
-  const deletePhotos = async (doc: any) => {
-    setPhotos([]);
+  const deletePhotos = async () => {
+    props.photoState.setPhotos([]);
   };
 
   const deletePhoto = async (filepath: any) => {
-    const reducedPhotos = photos.filter((photo) => photo.filepath != filepath);
-    setPhotos(reducedPhotos);
+    const reducedPhotos = props.photoState.photos.filter((photo) => photo.filepath !== filepath);
+    props.photoState.setPhotos(reducedPhotos);
   };
 
-  useEffect(() => {
-    if (photos && photos.length) {
-      return;
-    }
-
-    initPhotos();
-  }, []);
-
-  useEffect(() => {
-    updateDB();
-  }, [photos]);
+  if (!props.photoState) {
+    return <CircularProgress />;
+  }
 
   // Grid with overlays: https://material-ui.com/components/grid-list/
   return (
-    <div>
-      <div style={{ display: 'flex', flex: '1' }}>
+    <Box width={1}>
+      <Box mb={3}>
         <Grid container>
-          {photos.map((photo, index) => (
-            <Grid item xs={12} sm={6} md={4} lg={3} key={index}>
-              <Paper>
-                <CardMedia src={photo.dataUrl} component="img" />
-                <div style={{ cursor: 'pointer' }} onClick={() => deletePhoto(photo.filepath)}>
-                  <SvgIcon component={DeleteForever} /> {photo.filepath}
-                </div>
-              </Paper>
+          <Grid container item>
+            {props.photoState.photos.map((photo, index) => (
+              <Grid item xs={12} sm={6} md={4} lg={3} key={index}>
+                <Card>
+                  <CardMedia src={photo.dataUrl} component="img" />
+                  <CardActions>
+                    <IconButton onClick={() => deletePhoto(photo.filepath)}>
+                      <DeleteForever />
+                    </IconButton>
+                  </CardActions>
+                </Card>
+              </Grid>
+            ))}
+          </Grid>
+        </Grid>
+      </Box>
+      <Box>
+        <Grid container>
+          <Grid container item spacing={3} justify="center">
+            <Grid item>
+              <Button variant="contained" color="primary" startIcon={<AddAPhoto />} onClick={() => takePhoto()}>
+                Add A Photo
+              </Button>
             </Grid>
-          ))}
-        </Grid>
-      </div>
-      <div>
-        <Grid container spacing={3} justify="center">
-          <Grid item>
-            <Fab color="primary" onClick={() => takePhoto(props.activity)}>
-              <SvgIcon component={AddAPhoto} />
-            </Fab>
-          </Grid>
-          <Grid item>
-            <Fab onClick={() => deletePhotos(props.activity)}>
-              <SvgIcon component={DeleteForever} />
-            </Fab>
+            <Grid item>
+              <Button variant="contained" startIcon={<DeleteForever />} onClick={() => deletePhotos()}>
+                Remvoe All Photos
+              </Button>
+            </Grid>
           </Grid>
         </Grid>
-      </div>
-    </div>
+      </Box>
+    </Box>
   );
 };
 

--- a/app/src/components/trip/TripDataControls.tsx
+++ b/app/src/components/trip/TripDataControls.tsx
@@ -84,7 +84,7 @@ export const TripDataControls: React.FC = (props) => {
         }
 
         try {
-          await databaseContext.database.upsert(String(row.activity_id), (existingDoc) => {
+          await databaseContext.database.upsert(row.activity_id, (existingDoc) => {
             return {
               ...existingDoc,
               docType: DocType.REFERENCE_ACTIVITY,
@@ -143,7 +143,7 @@ export const TripDataControls: React.FC = (props) => {
         }
 
         try {
-          await databaseContext.database.upsert('POI' + String(row.point_of_interest_id), (existingDoc) => {
+          await databaseContext.database.upsert('POI' + row.point_of_interest_id, (existingDoc) => {
             return {
               ...existingDoc,
               docType: DocType.REFERENCE_POINT_OF_INTEREST,

--- a/app/src/constants/activities.ts
+++ b/app/src/constants/activities.ts
@@ -44,3 +44,9 @@ export enum ActivitySyncStatus {
   SYNC_SUCCESSFUL = 'Sync Successful',
   SYNC_FAILED = 'Sync Failed'
 }
+
+export enum FormValidationStatus {
+  NOT_VALIDATED = 'Not Validated',
+  INVALID = 'Invalid',
+  VALID = 'Valid'
+}

--- a/app/src/features/home/references/ReferencesActivityPage.tsx
+++ b/app/src/features/home/references/ReferencesActivityPage.tsx
@@ -6,6 +6,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Feature } from 'geojson';
 import { MapContextMenuData } from '../map/MapPageControls';
+import { IPhoto } from 'components/photo/PhotoContainer';
 
 const useStyles = makeStyles((theme) => ({
   heading: {
@@ -49,12 +50,15 @@ const ReferencesActivityPage: React.FC<IReferencesActivityPage> = (props) => {
   */
   const [doc, setDoc] = useState(null);
 
+  const [photos, setPhotos] = useState<IPhoto[]>([]);
+
   useEffect(() => {
     const getActivityData = async () => {
       const activityResults = await databaseContext.database.find({ selector: { _id: urlParams['id'] } });
 
       // TODO these are reference activities, so do we really have an extent to set? Or are we just zooming to where the geometry is?
       setGeometry(activityResults.docs[0].geometry);
+      setPhotos(activityResults.docs[0].photos);
       setDoc(activityResults.docs[0]);
     };
 
@@ -71,6 +75,7 @@ const ReferencesActivityPage: React.FC<IReferencesActivityPage> = (props) => {
         classes={classes}
         activity={doc}
         mapId={doc._id}
+        photoState={{ photos, setPhotos }}
         geometryState={{ geometry, setGeometry }}
         extentState={{ extent, setExtent }}
         contextMenuState={{ state: contextMenuState, setContextMenuState }} // whether someone clicked, and click x & y

--- a/app/src/features/home/search/SearchActivityPage.tsx
+++ b/app/src/features/home/search/SearchActivityPage.tsx
@@ -1,9 +1,14 @@
-import { CircularProgress, Container, makeStyles } from '@material-ui/core';
+import { Box, Button, CircularProgress, Container, makeStyles, Paper } from '@material-ui/core';
+import { Save } from '@material-ui/icons';
 import ActivityComponent from 'components/activity/ActivityComponent';
+import { IPhoto } from 'components/photo/PhotoContainer';
+import { ActivityStatus, FormValidationStatus } from 'constants/activities';
 import { Feature } from 'geojson';
 import { useInvasivesApi } from 'hooks/useInvasivesApi';
+import { ICreateOrUpdateActivity } from 'interfaces/useInvasivesApi-interfaces';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { debounced } from 'utils/FunctionUtils';
 import { MapContextMenuData } from '../map/MapPageControls';
 
 const useStyles = makeStyles((theme) => ({
@@ -37,7 +42,97 @@ const SearchActivityPage: React.FC<ISearchActivityPage> = (props) => {
   const [extent, setExtent] = useState(null);
   const [contextMenuState, setContextMenuState] = useState<MapContextMenuData>({ isOpen: false, lat: 0, lng: 0 });
 
-  const [doc, setDoc] = useState(null);
+  const [activity, setActivity] = useState(null);
+
+  const [photos, setPhotos] = useState<IPhoto[]>([]);
+
+  const handleUpdate = async () => {
+    try {
+      const updatedActivity: ICreateOrUpdateActivity = {
+        activity_id: activity.activityId,
+        created_timestamp: activity.dateCreated,
+        activity_type: activity.activityType,
+        activity_subtype: activity.activitySubtype,
+        geometry: activity.geometry,
+        media: activity.photos.map((photo) => {
+          return { file_name: photo.filepath, encoded_file: photo.dataUrl };
+        }),
+        form_data: activity.formData
+      };
+
+      await invasivesApi.updateActivity(updatedActivity);
+      // TODO success messaging
+    } catch (error) {
+      // TODO error messaging
+    }
+  };
+
+  /**
+   * Save the geometry.
+   *
+   * @param {Feature} geoJSON The geometry in GeoJSON format
+   */
+  const saveGeometry = async (geometry: Feature[]) => {
+    setActivity({ ...activity, geometry: geometry, status: ActivityStatus.EDITED, dateUpdated: new Date() });
+  };
+
+  /**
+   * Save the photos.
+   *
+   * @param {IPhoto} photos An array of photo objects.
+   */
+  const savePhotos = async (photos: IPhoto[]) => {
+    setActivity({ ...activity, photos: photos, dateUpdated: new Date() });
+  };
+
+  /**
+   * Save the form when it is submitted.
+   *
+   * Note: this runs after validation has run, and only if there were no errors.
+   *
+   * @param {*} event the form submit event
+   */
+  const onFormSubmitSuccess = (event: any, formRef: any) => {
+    /*
+    There is an issue where `schemaValidationErrors` and `schemaValidationErrorSchema` are not reset properly if the
+    onSubmit hook triggers a re-render. This results in the validation errors persisting on the UI even after the
+    user fixed the invalid field data.
+
+    Temporary solution: manually reset the aforementioned fields.
+
+    When the issue is resolved, only the `setActivity(...)` call is needed, and the `formRef.setState(...)` wrapper can be
+    removed.
+
+    See https://github.com/rjsf-team/react-jsonschema-form/issues/2102
+    See https://github.com/rjsf-team/react-jsonschema-form/issues/666
+    */
+    formRef.setState({ ...formRef.state, schemaValidationErrors: [], schemaValidationErrorSchema: {} }, () => {
+      setActivity({
+        ...activity,
+        formData: event.formData,
+        status: ActivityStatus.EDITED,
+        dateUpdated: new Date(),
+        formStatus: FormValidationStatus.VALID
+      });
+    });
+  };
+
+  /**
+   * Save the form whenever it changes.
+   *
+   * Note: debouncing will prevent this from running more than once per `500` milliseconds.
+   *
+   * @param {*} event the form change event
+   */
+  const onFormChange = debounced(500, (event: any) => {
+    return setActivity({
+      ...activity,
+      formData: event.formData,
+      status: ActivityStatus.EDITED,
+      dateUpdated: new Date(),
+      formStatus: FormValidationStatus.NOT_VALIDATED
+    });
+  });
 
   useEffect(() => {
     const getActivityData = async () => {
@@ -45,52 +140,80 @@ const SearchActivityPage: React.FC<ISearchActivityPage> = (props) => {
 
       if (!response) {
         // TODO error messaging
+        return;
       }
 
-      const photos = [];
-      if (response.media_keys && response.media_keys.length) {
-        try {
-          const mediaResults = await invasivesApi.getMedia(response.media_keys);
-
-          mediaResults.forEach((media) => {
-            photos.push({ filepath: media.file_name, dataUrl: media.encoded_file });
-          });
-        } catch {
-          // TODO handle errors appropriately
-        }
-      }
-
-      const activity = {
-        _id: String(response.activity_id),
+      const activityDoc = {
+        _id: response.activity_id,
+        activityId: response.activity_id,
+        dateCreated: response.created_timestamp,
         activityType: response.activity_type,
         activitySubtype: response.activity_subtype,
         geometry: response.activity_payload.geometry,
         formData: response.activity_payload.form_data,
-        photos: photos
+        photos:
+          (response.media &&
+            response.media.length &&
+            response.media.map((media) => {
+              return { filepath: media.file_name, dataUrl: media.encoded_file };
+            })) ||
+          []
       };
 
       // TODO these are search result activities (online only), so do we really have an extent to set? Or are we just zooming to where the geometry is?
-      setGeometry(activity.geometry);
-      setDoc(activity);
+      setGeometry(activityDoc.geometry);
+      setPhotos(activityDoc.photos);
+      setActivity(activityDoc);
     };
 
     getActivityData();
   }, []);
 
-  if (!doc) {
+  useEffect(() => {
+    if (!activity) {
+      return;
+    }
+
+    saveGeometry(geometry);
+  }, [geometry]);
+
+  useEffect(() => {
+    if (!activity) {
+      return;
+    }
+
+    savePhotos(photos);
+  }, [photos]);
+
+  if (!activity) {
     return <CircularProgress />;
   }
 
   return (
     <Container className={props.classes.container}>
+      <Box mb={3}>
+        <Button variant="contained" color="primary" startIcon={<Save />} onClick={handleUpdate}>
+          Update Activity
+        </Button>
+      </Box>
+
       <ActivityComponent
         classes={classes}
-        activity={doc}
-        mapId={doc._id}
+        activity={activity}
+        onFormChange={onFormChange}
+        onFormSubmitSuccess={onFormSubmitSuccess}
+        photoState={{ photos, setPhotos }}
+        mapId={activity._id}
         geometryState={{ geometry, setGeometry }}
         extentState={{ extent, setExtent }}
         contextMenuState={{ state: contextMenuState, setContextMenuState }}
       />
+
+      <Box mt={3}>
+        <Button variant="contained" color="primary" startIcon={<Save />} onClick={handleUpdate}>
+          Update Activity
+        </Button>
+      </Box>
     </Container>
   );
 };

--- a/app/src/features/home/search/SearchPage.tsx
+++ b/app/src/features/home/search/SearchPage.tsx
@@ -106,7 +106,7 @@ const SearchPage: React.FC<ISearchPagePage> = (props) => {
       limit: itemsPerPage,
       sort_by: sortColumn,
       sort_direction: (sortDirection === '-' && SORT_DIRECTION.DESC) || SORT_DIRECTION.ASC,
-      column_names: ['activity_id', 'activity_type', 'activity_subtype', 'received_timestamp'],
+      column_names: ['activity_id', 'activity_type', 'activity_subtype', 'created_timestamp', 'received_timestamp'],
       ...startDateFilter,
       ...endDateFilter,
       ...activityTypeFilter // NICK TODO WIP - Update backend search to accept array of type, etc. Move it all into the URL????
@@ -121,9 +121,11 @@ const SearchPage: React.FC<ISearchPagePage> = (props) => {
 
       const activities = response.rows.map((activity) => {
         return {
-          _id: String(activity.activity_id),
+          _id: activity.activity_id,
+          activityId: activity.activity_id,
           activityType: activity.activity_type,
           activitySubtype: activity.activity_subtype,
+          dateCreated: activity.created_timestamp,
           dateReceived: activity.received_timestamp
         };
       });

--- a/app/src/hooks/useInvasivesApi.ts
+++ b/app/src/hooks/useInvasivesApi.ts
@@ -1,7 +1,7 @@
 import { useKeycloak } from '@react-keycloak/web';
 import axios from 'axios';
 import { DatabaseContext } from 'contexts/DatabaseContext';
-import { IActivitySearchCriteria, ICreateActivity } from 'interfaces/useInvasivesApi-interfaces';
+import { IActivitySearchCriteria, ICreateOrUpdateActivity } from 'interfaces/useInvasivesApi-interfaces';
 import { IPointOfInterestSearchCriteria, ICreatePointOfInterest } from 'interfaces/useInvasivesApi-interfaces';
 import qs from 'qs';
 import { useContext, useMemo } from 'react';
@@ -96,11 +96,23 @@ export const useInvasivesApi = () => {
   /**
    * Create a new activity record.
    *
-   * @param {ICreateActivity} activity
+   * @param {ICreateOrUpdateActivity} activity
    * @return {*}  {Promise<any>}
    */
-  const createActivity = async (activity: ICreateActivity): Promise<any> => {
+  const createActivity = async (activity: ICreateOrUpdateActivity): Promise<any> => {
     const { data } = await api.post('/api/activity', activity);
+
+    return data;
+  };
+
+  /**
+   * Update an existing activity record.
+   *
+   * @param {ICreateOrUpdateActivity} activity
+   * @return {*}  {Promise<any>}
+   */
+  const updateActivity = async (activity: ICreateOrUpdateActivity): Promise<any> => {
+    const { data } = await api.put('/api/activity', activity);
 
     return data;
   };
@@ -143,6 +155,7 @@ export const useInvasivesApi = () => {
     getActivities,
     getActivityById,
     createActivity,
+    updateActivity,
     getApiSpec,
     getCachedApiSpec,
     getPointsOfInterest

--- a/app/src/interfaces/useInvasivesApi-interfaces.ts
+++ b/app/src/interfaces/useInvasivesApi-interfaces.ts
@@ -85,12 +85,14 @@ export interface IActivitySearchCriteria {
 }
 
 /**
- * Create activity endpoint post body.
+ * Create or Update activity endpoint post body.
  *
  * @export
- * @interface ICreateActivity
+ * @interface ICreateOrUpdateActivity
  */
-export interface ICreateActivity {
+export interface ICreateOrUpdateActivity {
+  activity_id: string;
+  created_timestamp: string;
   activity_type: ActivityType;
   activity_subtype: ActivitySubtype;
   geometry: Feature[];

--- a/app/src/utils/FunctionUtils.ts
+++ b/app/src/utils/FunctionUtils.ts
@@ -1,0 +1,46 @@
+/**
+ * Wraps a function in a debounce function, which prevents it from being called until a delay period has elapsed.
+ * Repeated calls within the delay period will reset the delay.
+ *
+ * @param {number} delay delay in milliseconds between calls that must elapse before the function will be executed
+ * @param {(...args: any) => any} fn function to debounce
+ * @returns {(...args: any) => any}
+ */
+export const debounced = function (delay: number, fn: (...args: any) => any): (...args: any) => any {
+  let timerId: NodeJS.Timeout;
+
+  return (...args) => {
+    if (timerId) {
+      clearTimeout(timerId);
+    }
+
+    timerId = setTimeout(() => {
+      fn(...args);
+      timerId = null;
+    }, delay);
+  };
+};
+
+/**
+ * Wraps a function in a throttle function, which prevents it from being called again until a delay period has
+ * elapsed. Repeated calls within the delay period will be ignored.
+ *
+ * @param {number} delay delay in milliseconds between calls that must elapse before the function will be executed again
+ * @param {(...args: any) => any} fn function to throttle
+ * @returns {(...args: any) => any}
+ */
+export const throttled = function (delay: number, fn: (...args: any) => any): (...args: any) => any {
+  let lastCall = 0;
+
+  return (...args) => {
+    const now = new Date().getTime();
+
+    if (now - lastCall < delay) {
+      return;
+    }
+
+    lastCall = now;
+
+    return fn(...args);
+  };
+};

--- a/database/src/migrations/20200811120312_activity_incoming_data.ts
+++ b/database/src/migrations/20200811120312_activity_incoming_data.ts
@@ -28,9 +28,9 @@ export async function up(knex: Knex): Promise<void> {
     COMMENT ON COLUMN ${DB_SCHEMA}.activity_incoming_data.activity_type IS 'Type of record';
     CREATE INDEX activity_incoming_data_activity_type_idx on ${DB_SCHEMA}.activity_incoming_data (activity_type);
 
-    ALTER TABLE ${DB_SCHEMA}.activity_incoming_data ADD COLUMN activity_sub_type VARCHAR(200) NULL;
-    COMMENT ON COLUMN ${DB_SCHEMA}.activity_incoming_data.activity_sub_type IS 'Sub Type of record';
-    CREATE INDEX activity_incoming_data_activity_sub_type_idx on ${DB_SCHEMA}.activity_incoming_data (activity_sub_type);
+    ALTER TABLE ${DB_SCHEMA}.activity_incoming_data ADD COLUMN activity_subtype VARCHAR(200) NULL;
+    COMMENT ON COLUMN ${DB_SCHEMA}.activity_incoming_data.activity_subtype IS 'Sub Type of record';
+    CREATE INDEX activity_incoming_data_activity_subtype_idx on ${DB_SCHEMA}.activity_incoming_data (activity_subtype);
 
     ALTER TABLE ${DB_SCHEMA}.activity_incoming_data ADD COLUMN created_timestamp timestamp NOT NULL DEFAULT NOW();
     COMMENT ON COLUMN ${DB_SCHEMA}.activity_incoming_data.created_timestamp IS 'The date and time data was created on the users device.';


### PR DESCRIPTION
62: Edit single Activity + Misc Updates
- Update form container logic
  - Specifically, there is a bug with the current RJSF package where error state isn't reset properly when the `submit` hook of the RJSF form leads to a re-render of the form (as it does with the search activity page). Work around for now is to manually reset some of that state during the `submit` workflow.
    - This isn't an issue with the regular `current activity` page, because we save the changed form data in the local database (which doesn't trigger a re-render of the form component).
- Update photo container (to take photo state props similar to the map and form containers)
- Add support for new created_timestamp activity column
- Fix a few instances of `disabled` that should have been `isDisabled`
- Other misc updates