### PR TITLE
964: Fix api URL

### DIFF
--- a/app/src/hooks/useInvasivesApi.ts
+++ b/app/src/hooks/useInvasivesApi.ts
@@ -6,7 +6,10 @@ import { IPointOfInterestSearchCriteria, ICreatePointOfInterest } from 'interfac
 import qs from 'qs';
 import { useContext, useMemo } from 'react';
 
-const API_URL = `${process.env.API_HOST}:${process.env.API_PORT}`;
+const API_HOST = process.env.API_HOST;
+const API_PORT = process.env.API_PORT;
+
+const API_URL = (API_PORT && `${API_HOST}:${API_PORT}`) || API_HOST;
 
 /**
  * Returns an instance of axios with baseURL and authorization headers set.


### PR DESCRIPTION
I update the app API_URL to be dynamic based on environment variables, but the port isnt always set (as in openshift) so it was causing issues.

Updated it to only use the port if its set.