### PR TITLE
271: Autopopulate/Prefill logic required on search activity page

### DIFF
--- a/app/src/components/form/FormContainer.tsx
+++ b/app/src/components/form/FormContainer.tsx
@@ -69,8 +69,8 @@ const FormContainer: React.FC<IFormContainerProps> = (props) => {
         <FormControlsComponent
           onSubmit={() => formRef.submit()}
           isDisabled={isDisabled}
-          onCopy={() => props.copyFormData()}
-          onPaste={() => props.pasteFormData()}
+          onCopy={props.copyFormData ? () => props.copyFormData() : null}
+          onPaste={props.pasteFormData ? () => props.pasteFormData() : null}
           activitySubtype={props.activity.activitySubtype}
         />
       </Box>

--- a/app/src/components/form/FormControlsComponent.tsx
+++ b/app/src/components/form/FormControlsComponent.tsx
@@ -1,6 +1,5 @@
 import { Button, Grid } from '@material-ui/core';
 import React from 'react';
-import { createNamedExports } from 'typescript';
 
 export interface IFormControlsComponentProps {
   classes?: any;

--- a/app/src/components/form/FormControlsComponent.tsx
+++ b/app/src/components/form/FormControlsComponent.tsx
@@ -1,5 +1,6 @@
 import { Button, Grid } from '@material-ui/core';
 import React from 'react';
+import { createNamedExports } from 'typescript';
 
 export interface IFormControlsComponentProps {
   classes?: any;
@@ -32,37 +33,30 @@ const FormControlsComponent: React.FC<IFormControlsComponentProps> = (props) => 
               Check Form For Errors
             </Button>
           </Grid>
-          <Grid item>
-            <Button
-              disabled={isDisabled}
-              variant="contained"
-              color="primary"
-              onClick={() => {
-                if (!props.onCopy) {
-                  return;
-                }
-
-                props.onCopy();
-              }}>
-              Copy Form Data
-            </Button>
-          </Grid>
+          {props.onCopy && (
+            <Grid item>
+              <Button
+                disabled={isDisabled}
+                variant="contained"
+                color="primary"
+                onClick={() => props.onCopy()}
+              >
+                Copy Form Data
+              </Button>
+            </Grid>
+          )}
           {
             sessionStorage.getItem('copiedFormData') &&
             sessionStorage.getItem('activitySubtype') === props.activitySubtype &&
+            props.onPaste &&
             (
               <Grid item>
                 <Button
                   disabled={isDisabled}
                   variant="contained"
                   color="primary"
-                  onClick={() => {
-                    if (!props.onPaste) {
-                      return;
-                    }
-
-                    props.onPaste();
-                  }}>
+                  onClick={() => props.onPaste()}
+                >
                   Paste Form Data
                 </Button>
               </Grid>

--- a/app/src/features/home/activity/ActivityPage.tsx
+++ b/app/src/features/home/activity/ActivityPage.tsx
@@ -7,13 +7,13 @@ import { DatabaseContext } from 'contexts/DatabaseContext';
 import { Feature } from 'geojson';
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import moment from 'moment';
-import * as turf from '@turf/turf';
 import { debounced } from 'utils/FunctionUtils';
 import { MapContextMenuData } from '../map/MapContextMenu';
 import { getCustomValidator, getAreaValidator, getWindValidator } from 'rjsf/business-rules/customValidation';
 import { populateHerbicideRates } from 'rjsf/business-rules/populateCalculatedFields';
 import { notifySuccess } from 'utils/NotificationUtils';
 import { retrieveFormDataFromSession, saveFormDataToSession } from 'utils/saveRetrieveFormData';
+import { calculateLatLng, calculateGeometryArea } from 'utils/geometryHelpers';
 
 const useStyles = makeStyles((theme) => ({
   heading: {
@@ -59,65 +59,6 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
   const docId = doc && doc._id;
 
   const [photos, setPhotos] = useState<IPhoto[]>([]);
-
-  /**
-   * Calculate the net area for the total geometry
-   * 
-   * @param {Feature[]} geoJSON The geometry in GeoJSON format
-   */
-  const calculateGeometryArea = (geometry: Feature[]) => {
-    let totalArea = 0;
-
-    if (!geometry || !geometry.length || geometry[0].geometry.type === "LineString") {
-      return parseFloat(totalArea.toFixed(0));
-    }
-
-    const geo = geometry[0];
-    if (geo.geometry.type === "Point" && geo.properties.hasOwnProperty('radius')) {
-      totalArea = (Math.PI * Math.pow(geo.properties.radius, 2));
-    } else if (geo.geometry.type === "Polygon") {
-      totalArea = turf.area(turf.polygon(geo.geometry['coordinates']));
-    }
-
-    return parseFloat(totalArea.toFixed(0));
-  };
-
-  /**
-   * Calculate the anchor point lat/lng for the geometry
-   * 
-   * @param {Feature[]} geoJSON The geometry in GeoJSON format
-   */
-  const calculateLatLng = (geom: Feature[]) => {
-    if (!geom[0] || !geom[0].geometry) return;
-
-    const geo = geom[0].geometry;
-    const firstCoord = geo['coordinates'][0];
-
-    let latitude = null;
-    let longitude = null;
-
-    if (geo.type === 'Point') {
-      latitude = geo.coordinates[1];
-      longitude = firstCoord;
-    } else if (geo.type === 'LineString') {
-      latitude = firstCoord[1];
-      longitude = firstCoord[0];
-    } else if (!geom[0].properties.isRectangle) {
-      latitude = firstCoord[0][1];
-      longitude = firstCoord[0][0];
-    } else {
-      const centerPoint = turf.center(turf.polygon(geo['coordinates'])).geometry;
-      latitude = centerPoint.coordinates[1];
-      longitude = centerPoint.coordinates[0];
-    }
-
-    const latlng = {
-      latitude: parseFloat(latitude.toFixed(6)),
-      longitude: parseFloat(longitude.toFixed(6))
-    }
-
-    return latlng;
-  };
 
   /**
    * Set the default form data values

--- a/app/src/features/home/search/SearchActivityPage.tsx
+++ b/app/src/features/home/search/SearchActivityPage.tsx
@@ -12,6 +12,7 @@ import { debounced } from 'utils/FunctionUtils';
 import { MapContextMenuData } from '../map/MapContextMenu';
 import { populateHerbicideRates } from 'rjsf/business-rules/populateCalculatedFields';
 import { calculateLatLng, calculateGeometryArea } from 'utils/geometryHelpers';
+import { getCustomValidator, getAreaValidator, getWindValidator } from 'rjsf/business-rules/customValidation';
 
 const useStyles = makeStyles((theme) => ({
   heading: {
@@ -228,6 +229,7 @@ const SearchActivityPage: React.FC<ISearchActivityPage> = (props) => {
       </Box>
 
       <ActivityComponent
+        customValidation={getCustomValidator([getAreaValidator(activity.activitySubtype), getWindValidator(activity.activitySubtype)])}
         classes={classes}
         activity={activity}
         onFormChange={onFormChange}

--- a/app/src/features/home/search/SearchActivityPage.tsx
+++ b/app/src/features/home/search/SearchActivityPage.tsx
@@ -10,6 +10,8 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { debounced } from 'utils/FunctionUtils';
 import { MapContextMenuData } from '../map/MapContextMenu';
+import { populateHerbicideRates } from 'rjsf/business-rules/populateCalculatedFields';
+import { calculateLatLng, calculateGeometryArea } from 'utils/geometryHelpers';
 
 const useStyles = makeStyles((theme) => ({
   heading: {
@@ -75,7 +77,22 @@ const SearchActivityPage: React.FC<ISearchActivityPage> = (props) => {
    * @param {Feature} geoJSON The geometry in GeoJSON format
    */
   const saveGeometry = async (geometry: Feature[]) => {
-    setActivity({ ...activity, geometry: geometry, status: ActivityStatus.EDITED, dateUpdated: new Date() });
+    const { latitude, longitude } = calculateLatLng(geometry) || {};
+
+    const formData = activity.formData;
+    const areaOfGeometry = calculateGeometryArea(geometry);
+
+    const updatedFormData = {
+      ...formData,
+      activity_data: {
+        ...formData.activity_data,
+        latitude,
+        longitude,
+        reported_area: areaOfGeometry
+      }
+    };
+
+    setActivity({ ...activity, geometry: geometry, status: ActivityStatus.EDITED, dateUpdated: new Date(), formData: updatedFormData });
   };
 
   /**
@@ -128,9 +145,15 @@ const SearchActivityPage: React.FC<ISearchActivityPage> = (props) => {
    */
   const onFormChange = useCallback(
     debounced(100, (event: any) => {
+      // populate herbicide application rate
+      const updatedActivitySubtypeData = populateHerbicideRates(
+        activity.formData.activity_subtype_data,
+        event.formData.activity_subtype_data
+      );
+
       return setActivity({
         ...activity,
-        formData: event.formData,
+        formData: { ...event.formData, activity_subtype_data: updatedActivitySubtypeData },
         status: ActivityStatus.EDITED,
         dateUpdated: new Date(),
         formStatus: FormValidationStatus.NOT_VALIDATED

--- a/app/src/utils/geometryHelpers.ts
+++ b/app/src/utils/geometryHelpers.ts
@@ -1,0 +1,61 @@
+import { Feature } from 'geojson';
+import * as turf from '@turf/turf';
+
+/**
+ * Calculate the net area for the total geometry
+ * 
+ * @param {Feature[]} geoJSON The geometry in GeoJSON format
+ */
+export function calculateGeometryArea(geometry: Feature[]) {
+  let totalArea = 0;
+
+  if (!geometry || !geometry.length || geometry[0].geometry.type === "LineString") {
+    return parseFloat(totalArea.toFixed(0));
+  }
+
+  const geo = geometry[0];
+  if (geo.geometry.type === "Point" && geo.properties.hasOwnProperty('radius')) {
+    totalArea = (Math.PI * Math.pow(geo.properties.radius, 2));
+  } else if (geo.geometry.type === "Polygon") {
+    totalArea = turf.area(turf.polygon(geo.geometry['coordinates']));
+  }
+
+  return parseFloat(totalArea.toFixed(0));
+};
+
+/**
+ * Calculate the anchor point lat/lng for the geometry
+ * 
+ * @param {Feature[]} geoJSON The geometry in GeoJSON format
+ */
+export function calculateLatLng(geom: Feature[]) {
+  if (!geom[0] || !geom[0].geometry) return;
+
+  const geo = geom[0].geometry;
+  const firstCoord = geo['coordinates'][0];
+
+  let latitude = null;
+  let longitude = null;
+
+  if (geo.type === 'Point') {
+    latitude = geo.coordinates[1];
+    longitude = firstCoord;
+  } else if (geo.type === 'LineString') {
+    latitude = firstCoord[1];
+    longitude = firstCoord[0];
+  } else if (!geom[0].properties.isRectangle) {
+    latitude = firstCoord[0][1];
+    longitude = firstCoord[0][0];
+  } else {
+    const centerPoint = turf.center(turf.polygon(geo['coordinates'])).geometry;
+    latitude = centerPoint.coordinates[1];
+    longitude = centerPoint.coordinates[0];
+  }
+
+  const latlng = {
+    latitude: parseFloat(latitude.toFixed(6)),
+    longitude: parseFloat(longitude.toFixed(6))
+  }
+
+  return latlng;
+};

--- a/app/src/utils/geometryHelpers.ts
+++ b/app/src/utils/geometryHelpers.ts
@@ -21,7 +21,7 @@ export function calculateGeometryArea(geometry: Feature[]) {
   }
 
   return parseFloat(totalArea.toFixed(0));
-};
+}
 
 /**
  * Calculate the anchor point lat/lng for the geometry
@@ -58,4 +58,4 @@ export function calculateLatLng(geom: Feature[]) {
   }
 
   return latlng;
-};
+}


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- add in ability to update saved geo and herbicide app rates on search activity page
- copy paste functionality has been disabled on search activity page for now (can be refactored to be added later if it is something that is needed)
- #271 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Locally