### PR TITLE
268: UI for Treatment data alongside Monitoring

### DIFF
--- a/api/src/openapi/api-doc.json
+++ b/api/src/openapi/api-doc.json
@@ -902,8 +902,7 @@
         "properties": {
           "activity_id": {
             "type": "string",
-            "title": "Observation Id",
-            "default": "N/A"
+            "title": "Observation Id"
           },
           "applicator1_first_name": {
             "type": "string",
@@ -964,8 +963,7 @@
         "properties": {
           "activity_id": {
             "type": "string",
-            "title": "Observation Id",
-            "default": "N/A"
+            "title": "Observation Id"
           },
           "applicator1_first_name": {
             "type": "string",

--- a/app/src/components/activity/ActivityComponent.tsx
+++ b/app/src/components/activity/ActivityComponent.tsx
@@ -1,9 +1,11 @@
 import { Accordion, AccordionDetails, AccordionSummary, Typography } from '@material-ui/core';
 import { ExpandMore } from '@material-ui/icons';
+import { DocType } from 'constants/database';
+import { DatabaseContext } from 'contexts/DatabaseContext';
 import FormContainer, { IFormContainerProps } from 'components/form/FormContainer';
 import MapContainer, { IMapContainerProps } from 'components/map/MapContainer';
 import PhotoContainer, { IPhotoContainerProps } from 'components/photo/PhotoContainer';
-import React from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 
 export interface IActivityComponentProps extends IMapContainerProps, IFormContainerProps, IPhotoContainerProps {
   classes?: any;
@@ -14,8 +16,56 @@ export interface IActivityComponentProps extends IMapContainerProps, IFormContai
 }
 
 const ActivityComponent: React.FC<IActivityComponentProps> = (props) => {
+  const databaseContext = useContext(DatabaseContext);
+  const [linkedActivityProps, setLinkedActivityProps] = useState(null);
+
+  useEffect(() => {
+    const getActivityData = async (databaseContext, activityId) => {
+      const appStateResults = await databaseContext.database.find({ selector: { _id: DocType.APPSTATE } });
+
+      if (!appStateResults || !appStateResults.docs || !appStateResults.docs.length) {
+        return;
+      }
+
+      const activityResults = await databaseContext.database.find({
+        selector: { _id: activityId }
+      });
+
+      setLinkedActivityProps({ ...props, activity: activityResults.docs[0], isDisabled: true });
+    };
+
+    if (props.activity.activityType === 'Monitoring') {
+      const { activity: { formData } } = props;
+      getActivityData(databaseContext, formData.activity_type_data.activity_id);
+    }
+  }, [databaseContext]);
+
   return (
     <>
+      {/* Display the linked activity record information alongside the actual activity record */}
+      {linkedActivityProps && (
+        <>
+          <Accordion>
+            <AccordionSummary expandIcon={<ExpandMore />} aria-controls="panel-form-content" id="panel-form-header">
+              <Typography className={linkedActivityProps.classes.heading}>Linked Activity Form</Typography>
+            </AccordionSummary>
+            <AccordionDetails className={linkedActivityProps.classes.formContainer}>
+              <FormContainer {...linkedActivityProps} />
+            </AccordionDetails>
+          </Accordion>
+          {linkedActivityProps.activity.photos.length > 0 && (
+            <Accordion>
+              <AccordionSummary expandIcon={<ExpandMore />} aria-controls="panel-photo-content" id="panel-photo-header">
+                <Typography className={linkedActivityProps.classes.heading}>Photos</Typography>
+              </AccordionSummary>
+              <AccordionDetails className={linkedActivityProps.classes.photoContainer}>
+                <PhotoContainer {...linkedActivityProps} />
+              </AccordionDetails>
+            </Accordion>
+          )}
+        </>
+      )}
+
       <Accordion defaultExpanded={true}>
         <AccordionSummary expandIcon={<ExpandMore />} aria-controls="panel-map-content" id="panel-map-header">
           <Typography className={props.classes.heading}>Map</Typography>
@@ -26,7 +76,7 @@ const ActivityComponent: React.FC<IActivityComponentProps> = (props) => {
       </Accordion>
       <Accordion>
         <AccordionSummary expandIcon={<ExpandMore />} aria-controls="panel-form-content" id="panel-form-header">
-          <Typography className={props.classes.heading}>Form</Typography>
+          <Typography className={props.classes.heading}>Activity Form</Typography>
         </AccordionSummary>
         <AccordionDetails className={props.classes.formContainer}>
           <FormContainer {...props} />

--- a/app/src/components/activity/ActivityComponent.tsx
+++ b/app/src/components/activity/ActivityComponent.tsx
@@ -20,7 +20,7 @@ const ActivityComponent: React.FC<IActivityComponentProps> = (props) => {
   const [linkedActivityProps, setLinkedActivityProps] = useState(null);
 
   useEffect(() => {
-    const getActivityData = async (databaseContext, activityId) => {
+    const getActivityData = async () => {
       const appStateResults = await databaseContext.database.find({ selector: { _id: DocType.APPSTATE } });
 
       if (!appStateResults || !appStateResults.docs || !appStateResults.docs.length) {
@@ -28,15 +28,14 @@ const ActivityComponent: React.FC<IActivityComponentProps> = (props) => {
       }
 
       const activityResults = await databaseContext.database.find({
-        selector: { _id: activityId }
+        selector: { _id: props.activity.formData.activity_type_data.activity_id }
       });
 
       setLinkedActivityProps({ ...props, activity: activityResults.docs[0], isDisabled: true });
     };
 
     if (props.activity.activityType === 'Monitoring') {
-      const { activity: { formData } } = props;
-      getActivityData(databaseContext, formData.activity_type_data.activity_id);
+      getActivityData();
     }
   }, [databaseContext]);
 

--- a/app/src/components/activity/ActivityComponent.tsx
+++ b/app/src/components/activity/ActivityComponent.tsx
@@ -37,7 +37,7 @@ const ActivityComponent: React.FC<IActivityComponentProps> = (props) => {
     if (props.activity.activityType === 'Monitoring') {
       getActivityData();
     }
-  }, [databaseContext]);
+  }, [databaseContext, props]);
 
   return (
     <>

--- a/app/src/components/activity/ActivityComponent.tsx
+++ b/app/src/components/activity/ActivityComponent.tsx
@@ -55,7 +55,7 @@ const ActivityComponent: React.FC<IActivityComponentProps> = (props) => {
           {linkedActivityProps.activity.photos.length > 0 && (
             <Accordion>
               <AccordionSummary expandIcon={<ExpandMore />} aria-controls="panel-photo-content" id="panel-photo-header">
-                <Typography className={linkedActivityProps.classes.heading}>Photos</Typography>
+                <Typography className={linkedActivityProps.classes.heading}>Linked Activity Photos</Typography>
               </AccordionSummary>
               <AccordionDetails className={linkedActivityProps.classes.photoContainer}>
                 <PhotoContainer {...linkedActivityProps} />
@@ -83,7 +83,7 @@ const ActivityComponent: React.FC<IActivityComponentProps> = (props) => {
       </Accordion>
       <Accordion>
         <AccordionSummary expandIcon={<ExpandMore />} aria-controls="panel-photo-content" id="panel-photo-header">
-          <Typography className={props.classes.heading}>Photos</Typography>
+          <Typography className={props.classes.heading}>Activity Photos</Typography>
         </AccordionSummary>
         <AccordionDetails className={props.classes.photoContainer}>
           <PhotoContainer {...props} />

--- a/app/src/components/photo/PhotoContainer.tsx
+++ b/app/src/components/photo/PhotoContainer.tsx
@@ -14,6 +14,7 @@ export interface IPhoto {
 export interface IPhotoContainerProps {
   classes?: any;
   photoState: { photos: IPhoto[]; setPhotos: (photo: IPhoto[]) => void };
+  isDisabled?: boolean;
 }
 
 const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
@@ -48,7 +49,6 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
     return <CircularProgress />;
   }
 
-  // Grid with overlays: https://material-ui.com/components/grid-list/
   return (
     <Box width={1}>
       <Box mb={3}>
@@ -58,33 +58,37 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
               <Grid item xs={12} sm={6} md={4} lg={3} key={index}>
                 <Card>
                   <CardMedia src={photo.dataUrl} component="img" />
-                  <CardActions>
-                    <IconButton onClick={() => deletePhoto(photo.filepath)}>
-                      <DeleteForever />
-                    </IconButton>
-                  </CardActions>
+                  {!props.isDisabled && (
+                    <CardActions>
+                      <IconButton onClick={() => deletePhoto(photo.filepath)}>
+                        <DeleteForever />
+                      </IconButton>
+                    </CardActions>
+                  )}
                 </Card>
               </Grid>
             ))}
           </Grid>
         </Grid>
       </Box>
-      <Box>
-        <Grid container>
-          <Grid container item spacing={3} justify="center">
-            <Grid item>
-              <Button variant="contained" color="primary" startIcon={<AddAPhoto />} onClick={() => takePhoto()}>
-                Add A Photo
-              </Button>
-            </Grid>
-            <Grid item>
-              <Button variant="contained" startIcon={<DeleteForever />} onClick={() => deletePhotos()}>
-                Remove All Photos
-              </Button>
+      {!props.isDisabled && (
+        <Box>
+          <Grid container>
+            <Grid container item spacing={3} justify="center">
+              <Grid item>
+                <Button variant="contained" color="primary" startIcon={<AddAPhoto />} onClick={() => takePhoto()}>
+                  Add A Photo
+                </Button>
+              </Grid>
+              <Grid item>
+                <Button variant="contained" startIcon={<DeleteForever />} onClick={() => deletePhotos()}>
+                  Remove All Photos
+                </Button>
+              </Grid>
             </Grid>
           </Grid>
-        </Grid>
-      </Box>
+        </Box>
+      )}
     </Box>
   );
 };

--- a/app/src/utils/addActivity.ts
+++ b/app/src/utils/addActivity.ts
@@ -43,7 +43,6 @@ export async function addActivityToDB(
         activity_id: linkedRecord._id
       };
     } else {
-      console.log('in here', linkedRecord);
       formData.activity_type_data = {
         activity_id: linkedRecord._id
       };

--- a/app/src/utils/addActivity.ts
+++ b/app/src/utils/addActivity.ts
@@ -43,6 +43,7 @@ export async function addActivityToDB(
         activity_id: linkedRecord._id
       };
     } else {
+      console.log('in here', linkedRecord);
       formData.activity_type_data = {
         activity_id: linkedRecord._id
       };


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- UI for Treatment data alongside Monitoring
- #268 
- currently it will display the linked activity form and photos (if any exist) and no editable actions allowed on the linked record
- only main form, photos, and map is editable

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Locally

## Screenshots

<img width="1259" alt="sss" src="https://user-images.githubusercontent.com/28017034/103105578-94b95a00-45e3-11eb-8567-9d5ac86e8f5a.png">