### PR TITLE
Map Popout Component from the Bottom

### DIFF
--- a/app/src/components/map/MapContainer.tsx
+++ b/app/src/components/map/MapContainer.tsx
@@ -268,11 +268,13 @@ const MapContainer: React.FC<IMapContainerProps> = (props) => {
             layer.on('click', function () {
               // Fires on click of single feature
               interactObj.onClickCallback();
-              L.popup()
-                .setLatLng([feature.geometry.coordinates[1], feature.geometry.coordinates[0]])
-                //.setContent(interactObj.popUpComponent)
-                .setContent(content)
-                .openOn(mapRef.current);
+              if (feature.geometry.type !== 'Polygon') {
+                L.popup()
+                  .setLatLng([feature.geometry.coordinates[1], feature.geometry.coordinates[0]])
+                  //.setContent(interactObj.popUpComponent)
+                  .setContent(content)
+                  .openOn(mapRef.current);
+              }
             });
           }
         });

--- a/app/src/features/home/map/MapPage.tsx
+++ b/app/src/features/home/map/MapPage.tsx
@@ -149,12 +149,6 @@ const MapPage: React.FC<IMapProps> = (props) => {
     setContextMenuState({ ...contextMenuState, isOpen: false });
   };
 
-  //testing
-  const handleContextMenuOpen = () => {
-    setContextMenuState({ ...contextMenuState, isOpen: true });
-  };
-  //end testing
-
   const changeContextMenu = (targetContextMenu: contextMenuType) => {};
 
   // todo: handle closing of popup, this does not work:

--- a/app/src/features/home/map/MapPage.tsx
+++ b/app/src/features/home/map/MapPage.tsx
@@ -27,16 +27,16 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: '100%'
   },
   mapGridItemShrunk: {
-    height: '100%',
-    width: '66.66%'
+    height: '60%',
+    width: '100%'
   },
   popOutGridItemExpanded: {
-    height: '100%',
-    width: '33.33%'
+    height: '40%',
+    width: '100%'
   },
   popOutGridItemShrunk: {
-    height: '100%',
-    width: '0%'
+    height: '0%',
+    width: '100%'
   },
   popOutComponent: {
     height: '100%',
@@ -149,6 +149,12 @@ const MapPage: React.FC<IMapProps> = (props) => {
     setContextMenuState({ ...contextMenuState, isOpen: false });
   };
 
+  //testing
+  const handleContextMenuOpen = () => {
+    setContextMenuState({ ...contextMenuState, isOpen: true });
+  };
+  //end testing
+
   const changeContextMenu = (targetContextMenu: contextMenuType) => {};
 
   // todo: handle closing of popup, this does not work:
@@ -191,13 +197,15 @@ const MapPage: React.FC<IMapProps> = (props) => {
 
       geos.push(row.geometry[0]);
 
+      const coordinatesString = `(${row.geometry[0].geometry.coordinates[1].toFixed(2)}, ${row.geometry[0].geometry.coordinates[0].toFixed(2)})`;
+
       switch (row.docType) {
         case DocType.POINT_OF_INTEREST:
           interactiveGeos.push({
             //mapContext: MapContext.MAIN_MAP,
             recordDocID: row._id,
             recordDocType: row.docType,
-            description: 'New Point of Interest:\n ' + row._id + '\n' + row.geometry[0].coordinates,
+            description: 'New Point of Interest:\n ' + row._id + '\n' + coordinatesString,
 
             // basic display:
             geometry: row.geometry[0],
@@ -209,7 +217,7 @@ const MapPage: React.FC<IMapProps> = (props) => {
               //setInteractiveGeometry([interactiveGeos])
               console.log('clicked geo');
               handleGeoClick(row);
-            }, //try to get this one workign first
+            }, //try to get this one working first
             popUpComponent: PointOfInterestPopUp
           });
           /* isSelected?: boolean;
@@ -227,7 +235,7 @@ const MapPage: React.FC<IMapProps> = (props) => {
             //mapContext: MapContext.MAIN_MAP,
             recordDocID: row._id,
             recordDocType: row.docType,
-            description: 'Past Activity:\n ' + row._id + '\n' + row.geometry[0].coordinates,
+            description: 'Past Activity:\n ' + row._id + '\n' + coordinatesString,
 
             // basic display:
             geometry: row.geometry[0],
@@ -240,7 +248,7 @@ const MapPage: React.FC<IMapProps> = (props) => {
               console.log('before handle  geo');
               handleGeoClick(row);
               //console.log('clicked geo');
-            }, //try to get this one workign first
+            }, //try to get this one working first
             popUpComponent: PointOfInterestPopUp
           });
           break;
@@ -249,7 +257,7 @@ const MapPage: React.FC<IMapProps> = (props) => {
             //mapContext: MapContext.MAIN_MAP,
             recordDocID: row._id,
             recordDocType: row.docType,
-            description: 'Activity:\n ' + row._id + '\n' + row.geometry[0].coordinates,
+            description: 'Activity:\n ' + row._id + '\n' + coordinatesString,
 
             // basic display:
             geometry: row.geometry[0],
@@ -262,7 +270,7 @@ const MapPage: React.FC<IMapProps> = (props) => {
               console.log('before handle  geo');
               handleGeoClick(row);
               //console.log('clicked geo');
-            }, //try to get this one workign first
+            }, //try to get this one working first
             popUpComponent: PointOfInterestPopUp
           });
           /* isSelected?: boolean;
@@ -280,7 +288,7 @@ const MapPage: React.FC<IMapProps> = (props) => {
             //mapContext: MapContext.MAIN_MAP,
             recordDocID: row._id,
             recordDocType: row.docType,
-            description: 'Point of Interest:\n ' + row._id + '\n' + row.geometry[0].coordinates,
+            description: 'Point of Interest:\n ' + row._id + '\n' + coordinatesString,
 
             // basic display:
             geometry: row.geometry[0],
@@ -293,7 +301,7 @@ const MapPage: React.FC<IMapProps> = (props) => {
               console.log('before handle  geo');
               handleGeoClick(row);
               //console.log('clicked geo');
-            }, //try to get this one workign first
+            }, //try to get this one working first
             popUpComponent: PointOfInterestPopUp
           });
           /* isSelected?: boolean;

--- a/app/src/features/home/map/MapPage.tsx
+++ b/app/src/features/home/map/MapPage.tsx
@@ -149,8 +149,6 @@ const MapPage: React.FC<IMapProps> = (props) => {
     setContextMenuState({ ...contextMenuState, isOpen: false });
   };
 
-  const changeContextMenu = (targetContextMenu: contextMenuType) => {};
-
   // todo: handle closing of popup, this does not work:
   /*
   const togglePopup = async () => {

--- a/app/src/features/home/map/MapPage.tsx
+++ b/app/src/features/home/map/MapPage.tsx
@@ -148,6 +148,7 @@ const MapPage: React.FC<IMapProps> = (props) => {
   };
 
   const handleGeoClick = (geo: any) => {
+    console.log('GEO', geo);
     setShowPopOut(true);
     setSelectedInteractiveGeometry(geo);
   };
@@ -180,7 +181,10 @@ const MapPage: React.FC<IMapProps> = (props) => {
 
       geos.push(row.geometry[0]);
 
-      const coordinatesString = `(${row.geometry[0].geometry.coordinates[1].toFixed(2)}, ${row.geometry[0].geometry.coordinates[0].toFixed(2)})`;
+      let coordinatesString = 'Polygon';
+      if (row.geometry[0].geometry.type !== 'Polygon') {
+        coordinatesString = `(${row.geometry[0]?.geometry.coordinates[1]?.toFixed(2)}, ${row.geometry[0]?.geometry.coordinates[0]?.toFixed(2)})`;
+      }
 
       switch (row.docType) {
         case DocType.POINT_OF_INTEREST:
@@ -344,6 +348,7 @@ const MapPage: React.FC<IMapProps> = (props) => {
         <Grid className={showPopOut ? classes.popOutGridItemExpanded : classes.popOutGridItemShrunk} item>
           <PopOutComponent
             buttonCloseCallback={() => {
+              console.log("hey")
               setShowPopOut(false);
             }}
             selectedGeo={selectedInteractiveGeometry}>

--- a/app/src/features/home/map/MapPage.tsx
+++ b/app/src/features/home/map/MapPage.tsx
@@ -148,7 +148,6 @@ const MapPage: React.FC<IMapProps> = (props) => {
   };
 
   const handleGeoClick = (geo: any) => {
-    console.log('GEO', geo);
     setShowPopOut(true);
     setSelectedInteractiveGeometry(geo);
   };
@@ -348,7 +347,6 @@ const MapPage: React.FC<IMapProps> = (props) => {
         <Grid className={showPopOut ? classes.popOutGridItemExpanded : classes.popOutGridItemShrunk} item>
           <PopOutComponent
             buttonCloseCallback={() => {
-              console.log("hey")
               setShowPopOut(false);
             }}
             selectedGeo={selectedInteractiveGeometry}>

--- a/app/src/features/home/map/MapPage.tsx
+++ b/app/src/features/home/map/MapPage.tsx
@@ -8,7 +8,7 @@ import { DatabaseChangesContext } from 'contexts/DatabaseChangesContext';
 import { DatabaseContext } from 'contexts/DatabaseContext';
 import { Feature } from 'geojson';
 import React, {  useContext, useEffect, useState } from 'react';
-import { contextMenuType, MapContextMenu, MapContextMenuData } from './MapContextMenu';
+import { MapContextMenu, MapContextMenuData } from './MapContextMenu';
 
 const useStyles = makeStyles((theme: Theme) => ({
   mapContainer: {
@@ -50,7 +50,6 @@ interface IMapProps {
 }
 
 const PointOfInterestPopUp = (name: string) => {
-  //return <div> {props.name} </div>;
   return '<div>' + name + '</div>';
 };
 
@@ -136,7 +135,6 @@ const MapPage: React.FC<IMapProps> = (props) => {
 
   // "is it open?", "what coordinates of the mouse?", that kind of thing:
   const initialContextMenuState: MapContextMenuData = { isOpen: false, lat: 0, lng: 0 };
-  //const [contextMenuState, setContextMenuState] = useState({ isOpen: false });
   const [contextMenuState, setContextMenuState] = useState(initialContextMenuState);
 
   // don't load the map until interactive geos ready
@@ -148,13 +146,6 @@ const MapPage: React.FC<IMapProps> = (props) => {
   const handleContextMenuClose = () => {
     setContextMenuState({ ...contextMenuState, isOpen: false });
   };
-
-  // todo: handle closing of popup, this does not work:
-  /*
-  const togglePopup = async () => {
-    setShowPopOut(!showPopOut);
-  };
-  */
 
   const handleGeoClick = (geo: any) => {
     setShowPopOut(true);
@@ -239,7 +230,6 @@ const MapPage: React.FC<IMapProps> = (props) => {
               //setInteractiveGeometry([interactiveGeos])
               console.log('before handle  geo');
               handleGeoClick(row);
-              //console.log('clicked geo');
             }, //try to get this one working first
             popUpComponent: PointOfInterestPopUp
           });
@@ -261,7 +251,6 @@ const MapPage: React.FC<IMapProps> = (props) => {
               //setInteractiveGeometry([interactiveGeos])
               console.log('before handle  geo');
               handleGeoClick(row);
-              //console.log('clicked geo');
             }, //try to get this one working first
             popUpComponent: PointOfInterestPopUp
           });
@@ -290,9 +279,8 @@ const MapPage: React.FC<IMapProps> = (props) => {
             // interactive
             onClickCallback: () => {
               //setInteractiveGeometry([interactiveGeos])
-              console.log('before handle  geo');
+              console.log('before handle geo');
               handleGeoClick(row);
-              //console.log('clicked geo');
             }, //try to get this one working first
             popUpComponent: PointOfInterestPopUp
           });


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Make popout component for map enter from bottom of screen and fix coordinates being undefined

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring

## How Has This Been Tested?

- Local dev environment

## Screenshots

<img width="1229" alt="bottompopout" src="https://user-images.githubusercontent.com/28017034/100668920-8001e300-3311-11eb-8017-983eb0c34068.png">

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
