### PR TITLE
Fix broken postman tests/collection

### DIFF
--- a/testing/integration/postman/InvasivesBC-API-DEV.postman_collection.json
+++ b/testing/integration/postman/InvasivesBC-API-DEV.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "873004be-7b90-4df6-bce4-ee85f090d847",
+		"_postman_id": "13008b69-21dd-464b-acc7-d068e53aa0e0",
 		"name": "InvasivesBC-API-DEV",
 		"description": "API for InvasivesBC (Ionic Version)",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -15,7 +15,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "81a394d9-34bf-4028-a8ef-08d06673e846",
+								"id": "c3253528-f012-48f2-b35f-1aa9e5f76296",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {\r",
 									"    pm.response.to.have.status(200);\r",
@@ -95,7 +95,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "02b307a1-be0b-4e35-9427-85d863903e37",
+								"id": "08a4c19f-5372-45c9-a47d-0c5db9c343a9",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {\r",
 									"    pm.response.to.have.status(200);\r",
@@ -111,7 +111,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "20b6cebd-7935-4f2e-92f2-b00c67c16939",
+								"id": "96197785-e6fe-4fa9-b32f-1aabcc608005",
 								"exec": [
 									"const uuid = require('uuid');\r",
 									"const activity_id = uuid.v4();\r",
@@ -129,7 +129,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"activity_id\": \"{{ACTIVITY_ID}}\",\r\n    \"created_timestamp\": \"2020-11-24T17:55:33+0000\",\r\n    \"media\": [],\r\n    \"geometry\": [\r\n        {\r\n            \"type\": \"Feature\",\r\n            \"geometry\": {\r\n                \"type\": \"Polygon\",\r\n                \"coordinates\": [\r\n                    [\r\n                        [\r\n                            -123.36565017700195,\r\n                            48.453399614563764\r\n                        ],\r\n                        [\r\n                            -123.3797264099121,\r\n                            48.441842443378555\r\n                        ],\r\n                        [\r\n                            -123.36264610290526,\r\n                            48.435692728712105\r\n                        ],\r\n                        [\r\n                            -123.3467674255371,\r\n                            48.448333001219005\r\n                        ],\r\n                        [\r\n                            -123.36565017700195,\r\n                            48.453399614563764\r\n                        ]\r\n                    ]\r\n                ]\r\n            },\r\n            \"properties\": {}\r\n        }\r\n    ],\r\n    \"form_data\": {\r\n        \"activity_data\": {\r\n            \"invasive_species_agency_code\": \"CCCIPC\",\r\n            \"jurisdiction_code\": \"DOT\",\r\n            \"species_id\": \"test\",\r\n            \"access_description\": \"123\"\r\n        },\r\n        \"activity_type_data\": {\r\n            \"negative_obs_ind\": false,\r\n            \"observation_date_time\": \"2020-11-30T16:36:51-08:00\",\r\n            \"reported_area\": 3.99,\r\n            \"observation_type_code\": \"OP\",\r\n            \"observer_first_name\": \"wwwe\",\r\n            \"observer_last_name\": \"wewew\"\r\n        },\r\n        \"activity_subtype_data\": {\r\n            \"flowering\": false,\r\n            \"legacy_site_ind\": false,\r\n            \"early_detection_rapid_resp_ind\": false,\r\n            \"research_detection_ind\": false,\r\n            \"well_ind\": false,\r\n            \"special_care_ind\": false,\r\n            \"biological_ind\": false,\r\n            \"invasive_plant_code\": \"BA\",\r\n            \"invasive_plant_density_code\": \"M\",\r\n            \"invasive_plant_distribution_code\": \"RS\",\r\n            \"soil_texture_code\": \"F\",\r\n            \"specific_use_code\": \"PL\",\r\n            \"slope_code\": \"SS\",\r\n            \"aspect_code\": \"SE\",\r\n            \"proposed_treatment_code\": \"BT\",\r\n            \"plant_life_stage_code\": \"MIF\",\r\n            \"plant_health_code\": \"GH\",\r\n            \"plant_seed_stage_code\": \"SF\"\r\n        }\r\n    },\r\n    \"activity_type\": \"Treatment\",\r\n    \"activity_subtype\": \"Activity_Treatment_BiologicalDispersalPlant\"\r\n}",
+							"raw": "{\r\n    \"activity_id\": \"{{ACTIVITY_ID}}\",\r\n    \"created_timestamp\": \"2020-11-24T17:55:33+0000\",\r\n    \"media\": [],\r\n    \"locationAndGeometry\": {\r\n        \"anchorPointX\": 10,\r\n        \"anchorPointY\": 12\r\n    },\r\n    \"geometry\": [\r\n        {\r\n            \"type\": \"Feature\",\r\n            \"geometry\": {\r\n                \"type\": \"Polygon\",\r\n                \"coordinates\": [\r\n                    [\r\n                        [\r\n                            -123.36565017700195,\r\n                            48.453399614563764\r\n                        ],\r\n                        [\r\n                            -123.3797264099121,\r\n                            48.441842443378555\r\n                        ],\r\n                        [\r\n                            -123.36264610290526,\r\n                            48.435692728712105\r\n                        ],\r\n                        [\r\n                            -123.3467674255371,\r\n                            48.448333001219005\r\n                        ],\r\n                        [\r\n                            -123.36565017700195,\r\n                            48.453399614563764\r\n                        ]\r\n                    ]\r\n                ]\r\n            },\r\n            \"properties\": {}\r\n        }\r\n    ],\r\n    \"form_data\": {\r\n        \"activity_data\": {\r\n            \"invasive_species_agency_code\": \"CCCIPC\",\r\n            \"jurisdiction_code\": \"DOT\",\r\n            \"species_id\": \"test\",\r\n            \"access_description\": \"123\"\r\n        },\r\n        \"activity_type_data\": {\r\n            \"negative_obs_ind\": false,\r\n            \"observation_date_time\": \"2020-11-30T16:36:51-08:00\",\r\n            \"reported_area\": 3.99,\r\n            \"observation_type_code\": \"OP\",\r\n            \"observer_first_name\": \"wwwe\",\r\n            \"observer_last_name\": \"wewew\"\r\n        },\r\n        \"activity_subtype_data\": {\r\n            \"flowering\": false,\r\n            \"legacy_site_ind\": false,\r\n            \"early_detection_rapid_resp_ind\": false,\r\n            \"research_detection_ind\": false,\r\n            \"well_ind\": false,\r\n            \"special_care_ind\": false,\r\n            \"biological_ind\": false,\r\n            \"invasive_plant_code\": \"BA\",\r\n            \"invasive_plant_density_code\": \"M\",\r\n            \"invasive_plant_distribution_code\": \"RS\",\r\n            \"soil_texture_code\": \"F\",\r\n            \"specific_use_code\": \"PL\",\r\n            \"slope_code\": \"SS\",\r\n            \"aspect_code\": \"SE\",\r\n            \"proposed_treatment_code\": \"BT\",\r\n            \"plant_life_stage_code\": \"MIF\",\r\n            \"plant_health_code\": \"GH\",\r\n            \"plant_seed_stage_code\": \"SF\"\r\n        }\r\n    },\r\n    \"activity_type\": \"Treatment\",\r\n    \"activity_subtype\": \"Activity_Treatment_BiologicalDispersalPlant\"\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -155,7 +155,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e0644ea3-4d9c-4e1a-9a0d-5096698334ac",
+								"id": "91cf106e-fa51-4723-a27b-920a26e3d872",
 								"exec": [
 									"pm.test(\"Successful POST request\", function () {\r",
 									"    pm.expect(pm.response.code).to.be.oneOf([200,201,202]);\r",
@@ -275,7 +275,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "60f1300e-3ca3-437a-b814-9724342503c9",
+								"id": "27743af4-7c7b-4450-8adc-707d69888e13",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {\r",
 									"    pm.response.to.have.status(200);\r",
@@ -294,7 +294,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"activity_id\": \"{{ACTIVITY_ID}}\",\r\n    \"created_timestamp\": \"2020-11-25T17:55:33+0000\",\r\n    \"media\": [],\r\n    \"geometry\": [\r\n        {\r\n            \"type\": \"Feature\",\r\n            \"geometry\": {\r\n                \"type\": \"Polygon\",\r\n                \"coordinates\": [\r\n                    [\r\n                        [\r\n                            -123.36565017700195,\r\n                            48.453399614563764\r\n                        ],\r\n                        [\r\n                            -123.3797264099121,\r\n                            48.441842443378555\r\n                        ],\r\n                        [\r\n                            -123.36264610290526,\r\n                            48.435692728712105\r\n                        ],\r\n                        [\r\n                            -123.3467674255371,\r\n                            48.448333001219005\r\n                        ],\r\n                        [\r\n                            -123.36565017700195,\r\n                            48.453399614563764\r\n                        ]\r\n                    ]\r\n                ]\r\n            },\r\n            \"properties\": {}\r\n        }\r\n    ],\r\n    \"form_data\": {\r\n        \"activity_data\": {\r\n            \"invasive_species_agency_code\": \"CCCIPC\",\r\n            \"jurisdiction_code\": \"DOT\",\r\n            \"species_id\": \"test\",\r\n            \"access_description\": \"123\"\r\n        },\r\n        \"activity_type_data\": {\r\n            \"negative_obs_ind\": false,\r\n            \"observation_date_time\": \"2020-11-30T16:36:51-08:00\",\r\n            \"reported_area\": 3.99,\r\n            \"observation_type_code\": \"OP\",\r\n            \"observer_first_name\": \"wwwe\",\r\n            \"observer_last_name\": \"wewew\"\r\n        },\r\n        \"activity_subtype_data\": {\r\n            \"flowering\": false,\r\n            \"legacy_site_ind\": false,\r\n            \"early_detection_rapid_resp_ind\": false,\r\n            \"research_detection_ind\": false,\r\n            \"well_ind\": false,\r\n            \"special_care_ind\": false,\r\n            \"biological_ind\": false,\r\n            \"invasive_plant_code\": \"BA\",\r\n            \"invasive_plant_density_code\": \"M\",\r\n            \"invasive_plant_distribution_code\": \"RS\",\r\n            \"soil_texture_code\": \"F\",\r\n            \"specific_use_code\": \"PL\",\r\n            \"slope_code\": \"SS\",\r\n            \"aspect_code\": \"SE\",\r\n            \"proposed_treatment_code\": \"BT\",\r\n            \"plant_life_stage_code\": \"MIF\",\r\n            \"plant_health_code\": \"GH\",\r\n            \"plant_seed_stage_code\": \"SF\"\r\n        }\r\n    },\r\n    \"activity_type\": \"Treatment\",\r\n    \"activity_subtype\": \"Activity_Treatment_BiologicalDispersalPlant\"\r\n}",
+							"raw": "{\r\n    \"activity_id\": \"{{ACTIVITY_ID}}\",\r\n    \"created_timestamp\": \"2020-11-25T17:55:33+0000\",\r\n    \"media\": [],\r\n    \"locationAndGeometry\": {\r\n        \"anchorPointX\": 10,\r\n        \"anchorPointY\": 12\r\n    },\r\n    \"geometry\": [\r\n        {\r\n            \"type\": \"Feature\",\r\n            \"geometry\": {\r\n                \"type\": \"Polygon\",\r\n                \"coordinates\": [\r\n                    [\r\n                        [\r\n                            -123.36565017700195,\r\n                            48.453399614563764\r\n                        ],\r\n                        [\r\n                            -123.3797264099121,\r\n                            48.441842443378555\r\n                        ],\r\n                        [\r\n                            -123.36264610290526,\r\n                            48.435692728712105\r\n                        ],\r\n                        [\r\n                            -123.3467674255371,\r\n                            48.448333001219005\r\n                        ],\r\n                        [\r\n                            -123.36565017700195,\r\n                            48.453399614563764\r\n                        ]\r\n                    ]\r\n                ]\r\n            },\r\n            \"properties\": {}\r\n        }\r\n    ],\r\n    \"form_data\": {\r\n        \"activity_data\": {\r\n            \"invasive_species_agency_code\": \"CCCIPC\",\r\n            \"jurisdiction_code\": \"DOT\",\r\n            \"species_id\": \"test\",\r\n            \"access_description\": \"123\"\r\n        },\r\n        \"activity_type_data\": {\r\n            \"negative_obs_ind\": false,\r\n            \"observation_date_time\": \"2020-11-30T16:36:51-08:00\",\r\n            \"reported_area\": 3.99,\r\n            \"observation_type_code\": \"OP\",\r\n            \"observer_first_name\": \"wwwe\",\r\n            \"observer_last_name\": \"wewew\"\r\n        },\r\n        \"activity_subtype_data\": {\r\n            \"flowering\": false,\r\n            \"legacy_site_ind\": false,\r\n            \"early_detection_rapid_resp_ind\": false,\r\n            \"research_detection_ind\": false,\r\n            \"well_ind\": false,\r\n            \"special_care_ind\": false,\r\n            \"biological_ind\": false,\r\n            \"invasive_plant_code\": \"BA\",\r\n            \"invasive_plant_density_code\": \"M\",\r\n            \"invasive_plant_distribution_code\": \"RS\",\r\n            \"soil_texture_code\": \"F\",\r\n            \"specific_use_code\": \"PL\",\r\n            \"slope_code\": \"SS\",\r\n            \"aspect_code\": \"SE\",\r\n            \"proposed_treatment_code\": \"BT\",\r\n            \"plant_life_stage_code\": \"MIF\",\r\n            \"plant_health_code\": \"GH\",\r\n            \"plant_seed_stage_code\": \"SF\"\r\n        }\r\n    },\r\n    \"activity_type\": \"Treatment\",\r\n    \"activity_subtype\": \"Activity_Treatment_BiologicalDispersalPlant\"\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -326,7 +326,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "cf7b91c0-8030-4186-9f6e-0257944f0c15",
+								"id": "ea97fb1a-1946-487c-90ac-1fbda84e21fa",
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {\r",
 									"    pm.response.to.have.status(200);\r",
@@ -377,7 +377,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "2beb9382-c093-4a32-a6fe-0a9f807ad762",
+								"id": "07acba7a-32d6-4bc8-96a3-9af8eeafe649",
 								"exec": [
 									"pm.test(\"Successful POST request\", function () {\r",
 									"    pm.expect(pm.response.code).to.be.oneOf([200,201,202]);\r",
@@ -424,37 +424,6 @@
 					},
 					"response": [
 						{
-							"name": "Unauthorized user",
-							"originalRequest": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n    \"activityType\": \"<string>\",\n    \"activityTypeData\": \"<object>\",\n    \"activitySubType\": \"<string>\",\n    \"activitySubTypeData\": \"<object>\",\n    \"date\": \"<date>\",\n    \"locationAndGeometry\": {\n        \"anchorPointY\": \"<integer>\",\n        \"anchorPointX\": \"<integer>\",\n        \"area\": \"<integer>\",\n        \"geometry\": \"<object>\",\n        \"jurisdiction\": \"<string>\",\n        \"agency\": \"<string>\",\n        \"observer1FirstName\": \"<string>\",\n        \"observer1LastName\": \"<string>\",\n        \"locationComment\": \"<string>\",\n        \"generalComment\": \"<string>\",\n        \"photoTaken\": \"<boolean>\"\n    },\n    \"deviceRequestUID\": \"<string>\"\n}"
-								},
-								"url": {
-									"raw": "{{baseUrl}}/activity",
-									"host": [
-										"{{baseUrl}}"
-									],
-									"path": [
-										"activity"
-									]
-								}
-							},
-							"status": "Unauthorized",
-							"code": 401,
-							"_postman_previewlanguage": "json",
-							"header": [
-								{
-									"key": "Content-Type",
-									"value": "application/json"
-								}
-							],
-							"cookie": [],
-							"body": "{\n \"message\": \"Duis deserunt\",\n \"errors\": [\n  \"laborum\",\n  \"reprehenderit culpa sit do\"\n ]\n}"
-						},
-						{
 							"name": "Created",
 							"originalRequest": {
 								"method": "POST",
@@ -484,6 +453,37 @@
 							],
 							"cookie": [],
 							"body": "{\n \"activityType\": \"irure in est dolor\",\n \"activitySubType\": \"dolore adipisicing\",\n \"date\": \"ipsum aute\",\n \"locationAndGeometry\": \"dolor amet\"\n}"
+						},
+						{
+							"name": "Unauthorized user",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"activityType\": \"<string>\",\n    \"activityTypeData\": \"<object>\",\n    \"activitySubType\": \"<string>\",\n    \"activitySubTypeData\": \"<object>\",\n    \"date\": \"<date>\",\n    \"locationAndGeometry\": {\n        \"anchorPointY\": \"<integer>\",\n        \"anchorPointX\": \"<integer>\",\n        \"area\": \"<integer>\",\n        \"geometry\": \"<object>\",\n        \"jurisdiction\": \"<string>\",\n        \"agency\": \"<string>\",\n        \"observer1FirstName\": \"<string>\",\n        \"observer1LastName\": \"<string>\",\n        \"locationComment\": \"<string>\",\n        \"generalComment\": \"<string>\",\n        \"photoTaken\": \"<boolean>\"\n    },\n    \"deviceRequestUID\": \"<string>\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/activity",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"activity"
+									]
+								}
+							},
+							"status": "Unauthorized",
+							"code": 401,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n \"message\": \"Duis deserunt\",\n \"errors\": [\n  \"laborum\",\n  \"reprehenderit culpa sit do\"\n ]\n}"
 						}
 					]
 				}
@@ -496,7 +496,7 @@
 				{
 					"listen": "test",
 					"script": {
-						"id": "068a7628-ae10-4340-b57f-b3fd299e1c48",
+						"id": "cf44d89e-65b4-4949-a89f-615dfc5e8546",
 						"exec": [
 							"pm.test(\"Status code is 200\", function () {\r",
 							"    pm.response.to.have.status(200);\r",
@@ -573,7 +573,7 @@
 		{
 			"listen": "prerequest",
 			"script": {
-				"id": "782d934b-66af-4b48-af4e-85a06038c485",
+				"id": "6fa740fa-23a0-4b0e-a712-9c3148fc5e44",
 				"type": "text/javascript",
 				"exec": [
 					"const echoPostRequest = {",
@@ -624,7 +624,7 @@
 		{
 			"listen": "test",
 			"script": {
-				"id": "edb8055c-c065-48d8-a010-0bf244700892",
+				"id": "d07bdf12-5f4f-41d8-96db-c7d4d4ff834e",
 				"type": "text/javascript",
 				"exec": [
 					""


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- The `context_queries.ts` file that was added yesterday enforced a new property to be present on the body of requests and this was not present in our postman requests -> causing it to crash silently and result in a 500 instead of 200.

This PR fixes that issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Locally using postman and collection

## Screenshots

<img width="993" alt="Screenshot 2020-12-04 132726" src="https://user-images.githubusercontent.com/28017034/101216498-755a8d00-3634-11eb-865a-8c1d80c52776.png">

