### PR TITLE
134: Update S3 to work with gov object store config

### DIFF
--- a/api/src/utils/file-utils.ts
+++ b/api/src/utils/file-utils.ts
@@ -7,15 +7,14 @@ import { S3ACLRole } from '../constants/misc';
 import { MediaBase64 } from '../models/activity';
 
 const OBJECT_STORE_BUCKET_NAME = process.env.OBJECT_STORE_BUCKET_NAME;
-// const OBJECT_STORE_URL = process.env.OBJECT_STORE_URL || 'nrs.objectstore.gov.bc.ca';
-// const AWS_ENDPOINT = new AWS.Endpoint(OBJECT_STORE_URL);
+const OBJECT_STORE_URL = process.env.OBJECT_STORE_URL || 'nrs.objectstore.gov.bc.ca';
+const AWS_ENDPOINT = new AWS.Endpoint(OBJECT_STORE_URL);
 const S3 = new AWS.S3({
-  // endpoint: AWS_ENDPOINT.href,
+  endpoint: AWS_ENDPOINT.href,
   accessKeyId: process.env.OBJECT_STORE_ACCESS_KEY_ID,
   secretAccessKey: process.env.OBJECT_STORE_SECRET_KEY_ID,
   signatureVersion: 'v4',
-  s3ForcePathStyle: true,
-  region: 'ca-central-1'
+  s3ForcePathStyle: true
 });
 
 /**


### PR DESCRIPTION
 - Coincides with OpenShift secret updates for all 3 environments
  - secret: invasivesbci-object-store