### PR TITLE
Area type bug

### DIFF
--- a/app/src/features/home/activity/ActivityPage.tsx
+++ b/app/src/features/home/activity/ActivityPage.tsx
@@ -73,7 +73,7 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
       ? (Math.PI * Math.pow(geo.properties.radius, 2))
       : area(geo);
 
-    return totalArea.toFixed(2);
+    return parseFloat(totalArea.toFixed(2));
   };
 
   /**


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Fix bug where area was a string instead of expected number type causing form to error out

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Locally
