### PR TITLE
✂️ 256: Ability to copy paste form data between activities

### DIFF
--- a/api/src/openapi/api-doc.json
+++ b/api/src/openapi/api-doc.json
@@ -432,12 +432,14 @@
           "general_comment": {
             "type": "string",
             "title": "Comment",
-            "maximum": 300
+            "maximum": 300,
+            "default": ""
           },
           "access_description": {
             "type": "string",
             "title": "Access Description",
-            "maximum": 300
+            "maximum": 300,
+            "default": ""
           },
           "paper_file_id": {
             "type": "array",

--- a/app/src/components/activity/ActivityComponent.tsx
+++ b/app/src/components/activity/ActivityComponent.tsx
@@ -10,6 +10,7 @@ export interface IActivityComponentProps extends IMapContainerProps, IFormContai
   activity: any;
   customValidation?: any;
   pasteFormData?: Function;
+  copyFormData?: Function;
 }
 
 const ActivityComponent: React.FC<IActivityComponentProps> = (props) => {

--- a/app/src/components/activity/ActivityComponent.tsx
+++ b/app/src/components/activity/ActivityComponent.tsx
@@ -9,6 +9,7 @@ export interface IActivityComponentProps extends IMapContainerProps, IFormContai
   classes?: any;
   activity: any;
   customValidation?: any;
+  pasteFormData?: Function;
 }
 
 const ActivityComponent: React.FC<IActivityComponentProps> = (props) => {

--- a/app/src/components/form/FormContainer.tsx
+++ b/app/src/components/form/FormContainer.tsx
@@ -12,8 +12,6 @@ import ObjectFieldTemplate from 'rjsf/templates/ObjectFieldTemplate';
 import RootUISchemas from 'rjsf/uiSchema/RootUISchemas';
 import rjsfTheme from 'themes/rjsfTheme';
 import FormControlsComponent, { IFormControlsComponentProps } from './FormControlsComponent';
-import { notifySuccess } from 'utils/NotificationUtils';
-import { saveFormDataToSession } from 'utils/saveRetrieveFormData';
 
 export interface IFormContainerProps extends IFormControlsComponentProps {
   classes?: any;
@@ -21,6 +19,7 @@ export interface IFormContainerProps extends IFormControlsComponentProps {
   customValidation?: any;
   isDisabled?: boolean;
   pasteFormData?: Function;
+  copyFormData?: Function;
   /**
    * A function executed everytime the form changes.
    *
@@ -65,13 +64,6 @@ const FormContainer: React.FC<IFormContainerProps> = (props) => {
     return <CircularProgress />;
   }
 
-  const copyFormData = () => {
-    const { activity: { formData, activitySubtype } } = props;
-
-    saveFormDataToSession(formData, activitySubtype);
-    notifySuccess(databaseContext, 'Successfully copied form data.');
-  };
-
   const isDisabled = props.isDisabled || props.activity?.sync?.status === ActivitySyncStatus.SYNC_SUCCESSFUL || false;
 
   return (
@@ -80,7 +72,7 @@ const FormContainer: React.FC<IFormContainerProps> = (props) => {
         <FormControlsComponent
           onSubmit={() => formRef.submit()}
           isDisabled={isDisabled}
-          onCopy={() => copyFormData()}
+          onCopy={() => props.copyFormData()}
           onPaste={() => props.pasteFormData()}
           activitySubtype={props.activity.activitySubtype}
         />

--- a/app/src/components/form/FormContainer.tsx
+++ b/app/src/components/form/FormContainer.tsx
@@ -1,11 +1,10 @@
 import { Box, CircularProgress, ThemeProvider, Typography } from '@material-ui/core';
 import { IChangeEvent, ISubmitEvent } from '@rjsf/core';
 import Form from '@rjsf/material-ui';
-import { DatabaseContext } from 'contexts/DatabaseContext';
 import { ActivitySyncStatus } from 'constants/activities';
 import { useInvasivesApi } from 'hooks/useInvasivesApi';
 import { JSONSchema7 } from 'json-schema';
-import React, { useEffect, useState, useContext } from 'react';
+import React, { useEffect, useState } from 'react';
 import ArrayFieldTemplate from 'rjsf/templates/ArrayFieldTemplate';
 import FieldTemplate from 'rjsf/templates/FieldTemplate';
 import ObjectFieldTemplate from 'rjsf/templates/ObjectFieldTemplate';
@@ -44,8 +43,6 @@ const FormContainer: React.FC<IFormContainerProps> = (props) => {
   const [schemas, setSchemas] = useState<{ schema: any; uiSchema: any }>({ schema: null, uiSchema: null });
 
   const [formRef, setFormRef] = useState(null);
-
-  const databaseContext = useContext(DatabaseContext);
 
   useEffect(() => {
     const getApiSpec = async () => {

--- a/app/src/components/form/FormControlsComponent.tsx
+++ b/app/src/components/form/FormControlsComponent.tsx
@@ -5,6 +5,9 @@ export interface IFormControlsComponentProps {
   classes?: any;
   isDisabled?: boolean;
   onSubmit?: Function;
+  onCopy?: Function;
+  onPaste?: Function;
+  activitySubtype?: string;
 }
 
 const FormControlsComponent: React.FC<IFormControlsComponentProps> = (props) => {
@@ -29,6 +32,42 @@ const FormControlsComponent: React.FC<IFormControlsComponentProps> = (props) => 
               Check Form For Errors
             </Button>
           </Grid>
+          <Grid item>
+            <Button
+              disabled={isDisabled}
+              variant="contained"
+              color="primary"
+              onClick={() => {
+                if (!props.onCopy) {
+                  return;
+                }
+
+                props.onCopy();
+              }}>
+              Copy Form Data
+            </Button>
+          </Grid>
+          {
+            sessionStorage.getItem('copiedFormData') &&
+            sessionStorage.getItem('activitySubtype') === props.activitySubtype &&
+            (
+              <Grid item>
+                <Button
+                  disabled={isDisabled}
+                  variant="contained"
+                  color="primary"
+                  onClick={() => {
+                    if (!props.onPaste) {
+                      return;
+                    }
+
+                    props.onPaste();
+                  }}>
+                  Paste Form Data
+                </Button>
+              </Grid>
+            )
+          }
         </Grid>
       </Grid>
     </>

--- a/app/src/features/home/activity/ActivityPage.tsx
+++ b/app/src/features/home/activity/ActivityPage.tsx
@@ -222,9 +222,6 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
    */
   const onFormChange = useCallback(
     debounced(100, async (event: any) => {
-
-      console.log("inside form change event", event);
-
       // populate herbicide application rate
       const updatedActivitySubtypeData = populateHerbicideRates(
         doc.formData.activity_subtype_data,

--- a/app/src/features/home/activity/ActivityPage.tsx
+++ b/app/src/features/home/activity/ActivityPage.tsx
@@ -13,7 +13,7 @@ import { MapContextMenuData } from '../map/MapContextMenu';
 import { getCustomValidator, getAreaValidator, getWindValidator } from 'rjsf/business-rules/customValidation';
 import { populateHerbicideRates } from 'rjsf/business-rules/populateCalculatedFields';
 import { notifySuccess } from 'utils/NotificationUtils';
-import { retrieveFormDataFromSession } from 'utils/saveRetrieveFormData';
+import { retrieveFormDataFromSession, saveFormDataToSession } from 'utils/saveRetrieveFormData';
 
 const useStyles = makeStyles((theme) => ({
   heading: {
@@ -273,6 +273,16 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
     });
   };
 
+  /**
+   * Copy form data into session storage
+   */
+  const copyFormData = () => {
+    const { formData, activitySubtype } = doc;
+
+    saveFormDataToSession(formData, activitySubtype);
+    notifySuccess(databaseContext, 'Successfully copied form data.');
+  };
+
   useEffect(() => {
     const getActivityData = async () => {
       const appStateResults = await databaseContext.database.find({ selector: { _id: DocType.APPSTATE } });
@@ -341,6 +351,7 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
         extentState={{ extent, setExtent }}
         contextMenuState={{ state: contextMenuState, setContextMenuState }} // whether someone clicked, and click x & y
         pasteFormData={() => pasteFormData()}
+        copyFormData={() => copyFormData()}
       />
     </Container>
   );

--- a/app/src/rjsf/business-rules/formDataCopyFields.ts
+++ b/app/src/rjsf/business-rules/formDataCopyFields.ts
@@ -1,0 +1,8 @@
+export function getFieldsToCopy(data: any, type: string) {
+  if (type === 'Activity') {
+    const { activity_date_time, latitude, longitude, reported_area, ...activityDataToCopy } = data;
+    return activityDataToCopy;
+  }
+
+  return data;
+}

--- a/app/src/rjsf/business-rules/formDataCopyFields.ts
+++ b/app/src/rjsf/business-rules/formDataCopyFields.ts
@@ -1,3 +1,7 @@
+/*
+  Function to determine which fields to copy from provided activity_data/activity_type_data/activity_subtype_data
+  and apply some filters based on the type of data 
+*/
 export function getFieldsToCopy(data: any, type: string) {
   if (type === 'Activity') {
     const { activity_date_time, latitude, longitude, reported_area, ...activityDataToCopy } = data;

--- a/app/src/rjsf/business-rules/formDataCopyFields.ts
+++ b/app/src/rjsf/business-rules/formDataCopyFields.ts
@@ -4,7 +4,13 @@
 */
 export function getFieldsToCopy(data: any, type: string) {
   if (type === 'Activity') {
+    /*
+      These fields are not being included because they are either read-only fields that are generated
+      based on the geometry or editable fields that get autopopulated based on when the activity
+      was created
+    */
     const { activity_date_time, latitude, longitude, reported_area, ...activityDataToCopy } = data;
+
     return activityDataToCopy;
   }
 

--- a/app/src/utils/saveRetrieveFormData.ts
+++ b/app/src/utils/saveRetrieveFormData.ts
@@ -1,0 +1,36 @@
+import { getFieldsToCopy } from 'rjsf/business-rules/formDataCopyFields';
+
+/*
+  Function that takes in formData to save and the activitySubtype
+  and stores both into session storage for pasting ability later
+*/
+export function saveFormDataToSession(formData: any, activitySubtype: string): void {
+  const activityData = { ...formData.activity_data };
+
+  // call business rule function to exclude certain fields of the activity_data of the form data
+  const activityDataToCopy = getFieldsToCopy(activityData, 'Activity');
+
+  const formDataToCopy = {
+    ...formData,
+    activity_data: activityDataToCopy
+  };
+
+  sessionStorage.setItem('copiedFormData', JSON.stringify(formDataToCopy));
+  sessionStorage.setItem('activitySubtype', activitySubtype);
+};
+
+/*
+  Function to get the saved form data from session storage
+  and return it after ensuring the activity_data is not completely overriden
+  (due to business rule)
+*/
+export function retrieveFormDataFromSession(activity: any): any {
+  const formData = activity.formData;
+  const activityData = { ...formData.activity_data };
+  const newActivityData = { ...activityData, ...JSON.parse(sessionStorage.getItem('copiedFormData')).activity_data };
+
+  return {
+    ...JSON.parse(sessionStorage.getItem('copiedFormData')),
+    activity_data: newActivityData
+  };
+};

--- a/app/src/utils/saveRetrieveFormData.ts
+++ b/app/src/utils/saveRetrieveFormData.ts
@@ -17,7 +17,7 @@ export function saveFormDataToSession(formData: any, activitySubtype: string): v
 
   sessionStorage.setItem('copiedFormData', JSON.stringify(formDataToCopy));
   sessionStorage.setItem('activitySubtype', activitySubtype);
-};
+}
 
 /*
   Function to get the saved form data from session storage
@@ -33,4 +33,4 @@ export function retrieveFormDataFromSession(activity: any): any {
     ...JSON.parse(sessionStorage.getItem('copiedFormData')),
     activity_data: newActivityData
   };
-};
+}


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- ✂️ Ability to copy paste form data between activities
- Can copy paste entire formdata from a given activity into another activity (with some exceptions such as geo info) based on some business rules
- #256 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Locally

## Screenshots

<img width="1061" alt="copypaste" src="https://user-images.githubusercontent.com/28017034/101954490-0ee3ea80-3bb1-11eb-99a0-654ac2521115.png">

