### PR TITLE
✅ ❌ 239 & 246: Custom error and success messages for sync activities

### DIFF
--- a/app/src/components/activities-list/ActivitiesList.tsx
+++ b/app/src/components/activities-list/ActivitiesList.tsx
@@ -35,6 +35,7 @@ import 'styles/spinners.scss';
 import { notifyError, notifySuccess, notifyWarning } from 'utils/NotificationUtils';
 import ActivityListDate from './ActivityListDate';
 import { v4 as uuidv4 } from 'uuid';
+import { getErrorMessages } from 'utils/errorHandling';
 
 const useStyles = makeStyles((theme: Theme) => ({
   activitiesContent: {},
@@ -193,7 +194,6 @@ const ActivityList: React.FC<IActivityList> = (props) => {
           <Paper key={doc._id}>
             <ListItem
               button
-              // disabled={isDisabled}
               className={classes.activitiyListItem}
               onClick={() => setActiveActivityAndNavigateToActivityPage(doc)}>
               <ListItemIcon>
@@ -244,6 +244,8 @@ const ActivitiesList: React.FC = (props) => {
       }
     });
 
+    let errorMessages = [];
+
     // sync each activity one-by-one
     for (const activity of activityResult.docs) {
       try {
@@ -259,6 +261,8 @@ const ActivitiesList: React.FC = (props) => {
           form_data: activity.formData
         });
 
+        notifySuccess(databaseContext, `Syncing ${activity.activitySubtype.split('_')[2]} activity has succeeded.`);
+
         await databaseContext.database.upsert(activity._id, (activityDoc) => {
           return {
             ...activityDoc,
@@ -266,6 +270,10 @@ const ActivitiesList: React.FC = (props) => {
           };
         });
       } catch (error) {
+        const errorMessage = getErrorMessages(error.response.status, 'formSync');
+
+        errorMessages.push(`Syncing ${activity.activitySubtype.split('_')[2]} activity has failed: ${errorMessage}`);
+
         await databaseContext.database.upsert(activity._id, (activityDoc) => {
           return {
             ...activityDoc,
@@ -274,6 +282,10 @@ const ActivitiesList: React.FC = (props) => {
         });
       }
     }
+
+    errorMessages.forEach((err: string) => {
+      notifyError(databaseContext, err);
+    });
 
     setSyncing(false);
     setIsDisable(false);

--- a/app/src/utils/errorHandling.ts
+++ b/app/src/utils/errorHandling.ts
@@ -1,0 +1,20 @@
+/*
+  Utility function to generate a custom error message for our app based on the status code
+  and also where this function is being called from (ie; what action is being performed)
+*/
+export function getErrorMessages(errorCode: number, action: string): string {
+  let errorMessage = 'There has been an error. Please try again.';
+
+  if (action === 'formSync') {
+    switch(errorCode) {
+      case 400:
+        errorMessage = 'There seems to be an issue with your form, please check your form for errors and try again.'
+        break;
+      case 500:
+        errorMessage = 'Our system experienced an issue. Please try again.'
+        break;
+    }
+  }
+
+  return errorMessage;
+}


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Adding custom error and success message popups for sync activity failing and working cases
- #239 
- #246 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Locally, tested functionality

## Screenshots

<img width="1247" alt="formerrror" src="https://user-images.githubusercontent.com/28017034/101957758-e3fc9500-3bb6-11eb-94cb-6541310b25f7.png">
