### PR TITLE
No current activity - handle it gracefully

### DIFF
--- a/app/src/features/home/activity/ActivityPage.tsx
+++ b/app/src/features/home/activity/ActivityPage.tsx
@@ -1,4 +1,4 @@
-import { CircularProgress, Container, makeStyles, Box, Button } from '@material-ui/core';
+import { CircularProgress, Container, makeStyles, Box, Button, Typography } from '@material-ui/core';
 import { FileCopy } from '@material-ui/icons';
 import ActivityComponent from 'components/activity/ActivityComponent';
 import { IPhoto } from 'components/photo/PhotoContainer';
@@ -60,13 +60,12 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
   const [extent, setExtent] = useState(null);
   // "is it open?", "what coordinates of the mouse?", that kind of thing:
   const initialContextMenuState: MapContextMenuData = { isOpen: false, lat: 0, lng: 0 };
-  //const [contextMenuState, setContextMenuState] = useState({ isOpen: false });
   const [contextMenuState, setContextMenuState] = useState(initialContextMenuState);
 
   /* commented out for sonar cloud, but this will be needed to close the context menu for this page:
-  const handleContextMenuClose = () => {
-    setContextMenuState({ ...contextMenuState, isOpen: false });
-  };
+    const handleContextMenuClose = () => {
+      setContextMenuState({ ...contextMenuState, isOpen: false });
+    };
   */
 
   const [doc, setDoc] = useState(null);
@@ -323,6 +322,12 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
     const getActivityData = async () => {
       const activityResults = await getActivityResultsFromDB(props.activityId || null);
 
+      if (!activityResults) {
+        setIsLoading(false);
+        setDoc(false);
+        return;
+      }
+
       const updatedFormData = getDefaultFormDataValues(activityResults.docs[0]);
       const updatedDoc = { ...activityResults.docs[0], formData: updatedFormData };
 
@@ -346,7 +351,7 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
   }, [databaseContext, isCloned]);
 
   useEffect(() => {
-    if (isLoading) {
+    if (isLoading || !doc) {
       return;
     }
 
@@ -354,7 +359,7 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
   }, [geometry, isLoading, saveGeometry]);
 
   useEffect(() => {
-    if (isLoading) {
+    if (isLoading || !doc) {
       return;
     }
 
@@ -362,7 +367,7 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
   }, [extent, isLoading, saveExtent]);
 
   useEffect(() => {
-    if (isLoading) {
+    if (isLoading || !doc) {
       return;
     }
 
@@ -381,28 +386,41 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
 
   return (
     <Container className={props.classes.container}>
-      <ActivityComponent
-        customValidation={getCustomValidator([
-          getAreaValidator(doc.activitySubtype),
-          getWindValidator(doc.activitySubtype),
-          getHerbicideApplicationRateValidator()
-        ])}
-        classes={classes}
-        activity={doc}
-        linkedActivity={linkedActivity}
-        onFormChange={onFormChange}
-        onFormSubmitSuccess={onFormSubmitSuccess}
-        onFormSubmitError={onFormSubmitError}
-        photoState={{ photos, setPhotos }}
-        mapId={doc._id}
-        geometryState={{ geometry, setGeometry }}
-        extentState={{ extent, setExtent }}
-        contextMenuState={{ state: contextMenuState, setContextMenuState }} // whether someone clicked, and click x & y
-        pasteFormData={() => pasteFormData()}
-        copyFormData={() => copyFormData()}
-        cloneActivityButton={generateCloneActivityButton}
-        setParentFormRef={props.setParentFormRef}
-      />
+      {!doc && (
+        <>
+          <Box mb={3}>
+            <Typography variant="h4">Current Activity</Typography>
+          </Box>
+          <Typography>
+            There is no current activity. When you start creating an activity,
+            it will become your current activity and show up in this tab.
+          </Typography>
+        </>
+      )}
+      {doc && (
+        <ActivityComponent
+          customValidation={getCustomValidator([
+            getAreaValidator(doc.activitySubtype),
+            getWindValidator(doc.activitySubtype),
+            getHerbicideApplicationRateValidator()
+          ])}
+          classes={classes}
+          activity={doc}
+          linkedActivity={linkedActivity}
+          onFormChange={onFormChange}
+          onFormSubmitSuccess={onFormSubmitSuccess}
+          onFormSubmitError={onFormSubmitError}
+          photoState={{ photos, setPhotos }}
+          mapId={doc._id}
+          geometryState={{ geometry, setGeometry }}
+          extentState={{ extent, setExtent }}
+          contextMenuState={{ state: contextMenuState, setContextMenuState }} // whether someone clicked, and click x & y
+          pasteFormData={() => pasteFormData()}
+          copyFormData={() => copyFormData()}
+          cloneActivityButton={generateCloneActivityButton}
+          setParentFormRef={props.setParentFormRef}
+        />
+      )}
     </Container>
   );
 };

--- a/app/src/features/home/activity/ActivityPage.tsx
+++ b/app/src/features/home/activity/ActivityPage.tsx
@@ -324,7 +324,6 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
 
       if (!activityResults) {
         setIsLoading(false);
-        setDoc(false);
         return;
       }
 

--- a/app/src/features/home/activity/ActivityPage.tsx
+++ b/app/src/features/home/activity/ActivityPage.tsx
@@ -391,8 +391,8 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
             <Typography variant="h4">Current Activity</Typography>
           </Box>
           <Typography>
-            There is no current activity. When you start creating an activity,
-            it will become your current activity and show up in this tab.
+            There is no current activity. When you start creating an activity, it will become your current activity and
+            show up in this tab.
           </Typography>
         </>
       )}


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- No current activity - handle it gracefully
- Show message telling user they don't have a current activity selected, without crashing app

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Locally

## Screenshots

<img width="1248" alt="saucey" src="https://user-images.githubusercontent.com/28017034/107695660-c2c32e00-6c65-11eb-97a7-9216bb9ba1a8.png">