### PR TITLE
Update the activity post/put endpoints

### DIFF
--- a/api/src/openapi/api-doc.json
+++ b/api/src/openapi/api-doc.json
@@ -92,6 +92,16 @@
           }
         }
       },
+      "409": {
+        "description": "Conflict",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
       "503": {
         "description": "Service unavailable",
         "content": {

--- a/testing/integration/postman/InvasivesBC-API-DEV.postman_collection.json
+++ b/testing/integration/postman/InvasivesBC-API-DEV.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "f72ce1ec-b6ce-4e07-96a1-eb6d1c7e217f",
+		"_postman_id": "873004be-7b90-4df6-bce4-ee85f090d847",
 		"name": "InvasivesBC-API-DEV",
 		"description": "API for InvasivesBC (Ionic Version)",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -15,7 +15,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "9901370c-be67-4367-9b95-c99616014718",
+								"id": "81a394d9-34bf-4028-a8ef-08d06673e846",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {\r",
 									"    pm.response.to.have.status(200);\r",
@@ -95,7 +95,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "76c0ab5d-2744-41c2-88be-d87b841313ea",
+								"id": "02b307a1-be0b-4e35-9427-85d863903e37",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {\r",
 									"    pm.response.to.have.status(200);\r",
@@ -107,6 +107,21 @@
 								],
 								"type": "text/javascript"
 							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "20b6cebd-7935-4f2e-92f2-b00c67c16939",
+								"exec": [
+									"const uuid = require('uuid');\r",
+									"const activity_id = uuid.v4();\r",
+									"\r",
+									"console.log('ACTIVITY_ID', activity_id);\r",
+									"\r",
+									"pm.environment.set('ACTIVITY_ID', activity_id);"
+								],
+								"type": "text/javascript"
+							}
 						}
 					],
 					"request": {
@@ -114,7 +129,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"activity_id\": \"fa4777a2-7c52-4674-8885-7f1b6816e584\",\r\n    \"created_timestamp\": \"2020-11-24T17:55:33+0000\",\r\n    \"media\": [],\r\n    \"geometry\": [\r\n        {\r\n            \"type\": \"Feature\",\r\n            \"geometry\": {\r\n                \"type\": \"Polygon\",\r\n                \"coordinates\": [\r\n                    [\r\n                        [\r\n                            -123.36565017700195,\r\n                            48.453399614563764\r\n                        ],\r\n                        [\r\n                            -123.3797264099121,\r\n                            48.441842443378555\r\n                        ],\r\n                        [\r\n                            -123.36264610290526,\r\n                            48.435692728712105\r\n                        ],\r\n                        [\r\n                            -123.3467674255371,\r\n                            48.448333001219005\r\n                        ],\r\n                        [\r\n                            -123.36565017700195,\r\n                            48.453399614563764\r\n                        ]\r\n                    ]\r\n                ]\r\n            },\r\n            \"properties\": {}\r\n        }\r\n    ],\r\n    \"form_data\": {\r\n        \"activity_data\": {\r\n            \"invasive_species_agency_code\": \"CCCIPC\",\r\n            \"jurisdiction_code\": \"DOT\",\r\n            \"species_id\": \"test\",\r\n            \"access_description\": \"123\"\r\n        },\r\n        \"activity_type_data\": {\r\n            \"negative_obs_ind\": false,\r\n            \"observation_date_time\": \"2020-11-30T16:36:51-08:00\",\r\n            \"reported_area\": 3.99,\r\n            \"observation_type_code\": \"OP\",\r\n            \"observer_first_name\": \"wwwe\",\r\n            \"observer_last_name\": \"wewew\"\r\n        },\r\n        \"activity_subtype_data\": {\r\n            \"flowering\": false,\r\n            \"legacy_site_ind\": false,\r\n            \"early_detection_rapid_resp_ind\": false,\r\n            \"research_detection_ind\": false,\r\n            \"well_ind\": false,\r\n            \"special_care_ind\": false,\r\n            \"biological_ind\": false,\r\n            \"invasive_plant_code\": \"BA\",\r\n            \"invasive_plant_density_code\": \"M\",\r\n            \"invasive_plant_distribution_code\": \"RS\",\r\n            \"soil_texture_code\": \"F\",\r\n            \"specific_use_code\": \"PL\",\r\n            \"slope_code\": \"SS\",\r\n            \"aspect_code\": \"SE\",\r\n            \"proposed_treatment_code\": \"BT\",\r\n            \"plant_life_stage_code\": \"MIF\",\r\n            \"plant_health_code\": \"GH\",\r\n            \"plant_seed_stage_code\": \"SF\"\r\n        }\r\n    },\r\n    \"activity_type\": \"Treatment\",\r\n    \"activity_subtype\": \"Activity_Treatment_BiologicalDispersalPlant\"\r\n}",
+							"raw": "{\r\n    \"activity_id\": \"{{ACTIVITY_ID}}\",\r\n    \"created_timestamp\": \"2020-11-24T17:55:33+0000\",\r\n    \"media\": [],\r\n    \"geometry\": [\r\n        {\r\n            \"type\": \"Feature\",\r\n            \"geometry\": {\r\n                \"type\": \"Polygon\",\r\n                \"coordinates\": [\r\n                    [\r\n                        [\r\n                            -123.36565017700195,\r\n                            48.453399614563764\r\n                        ],\r\n                        [\r\n                            -123.3797264099121,\r\n                            48.441842443378555\r\n                        ],\r\n                        [\r\n                            -123.36264610290526,\r\n                            48.435692728712105\r\n                        ],\r\n                        [\r\n                            -123.3467674255371,\r\n                            48.448333001219005\r\n                        ],\r\n                        [\r\n                            -123.36565017700195,\r\n                            48.453399614563764\r\n                        ]\r\n                    ]\r\n                ]\r\n            },\r\n            \"properties\": {}\r\n        }\r\n    ],\r\n    \"form_data\": {\r\n        \"activity_data\": {\r\n            \"invasive_species_agency_code\": \"CCCIPC\",\r\n            \"jurisdiction_code\": \"DOT\",\r\n            \"species_id\": \"test\",\r\n            \"access_description\": \"123\"\r\n        },\r\n        \"activity_type_data\": {\r\n            \"negative_obs_ind\": false,\r\n            \"observation_date_time\": \"2020-11-30T16:36:51-08:00\",\r\n            \"reported_area\": 3.99,\r\n            \"observation_type_code\": \"OP\",\r\n            \"observer_first_name\": \"wwwe\",\r\n            \"observer_last_name\": \"wewew\"\r\n        },\r\n        \"activity_subtype_data\": {\r\n            \"flowering\": false,\r\n            \"legacy_site_ind\": false,\r\n            \"early_detection_rapid_resp_ind\": false,\r\n            \"research_detection_ind\": false,\r\n            \"well_ind\": false,\r\n            \"special_care_ind\": false,\r\n            \"biological_ind\": false,\r\n            \"invasive_plant_code\": \"BA\",\r\n            \"invasive_plant_density_code\": \"M\",\r\n            \"invasive_plant_distribution_code\": \"RS\",\r\n            \"soil_texture_code\": \"F\",\r\n            \"specific_use_code\": \"PL\",\r\n            \"slope_code\": \"SS\",\r\n            \"aspect_code\": \"SE\",\r\n            \"proposed_treatment_code\": \"BT\",\r\n            \"plant_life_stage_code\": \"MIF\",\r\n            \"plant_health_code\": \"GH\",\r\n            \"plant_seed_stage_code\": \"SF\"\r\n        }\r\n    },\r\n    \"activity_type\": \"Treatment\",\r\n    \"activity_subtype\": \"Activity_Treatment_BiologicalDispersalPlant\"\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -140,7 +155,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "84e211e6-0a61-4258-a6f1-5adc4f86a323",
+								"id": "e0644ea3-4d9c-4e1a-9a0d-5096698334ac",
 								"exec": [
 									"pm.test(\"Successful POST request\", function () {\r",
 									"    pm.expect(pm.response.code).to.be.oneOf([200,201,202]);\r",
@@ -191,37 +206,6 @@
 					},
 					"response": [
 						{
-							"name": "Created",
-							"originalRequest": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"activityType\": \"<string>\",\n    \"activityTypeData\": \"<object>\",\n    \"activitySubType\": \"<string>\",\n    \"activitySubTypeData\": \"<object>\",\n    \"date\": \"<date>\",\n    \"locationAndGeometry\": {\n        \"anchorPointY\": \"<integer>\",\n        \"anchorPointX\": \"<integer>\",\n        \"area\": \"<integer>\",\n        \"geometry\": \"<object>\",\n        \"jurisdiction\": \"<string>\",\n        \"agency\": \"<string>\",\n        \"observer1FirstName\": \"<string>\",\n        \"observer1LastName\": \"<string>\",\n        \"locationComment\": \"<string>\",\n        \"generalComment\": \"<string>\",\n        \"photoTaken\": \"<boolean>\"\n    },\n    \"deviceRequestUID\": \"<string>\"\n}"
-								},
-								"url": {
-									"raw": "{{baseUrl}}/activity",
-									"host": [
-										"{{baseUrl}}"
-									],
-									"path": [
-										"activity"
-									]
-								}
-							},
-							"status": "Created",
-							"code": 201,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "Content-Type",
-									"value": "application/json"
-								}
-							],
-							"cookie": [],
-							"body": "{\n \"activityType\": \"irure in est dolor\",\n \"activitySubType\": \"dolore adipisicing\",\n \"date\": \"ipsum aute\",\n \"locationAndGeometry\": \"dolor amet\"\n}"
-						},
-						{
 							"name": "Unauthorized user",
 							"originalRequest": {
 								"method": "POST",
@@ -251,6 +235,37 @@
 							],
 							"cookie": [],
 							"body": "{\n \"message\": \"Duis deserunt\",\n \"errors\": [\n  \"laborum\",\n  \"reprehenderit culpa sit do\"\n ]\n}"
+						},
+						{
+							"name": "Created",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"activityType\": \"<string>\",\n    \"activityTypeData\": \"<object>\",\n    \"activitySubType\": \"<string>\",\n    \"activitySubTypeData\": \"<object>\",\n    \"date\": \"<date>\",\n    \"locationAndGeometry\": {\n        \"anchorPointY\": \"<integer>\",\n        \"anchorPointX\": \"<integer>\",\n        \"area\": \"<integer>\",\n        \"geometry\": \"<object>\",\n        \"jurisdiction\": \"<string>\",\n        \"agency\": \"<string>\",\n        \"observer1FirstName\": \"<string>\",\n        \"observer1LastName\": \"<string>\",\n        \"locationComment\": \"<string>\",\n        \"generalComment\": \"<string>\",\n        \"photoTaken\": \"<boolean>\"\n    },\n    \"deviceRequestUID\": \"<string>\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/activity",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"activity"
+									]
+								}
+							},
+							"status": "Created",
+							"code": 201,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n \"activityType\": \"irure in est dolor\",\n \"activitySubType\": \"dolore adipisicing\",\n \"date\": \"ipsum aute\",\n \"locationAndGeometry\": \"dolor amet\"\n}"
 						}
 					]
 				},
@@ -260,7 +275,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "d0bfe496-0140-4a3f-aa27-8b6b15ba10c0",
+								"id": "60f1300e-3ca3-437a-b814-9724342503c9",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {\r",
 									"    pm.response.to.have.status(200);\r",
@@ -279,7 +294,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"activity_id\": \"fa4777a2-7c52-4674-8885-7f1b6816e584\",\r\n    \"created_timestamp\": \"2020-11-25T17:55:33+0000\",\r\n    \"media\": [],\r\n    \"geometry\": [\r\n        {\r\n            \"type\": \"Feature\",\r\n            \"geometry\": {\r\n                \"type\": \"Polygon\",\r\n                \"coordinates\": [\r\n                    [\r\n                        [\r\n                            -123.36565017700195,\r\n                            48.453399614563764\r\n                        ],\r\n                        [\r\n                            -123.3797264099121,\r\n                            48.441842443378555\r\n                        ],\r\n                        [\r\n                            -123.36264610290526,\r\n                            48.435692728712105\r\n                        ],\r\n                        [\r\n                            -123.3467674255371,\r\n                            48.448333001219005\r\n                        ],\r\n                        [\r\n                            -123.36565017700195,\r\n                            48.453399614563764\r\n                        ]\r\n                    ]\r\n                ]\r\n            },\r\n            \"properties\": {}\r\n        }\r\n    ],\r\n    \"form_data\": {\r\n        \"activity_data\": {\r\n            \"invasive_species_agency_code\": \"CCCIPC\",\r\n            \"jurisdiction_code\": \"DOT\",\r\n            \"species_id\": \"test\",\r\n            \"access_description\": \"123\"\r\n        },\r\n        \"activity_type_data\": {\r\n            \"negative_obs_ind\": false,\r\n            \"observation_date_time\": \"2020-11-30T16:36:51-08:00\",\r\n            \"reported_area\": 3.99,\r\n            \"observation_type_code\": \"OP\",\r\n            \"observer_first_name\": \"wwwe\",\r\n            \"observer_last_name\": \"wewew\"\r\n        },\r\n        \"activity_subtype_data\": {\r\n            \"flowering\": false,\r\n            \"legacy_site_ind\": false,\r\n            \"early_detection_rapid_resp_ind\": false,\r\n            \"research_detection_ind\": false,\r\n            \"well_ind\": false,\r\n            \"special_care_ind\": false,\r\n            \"biological_ind\": false,\r\n            \"invasive_plant_code\": \"BA\",\r\n            \"invasive_plant_density_code\": \"M\",\r\n            \"invasive_plant_distribution_code\": \"RS\",\r\n            \"soil_texture_code\": \"F\",\r\n            \"specific_use_code\": \"PL\",\r\n            \"slope_code\": \"SS\",\r\n            \"aspect_code\": \"SE\",\r\n            \"proposed_treatment_code\": \"BT\",\r\n            \"plant_life_stage_code\": \"MIF\",\r\n            \"plant_health_code\": \"GH\",\r\n            \"plant_seed_stage_code\": \"SF\"\r\n        }\r\n    },\r\n    \"activity_type\": \"Treatment\",\r\n    \"activity_subtype\": \"Activity_Treatment_BiologicalDispersalPlant\"\r\n}",
+							"raw": "{\r\n    \"activity_id\": \"{{ACTIVITY_ID}}\",\r\n    \"created_timestamp\": \"2020-11-25T17:55:33+0000\",\r\n    \"media\": [],\r\n    \"geometry\": [\r\n        {\r\n            \"type\": \"Feature\",\r\n            \"geometry\": {\r\n                \"type\": \"Polygon\",\r\n                \"coordinates\": [\r\n                    [\r\n                        [\r\n                            -123.36565017700195,\r\n                            48.453399614563764\r\n                        ],\r\n                        [\r\n                            -123.3797264099121,\r\n                            48.441842443378555\r\n                        ],\r\n                        [\r\n                            -123.36264610290526,\r\n                            48.435692728712105\r\n                        ],\r\n                        [\r\n                            -123.3467674255371,\r\n                            48.448333001219005\r\n                        ],\r\n                        [\r\n                            -123.36565017700195,\r\n                            48.453399614563764\r\n                        ]\r\n                    ]\r\n                ]\r\n            },\r\n            \"properties\": {}\r\n        }\r\n    ],\r\n    \"form_data\": {\r\n        \"activity_data\": {\r\n            \"invasive_species_agency_code\": \"CCCIPC\",\r\n            \"jurisdiction_code\": \"DOT\",\r\n            \"species_id\": \"test\",\r\n            \"access_description\": \"123\"\r\n        },\r\n        \"activity_type_data\": {\r\n            \"negative_obs_ind\": false,\r\n            \"observation_date_time\": \"2020-11-30T16:36:51-08:00\",\r\n            \"reported_area\": 3.99,\r\n            \"observation_type_code\": \"OP\",\r\n            \"observer_first_name\": \"wwwe\",\r\n            \"observer_last_name\": \"wewew\"\r\n        },\r\n        \"activity_subtype_data\": {\r\n            \"flowering\": false,\r\n            \"legacy_site_ind\": false,\r\n            \"early_detection_rapid_resp_ind\": false,\r\n            \"research_detection_ind\": false,\r\n            \"well_ind\": false,\r\n            \"special_care_ind\": false,\r\n            \"biological_ind\": false,\r\n            \"invasive_plant_code\": \"BA\",\r\n            \"invasive_plant_density_code\": \"M\",\r\n            \"invasive_plant_distribution_code\": \"RS\",\r\n            \"soil_texture_code\": \"F\",\r\n            \"specific_use_code\": \"PL\",\r\n            \"slope_code\": \"SS\",\r\n            \"aspect_code\": \"SE\",\r\n            \"proposed_treatment_code\": \"BT\",\r\n            \"plant_life_stage_code\": \"MIF\",\r\n            \"plant_health_code\": \"GH\",\r\n            \"plant_seed_stage_code\": \"SF\"\r\n        }\r\n    },\r\n    \"activity_type\": \"Treatment\",\r\n    \"activity_subtype\": \"Activity_Treatment_BiologicalDispersalPlant\"\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -311,7 +326,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "8147700b-738e-40da-94d1-bb3a6b7000fe",
+								"id": "cf7b91c0-8030-4186-9f6e-0257944f0c15",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {\r",
 									"    pm.response.to.have.status(200);\r",
@@ -362,7 +377,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "3b45a5d2-e5cb-49bd-9807-a4fb791218f2",
+								"id": "2beb9382-c093-4a32-a6fe-0a9f807ad762",
 								"exec": [
 									"pm.test(\"Successful POST request\", function () {\r",
 									"    pm.expect(pm.response.code).to.be.oneOf([200,201,202]);\r",
@@ -409,37 +424,6 @@
 					},
 					"response": [
 						{
-							"name": "Created",
-							"originalRequest": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"activityType\": \"<string>\",\n    \"activityTypeData\": \"<object>\",\n    \"activitySubType\": \"<string>\",\n    \"activitySubTypeData\": \"<object>\",\n    \"date\": \"<date>\",\n    \"locationAndGeometry\": {\n        \"anchorPointY\": \"<integer>\",\n        \"anchorPointX\": \"<integer>\",\n        \"area\": \"<integer>\",\n        \"geometry\": \"<object>\",\n        \"jurisdiction\": \"<string>\",\n        \"agency\": \"<string>\",\n        \"observer1FirstName\": \"<string>\",\n        \"observer1LastName\": \"<string>\",\n        \"locationComment\": \"<string>\",\n        \"generalComment\": \"<string>\",\n        \"photoTaken\": \"<boolean>\"\n    },\n    \"deviceRequestUID\": \"<string>\"\n}"
-								},
-								"url": {
-									"raw": "{{baseUrl}}/activity",
-									"host": [
-										"{{baseUrl}}"
-									],
-									"path": [
-										"activity"
-									]
-								}
-							},
-							"status": "Created",
-							"code": 201,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "Content-Type",
-									"value": "application/json"
-								}
-							],
-							"cookie": [],
-							"body": "{\n \"activityType\": \"irure in est dolor\",\n \"activitySubType\": \"dolore adipisicing\",\n \"date\": \"ipsum aute\",\n \"locationAndGeometry\": \"dolor amet\"\n}"
-						},
-						{
 							"name": "Unauthorized user",
 							"originalRequest": {
 								"method": "POST",
@@ -469,6 +453,37 @@
 							],
 							"cookie": [],
 							"body": "{\n \"message\": \"Duis deserunt\",\n \"errors\": [\n  \"laborum\",\n  \"reprehenderit culpa sit do\"\n ]\n}"
+						},
+						{
+							"name": "Created",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"activityType\": \"<string>\",\n    \"activityTypeData\": \"<object>\",\n    \"activitySubType\": \"<string>\",\n    \"activitySubTypeData\": \"<object>\",\n    \"date\": \"<date>\",\n    \"locationAndGeometry\": {\n        \"anchorPointY\": \"<integer>\",\n        \"anchorPointX\": \"<integer>\",\n        \"area\": \"<integer>\",\n        \"geometry\": \"<object>\",\n        \"jurisdiction\": \"<string>\",\n        \"agency\": \"<string>\",\n        \"observer1FirstName\": \"<string>\",\n        \"observer1LastName\": \"<string>\",\n        \"locationComment\": \"<string>\",\n        \"generalComment\": \"<string>\",\n        \"photoTaken\": \"<boolean>\"\n    },\n    \"deviceRequestUID\": \"<string>\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/activity",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"activity"
+									]
+								}
+							},
+							"status": "Created",
+							"code": 201,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n \"activityType\": \"irure in est dolor\",\n \"activitySubType\": \"dolore adipisicing\",\n \"date\": \"ipsum aute\",\n \"locationAndGeometry\": \"dolor amet\"\n}"
 						}
 					]
 				}
@@ -481,7 +496,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "eca5aa7e-2f29-447f-889f-ccd3230a0def",
+						"id": "068a7628-ae10-4340-b57f-b3fd299e1c48",
 						"exec": [
 							"pm.test(\"Status code is 200\", function () {\r",
 							"    pm.response.to.have.status(200);\r",
@@ -558,7 +573,7 @@
 		{
 			"listen": "prerequest",
 			"script": {
-				"id": "91669636-18cc-4a2a-b099-b9af7833821c",
+				"id": "782d934b-66af-4b48-af4e-85a06038c485",
 				"type": "text/javascript",
 				"exec": [
 					"const echoPostRequest = {",
@@ -609,7 +624,7 @@
 		{
 			"listen": "test",
 			"script": {
-				"id": "7f885bd2-d5b2-493f-b564-345d17b8481b",
+				"id": "edb8055c-c065-48d8-a010-0bf244700892",
 				"type": "text/javascript",
 				"exec": [
 					""

--- a/testing/integration/postman/invasives_api_dev.environment.json
+++ b/testing/integration/postman/invasives_api_dev.environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "dd67b614-0c0d-4ea2-8c7d-689e3c6983d2",
+	"id": "e9020884-bf07-47cb-9efe-37ce963b9d1a",
 	"name": "InvasivesBC-Environment-DEV",
 	"values": [
 		{
@@ -41,9 +41,14 @@
 			"key": "KEYCLOAK_CLIENT_ID",
 			"value": "invasives-bc",
 			"enabled": true
+		},
+		{
+			"key": "ACTIVITY_ID",
+			"value": "",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2020-11-20T19:03:57.065Z",
-	"_postman_exported_using": "Postman/7.35.0"
+	"_postman_exported_at": "2020-12-02T00:13:33.606Z",
+	"_postman_exported_using": "Postman/7.36.0"
 }


### PR DESCRIPTION
# Overview

Update the activity post/put endpoints
 - POST will now throw a 409 error if you use an existing activity_id.
   - It attempts to fetch an existing record with the provided activity_id, and if it finds one throws a 409, otherwise it proceeds to create the new record.

Update the postman tests
 - an ACTIVITY_ID uuid env var is generated by the POST /activity request, and subsequently used by the PUT request

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

Via postman.

## Checklist:

~~- [ ] My code follows the style guidelines of this project~~

- [x] I have performed a self-review of my own code

~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] New and existing unit tests pass locally with my changes~~
