### PR TITLE
Trip step UX enhancement

### DIFF
--- a/app/src/features/home/plan/PlanPage.tsx
+++ b/app/src/features/home/plan/PlanPage.tsx
@@ -168,7 +168,7 @@ const PlanPage: React.FC<IPlanPageProps> = (props) => {
   const SingleTrip: React.FC = (props) => {
     //todo: add trip_id to props and let trip manage db itself
     const [stepState, setStepState] = useState([
-      {},//just here so indexes match up with step number
+      {}, //just here so indexes match up with step number
       { status: TripStatusCode.initial, expanded: false },
       { status: TripStatusCode.initial, expanded: false },
       { status: TripStatusCode.initial, expanded: false },
@@ -185,14 +185,14 @@ const PlanPage: React.FC<IPlanPageProps> = (props) => {
     };
 
     const helperCloseOtherAccordions = (expanded, stepNumber) => {
+      console.dir(expanded);
       let newState: any = [...stepState];
-      for(let i = 1; i < (stepState.length); i++){
-        let expanded2 = (i == stepNumber && expanded)? true: false;
-        newState[i] = {...newState[i], expanded: expanded2}
+      for (let i = 1; i < stepState.length; i++) {
+        let expanded2 = i == stepNumber && expanded ? true : false;
+        newState[i] = { ...newState[i], expanded: expanded2 };
       }
-      setStepState([...newState])
-    }
-
+      setStepState([...newState]);
+    };
 
     return (
       <Grid item md={12}>
@@ -209,7 +209,9 @@ const PlanPage: React.FC<IPlanPageProps> = (props) => {
               expanded={stepState[1].expanded}
               tripStepDetailsClassName={classes.activityRecordList}
               stepStatus={helperCheckForGeo()}
-              stepAccordionOnChange={(expanded) => {helperCloseOtherAccordions(expanded, 1)}}>
+              stepAccordionOnChange={(event, expanded) => {
+                helperCloseOtherAccordions(expanded, 1);
+              }}>
               <Paper className={classes.paper}>
                 <Typography variant="body1">
                   Draw a polygon or square on the map, or upload a KML containing 1 shape.
@@ -224,7 +226,9 @@ const PlanPage: React.FC<IPlanPageProps> = (props) => {
               expanded={stepState[2].expanded}
               tripStepDetailsClassName={classes.activityRecordList}
               stepStatus={stepState[2].status}
-              stepAccordionOnChange={(expanded) => {helperCloseOtherAccordions(expanded, 2)}}>
+              stepAccordionOnChange={(event, expanded) => {
+                helperCloseOtherAccordions(expanded, 2);
+              }}>
               <ActivityDataFilter />
             </TripStep>
             <TripStep
@@ -234,7 +238,9 @@ const PlanPage: React.FC<IPlanPageProps> = (props) => {
               expanded={stepState[3].expanded}
               tripStepDetailsClassName={classes.pointOfInterestList}
               stepStatus={stepState[3].status}
-              stepAccordionOnChange={(expanded) => {helperCloseOtherAccordions(expanded, 3)}}>
+              stepAccordionOnChange={(event, expanded) => {
+                helperCloseOtherAccordions(expanded, 3);
+              }}>
               <PointOfInterestDataFilter />
             </TripStep>
             <TripStep
@@ -244,7 +250,9 @@ const PlanPage: React.FC<IPlanPageProps> = (props) => {
               expanded={stepState[4].expanded}
               tripStepDetailsClassName={classes.pointOfInterestList}
               stepStatus={stepState[4].status}
-              stepAccordionOnChange={(expanded) => {helperCloseOtherAccordions(expanded, 4)}}>
+              stepAccordionOnChange={(event, expanded) => {
+                helperCloseOtherAccordions(expanded, 4);
+              }}>
               <MetabaseSearch />
             </TripStep>
             <TripStep
@@ -254,7 +262,9 @@ const PlanPage: React.FC<IPlanPageProps> = (props) => {
               expanded={stepState[5].expanded}
               tripStepDetailsClassName={classes.pointOfInterestList}
               stepStatus={stepState[5].status}
-              stepAccordionOnChange={(expanded) => {helperCloseOtherAccordions(expanded, 5)}}>
+              stepAccordionOnChange={(event, expanded) => {
+                helperCloseOtherAccordions(expanded, 5);
+              }}>
               <TripDataControls />
               <ManageDatabaseComponent />
             </TripStep>
@@ -271,12 +281,12 @@ const PlanPage: React.FC<IPlanPageProps> = (props) => {
     additionalText: string;
     tripStepDetailsClassName: string;
     stepStatus: TripStatusCode;
-    stepAccordionOnChange?: (expanded) => void;
+    stepAccordionOnChange?: (event, expanded) => void;
   }
 
   const TripStep: React.FC<ITripStep> = (props) => {
     return (
-      <Accordion defaultExpanded={props.expanded} onChange={props.stepAccordionOnChange}>
+      <Accordion defaultExpanded={props.expanded} expanded={props.expanded} onChange={props.stepAccordionOnChange}>
         <AccordionSummary
           className={classes.accordionSummary}
           expandIcon={<ExpandMore fontSize="large" />}

--- a/app/src/features/home/plan/PlanPage.tsx
+++ b/app/src/features/home/plan/PlanPage.tsx
@@ -167,9 +167,10 @@ const PlanPage: React.FC<IPlanPageProps> = (props) => {
 
   const SingleTrip: React.FC = (props) => {
     //todo: add trip_id to props and let trip manage db itself
-    const [stepStatus, setStepStatus] = useState([
-      {},
-      { status: TripStatusCode.initial, expanded: true },
+    const [stepState, setStepState] = useState([
+      {},//just here so indexes match up with step number
+      { status: TripStatusCode.initial, expanded: false },
+      { status: TripStatusCode.initial, expanded: false },
       { status: TripStatusCode.initial, expanded: false },
       { status: TripStatusCode.initial, expanded: false },
       { status: TripStatusCode.initial, expanded: false }
@@ -179,9 +180,19 @@ const PlanPage: React.FC<IPlanPageProps> = (props) => {
       if (geometry) {
         return TripStatusCode.ready;
       } else {
-        return stepStatus[1].status;
+        return stepState[1].status;
       }
     };
+
+    const helperCloseOtherAccordions = (expanded, stepNumber) => {
+      let newState: any = [...stepState];
+      for(let i = 1; i < (stepState.length); i++){
+        let expanded2 = (i == stepNumber && expanded)? true: false;
+        newState[i] = {...newState[i], expanded: expanded2}
+      }
+      setStepState([...newState])
+    }
+
 
     return (
       <Grid item md={12}>
@@ -195,9 +206,10 @@ const PlanPage: React.FC<IPlanPageProps> = (props) => {
               title="Step 1: Add a spatial boundary for your trip."
               helpText="The 'spatial filter' to your search.  Put bounds around data you need to pack with you."
               additionalText="other"
-              expanded={true}
+              expanded={stepState[1].expanded}
               tripStepDetailsClassName={classes.activityRecordList}
-              stepStatus={helperCheckForGeo()}>
+              stepStatus={helperCheckForGeo()}
+              stepAccordionOnChange={(expanded) => {helperCloseOtherAccordions(expanded, 1)}}>
               <Paper className={classes.paper}>
                 <Typography variant="body1">
                   Draw a polygon or square on the map, or upload a KML containing 1 shape.
@@ -209,36 +221,40 @@ const PlanPage: React.FC<IPlanPageProps> = (props) => {
               title="Step 2: Choose past field activity data."
               helpText="This is where you can cache past activities (observations etc.) to the app.  If you want to search for records in a particular area, draw a polygon on the map."
               additionalText="other"
-              expanded={false}
+              expanded={stepState[2].expanded}
               tripStepDetailsClassName={classes.activityRecordList}
-              stepStatus={stepStatus[1].status}>
+              stepStatus={stepState[2].status}
+              stepAccordionOnChange={(expanded) => {helperCloseOtherAccordions(expanded, 2)}}>
               <ActivityDataFilter />
             </TripStep>
             <TripStep
               title="Step 3: Choose data from other systems, (IAPP)"
               helpText="This is where you can cache IAPP sites, and later other points of interest.  If you want to search for records in a particular area, draw a polygon on the map."
               additionalText="other"
-              expanded={false}
+              expanded={stepState[3].expanded}
               tripStepDetailsClassName={classes.pointOfInterestList}
-              stepStatus={stepStatus[1].status}>
+              stepStatus={stepState[3].status}
+              stepAccordionOnChange={(expanded) => {helperCloseOtherAccordions(expanded, 3)}}>
               <PointOfInterestDataFilter />
             </TripStep>
             <TripStep
               title="OPTIONAL: Get data from a Metabase Question"
               helpText="If you have a Metabase question that contains field activity ID's, you can load those records here."
               additionalText="other"
-              expanded={false}
+              expanded={stepState[4].expanded}
               tripStepDetailsClassName={classes.pointOfInterestList}
-              stepStatus={stepStatus[1].status}>
+              stepStatus={stepState[4].status}
+              stepAccordionOnChange={(expanded) => {helperCloseOtherAccordions(expanded, 4)}}>
               <MetabaseSearch />
             </TripStep>
             <TripStep
               title="Last Step: Cache, Refresh, or Delete data for Trip "
               helpText="Cache the data and map data for the region you have selected, or refresh it, or delete."
               additionalText="other"
-              expanded={false}
+              expanded={stepState[5].expanded}
               tripStepDetailsClassName={classes.pointOfInterestList}
-              stepStatus={stepStatus[1].status}>
+              stepStatus={stepState[5].status}
+              stepAccordionOnChange={(expanded) => {helperCloseOtherAccordions(expanded, 5)}}>
               <TripDataControls />
               <ManageDatabaseComponent />
             </TripStep>
@@ -255,11 +271,12 @@ const PlanPage: React.FC<IPlanPageProps> = (props) => {
     additionalText: string;
     tripStepDetailsClassName: string;
     stepStatus: TripStatusCode;
+    stepAccordionOnChange?: (expanded) => void;
   }
 
   const TripStep: React.FC<ITripStep> = (props) => {
     return (
-      <Accordion defaultExpanded={props.expanded}>
+      <Accordion defaultExpanded={props.expanded} onChange={props.stepAccordionOnChange}>
         <AccordionSummary
           className={classes.accordionSummary}
           expandIcon={<ExpandMore fontSize="large" />}


### PR DESCRIPTION
Only let the user have one trip step open at a time, i.e., close the others if they open another.
This is meant to prevent the user from having too man accordions open at once and getting disoriented.

# Overview

This PR includes the following proposed change(s):

- {List all the changes, if possible add the linked issue/ticket #}

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
