### PR TITLE
209: Get form and photos into popout component for activities on map

### DIFF
--- a/app/src/components/photo/PhotoContainer.tsx
+++ b/app/src/components/photo/PhotoContainer.tsx
@@ -79,7 +79,7 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
             </Grid>
             <Grid item>
               <Button variant="contained" startIcon={<DeleteForever />} onClick={() => deletePhotos()}>
-                Remvoe All Photos
+                Remove All Photos
               </Button>
             </Grid>
           </Grid>

--- a/app/src/components/points-of-interest/ActivitiesPOI/ActivitiesPOI.tsx
+++ b/app/src/components/points-of-interest/ActivitiesPOI/ActivitiesPOI.tsx
@@ -1,0 +1,49 @@
+import { Accordion, AccordionDetails, AccordionSummary, makeStyles, Typography } from '@material-ui/core';
+import { ExpandMore } from '@material-ui/icons';
+import React from 'react';
+import FormContainer from 'components/form/FormContainer';
+import PhotoContainer from 'components/photo/PhotoContainer';
+
+const useStyles = makeStyles((theme) => ({
+  heading: {
+    fontSize: theme.typography.pxToRem(18),
+    fontWeight: theme.typography.fontWeightRegular,
+  }
+}));
+
+export interface ActivityPOIPropType {
+  containerProps: any;
+}
+
+export const ActivitiesPOI: React.FC<ActivityPOIPropType> = (props) => {
+  const classes = useStyles();
+
+  const { containerProps } = props;
+
+  console.log(containerProps)
+
+  return (
+    <>
+      <Typography align="center" className={classes.heading}>
+        {containerProps.activity.activityType}: {containerProps.activity.activityId}
+      </Typography>
+      <br />
+      <Accordion>
+        <AccordionSummary expandIcon={<ExpandMore />} aria-controls="panel-form-content" id="panel-form-header">
+          <Typography className={classes.heading}>Form</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <FormContainer {...containerProps} />
+        </AccordionDetails>
+      </Accordion>
+      <Accordion>
+        <AccordionSummary expandIcon={<ExpandMore />} aria-controls="panel-photo-content" id="panel-photo-header">
+          <Typography className={classes.heading}>Photos</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <PhotoContainer {...containerProps} />
+        </AccordionDetails>
+      </Accordion>
+    </>
+  );
+}

--- a/app/src/components/points-of-interest/ActivitiesPOI/ActivitiesPOI.tsx
+++ b/app/src/components/points-of-interest/ActivitiesPOI/ActivitiesPOI.tsx
@@ -20,8 +20,6 @@ export const ActivitiesPOI: React.FC<ActivityPOIPropType> = (props) => {
 
   const { containerProps } = props;
 
-  console.log(containerProps)
-
   return (
     <>
       <Typography align="center" className={classes.heading}>

--- a/app/src/features/home/map/MapPage.tsx
+++ b/app/src/features/home/map/MapPage.tsx
@@ -44,10 +44,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: '100%',
     width: '100%',
     backgroundColor: theme.palette.background.paper
-  },
-  heading: {
-    fontSize: theme.typography.pxToRem(18),
-    fontWeight: theme.typography.fontWeightRegular
   }
 }));
 


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- https://github.com/bcgov/invasivesbc/issues/209
- Get form and photos into popout component for activities on map

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Locally

## Screenshots

<img width="1241" alt="Screenshot 2020-12-01 144121" src="https://user-images.githubusercontent.com/28017034/100805337-54e7c400-33e3-11eb-96c7-4642c26392fd.png">
<img width="1243" alt="Screenshot 2020-12-01 144143" src="https://user-images.githubusercontent.com/28017034/100805340-56b18780-33e3-11eb-8105-ff34bb4dd586.png">
