### PR TITLE
🔀 261: Sort plant and animal activities to list plant followed by animal

### DIFF
--- a/app/src/components/activities-list/ActivitiesList.tsx
+++ b/app/src/components/activities-list/ActivitiesList.tsx
@@ -181,10 +181,29 @@ const ActivityList: React.FC<IActivityList> = (props) => {
     history.push(`/home/activity`);
   };
 
+  /*
+    Sort activities to show plant activities before animal
+  */
+  const sortActivitiesBySubtype = (activities: any[]): any[] => {
+    const sortedActivities = [];
+
+    activities.forEach((activity: any) => {
+      if (activity.activitySubtype.includes('Plant')) {
+        sortedActivities.unshift(activity);
+      } else {
+        sortedActivities.push(activity);
+      }
+    });
+
+    return sortedActivities;
+  };
+
   return (
     <List className={classes.activityList}>
-      {docs.map((doc) => {
+      {sortActivitiesBySubtype(docs).map((doc) => {
         const isDisabled = props.isDisabled || doc.sync.status === ActivitySyncStatus.SYNC_SUCCESSFUL;
+
+        console.log(doc);
 
         return (
           <Paper key={doc._id}>

--- a/app/src/components/activities-list/ActivitiesList.tsx
+++ b/app/src/components/activities-list/ActivitiesList.tsx
@@ -203,8 +203,6 @@ const ActivityList: React.FC<IActivityList> = (props) => {
       {sortActivitiesBySubtype(docs).map((doc) => {
         const isDisabled = props.isDisabled || doc.sync.status === ActivitySyncStatus.SYNC_SUCCESSFUL;
 
-        console.log(doc);
-
         return (
           <Paper key={doc._id}>
             <ListItem


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Sort plant and animal activities to list plant followed by animal
- #261 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Locally, create new activities and the order is preserved

## Screenshots

<img width="974" alt="Screenshot 2020-12-14 112556" src="https://user-images.githubusercontent.com/28017034/102125866-26b0ae00-3dff-11eb-8725-5c510a9b807f.png">
