### PR TITLE
Issue694

### DIFF
--- a/app/src/components/map/MapContainer.css
+++ b/app/src/components/map/MapContainer.css
@@ -14,6 +14,12 @@
   transform: scale(1.4) translate(0, -5px);
 }
 
+.leaflet-draw-draw-circlemarker{
+  background-image: url(./icons/cross-circle.svg) !important;
+  background-position: center !important;
+  background-size: cover !important;
+}
+
 .leaflet-control-locate.leaflet-control {
   transform: scale(1.5);
 }

--- a/app/src/components/map/icons/cross-circle.svg
+++ b/app/src/components/map/icons/cross-circle.svg
@@ -1,0 +1,12 @@
+<svg width="150" height="150" xmlns="http://www.w3.org/2000/svg">
+
+ <g>
+  <title>Layer 1</title>
+  <ellipse stroke="#000" ry="30" rx="30" id="svg_1" cy="300" cx="409" fill="#fff"/>
+  <g stroke="null" id="svg_6">
+   <ellipse stroke="#3D3D3D" stroke-width="10" ry="30" rx="30" id="svg_3" cy="75" cx="75" fill="#fff"/>
+   <line stroke="#3D3D3D" stroke-width="10" id="svg_4" y2="114.425" x2="75" y1="35.575" x1="75" fill="none"/>
+   <line stroke="#3D3D3D" stroke-width="10" id="svg_5" y2="75" x2="114.425" y1="75" x1="35.575" fill="none"/>
+  </g>
+ </g>
+</svg>

--- a/app/src/components/map/icons/cross-circle.svg
+++ b/app/src/components/map/icons/cross-circle.svg
@@ -4,7 +4,7 @@
   <title>Layer 1</title>
   <ellipse stroke="#000" ry="30" rx="30" id="svg_1" cy="300" cx="409" fill="#fff"/>
   <g stroke="null" id="svg_6">
-   <ellipse stroke="#3D3D3D" stroke-width="10" ry="30" rx="30" id="svg_3" cy="75" cx="75" fill="#fff"/>
+   <ellipse stroke="#3D3D3D" stroke-width="10" ry="20" rx="20" id="svg_3" cy="75" cx="75" fill="#fff"/>
    <line stroke="#3D3D3D" stroke-width="10" id="svg_4" y2="114.425" x2="75" y1="35.575" x1="75" fill="none"/>
    <line stroke="#3D3D3D" stroke-width="10" id="svg_5" y2="75" x2="114.425" y1="75" x1="35.575" fill="none"/>
   </g>

--- a/app/src/features/home/activity/ActivityPage.tsx
+++ b/app/src/features/home/activity/ActivityPage.tsx
@@ -247,7 +247,6 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
         dateUpdated: new Date(),
         formStatus: FormValidationStatus.VALID
       };
-
       setDoc({ ...doc, ...updatedFormValues });
 
       await databaseContext.database.upsert(docId, (activity) => {
@@ -403,6 +402,24 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
     }
   };
 
+  //this sets up initial values for some of the fields in activity.
+  const setUpInitialValues = (activity: any, formData: any): Object => {
+    //Observations -- all:
+    if (activity.activityType === 'Observation' && !formData.activity_subtype_data) {
+      //set the invasice plants to start with 1 element, rather than with 0
+      formData.activity_subtype_data = {};
+      formData.activity_subtype_data.invasive_plants = [{ occurrence: 'Positive occurrence' }];
+    }
+    //Observations -- Plant Terrestrial activity:
+    if (activity.activitySubtype === 'Activity_Observation_PlantTerrestrial' && !formData.activity_subtype_data) {
+      //set specific use to 'None'
+      formData.activity_subtype_data = {};
+      formData.activity_subtype_data.observation_plant_terrestrial_data = {};
+      formData.activity_subtype_data.observation_plant_terrestrial_data.specific_use_code = 'NO';
+    }
+    return formData;
+  };
+
   useEffect(() => {
     const getActivityData = async () => {
       const activityResults = await getActivityResultsFromDB(props.activityId || null);
@@ -412,7 +429,8 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
         return;
       }
 
-      const updatedFormData = getDefaultFormDataValues(activityResults.docs[0]);
+      let updatedFormData = getDefaultFormDataValues(activityResults.docs[0]);
+      updatedFormData = setUpInitialValues(activityResults.docs[0], updatedFormData);
       const updatedDoc = { ...activityResults.docs[0], formData: updatedFormData };
 
       await handleRecordLinking(updatedDoc);


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- [x] On Observation forms, the first Invasive Plant Selection fields should show instead of having to click "add item" - and then have the "Add item" button below to add new items with some text beside it that says "Add additional invasive plant observation if the geometry is the same".  
- [x] Add UTMs in addition to Lat/longs (also in ticket 607).
- [x] Change the “Point” geometry to have cross-hairs or something to make it more obvious it's a "point" not a circle, or edit to say "create a point" in the hover over explanatory text (and ensure this change occurs for all the maps where you have to select a geometry).
- [x] change specific use code to "none" as the default (and ensure this is the case for all other forms)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
