### PR TITLE
🗺️ Fix height issue with box, map container not showing

### DIFF
--- a/app/src/features/home/map/MapPage.tsx
+++ b/app/src/features/home/map/MapPage.tsx
@@ -1,4 +1,4 @@
-import { Button, CircularProgress, Container, Grid, makeStyles, Theme } from '@material-ui/core';
+import { Button, CircularProgress, Container, Grid, makeStyles, Theme, Box } from '@material-ui/core';
 import clsx from 'clsx';
 import { IPhoto } from 'components/photo/PhotoContainer';
 import { interactiveGeoInputData } from 'components/map/GeoMeta';
@@ -363,7 +363,7 @@ const MapPage: React.FC<IMapProps> = (props) => {
   };
 
   return (
-    <>
+    <Box height="100vh" width="100vw" display="flex" overflow="hidden"> 
       <Grid className={classes.mainGrid} container>
         <Grid className={showPopOut ? classes.mapGridItemShrunk : classes.mapGridItemExpanded} item>
           <Container className={clsx(classes.mapContainer)} maxWidth={false} disableGutters={true}>
@@ -404,7 +404,7 @@ const MapPage: React.FC<IMapProps> = (props) => {
         contextMenuState={{ state: contextMenuState, setContextMenuState }}
         handleClose={handleContextMenuClose}
       />
-    </>
+    </Box>
   );
 };
 


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Fix height issue with box, map container not showing
- When root styles were removed from `App.tsx` seems to no longer be setting height properly so mapcontainer was not displaying as expected

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Locally, map container now renders correctly

## Screenshots

<img width="1244" alt="mappp" src="https://user-images.githubusercontent.com/28017034/102147442-9a62b300-3e1f-11eb-908d-e2d84f075444.png">
