### PR TITLE
194: Add network plugin support

### DIFF
--- a/api/src/paths/activity/{activityId}.ts
+++ b/api/src/paths/activity/{activityId}.ts
@@ -124,7 +124,7 @@ function getMedia(): RequestHandler {
 
     const result: IMediaItem[] = response.map((s3Object: GetObjectOutput) => {
       // Encode image buffer as base64
-      const contentString = Buffer.from(s3Object.Body).toString('base64');
+      const contentString = Buffer.from(s3Object.Body as Buffer).toString('base64');
 
       // Append DATA Url string
       const encodedFile = `data:${s3Object.ContentType};base64,${contentString}`;

--- a/api/src/paths/media.ts
+++ b/api/src/paths/media.ts
@@ -79,7 +79,7 @@ function getMedia(): RequestHandler {
 
     const mediaItems: IMediaItem[] = response.map((s3Object: GetObjectOutput) => {
       // Encode image buffer as base64
-      const contentString = Buffer.from(s3Object.Body).toString('base64');
+      const contentString = Buffer.from(s3Object.Body as Buffer).toString('base64');
 
       // Append DATA Url string
       const encodedFile = `data:${s3Object.ContentType};base64,${contentString}`;
@@ -109,7 +109,7 @@ function getMedia(): RequestHandler {
  */
 export function uploadMedia(): RequestHandler {
   return async (req, res, next) => {
-    defaultLog.debug({ label: "uploadMedia", message: 'uploadMedia', body: req.body });
+    defaultLog.debug({ label: 'uploadMedia', message: 'uploadMedia', body: req.body });
 
     if (!req.body.media || !req.body.media.length) {
       // no media objects included, skipping media upload step
@@ -149,7 +149,7 @@ export function uploadMedia(): RequestHandler {
 
     const results = await Promise.all(s3UploadPromises);
 
-    req['mediaKeys'] = results.map(result => result.Key);
+    req['mediaKeys'] = results.map((result) => result.Key);
 
     next();
   };

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,84 +1,73 @@
 import { DeviceInfo } from '@capacitor/core';
 import { IonReactRouter } from '@ionic/react-router';
-import { CircularProgress, makeStyles, ThemeProvider } from '@material-ui/core';
+import { Box, CircularProgress, ThemeProvider } from '@material-ui/core';
 // Strange looking `type {}` import below, see: https://github.com/microsoft/TypeScript/issues/36812
 import type {} from '@material-ui/lab/themeAugmentation'; // this allows `@material-ui/lab` components to be themed
 import { DatabaseChangesContextProvider } from 'contexts/DatabaseChangesContext';
+import { DatabaseContext, DatabaseContextProvider, IDatabaseContext } from 'contexts/DatabaseContext';
+import { NetworkContextProvider } from 'contexts/NetworkContext';
 import Keycloak, { KeycloakConfig, KeycloakInstance } from 'keycloak-js';
 import React from 'react';
 import appTheme from 'themes/appTheme';
 import AppRouter from './AppRouter';
-import { DatabaseContext, DatabaseContextProvider, IDatabaseContext } from './contexts/DatabaseContext';
-
-const useStyles = makeStyles(() => ({
-  root: {
-    height: '100vh',
-    width: '100vw',
-    display: 'flex',
-    overflow: 'hidden'
-  }
-}));
 
 interface IAppProps {
   deviceInfo: DeviceInfo;
 }
 
 const App: React.FC<IAppProps> = (props) => {
-  const classes = useStyles();
-
-  const keycloakConfig: KeycloakConfig = {
+  const keycloakInstanceConfig: KeycloakConfig = {
     realm: 'dfmlcg7z',
     url: 'https://dev.oidc.gov.bc.ca/auth/',
     clientId: 'invasives-bc'
   };
 
   //@ts-ignore
-  const keycloak: KeycloakInstance = new Keycloak(keycloakConfig);
+  const keycloak: KeycloakInstance = new Keycloak(keycloakInstanceConfig);
 
-  let initConfig = null;
+  let keycloakConfig = null;
 
   if (window['cordova']) {
-    initConfig = {
-      ...initConfig,
-      ...{
-        flow: 'hybrid',
-        redirectUri: 'http://127.0.0.1',
-        checkLoginIframe: false,
-        onLoad: 'login-required'
-      }
+    keycloakConfig = {
+      flow: 'hybrid',
+      redirectUri: 'http://127.0.0.1',
+      checkLoginIframe: false,
+      onLoad: 'login-required'
     };
   } else {
-    initConfig = { onLoad: 'login-required', checkLoginIframe: false };
+    keycloakConfig = { onLoad: 'login-required', checkLoginIframe: false };
   }
 
   const appRouterProps = {
     deviceInfo: props.deviceInfo,
     keycloak,
-    initConfig
+    keycloakConfig
   };
 
   return (
-    <div className={classes.root}>
+    <Box height="100vh" width="100vw" display="flex" overflow="hidden">
       <ThemeProvider theme={appTheme}>
         <IonReactRouter>
-          <DatabaseContextProvider>
-            <DatabaseContext.Consumer>
-              {(databaseContext: IDatabaseContext) => {
-                if (!databaseContext.database) {
-                  // database not ready, delay loading app
-                  return <CircularProgress />;
-                }
-                return (
-                  <DatabaseChangesContextProvider>
-                    <AppRouter { ...appRouterProps } />
-                  </DatabaseChangesContextProvider>
-                );
-              }}
-            </DatabaseContext.Consumer>
-          </DatabaseContextProvider>
+          <NetworkContextProvider>
+            <DatabaseContextProvider>
+              <DatabaseContext.Consumer>
+                {(databaseContext: IDatabaseContext) => {
+                  if (!databaseContext.database) {
+                    // database not ready, delay loading app
+                    return <CircularProgress />;
+                  }
+                  return (
+                    <DatabaseChangesContextProvider>
+                      <AppRouter {...appRouterProps} />
+                    </DatabaseChangesContextProvider>
+                  );
+                }}
+              </DatabaseContext.Consumer>
+            </DatabaseContextProvider>
+          </NetworkContextProvider>
         </IonReactRouter>
       </ThemeProvider>
-    </div>
+    </Box>
   );
 };
 

--- a/app/src/AppRouter.tsx
+++ b/app/src/AppRouter.tsx
@@ -1,47 +1,52 @@
+import { CircularProgress } from '@material-ui/core';
+import { NetworkContext } from 'contexts/NetworkContext';
 import HomeRouter from 'features/home/HomeRouter';
 import AuthLayout from 'layouts/AuthLayout';
 import PublicLayout from 'layouts/PublicLayout';
 import AccessDenied from 'pages/misc/AccessDenied';
 import { NotFoundPage } from 'pages/misc/NotFoundPage';
-import React from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Redirect, Switch } from 'react-router-dom';
 import AppRoute from 'utils/AppRoute';
 
 interface IAppRouterProps {
   deviceInfo: any;
   keycloak: any;
-  initConfig: any;
+  keycloakConfig: any;
 }
 
 const AppRouter: React.FC<IAppRouterProps> = (props) => {
-  const layout = props.deviceInfo ? PublicLayout : AuthLayout;
+  const networkContext = useContext(NetworkContext);
+
+  const [layout, setLayout] = useState<React.FC<any>>(null);
 
   const getTitle = (page: string) => {
     return `InvasivesBC - ${page}`;
   };
 
+  useEffect(() => {
+    // If on mobile and have no internet connection, then bypass keycloak
+    const layout = window['cordova'] && !networkContext?.connected ? PublicLayout : AuthLayout;
+
+    setLayout(() => layout);
+  }, [networkContext]);
+
+  if (!layout) {
+    return <CircularProgress />;
+  }
+
   return (
     <Switch>
       <Redirect exact from="/" to="/home" />
-      <AppRoute
-        path="/forbidden"
-        title={getTitle('Forbidden')}
-        component={AccessDenied}
-        layout={PublicLayout}
-      />
-      <AppRoute
-        path="/page-not-found"
-        title={getTitle('Page Not Found')}
-        component={NotFoundPage}
-        layout={PublicLayout}
-      />
+      <AppRoute path="/forbidden" title={getTitle('Forbidden')} component={AccessDenied} layout={PublicLayout} />
+      <AppRoute path="/page-not-found" title={getTitle('Not Found')} component={NotFoundPage} layout={PublicLayout} />
       <AppRoute
         path="/home"
+        title={getTitle('Home')}
         component={HomeRouter}
         layout={layout}
-        title={getTitle('Home')}
         keycloak={props.keycloak}
-        initConfig={props.initConfig}
+        keycloakConfig={props.keycloakConfig}
       />
       <AppRoute title="*" path="*" component={() => <Redirect to="/page-not-found" />} />
     </Switch>

--- a/app/src/components/activities-list/ActivitiesList.tsx
+++ b/app/src/components/activities-list/ActivitiesList.tsx
@@ -35,6 +35,7 @@ import 'styles/spinners.scss';
 import { notifyError, notifySuccess, notifyWarning } from 'utils/NotificationUtils';
 import ActivityListDate from './ActivityListDate';
 import { v4 as uuidv4 } from 'uuid';
+import NetworkStatusComponent from 'components/network/NetworkStatusComponent';
 
 const useStyles = makeStyles((theme: Theme) => ({
   activitiesContent: {},
@@ -71,11 +72,6 @@ const useStyles = makeStyles((theme: Theme) => ({
       display: 'inline',
       marginRight: '1rem'
     }
-  },
-  actionsBar: {
-    display: 'flex',
-    flexDirection: 'row-reverse',
-    marginBottom: '2rem'
   }
 }));
 
@@ -253,9 +249,11 @@ const ActivitiesList: React.FC = (props) => {
           activity_type: activity.activityType,
           activity_subtype: activity.activitySubtype,
           geometry: activity.geometry,
-          media: activity.photos && activity.photos.map((photo) => {
-            return { file_name: photo.filepath, encoded_file: photo.dataUrl };
-          }),
+          media:
+            activity.photos &&
+            activity.photos.map((photo) => {
+              return { file_name: photo.filepath, encoded_file: photo.dataUrl };
+            }),
           form_data: activity.formData
         });
 
@@ -303,8 +301,8 @@ const ActivitiesList: React.FC = (props) => {
 
   return (
     <>
-      <div>
-        <div className={classes.actionsBar}>
+      <Box>
+        <Box mb={3} display="flex" flexDirection="row-reverse">
           <Button
             disabled={isDisabled}
             variant="contained"
@@ -313,13 +311,13 @@ const ActivitiesList: React.FC = (props) => {
             onClick={() => syncActivities()}>
             Sync Activities
           </Button>
-        </div>
-        <div className={classes.activitiesContent}>
-          <div>
-            <div>
+        </Box>
+        <Box className={classes.activitiesContent}>
+          <Box>
+            <Box>
               <Typography variant="h5">Observations</Typography>
-            </div>
-            <div className={classes.newActivityButtonsRow}>
+            </Box>
+            <Box className={classes.newActivityButtonsRow}>
               <Button
                 disabled={isDisabled}
                 variant="contained"
@@ -351,13 +349,13 @@ const ActivitiesList: React.FC = (props) => {
               </Button>
 
               <ActivityList isDisabled={isDisabled} activityType={ActivityType.Observation} />
-            </div>
-          </div>
-          <div>
-            <div>
+            </Box>
+          </Box>
+          <Box>
+            <Box>
               <Typography variant="h5">Treatments</Typography>
-            </div>
-            <div className={classes.newActivityButtonsRow}>
+            </Box>
+            <Box className={classes.newActivityButtonsRow}>
               <Button
                 disabled={isDisabled}
                 variant="contained"
@@ -418,13 +416,13 @@ const ActivitiesList: React.FC = (props) => {
               </Button>
 
               <ActivityList isDisabled={isDisabled} activityType={ActivityType.Treatment} />
-            </div>
-          </div>
-          <div>
-            <div>
+            </Box>
+          </Box>
+          <Box>
+            <Box>
               <Typography variant="h5">Monitorings</Typography>
-            </div>
-            <div className={classes.newActivityButtonsRow}>
+            </Box>
+            <Box className={classes.newActivityButtonsRow}>
               <Button
                 disabled={isDisabled}
                 variant="contained"
@@ -482,13 +480,13 @@ const ActivitiesList: React.FC = (props) => {
               </Button>
 
               <ActivityList isDisabled={isDisabled} activityType={ActivityType.Monitoring} />
-            </div>
-          </div>
-          <div>
-            <div>
+            </Box>
+          </Box>
+          <Box>
+            <Box>
               <Typography variant="h5">Development/Testing</Typography>
-            </div>
-            <div className={classes.newActivityButtonsRow}>
+            </Box>
+            <Box className={classes.newActivityButtonsRow}>
               <Button
                 disabled={isDisabled}
                 variant="contained"
@@ -510,10 +508,10 @@ const ActivitiesList: React.FC = (props) => {
                 onClick={() => notifyWarning(databaseContext, 'A Warning message!')}>
                 Simulate Warning
               </Button>
-            </div>
-          </div>
-        </div>
-      </div>
+            </Box>
+          </Box>
+        </Box>
+      </Box>
     </>
   );
 };

--- a/app/src/components/network/NetworkStatusComponent.tsx
+++ b/app/src/components/network/NetworkStatusComponent.tsx
@@ -1,0 +1,34 @@
+import { Box, Typography } from '@material-ui/core';
+import { NetworkContext } from 'contexts/NetworkContext';
+import React, { useContext, useEffect, useState } from 'react';
+
+interface INetworkStatusComponentProps {
+  classes?: any;
+}
+
+const NetworkStatusComponent: React.FC<INetworkStatusComponentProps> = (props) => {
+  const networkContext = useContext(NetworkContext);
+
+  const defaultConnectionStatusString = (!window['cordova'] && 'Online') || '';
+
+  const [networkStatusString, setNetworkStatusString] = useState(defaultConnectionStatusString);
+
+  useEffect(() => {
+    if (!networkContext) {
+      return;
+    }
+
+    const connectionStatus = (networkContext.connected && 'Online') || 'Offline';
+    const connectionStatusString = `${connectionStatus} (type: ${networkContext.connectionType})`;
+
+    setNetworkStatusString(connectionStatusString);
+  }, [networkContext]);
+
+  return (
+    <Box p={1}>
+      <Typography variant="h5">Network Status: {networkStatusString}</Typography>
+    </Box>
+  );
+};
+
+export default NetworkStatusComponent;

--- a/app/src/components/tabs/TabsContainer.tsx
+++ b/app/src/components/tabs/TabsContainer.tsx
@@ -3,18 +3,11 @@ import { Assignment, Bookmarks, Explore, HomeWork, Map, Search } from '@material
 import React, { useCallback, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 
-function a11yProps(index: any) {
-  return {
-    id: `home-tab-${index}`,
-    'aria-controls': `home-tabpanel-${index}`
-  };
-}
-
-interface IBaseProps {
+interface ITabsContainerProps {
   classes?: any;
 }
 
-const TabsContainer: React.FC<IBaseProps> = (props) => {
+const TabsContainer: React.FC<ITabsContainerProps> = (props) => {
   const history = useHistory();
 
   const urlContainsPath = (path: string): string => {
@@ -55,33 +48,16 @@ const TabsContainer: React.FC<IBaseProps> = (props) => {
   }, [history.location.pathname, getActiveTab]);
 
   return (
-    <div className={props.classes.tabBar}>
-      <AppBar position="static">
-        <Tabs value={activeTab} onChange={handleChange} variant="scrollable" scrollButtons="on">
-          <Tab label="Search" icon={<Search />} onClick={() => history.push('/home/search')} {...a11yProps(1)} />
-          <Tab label="Plan My Trip" icon={<Explore />} onClick={() => history.push('/home/plan')} {...a11yProps(1)} />
-          <Tab
-            label="References"
-            icon={<Bookmarks />}
-            onClick={() => history.push('/home/references')}
-            {...a11yProps(2)}
-          />
-          <Tab
-            label="My Activities"
-            icon={<HomeWork />}
-            onClick={() => history.push('/home/activities')}
-            {...a11yProps(3)}
-          />
-          <Tab label="Map" icon={<Map />} onClick={() => history.push('/home/map')} {...a11yProps(4)} />
-          <Tab
-            label="Current Activity"
-            icon={<Assignment />}
-            onClick={() => history.push('/home/activity')}
-            {...a11yProps(5)}
-          />
-        </Tabs>
-      </AppBar>
-    </div>
+    <AppBar position="static">
+      <Tabs value={activeTab} onChange={handleChange} variant="scrollable" scrollButtons="on">
+        <Tab label="Search" icon={<Search />} onClick={() => history.push('/home/search')} />
+        <Tab label="Plan My Trip" icon={<Explore />} onClick={() => history.push('/home/plan')} />
+        <Tab label="References" icon={<Bookmarks />} onClick={() => history.push('/home/references')} />
+        <Tab label="My Activities" icon={<HomeWork />} onClick={() => history.push('/home/activities')} />
+        <Tab label="Map" icon={<Map />} onClick={() => history.push('/home/map')} />
+        <Tab label="Current Activity" icon={<Assignment />} onClick={() => history.push('/home/activity')} />
+      </Tabs>
+    </AppBar>
   );
 };
 

--- a/app/src/contexts/DatabaseChangesContext.tsx
+++ b/app/src/contexts/DatabaseChangesContext.tsx
@@ -17,7 +17,7 @@ export const DatabaseChangesContextProvider: React.FC = (props) => {
   const [databaseChanges, setDatabaseChanges] = useState<IDatabaseChanges>(null);
   const [changesListener, setChangesListener] = useState<PouchDB.Core.Changes<any>>(null);
 
-  const setupDatabase = async () => {
+  const setupDatabaseChanges = async () => {
     if (!changesListener || changesListener['isCancelled']) {
       const listener = databaseContext.database
         .changes({ live: true, since: 'now' })
@@ -31,18 +31,17 @@ export const DatabaseChangesContextProvider: React.FC = (props) => {
     }
   };
 
-  const cleanupDatabase = () => {
+  const cleanupDatabaseChanges = () => {
     if (changesListener) {
       changesListener.cancel();
     }
   };
 
-  // TODO Update [] dependencies to properly run cleanup (if keycloak expires?)
   useEffect(() => {
-    setupDatabase();
+    setupDatabaseChanges();
 
     return () => {
-      cleanupDatabase();
+      cleanupDatabaseChanges();
     };
   }, [databaseContext]);
 

--- a/app/src/contexts/NetworkContext.tsx
+++ b/app/src/contexts/NetworkContext.tsx
@@ -1,0 +1,29 @@
+import { Network, NetworkStatus } from '@capacitor/core';
+import React, { useEffect, useState } from 'react';
+
+export const NetworkContext = React.createContext<NetworkStatus>(null);
+
+/**
+ * Provides access to the database and to related functions to manipulate the database instance.
+ *
+ * @param {*} props
+ */
+export const NetworkContextProvider: React.FC = (props) => {
+  const [networkContext, setNetworkContext] = useState<NetworkStatus>(null);
+
+  useEffect(() => {
+    // Remove old listeners, if any
+    Network.removeAllListeners();
+
+    // Add new listener
+    Network.addListener('networkStatusChange', (status) => {
+      setNetworkContext(status);
+    });
+
+    return () => {
+      Network.removeAllListeners();
+    };
+  }, [Network]);
+
+  return <NetworkContext.Provider value={networkContext}>{props.children}</NetworkContext.Provider>;
+};

--- a/app/src/features/home/HomeLayout.tsx
+++ b/app/src/features/home/HomeLayout.tsx
@@ -1,34 +1,15 @@
-import { Collapse, IconButton, makeStyles, Theme } from '@material-ui/core';
-import CloseIcon from '@material-ui/icons/Close';
-import { Alert } from '@material-ui/lab';
-import TabsContainer from 'components/tabs/TabsContainer';
-import { DatabaseContext } from 'contexts/DatabaseContext';
-import React, { useContext, useEffect, useState } from 'react';
-import MarkunreadMailboxIcon from '@material-ui/icons/MarkunreadMailbox';
+import { Box, Collapse, IconButton } from '@material-ui/core';
 import Badge from '@material-ui/core/Badge';
+import { Close, MarkunreadMailbox } from '@material-ui/icons';
+import { Alert } from '@material-ui/lab';
+import NetworkStatusComponent from 'components/network/NetworkStatusComponent';
+import TabsContainer from 'components/tabs/TabsContainer';
 import { DocType } from 'constants/database';
 import { DatabaseChangesContext } from 'contexts/DatabaseChangesContext';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  homeLayoutRoot: {
-    width: 'inherit',
-    height: '100%',
-    display: 'flex',
-    flex: '1',
-    flexDirection: 'column'
-  },
-  tabsContainer: {
-    flexGrow: 1,
-    width: '100%'
-  },
-  homeContainer: {
-    flex: '1',
-    overflow: 'auto'
-  }
-}));
+import { DatabaseContext } from 'contexts/DatabaseContext';
+import React, { useContext, useEffect, useState } from 'react';
 
 const HomeLayout = (props: any) => {
-  const classes = useStyles();
   const databaseContext = useContext(DatabaseContext);
   const databaseChangesContext = useContext(DatabaseChangesContext);
 
@@ -88,8 +69,8 @@ const HomeLayout = (props: any) => {
   };
 
   return (
-    <div className={classes.homeLayoutRoot}>
-      <TabsContainer classes={classes.tabsContainer} />
+    <Box width="inherit" height="100%" display="flex" flex="1" flexDirection="column">
+      <TabsContainer />
       <Collapse timeout={50} in={isOpen}>
         <Alert
           // severity can't be null so this is a workaround
@@ -103,16 +84,28 @@ const HomeLayout = (props: any) => {
                 acknowledgeNotification(notification._id);
               }}>
               <Badge badgeContent={notificationCount}>
-                <MarkunreadMailboxIcon></MarkunreadMailboxIcon>
+                <MarkunreadMailbox />
               </Badge>
-              <CloseIcon fontSize="inherit" />
+              <Close fontSize="inherit" />
             </IconButton>
           }>
           <strong>{notification == null ? null : notification.text}</strong>
         </Alert>
       </Collapse>
-      <div className={classes.homeContainer}>{props.children}</div>
-    </div>
+      <Box mb="43px" display="flex" overflow="auto">
+        {props.children}
+      </Box>
+      <Box
+        height="43px"
+        position="absolute"
+        bottom="0"
+        left="0"
+        right="0"
+        bgcolor="primary.main"
+        color="primary.contrastText">
+        <NetworkStatusComponent />
+      </Box>
+    </Box>
   );
 };
 

--- a/app/src/features/home/HomeRouter.tsx
+++ b/app/src/features/home/HomeRouter.tsx
@@ -17,27 +17,48 @@ interface IHomeRouterProps {
 }
 
 const HomeRouter: React.FC<IHomeRouterProps> = (props) => {
+  const getTitle = (page: string) => {
+    return `InvasivesBC - ${page}`;
+  };
+
   return (
     <Switch>
       <Redirect exact from="/home" to="/home/activities" />
-      <PrivateRoute exact layout={HomeLayout} path="/home/search" component={SearchPage} componentProps={props} />
+      <PrivateRoute
+        exact
+        layout={HomeLayout}
+        path="/home/search"
+        title={getTitle('Search')}
+        component={SearchPage}
+        componentProps={props}
+      />
       <PrivateRoute
         layout={HomeLayout}
         path="/home/search/activity/:id?"
+        title={getTitle('Edit')}
         component={SearchActivityPage}
         componentProps={props}
       />
-      <PrivateRoute exact layout={HomeLayout} path="/home/plan" component={PlanPage} componentProps={props} />
+      <PrivateRoute
+        exact
+        layout={HomeLayout}
+        path="/home/plan"
+        title={getTitle('Plan')}
+        component={PlanPage}
+        componentProps={props}
+      />
       <PrivateRoute
         exact
         layout={HomeLayout}
         path="/home/references"
+        title={getTitle('Reference')}
         component={ReferencesPage}
         componentProps={props}
       />
       <PrivateRoute
         layout={HomeLayout}
         path="/home/references/activity/:id?"
+        title={getTitle('Activity')}
         component={ReferencesActivityPage}
         componentProps={props}
       />
@@ -45,11 +66,26 @@ const HomeRouter: React.FC<IHomeRouterProps> = (props) => {
         exact
         layout={HomeLayout}
         path="/home/activities"
+        title={getTitle('Activities')}
         component={ActivitiesPage}
         componentProps={props}
       />
-      <PrivateRoute exact layout={HomeLayout} path="/home/map" component={MapPage} componentProps={props} />
-      <PrivateRoute exact layout={HomeLayout} path="/home/activity" component={ActivityPage} componentProps={props} />
+      <PrivateRoute
+        exact
+        layout={HomeLayout}
+        path="/home/map"
+        title={getTitle('Map')}
+        component={MapPage}
+        componentProps={props}
+      />
+      <PrivateRoute
+        exact
+        layout={HomeLayout}
+        path="/home/activity"
+        title={getTitle('Activity')}
+        component={ActivityPage}
+        componentProps={props}
+      />
       {/*  Catch any unknown routes, and re-direct to the not found page */}
       <AppRoute title="*" path="/home/*" component={() => <Redirect to="/page-not-found" />} />
     </Switch>

--- a/app/src/layouts/AuthLayout.tsx
+++ b/app/src/layouts/AuthLayout.tsx
@@ -7,21 +7,21 @@ import getKeycloakEventHandler from '../utils/KeycloakEventHandler';
 
 interface IAuthLayoutProps {
   keycloak: any;
-  initConfig: any;
+  keycloakConfig: any;
 }
 
 const AuthLayout: React.FC<IAuthLayoutProps> = (props) => {
   return (
     <KeycloakProvider
       keycloak={props.keycloak}
-      initConfig={props.initConfig}
+      initConfig={props.keycloakConfig}
       LoadingComponent={<CircularProgress />}
       onEvent={getKeycloakEventHandler(props.keycloak)}>
       <AuthStateContextProvider>
         <AuthStateContext.Consumer>
           {(context) => {
             if (!context.ready) {
-              return <CircularProgress></CircularProgress>;
+              return <CircularProgress />;
             }
 
             return <PublicLayout>{props.children}</PublicLayout>;

--- a/app/src/layouts/PublicLayout.tsx
+++ b/app/src/layouts/PublicLayout.tsx
@@ -1,17 +1,7 @@
-import {
-  CssBaseline,
-  makeStyles,
-  Theme
-} from '@material-ui/core';
+import { Box, CssBaseline, makeStyles, Theme } from '@material-ui/core';
 import React from 'react';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  publicLayoutRoot: {
-    height: 'inherit',
-    width: 'inherit',
-    display: 'flex',
-    flexDirection: 'column'
-  },
   mainContent: {
     flex: 1,
     width: 'inherit',
@@ -28,16 +18,14 @@ const PublicLayout: React.FC = (props) => {
   const classes = useStyles();
 
   return (
-    <div className={classes.publicLayoutRoot}>
+    <Box mb={2} height="inherit" width="inherit" display="flex" flexDirection="column">
       <CssBaseline />
       <main className={classes.mainContent}>
-        {/* <ErrorBoundary FallbackComponent={ErrorDialog}> */}
         {React.Children.map(props.children, (child: any) => {
           return React.cloneElement(child, { classes: classes });
         })}
-        {/* </ErrorBoundary> */}
       </main>
-    </div>
+    </Box>
   );
 };
 

--- a/app/src/themes/appTheme.ts
+++ b/app/src/themes/appTheme.ts
@@ -53,7 +53,8 @@ const appTheme = createMuiTheme({
     MuiContainer: {
       // https://material-ui.com/api/container/
       root: {
-        maxWidth: 'xl'
+        maxWidth: 'xl',
+        margin: 'auto'
       }
     }
   }

--- a/app/src/utils/AppRoute.tsx
+++ b/app/src/utils/AppRoute.tsx
@@ -6,7 +6,7 @@ export type IAppRouteProps = RouteProps & {
   layout?: React.ComponentType<any>;
   title: string;
   keycloak?: any;
-  initConfig?: any;
+  keycloakConfig?: any;
 };
 
 const AppRoute: React.FC<IAppRouteProps> = ({
@@ -14,23 +14,18 @@ const AppRoute: React.FC<IAppRouteProps> = ({
   layout,
   title,
   keycloak,
-  initConfig,
+  keycloakConfig,
   ...rest
 }) => {
   const Layout = layout === undefined ? (props: any) => <>{props.children}</> : layout;
 
   document.title = title;
 
-  const layoutProps = {
-    keycloak,
-    initConfig
-  };
-
   return (
     <Route
       {...rest}
       render={(props) => (
-        <Layout { ...layoutProps } >
+        <Layout keycloak={keycloak} keycloakConfig={keycloakConfig}>
           <Component {...props} />
         </Layout>
       )}

--- a/app/src/utils/PrivateRoute.tsx
+++ b/app/src/utils/PrivateRoute.tsx
@@ -4,6 +4,7 @@ import { Route, RouteProps } from 'react-router-dom';
 interface IPrivateRouteProps extends RouteProps {
   component: React.ComponentType<any>;
   layout: React.ComponentType<any>;
+  title: string;
   componentProps?: any;
 }
 
@@ -13,6 +14,8 @@ interface IPrivateRouteProps extends RouteProps {
  */
 const PrivateRoute: React.FC<IPrivateRouteProps> = (props) => {
   let { component: Component, layout: Layout, ...rest } = props;
+
+  document.title = props.title;
 
   return (
     <Route


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- New context that provides network information
- Added a footer bar to display network information
  - This isn't necessarily the only place to show it, but is working first pass.
- Added titles to the tabs (they show up in the browser tab)
- Updated some `div` to `Box`, in keeping with material-ui style.
  - Moved some css from useStyles into the inline settings of the Box component
- Updated `initConfig` to `keycloakConfig` just for readability
- Misc updates/tweaks

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Locally.  The main change is the addition of the network context which works (and is simple).  
More testing will be needed to ensure the larger goal of moving between offline/online and syncing and keycloak tokens is working.  Possibly some discussions around how best to manage those states (online vs offline), and what considerations there are around the user workflow.

## Screenshots

![image](https://user-images.githubusercontent.com/903781/101963498-bd912680-3bc3-11eb-9e95-80de5ceb7c71.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
~~[ ] I have made corresponding changes to the documentation~~
~~[ ] New and existing unit tests pass locally with my changes~~
