### PR TITLE
issue 626

### DIFF
--- a/app/src/features/home/activity/ActivityPage.tsx
+++ b/app/src/features/home/activity/ActivityPage.tsx
@@ -18,6 +18,7 @@ import {
   getTemperatureValidator,
   getHerbicideApplicationRateValidator,
   getTransectOffsetDistanceValidator,
+  getVegTransectPointsPercentCoverValidator,
   getJurisdictionPercentValidator,
   getSlopeAspectBothFlatValidator,
   getInvasivePlantsValidator,
@@ -532,6 +533,7 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
             getDuplicateInvasivePlantsValidator(doc.activitySubtype),
             getHerbicideApplicationRateValidator(),
             getTransectOffsetDistanceValidator(),
+            getVegTransectPointsPercentCoverValidator(),
             getJurisdictionPercentValidator(),
             getInvasivePlantsValidator(linkedActivity)
           ])}

--- a/app/src/rjsf/uiSchema/BaseUISchemaComponents.ts
+++ b/app/src/rjsf/uiSchema/BaseUISchemaComponents.ts
@@ -566,9 +566,7 @@ const LumpedSpeciesPercentCover = {
   lumped_species_type: {
     'ui:widget': 'single-select-autocomplete'
   },
-  percent_covered: {
-    'ui:widget': 'single-select-autocomplete'
-  }
+  percent_covered: {}
 };
 
 const LumpedSpeciesDaubenmire = {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- [x] The sum of the "Vegetation Total Percentage" should be flagged if the sum does not equal 100. This may already be in place with the Phenology total percent calculation.

- [x] help text change for phenology under the biological release & biological release monitoring (the monitoring form of the treatment), once the forms are more finalized after meeting on Tuesday, @mikeshasko to send spreadsheet to Susan to obtain help-text.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
