### PR TITLE
Issue885

### DIFF
--- a/api/src/openapi/api-doc.json
+++ b/api/src/openapi/api-doc.json
@@ -2532,7 +2532,7 @@
       },
       "TerrestrialPlants": {
         "type": "object",
-        "required": ["invasive_plant_code", "occurrence"],
+        "required": ["invasive_plant_code", "occurrence", "voucher_specimen_collected", "edna_sample"],
         "properties": {
           "invasive_plant_code": {
             "type": "string",
@@ -2552,9 +2552,148 @@
             "enum": ["Positive occurrence", "Negative occurrence"],
             "default": "Positive occurrence",
             "x-tooltip-text": "The observation describes the presence or absence of target invasive plants within a defined area"
+          },
+          "voucher_specimen_collected": {
+            "type": "string",
+            "title": "Voucher Specimen Collected",
+            "enum": ["Yes", "No"],
+            "default": "No",
+            "x-tooltip-text": "Ideal to collect entire plant structure for verification purposes."
+          },
+          "edna_sample": {
+            "title": "eDNA sample",
+            "type": "string",
+            "enum": ["Yes", "No"],
+            "default": "No",
+            "x-tooltip-text": "Genetic material that can be extracted from bulk environmental samples such as water and soil."
           }
         },
         "dependencies": {
+          "edna_sample": {
+            "oneOf": [
+              {
+                "properties": {
+                  "edna_sample": {
+                    "enum": ["Yes"]
+                  },
+                  "enda_sample_information": {
+                    "type": "object",
+                    "title": "eDNA Sample Information",
+                    "properties": {
+                      "edna_sample_id": {
+                        "title": "eDNA sample ID",
+                        "type": "number"
+                      },
+                      "genetic_structure_collected": {
+                        "title": "Genetic Structure Collected",
+                        "type": "string"
+                      }
+                    },
+                    "required": ["edna_sample_id", "genetic_structure_collected"]
+                  }
+                },
+                "required": ["enda_sample_information"]
+              },
+              {
+                "properties": {
+                  "edna_sample": {
+                    "enum": ["No"]
+                  }
+                }
+              }
+            ]
+          },
+          "voucher_specimen_collected": {
+            "oneOf": [
+              {
+                "properties": {
+                  "voucher_specimen_collected": {
+                    "enum": ["Yes"]
+                  },
+                  "voucher_specimen_collection_information": {
+                    "type": "object",
+                    "title": "Voucher Specimen Collection Information",
+                    "required": [
+                      "voucher_sample_id",
+                      "date_voucher_collected",
+                      "accession_number",
+                      "name_of_herbarium",
+                      "voucher_verification_completed_by",
+                      "exact_utm_coords",
+                      "date_voucher_verified"
+                    ],
+                    "properties": {
+                      "voucher_sample_id": {
+                        "title": "Voucher Sample ID",
+                        "type": "string",
+                        "x-tooltip-text": "Unique identifier for each voucher collected."
+                      },
+                      "date_voucher_collected": {
+                        "title": "Date Voucher Collected",
+                        "type": "string",
+                        "format": "date"
+                      },
+                      "date_voucher_verified": {
+                        "title": "Date voucher verified",
+                        "type": "string",
+                        "format": "date"
+                      },
+                      "name_of_herbarium": {
+                        "title": "Name of Herbarium",
+                        "type": "string"
+                      },
+                      "accession_number": {
+                        "title": "Accession number",
+                        "type": "string"
+                      },
+                      "voucher_verification_completed_by": {
+                        "type": "object",
+                        "title": "Voucher verification completed by",
+                        "required": ["person_name", "organization"],
+                        "properties": {
+                          "person_name": {
+                            "type": "string",
+                            "title": "Name"
+                          },
+                          "organization": {
+                            "type": "string",
+                            "title": "Organization"
+                          }
+                        }
+                      },
+                      "exact_utm_coords": {
+                        "title": "Exact UTM coordinates of voucher collection site",
+                        "type": "object",
+                        "required": ["utm_zone", "utm_easting", "utm_northing"],
+                        "properties": {
+                          "utm_zone": {
+                            "title": "UTM Zone",
+                            "type": "number"
+                          },
+                          "utm_easting": {
+                            "title": "UTM Easting",
+                            "type": "number"
+                          },
+                          "utm_northing": {
+                            "title": "UTM Northing",
+                            "type": "number"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "required": ["voucher_specimen_collection_information"]
+              },
+              {
+                "properties": {
+                  "voucher_specimen_collected": {
+                    "enum": ["No"]
+                  }
+                }
+              }
+            ]
+          },
           "occurrence": {
             "oneOf": [
               {

--- a/app/src/rjsf/uiSchema/BaseUISchemaComponents.ts
+++ b/app/src/rjsf/uiSchema/BaseUISchemaComponents.ts
@@ -81,6 +81,7 @@ const ProjectCode = {
 };
 
 const TerrestrialPlants = {
+  ...ThreeColumnStyle,
   invasive_plant_code: {
     'ui:widget': 'single-select-autocomplete'
   },


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- [x] add a "voucher specimen collected" mandatory field in the same location as it is in the aquatic plant observation form, with help text: "Ideal to collect entire plant structure for verification purposes". 
- [x] if a user chooses yes to "Voucher specimen collected, the following optional fields show up (if they choose no, none of these show up):
o	Voucher Sample ID – text (help text: Unique identifier for each voucher collected.)
o	Date voucher collected
o	Exact UTM coordinates of voucher collection site (zone, easting, northing: user entered)
o	Voucher verification completed by (name and organization)
o	Date voucher verified 
o	Accession number (name of herbarium and accession number)
- [x] add a "eDNA sample"  mandatory field with the choices to be – Y/N (help text: Genetic material that can be extracted from bulk environmental samples such as water and soil).   If they choose yes, then the "eDNA sample ID" and "genetic structure collected" fields should pop up, but if they choose "no", it should not show those fields.  Default should be "no".  

## Type of change

- [x] New feature (non-breaking change which adds functionality)

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
