### PR TITLE
Update POST /activity response

### DIFF
--- a/api/src/queries/activity-queries.ts
+++ b/api/src/queries/activity-queries.ts
@@ -64,7 +64,7 @@ export const postActivitySQL = (activity: ActivityPostRequestBody): SQLStatement
   sqlStatement.append(SQL`
     )
     RETURNING
-      activity_incoming_data_id;
+      activity_id;
   `);
 
   return sqlStatement;


### PR DESCRIPTION
The response isn't strictly needed, but the previous value was not useful in any way, as it was just the postgres serial id for the row.

The new response is the activity_id, which is the relevant id we use to track a unique activity.  That being said, the activity_id is already required to call the POST endpoint in the first place, so the caller should already have it on hand. 

So, It might be just as valid to have no response (other than the 200 OK).  Thoughts?