### PR TITLE
Try fix for #637 issue

### DIFF
--- a/app/src/contexts/authStateContext.tsx
+++ b/app/src/contexts/authStateContext.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import useKeycloakWrapper from 'hooks/useKeycloakWrapper';
+import { useInvasivesApi } from 'hooks/useInvasivesApi';
 
 export interface IAuthState {
   ready?: boolean;
@@ -11,6 +12,7 @@ export const AuthStateContext = React.createContext<IAuthState>({
 
 export const AuthStateContextProvider: React.FC = (props) => {
   const keycloak = useKeycloakWrapper();
+  const invasivesApi = useInvasivesApi();
 
   const [userInfo, setUserInfo] = React.useState<any>(null);
 
@@ -22,6 +24,14 @@ export const AuthStateContextProvider: React.FC = (props) => {
 
     loadUserInfo();
   }, [keycloak.obj]);
+
+  React.useEffect(() => {
+    const getApiSpec = async () => {
+      await invasivesApi.getCachedApiSpec();
+    };
+
+    getApiSpec();
+  }, []);
 
   return (
     <AuthStateContext.Provider value={{ ready: keycloak.obj?.authenticated && !!userInfo }}>


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Try fix for issue where the form doesn't load when you are on ios (offline)
- The API spec is needed for form to load and the api spec does not get cached until you open a form in online mode - so now it has been changed so that the spec gets cached once user is online and authed so as long as they open the app once in online mode before going into the field, their spec will be cached in pouch and they should be able to create forms successfully in field (offline)
- #637 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Yet to be tested by someone who has simulator or ios device (@micheal-w-wells possibly)