### PR TITLE
IAPP Migrations 163-164: surveys, sites, treatments

### DIFF
--- a/app/src/components/points-of-interest/IAPP/IAPP-Site.tsx
+++ b/app/src/components/points-of-interest/IAPP/IAPP-Site.tsx
@@ -13,7 +13,6 @@ const useStyles = makeStyles((theme) => ({
     align: 'center'
   },
   container: {
-    maxWidth: 'x'
   },
   siteContainer: {},
   surveyContainer: {},

--- a/app/src/components/points-of-interest/IAPP/IAPP-Site.tsx
+++ b/app/src/components/points-of-interest/IAPP/IAPP-Site.tsx
@@ -1,9 +1,6 @@
 import { Container, Accordion, AccordionDetails, AccordionSummary, Grid, makeStyles, Paper, Typography,
   TableContainer, TableCell, TableRow, TableHead, Table, TableBody } from '@material-ui/core';
 import { ExpandMore } from '@material-ui/icons';
-import FormContainer, { IFormContainerProps } from 'components/form/FormContainer';
-import MapContainer, { IMapContainerProps } from 'components/map/MapContainer';
-import PhotoContainer, { IPhotoContainerProps } from 'components/photo/PhotoContainer';
 import React from 'react';
 
 const useStyles = makeStyles((theme) => ({
@@ -45,7 +42,7 @@ export interface IAPPSitePropType {
 export const IAPPSite: React.FC<IAPPSitePropType> = (props) => {
   const classes = useStyles();
 
-  const {site_id, map_sheet, slope, aspect, elevation, specific_use, soil_texture, surveys, mechanical_treatments, comments}
+  const {site_id, map_sheet, slope, aspect, specific_use, soil_texture, surveys, mechanical_treatments, comments}
      = props?.record?.point_of_interest_payload?.form_data?.point_of_interest_type_data;
   const {access_description, created_date_on_device}
      = props?.record?.point_of_interest_payload?.form_data?.point_of_interest_data;
@@ -58,8 +55,8 @@ export const IAPPSite: React.FC<IAPPSitePropType> = (props) => {
   const ifApplicable = (value) => (value && String(value).trim() != '') ? value : <div className={classes.missingValue}>N/A</div>;
 
   return (
-    <Container style={{maxWidth: 1200}}>
-      <Accordion defaultExpanded={true} className={classes.container}>
+    <Container className={classes.container}>
+      <Accordion defaultExpanded={true}>
         <AccordionSummary expandIcon={<ExpandMore />} aria-controls="panel-map-content" id="panel-map-header">
           <Typography className={classes.heading}>
             Legacy IAPP Site: {site_id}

--- a/app/src/components/points-of-interest/IAPP/IAPP-Site.tsx
+++ b/app/src/components/points-of-interest/IAPP/IAPP-Site.tsx
@@ -110,7 +110,43 @@ export const IAPPSite: React.FC<IAPPSitePropType> = (props) => {
         <AccordionSummary expandIcon={<ExpandMore />} aria-controls="panel-map-content" id="panel-map-header">
           <Typography className={classes.heading}>Survey Details on Site {site_id}</Typography>
         </AccordionSummary>
-        <AccordionDetails className={classes.siteContainer}>{JSON.stringify(props?.record)}</AccordionDetails>
+        <AccordionDetails className={classes.surveyContainer}>
+          {!surveys || surveys.length === 0 && <Container>No Surveys</Container>}
+          {surveys && surveys.length !== 0 &&
+            <TableContainer component={Paper}>
+              <Table className={classes.table} aria-label="surveys">
+                <TableHead>
+                  <TableRow>
+                    <TableCell className={classes.cell}>Survey ID</TableCell>
+                    <TableCell className={classes.cell}>Common Name</TableCell>
+                    <TableCell className={classes.cell}>Species</TableCell>
+                    <TableCell className={classes.cell}>Survey Date</TableCell>
+                    <TableCell className={classes.cell}>Agency</TableCell>
+                    <TableCell className={classes.cell}>Hectares</TableCell>
+                    <TableCell align="center" className={classes.cell}>Density</TableCell>
+                    <TableCell align="center" className={classes.cell}>Distribution</TableCell>
+                    <TableCell className={classes.wideCell}>Comments</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {surveys.map((row) => (
+                    <TableRow key={row.SurveyID}>
+                      <TableCell className={classes.cell}>{ifApplicable(row.SurveyID)}</TableCell>
+                      <TableCell className={classes.cell}>{ifApplicable(row.CommonName)}</TableCell>
+                      <TableCell className={classes.cell}>{ifApplicable(row.Species)}</TableCell>
+                      <TableCell className={classes.cell}>{ifApplicable(row.SurveyDate)}</TableCell>
+                      <TableCell className={classes.cell}>{ifApplicable(row.SurveyAgency)}</TableCell>
+                      <TableCell className={classes.cell}>{ifApplicable(row.EstArea)}</TableCell>
+                      <TableCell align="center" className={classes.cell}>{ifApplicable(row.Density)}</TableCell>
+                      <TableCell align="center" className={classes.cell}>{ifApplicable(row.Distribution)}</TableCell>
+                      <TableCell className={classes.wideCell}>{ifApplicable(row.Comment)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          }
+        </AccordionDetails>
       </Accordion>
       <Accordion defaultExpanded={true}>
         <AccordionSummary expandIcon={<ExpandMore />} aria-controls="panel-map-content" id="panel-map-header">

--- a/app/src/components/points-of-interest/IAPP/IAPP-Site.tsx
+++ b/app/src/components/points-of-interest/IAPP/IAPP-Site.tsx
@@ -188,6 +188,7 @@ export const IAPPSite: React.FC<IAPPSitePropType> = (props) => {
           }
         </AccordionDetails>
       </Accordion>
+      <br/><br/><br/><br/>
     </Container>
   );
 };

--- a/app/src/components/points-of-interest/IAPP/IAPP-Site.tsx
+++ b/app/src/components/points-of-interest/IAPP/IAPP-Site.tsx
@@ -1,5 +1,9 @@
-import { Accordion, AccordionDetails, AccordionSummary, Grid, makeStyles, Paper, Typography } from '@material-ui/core';
+import { Container, Accordion, AccordionDetails, AccordionSummary, Grid, makeStyles, Paper, Typography,
+  TableContainer, TableCell, TableRow, TableHead, Table, TableBody } from '@material-ui/core';
 import { ExpandMore } from '@material-ui/icons';
+import FormContainer, { IFormContainerProps } from 'components/form/FormContainer';
+import MapContainer, { IMapContainerProps } from 'components/map/MapContainer';
+import PhotoContainer, { IPhotoContainerProps } from 'components/photo/PhotoContainer';
 import React from 'react';
 
 const useStyles = makeStyles((theme) => ({
@@ -8,14 +12,31 @@ const useStyles = makeStyles((theme) => ({
     fontWeight: theme.typography.fontWeightRegular,
     align: 'center'
   },
-  siteContainer: {
-    height: '600px'
+  container: {
+    maxWidth: 'x'
   },
+  siteContainer: {},
+  surveyContainer: {},
+  treatmentContainer: {},
   photoContainer: {},
   paper: {
     padding: theme.spacing(2),
     textAlign: 'left',
     color: theme.palette.text.primary
+  },
+  table: {
+    width: "auto",
+    tableLayout: 'auto'
+  },
+  cell: {
+    whiteSpace: 'nowrap'
+  },
+  wideCell: {
+    whiteSpace: 'nowrap'
+  },
+  missingValue: {
+    fontStyle: 'italic',
+    color: '#777'
   }
 }));
 
@@ -25,113 +46,69 @@ export interface IAPPSitePropType {
 export const IAPPSite: React.FC<IAPPSitePropType> = (props) => {
   const classes = useStyles();
 
-  const getSiteID = () => {
-    return props?.record?.point_of_interest_payload?.form_data?.point_of_interest_type_data?.site_id;
-  };
+  const {site_id, map_sheet, slope, aspect, elevation, specific_use, soil_texture, surveys, mechanical_treatments, comments}
+     = props?.record?.point_of_interest_payload?.form_data?.point_of_interest_type_data;
+  const {access_description, created_date_on_device}
+     = props?.record?.point_of_interest_payload?.form_data?.point_of_interest_data;
+  const paper_file = props?.record?.point_of_interest_payload?.form_data?.point_of_interest_data?.paper_file[0]?.description;
+  const longitude = props?.record?.point_of_interest_payload?.geometry[0]?.geometry?.coordinates[0];
+  const latitude = props?.record?.point_of_interest_payload?.geometry[0]?.geometry?.coordinates[1];
+  const {Jur1, Jur1pct, Jur2, Jur2pct, Jur3, Jur3pct} = surveys ? surveys[0] : {Jur1: 'Not Specified', Jur1pct: '100', Jur2: '', Jur2pct: '0', Jur3: '', Jur3pct: '0'};
+  // Tester: {Jur1:'A', Jur1pct:'50', Jur2:'B', Jur2pct:'20', Jur3:'C', Jur3pct:'30'};
 
-  const getCreated = () => {
-    return props?.record?.point_of_interest_payload?.form_data?.point_of_interest_data?.created_date_on_device;
-  };
+  const ifApplicable = (value) => (value && String(value).trim() != '') ? value : <div className={classes.missingValue}>N/A</div>;
 
-  const getPaper = () => {
-    return props?.record?.point_of_interest_payload?.form_data?.point_of_interest_data?.paper_file[0]?.description;
-  };
-
-  const getLong = () => {
-    return props?.record?.point_of_interest_payload?.geometry[0]?.geometry?.coordinates[0];
-  };
-
-  const getLat = () => {
-    return props?.record?.point_of_interest_payload?.geometry[0]?.geometry?.coordinates[1];
-  };
-
-  const getMapsheet = () => {
-    return props?.record?.point_of_interest_payload?.form_data?.point_of_interest_type_data?.map_sheet;
-  };
-
-  const getSlope = () => {
-    return props?.record?.point_of_interest_payload?.form_data?.point_of_interest_type_data?.slope;
-  };
-
-  const getAspect = () => {
-    return props?.record?.point_of_interest_payload?.form_data?.point_of_interest_type_data?.aspect;
-  };
-
-  const getElevation = () => {
-    return props?.record?.point_of_interest_payload?.form_data?.point_of_interest_type_data?.elevation;
-  };
-
-  const getSpecificUse = () => {
-    return props?.record?.point_of_interest_payload?.form_data?.point_of_interest_type_data?.specific_use;
-  };
-
-  const getSoilTexture = () => {
-    return props?.record?.point_of_interest_payload?.form_data?.point_of_interest_type_data?.soil_texture;
-  };
   return (
-    <>
-      <Typography align="center" className={classes.heading}>
-        Legacy IAPP Site {getSiteID()}
-      </Typography>
-      <Accordion defaultExpanded={true}>
+    <Container style={{maxWidth: 1200}}>
+      <Accordion defaultExpanded={true} className={classes.container}>
         <AccordionSummary expandIcon={<ExpandMore />} aria-controls="panel-map-content" id="panel-map-header">
-          <Typography align="center" className={classes.heading}>
-            Site {getSiteID()} Details
+          <Typography className={classes.heading}>
+            Legacy IAPP Site: {site_id}
           </Typography>
         </AccordionSummary>
         <AccordionDetails className={classes.siteContainer}>
-          <Paper className={classes.paper} elevation={5}>
-            <Grid container xs={8} spacing={5}>
-              <Grid item xs={4}>
-                SiteID: {getSiteID()}
-              </Grid>
-              <Grid item xs={4}>
-                Created: {getCreated()}
-              </Grid>
-              <Grid item xs={4}>
-                PaperFile: {getPaper()}
-              </Grid>
-              <Grid item xs={4}>
-                Longitude: {getLong()}
-              </Grid>
-              <Grid item xs={4}>
-                Latitude: {getLat()}
-              </Grid>
-              <Grid item xs={4}>
-                Mapsheet: {getMapsheet()}
-              </Grid>
-              <Grid item xs={4}>
-                Slope: {getSlope()}
-              </Grid>
-              <Grid item xs={4}>
-                Aspect: {getAspect()}
-              </Grid>
-              <Grid item xs={4}>
-                Elevation: {getElevation()}
-              </Grid>
-              <Grid item xs={4}>
-                Specific Use: {getSpecificUse()}
-              </Grid>
-              <Grid item xs={4}>
-                Soil Texture: {getSoilTexture()}
-              </Grid>
-              <Grid item xs={4}>
-                All species found:
-              </Grid>
-              <Grid item xs={4}>
-                All species treated:
-              </Grid>
-              <Grid item xs={4}>
-                Species to be treated:
-              </Grid>
-            </Grid>
-          </Paper>
-          <br></br>
+          <Grid container spacing={1}>
+            <Grid item xs={3} sm={2}>Created</Grid>
+            <Grid item xs={9} sm={4}>{ifApplicable(created_date_on_device)}</Grid>
+            <Grid item xs={3} sm={2}>Slope</Grid>
+            <Grid item xs={9} sm={4}>{ifApplicable(slope)}</Grid>
+
+            <Grid item xs={3} sm={2}>PaperFile</Grid>
+            <Grid item xs={9} sm={4}>{ifApplicable(paper_file)}</Grid>
+            <Grid item xs={3} sm={2}>Aspect</Grid>
+            <Grid item xs={9} sm={4}>{ifApplicable(aspect)}</Grid>
+
+            <Grid item xs={3} sm={2}>Longitude</Grid>
+            <Grid item xs={9} sm={4}>{ifApplicable(longitude)}</Grid>
+            <Grid item xs={3} sm={2}>Latitude</Grid>
+            <Grid item xs={9} sm={4}>{ifApplicable(latitude)}</Grid>
+
+            <Grid item xs={3} sm={2}>Elevation</Grid>
+            <Grid item xs={9} sm={4}>{ifApplicable(latitude)}</Grid>
+            <Grid item xs={3} sm={2}>Specific Use</Grid>
+            <Grid item xs={9} sm={4}>{ifApplicable(specific_use)}</Grid>
+
+            <Grid item xs={3} sm={2}>Mapsheet</Grid>
+            <Grid item xs={9} sm={4}>{ifApplicable(map_sheet)}</Grid>
+            <Grid item xs={3} sm={2}>Soil Texture</Grid>
+            <Grid item xs={9} sm={4}>{ifApplicable(soil_texture)}</Grid>
+
+            <Grid item xs={3} sm={2}>Jurisdiction</Grid>
+            <Grid item xs={3}>{ifApplicable(Jur1)}{Jur1pct && Jur1pct != '0' ? ' (' + Jur1pct + '%)' : ''}</Grid>
+            <Grid item xs={3}>{Jur2 ?? ''}{Jur2pct && Jur2pct != '0' ? ' (' + Jur2pct + '%)' : ''}</Grid>
+            <Grid item xs={3}>{Jur3 ?? ''}{Jur3pct && Jur3pct != '0' ? ' (' + Jur3pct + '%)' : ''}</Grid>
+
+            <Grid item xs={3} sm={2}>Location</Grid>
+            <Grid item xs={9} sm={10}>{ifApplicable(access_description)}</Grid>
+
+            <Grid item xs={3} sm={2}>Comments</Grid>
+            <Grid item xs={9} sm={10}>{ifApplicable(comments)}</Grid>
+          </Grid>
         </AccordionDetails>
       </Accordion>
       <Accordion defaultExpanded={true}>
         <AccordionSummary expandIcon={<ExpandMore />} aria-controls="panel-map-content" id="panel-map-header">
-          <Typography className={classes.heading}>Survey Details</Typography>
+          <Typography className={classes.heading}>Survey Details on Site {site_id}</Typography>
         </AccordionSummary>
         <AccordionDetails className={classes.siteContainer}>{JSON.stringify(props?.record)}</AccordionDetails>
       </Accordion>
@@ -141,7 +118,6 @@ export const IAPPSite: React.FC<IAPPSitePropType> = (props) => {
         </AccordionSummary>
         <AccordionDetails className={classes.siteContainer}>{JSON.stringify(props?.record)}</AccordionDetails>
       </Accordion>
-      ;
-    </>
+    </Container>
   );
 };

--- a/app/src/components/points-of-interest/IAPP/IAPP-Site.tsx
+++ b/app/src/components/points-of-interest/IAPP/IAPP-Site.tsx
@@ -152,7 +152,41 @@ export const IAPPSite: React.FC<IAPPSitePropType> = (props) => {
         <AccordionSummary expandIcon={<ExpandMore />} aria-controls="panel-map-content" id="panel-map-header">
           <Typography className={classes.heading}>Treatment Details</Typography>
         </AccordionSummary>
-        <AccordionDetails className={classes.siteContainer}>{JSON.stringify(props?.record)}</AccordionDetails>
+        <AccordionDetails className={classes.treatmentContainer}>
+          {!mechanical_treatments || mechanical_treatments.length === 0 && <Container>No Treatments</Container>}
+          {mechanical_treatments && mechanical_treatments.length !== 0 &&
+            <TableContainer component={Paper}>
+              <Table className={classes.table} aria-label="surveys">
+                <TableHead>
+                  <TableRow>
+                    <TableCell className={classes.cell}>Mechanical ID</TableCell>
+                    <TableCell className={classes.cell}>Common Name</TableCell>
+                    <TableCell className={classes.cell}>Treatment Date</TableCell>
+                    <TableCell className={classes.cell}>Agency</TableCell>
+                    <TableCell className={classes.cell}>Hectares</TableCell>
+                    <TableCell align="center" className={classes.cell}>Mech Method</TableCell>
+                    <TableCell align="center" className={classes.cell}>PaperFile ID</TableCell>
+                    <TableCell className={classes.wideCell}>Comments</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {mechanical_treatments.map((row) => (
+                    <TableRow key={row.MechanicalID}>
+                      <TableCell className={classes.cell}>{ifApplicable(row.MechanicalID)}</TableCell>
+                      <TableCell className={classes.cell}>{ifApplicable(row.CommonName)}</TableCell>
+                      <TableCell className={classes.cell}>{ifApplicable(row.TreatmentDate)}</TableCell>
+                      <TableCell className={classes.cell}>{ifApplicable(row.TreatmentAgency)}</TableCell>
+                      <TableCell className={classes.cell}>{ifApplicable(row.AreaTreated)}</TableCell>
+                      <TableCell align="center" className={classes.cell}>{ifApplicable(row.MechanicalMethod)}</TableCell>
+                      <TableCell align="center" className={classes.cell}>{ifApplicable(row.PaperFileID)}</TableCell>
+                      <TableCell className={classes.wideCell}>{ifApplicable(row.Comment)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          }
+        </AccordionDetails>
       </Accordion>
     </Container>
   );

--- a/app/src/features/home/map/MapPage.tsx
+++ b/app/src/features/home/map/MapPage.tsx
@@ -181,7 +181,8 @@ const MapPage: React.FC<IMapProps> = (props) => {
 
       let coordinatesString = 'Polygon';
       if (row.geometry[0].geometry.type !== 'Polygon') {
-        coordinatesString = `(${row.geometry[0]?.geometry.coordinates[1]?.toFixed(2)}, ${row.geometry[0]?.geometry.coordinates[0]?.toFixed(2)})`;
+        const coords = [Number(row.geometry[0]?.geometry.coordinates[1]).toFixed(2), Number(row.geometry[0]?.geometry.coordinates[0]).toFixed(2)];
+        coordinatesString = `(${coords[0]}, ${coords[1]})`;
       }
 
       switch (row.docType) {

--- a/app/src/features/home/map/MapPage.tsx
+++ b/app/src/features/home/map/MapPage.tsx
@@ -39,7 +39,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     width: '100%'
   },
   popOutComponent: {
-    height: '100%',
     width: '100%',
     backgroundColor: theme.palette.background.paper
   }


### PR DESCRIPTION
# Overview

UI for IAPP Sites, Surveys, and [Mechanical] Treatments.

This PR includes the following proposed change(s):

- https://github.com/bcgov/invasivesbc/issues/163
- https://github.com/bcgov/invasivesbc/issues/164

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested in Chrome with responsive layout on various screen sizes

## Screenshots
![2020-12-02 16_52_25-w@RIP-DESKTOP_ _mnt_c](https://user-images.githubusercontent.com/4359195/100949333-e24c1680-34be-11eb-983e-13d111986ec9.png)
![2020-12-02 16_52_42-InvasivesBC - Home](https://user-images.githubusercontent.com/4359195/100949340-e6783400-34be-11eb-9b08-469ba0f73a78.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes


# Report:

Hey!  Just pushing this up as I believe it's probably polished enough for now - and hopefully any remaining refinements can be done as I tackle the additional Treatments data and we better refine the path forward as far as generalizing this stuff (don't want to spend too much time prettifying something which might not survive in its current form).

## Ticket Notes:
- Photos are not done here yet, and should be split to a new ticket (data needed).
- If we're never showing sites without survey data, we'll need to wipe those from the DB so they don't show up in searches - that should come before the UI.  I can do that, just want approval first by someone, and to make sure it'll get re-run if we re-import the data
- Similarly the survey data should hopefully have its sort order from newest->oldest preserved in the DB.  Appears so, but tough to check every row.  UI relies on this being correct.

# Remaining Questions/Notes:
(Mainly for @mikeshasko  Feel free to just check off if these are fine/resolved, or comment below)
## Site:
- [x] Note: 'point_of_interest_status' and 'original_bec_id' are not used/displayed here

## Surveys:
- [x] I'm including CommonName field to more easily match Treatments data (see below explanation)
- [x] Note: 'EmployerCode', 'Genus', 'MapCode', 'SurveyType', and 'WeedsFound' fields are not used/displayed.

## Treatments:
- [x] Treatments data provided doesnt appear to have 'Species' data, and only 'CommonName'.  Will need to look into that further if that's a data error.  Currently including 'CommonName' for easy reference to Surveys
- [x] Note: 'Employer', 'MapCode', 'TreatmentID' are not used/displayed.
- [x] Currently using 'MechanicalID', but we could we use 'TreatmentID' instead or as well


# Remaining Improvements Suggested:

- Bug discovered: When closing popup section, needs to also scroll user up to the top of the page to ensure a full map screen, and/or completely hide the bottom section.  If partially scrolled down when clicking "Close" it merely jumps down a bit but does not disappear.  Will look into this when doing treatments data issues, or can create a new bug ticket.
- Ideally popup should be animated, roughly 1-second timing, for a smooth transition between open/closed.  Can wait til final UI passes though.
- Horizontal scroll bar on treatments/surveys tables: could use visual indicator to help users know they can scroll sideways to see more columns.  Will attempt when working on additional treatments tickets. Seems to show sometimes but not always
- Pagination with limits per page for surveys/treatments tables.  Currently just shows all - if there are 20+ that's slightly awkward (but very rare). Low priority, but nice to have in a generalized table component.
- Generalized data view components for tables and POIs/Activities/References.  Will be tinkering at this while on additional treatments tickets and would like to use RJSF to generalize this stuff.  Deserves another ticket though.
- Close/Edit/Photos etc buttons need revising to take up one row elegantly.  They also should be centered - this is most noticeable when viewing on large screens
- (Possibly) Two-stages to the pop-up: first just shows a small point title/summary (10-20% of bottom of screen), clicking a "More" or "V" (down arrow) scrolls the screen down to view all the data.  Make sure it's clear to the user they can scroll back up to go back to the map, or close this popup and get a full map screen.
- (Possibly) Restore side-bar column view (like it used to be) when viewing on large screens.  We will still likely need mobile/tablets to have a drop-down view (just not enough screen space for all the data).  Leaving just the drop-down for now as it's generally easier to work with one universal view until we're hammering out finalized layouts.
- (Likely) Will be combining behavior of this popup section with the /home/activity editor component - you will be able to edit the Activity/POI/Reference (if available) in this popup section
 

