### PR TITLE
Issues 870 + 869

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -22,7 +22,7 @@ app.use(function (req: any, res: any, next: any) {
   res.setHeader('Access-Control-Allow-Credentials', true);
   res.setHeader(
     'Access-Control-Allow-Headers',
-    'X-Requested-With, Content-Type, Authorization, responseType,Access-Control-Allow-Origin'
+    'X-Requested-With, Content-Type, Authorization, responseType, Access-Control-Allow-Origin'
   );
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE, HEAD');
   res.setHeader('Access-Control-Allow-Origin', '*');

--- a/api/src/openapi/api-doc.json
+++ b/api/src/openapi/api-doc.json
@@ -402,6 +402,11 @@
             "title": "Longitude",
             "x-tooltip-text": "Longitude of the anchor point for the specified geometry"
           },
+          "utm_zone": {
+            "type": "string",
+            "title": "UTM Zone",
+            "x-tooltip-text": "UTM Zone of the anchor point for the specified geometry"
+          },
           "utm_easting": {
             "type": "number",
             "title": "UTM Easting",
@@ -412,16 +417,23 @@
             "title": "UTM Northing",
             "x-tooltip-text": "UTM Northing of the anchor point for the specified geometry"
           },
-          "utm_zone": {
-            "type": "string",
-            "title": "UTM Zone",
-            "x-tooltip-text": "UTM Zone of the anchor point for the specified geometry"
-          },
           "reported_area": {
             "type": "number",
             "title": "Area (m\u00B2)",
             "minimum": 1,
             "x-tooltip-text": "Area of the activity automatically created from the geometry in square metres"
+          },
+          "employer_code": {
+            "type": "string",
+            "title": "Employer",
+            "x-enum-code": {
+              "x-enum-code-category-name": "invasives",
+              "x-enum-code-header-name": "employer_code",
+              "x-enum-code-name": "code_name",
+              "x-enum-code-text": "code_description",
+              "x-enum-code-sort-order": "code_sort_order"
+            },
+            "x-tooltip-text": "Employer of an agent"
           },
           "invasive_species_agency_code": {
             "type": "string",
@@ -435,12 +447,13 @@
             },
             "x-tooltip-text": "Organization that is paying to have this work done"
           },
-          "general_comment": {
+          "location_description": {
             "type": "string",
-            "title": "Comment",
-            "maxLength": 2000,
+            "title": "Location Description",
+            "maxLength": 300,
+            "minLength": 5,
             "default": "",
-            "x-tooltip-text": "Plain text description of any supporting information about the observation that is not captured elsewhere (up to 2000 characters)"
+            "x-tooltip-text": "Text entry to provide location directions. Locations should start general and get more specific"
           },
           "access_description": {
             "type": "string",
@@ -448,7 +461,7 @@
             "maxLength": 300,
             "minLength": 5,
             "default": "",
-            "x-tooltip-text": "Text entry to provide location and access directions. Locations should start general and get more specific"
+            "x-tooltip-text": "Text entry to provide access directions."
           },
           "jurisdictions": {
             "type": "array",
@@ -464,7 +477,14 @@
             "items": {
               "$ref": "#/components/schemas/ProjectCode"
             },
-            "x-tooltip-text": "User defined identifier related to associated paper documents (alphanumeric, 50 characters)"
+            "x-tooltip-text": "User defined identifier that can be used to filter or sort records"
+          },
+          "general_comment": {
+            "type": "string",
+            "title": "Comment",
+            "maxLength": 2000,
+            "default": "",
+            "x-tooltip-text": "Plain text description of any supporting information about the observation that is not captured elsewhere (up to 2000 characters)"
           }
         }
       },
@@ -672,9 +692,13 @@
             "title": "Project Data",
             "properties": {
               "surveyors": {
-                "type": "string",
-                "title": "Surveyors",
-                "x-tooltip-text": "Supply surveyor names"
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Persons"
+                },
+                "x-tooltip-text": "Name of person(s) doing the observation",
+
+                "title": "Observer(s)"
               },
               "survey_type": {
                 "type": "string",
@@ -700,7 +724,7 @@
               },
               "inflow_other": {
                 "type": "string",
-                "title": "Inflow (Other)",
+                "title": "Inflow (Temp. or seasonal)",
                 "x-tooltip-text": "Temporary or seasonal water inflow(s) adjacent to observation (e.g. overland flow)"
               },
               "outflow": {
@@ -2858,117 +2882,234 @@
       },
       "AquaticPlants": {
         "type": "object",
+        "required": ["observation_type"],
         "properties": {
           "sample_point_id": {
             "type": "string",
             "title": "Sample Point ID",
             "x-tooltip-text": "For Presence Surveys. Number each sample point in the same waterbody (e.g. 001, 002, 003, etc). Do not use for Extent Surveys"
           },
-          "invasive_plant_code": {
+          "observation_type": {
             "type": "string",
-            "title": "Invasive Plant",
-            "x-enum-code": {
-              "x-enum-code-category-name": "invasives",
-              "x-enum-code-header-name": "invasive_plant_code",
-              "x-enum-code-name": "code_name",
-              "x-enum-code-text": "code_description",
-              "x-enum-code-sort-order": "code_sort_order"
-            },
-            "x-tooltip-text": "For Presence survey: select species observed at coordinates. For Extent Survey: select target species for survey"
-          },
-          "provincial_edrr": {
-            "type": "string",
-            "title": "Provincial EDRR",
-            "enum": ["Yes", "No"],
-            "x-tooltip-text": "The target species you have selected is a candidate for provincial eradication. Please contact the provincial government Invasive Plant Program to verify this report"
-          },
-          "invasive_plant_density_code": {
-            "type": "string",
-            "title": "Density",
-            "x-enum-code": {
-              "x-enum-code-category-name": "invasives",
-              "x-enum-code-header-name": "invasive_plant_density_code",
-              "x-enum-code-name": "code_name",
-              "x-enum-code-text": "code_description",
-              "x-enum-code-sort-order": "code_sort_order"
-            },
-            "x-tooltip-text": "Average number of individual plants per square meter expressed as a density class code"
-          },
-          "invasive_plant_distribution_code": {
-            "type": "string",
-            "title": "Distribution",
-            "x-enum-code": {
-              "x-enum-code-category-name": "invasives",
-              "x-enum-code-header-name": "invasive_plant_distribution_code",
-              "x-enum-code-name": "code_name",
-              "x-enum-code-text": "code_description",
-              "x-enum-code-sort-order": "code_sort_order"
-            },
-            "x-tooltip-text": "Description of the average arrangement of invasive plant clusters within the observation area expressed as a distribution code"
-          },
-          "plant_life_stage_code": {
-            "type": "string",
-            "title": "Life Stage",
-            "x-enum-code": {
-              "x-enum-code-category-name": "invasives",
-              "x-enum-code-header-name": "plant_life_stage_code",
-              "x-enum-code-name": "code_name",
-              "x-enum-code-text": "code_description",
-              "x-enum-code-sort-order": "code_sort_order"
-            },
-            "x-tooltip-text": "Select description of life stage that best describes the target plant(s)"
-          },
-          "plant_health_code": {
-            "type": "string",
-            "title": "Health",
-            "x-enum-code": {
-              "x-enum-code-category-name": "invasives",
-              "x-enum-code-header-name": "plant_health_code",
-              "x-enum-code-name": "code_name",
-              "x-enum-code-text": "code_description",
-              "x-enum-code-sort-order": "code_sort_order"
-            },
-            "x-tooltip-text": "Select description of plant vigour that best describes the target plant(s)"
-          },
-          "plant_seed_stage_code": {
-            "type": "string",
-            "title": "Seed Stage",
-            "x-enum-code": {
-              "x-enum-code-category-name": "invasives",
-              "x-enum-code-header-name": "plant_seed_stage_code",
-              "x-enum-code-name": "code_name",
-              "x-enum-code-text": "code_description",
-              "x-enum-code-sort-order": "code_sort_order"
-            },
-            "x-tooltip-text": "Select appropriate seed stage"
-          },
-          "voucher_specimen_collected": {
-            "type": "string",
-            "title": "Voucher Specimen Collected",
-            "enum": ["Yes", "No"],
-            "x-tooltip-text": "If specimen collected, provide details in observation comments"
-          },
-          "e_dna_sample": {
-            "type": "string",
-            "title": "eDNA Sample",
-            "x-tooltip-text": "Genetic material that can be extracted from bulk environmental samples such as water and soil"
-          },
-          "genetic_sample_id": {
-            "type": "string",
-            "title": "Genetic Sample ID",
-            "x-tooltip-text": "Unique identifier for each voucher collected. Helpful to include abbreviation of waterbody name"
-          },
-          "genetic_structure_collected": {
-            "type": "string",
-            "title": "Genetic Structure Collected",
-            "x-tooltip-text": "Describe plant parts collected. Ideal to collect entire plant structure for verification purposes"
-          },
-          "negative_obs_ind": {
-            "type": "string",
-            "title": "Negative Observation",
-            "enum": ["Yes", "No", "Unknown"],
-            "default": "No",
+            "title": "Observation Type",
+            "enum": ["Positive Observation", "Negative Observation"],
+            "default": "Positive Observation",
             "x-tooltip-text": "The observation describes the absence of target invasive plants within a defined area"
+          }
+        },
+        "dependencies": {
+          "observation_type": {
+            "oneOf": [
+              {
+                "properties": {
+                  "observation_type": {
+                    "enum": ["Negative Observation"]
+                  },
+                  "invasive_plant_code": {
+                    "type": "string",
+                    "title": "Invasive Plant",
+                    "x-enum-code": {
+                      "x-enum-code-category-name": "invasives",
+                      "x-enum-code-header-name": "invasive_plant_code",
+                      "x-enum-code-name": "code_name",
+                      "x-enum-code-text": "code_description",
+                      "x-enum-code-sort-order": "code_sort_order"
+                    },
+                    "x-tooltip-text": "For Presence survey: select species observed at coordinates. For Extent Survey: select target species for survey"
+                  },
+                  "invasive_plant_density_code": {
+                    "type": "string",
+                    "title": "Density",
+                    "x-enum-code": {
+                      "x-enum-code-category-name": "invasives",
+                      "x-enum-code-header-name": "invasive_plant_density_code",
+                      "x-enum-code-name": "code_name",
+                      "x-enum-code-text": "code_description",
+                      "x-enum-code-sort-order": "code_sort_order"
+                    },
+                    "x-tooltip-text": "Average number of individual plants per square meter expressed as a density class code"
+                  },
+                  "invasive_plant_distribution_code": {
+                    "type": "string",
+                    "title": "Distribution",
+                    "x-enum-code": {
+                      "x-enum-code-category-name": "invasives",
+                      "x-enum-code-header-name": "invasive_plant_distribution_code",
+                      "x-enum-code-name": "code_name",
+                      "x-enum-code-text": "code_description",
+                      "x-enum-code-sort-order": "code_sort_order"
+                    },
+                    "x-tooltip-text": "Description of the average arrangement of invasive plant clusters within the observation area expressed as a distribution code"
+                  },
+                  "plant_life_stage_code": {
+                    "type": "string",
+                    "title": "Life Stage",
+                    "x-enum-code": {
+                      "x-enum-code-category-name": "invasives",
+                      "x-enum-code-header-name": "plant_life_stage_code",
+                      "x-enum-code-name": "code_name",
+                      "x-enum-code-text": "code_description",
+                      "x-enum-code-sort-order": "code_sort_order"
+                    },
+                    "x-tooltip-text": "Average phenological stage of plant; rosette, flowering, etc"
+                  },
+                  "voucher_specimen_collected": {
+                    "type": "string",
+                    "title": "Voucher Specimen Collected",
+                    "enum": ["Yes", "No"],
+                    "x-tooltip-text": "If specimen collected, provide details in observation comments"
+                  },
+                  "edna_sample": {
+                    "type": "string",
+                    "title": "eDNA Sample",
+                    "enum": ["Yes", "No"],
+                    "default": "No",
+                    "x-tooltip-text": "Genetic material that can be extracted from bulk environmental samples such as water and soil"
+                  },
+                  "genetic_sample_id": {
+                    "type": "string",
+                    "title": "Genetic Sample ID",
+                    "x-tooltip-text": "Unique identifier for each voucher collected. Helpful to include abbreviation of waterbody name"
+                  },
+                  "genetic_structure_collected": {
+                    "type": "string",
+                    "title": "Genetic Structure Collected",
+                    "x-tooltip-text": "Describe plant parts collected. Ideal to collect entire plant structure for verification purposes"
+                  }
+                },
+                "required": ["voucher_specimen_collected", "edna_sample"],
+                "dependencies": {
+                  "edna_sample": {
+                    "oneOf": [
+                      {
+                        "properties": {
+                          "edna_sample": {
+                            "enum": ["Yes"]
+                          },
+                          "enda_sample_information": {
+                            "type": "object",
+                            "title": "eDNA Sample Information",
+                            "properties": {
+                              "edna_sample_id": {
+                                "title": "eDNA sample ID",
+                                "type": "number"
+                              },
+                              "genetic_structure_collected": {
+                                "title": "Genetic Structure Collected",
+                                "type": "string"
+                              }
+                            },
+                            "required": ["edna_sample_id", "genetic_structure_collected"]
+                          }
+                        },
+                        "required": ["enda_sample_information"]
+                      },
+                      {
+                        "properties": {
+                          "edna_sample": {
+                            "enum": ["No"]
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "voucher_specimen_collected": {
+                    "oneOf": [
+                      {
+                        "properties": {
+                          "voucher_specimen_collected": {
+                            "enum": ["Yes"]
+                          },
+                          "voucher_specimen_collection_information": {
+                            "type": "object",
+                            "title": "Voucher Specimen Collection Information",
+                            "required": [
+                              "voucher_sample_id",
+                              "date_voucher_collected",
+                              "accession_number",
+                              "name_of_herbarium",
+                              "voucher_verification_completed_by",
+                              "exact_utm_coords",
+                              "date_voucher_verified"
+                            ],
+                            "properties": {
+                              "voucher_sample_id": {
+                                "title": "Voucher Sample ID",
+                                "type": "string",
+                                "x-tooltip-text": "Unique identifier for each voucher collected."
+                              },
+                              "date_voucher_collected": {
+                                "title": "Date Voucher Collected",
+                                "type": "string",
+                                "format": "date"
+                              },
+                              "date_voucher_verified": {
+                                "title": "Date voucher verified",
+                                "type": "string",
+                                "format": "date"
+                              },
+                              "accession_number": {
+                                "title": "Accession number",
+                                "type": "string"
+                              },
+                              "voucher_verification_completed_by": {
+                                "type": "object",
+                                "title": "Voucher verification completed by",
+                                "required": ["person_name", "organization"],
+                                "properties": {
+                                  "person_name": {
+                                    "type": "string",
+                                    "title": "Name"
+                                  },
+                                  "organization": {
+                                    "type": "string",
+                                    "title": "Organization"
+                                  }
+                                }
+                              },
+                              "exact_utm_coords": {
+                                "title": "Exact UTM coordinates of voucher collection site",
+                                "type": "object",
+                                "required": ["utm_zone", "utm_easting", "utm_northing"],
+                                "properties": {
+                                  "utm_zone": {
+                                    "title": "UTM Zone",
+                                    "type": "number"
+                                  },
+                                  "utm_easting": {
+                                    "title": "UTM Easting",
+                                    "type": "number"
+                                  },
+                                  "utm_northing": {
+                                    "title": "UTM Northing",
+                                    "type": "number"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "required": ["voucher_specimen_collection_information"]
+                      },
+                      {
+                        "properties": {
+                          "voucher_specimen_collected": {
+                            "enum": ["No"]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "observation_type": {
+                    "enum": ["Positive Observation"]
+                  }
+                }
+              }
+            ]
           }
         }
       },
@@ -4611,13 +4752,13 @@
         "properties": {
           "water_sample_depth": {
             "type": "number",
-            "title": "Water Depth (m)",
+            "title": "Average depth of waterbody (m)",
             "x-tooltip-text": "Enter the water depth in metres"
           },
           "secchi_depth": {
             "type": "number",
             "title": "Secchi Depth (m)",
-            "x-tooltip-text": "Enter the secchi depth in metres"
+            "x-tooltip-text": "Enter the secchi depth in metres. The secchi depth is the depth of water beyond which a high-contrast pattern on a submerged disk is no longer visible."
           },
           "water_colour": {
             "type": "string",
@@ -4738,7 +4879,14 @@
           "waterbody_use": {
             "type": "string",
             "title": "Waterbody Use",
-            "x-tooltip-text": "Comment box to describe all observed uses of waterbody (e.g. fishing, boating, swimming, agriculture intake, industrial discharge, spawning channel, etc)"
+            "x-enum-code": {
+              "x-enum-code-category-name": "invasives",
+              "x-enum-code-header-name": "waterbody_use_code",
+              "x-enum-code-name": "code_name",
+              "x-enum-code-text": "code_description",
+              "x-enum-code-sort-order": "code_sort_order"
+            },
+            "x-tooltip-text": "Choose all observed uses of waterbody that apply. If other is chosen, add details in the comments."
           }
         }
       },

--- a/api/src/openapi/api-doc.json
+++ b/api/src/openapi/api-doc.json
@@ -715,7 +715,14 @@
               "adjacent_land_use": {
                 "type": "string",
                 "title": "Adjacent Land Use",
-                "x-tooltip-text": "Specify all that apply. Example: residential, parkland/commercial, agricultural, commercial, industrial, transportation (roadway/railway/floatplane) etc"
+                "x-enum-code": {
+                  "x-enum-code-category-name": "invasives",
+                  "x-enum-code-header-name": "adjacent_land_use_code",
+                  "x-enum-code-name": "code_name",
+                  "x-enum-code-text": "code_description",
+                  "x-enum-code-sort-order": "code_sort_order"
+                },
+                "x-tooltip-text": "Select all adjacent land uses that apply and add details in the comment box."
               },
               "inflow_permanent": {
                 "type": "string",
@@ -780,7 +787,14 @@
                       "adjacent_land_use": {
                         "type": "string",
                         "title": "Adjacent Land Use",
-                        "x-tooltip-text": "Specify all that apply. Example: residential, parkland/commercial, agricultural, commercial, industrial, transportation (roadway/railway/floatplane) etc"
+                        "x-enum-code": {
+                          "x-enum-code-category-name": "invasives",
+                          "x-enum-code-header-name": "adjacent_land_use_code",
+                          "x-enum-code-name": "code_name",
+                          "x-enum-code-text": "code_description",
+                          "x-enum-code-sort-order": "code_sort_order"
+                        },
+                        "x-tooltip-text": "Select all adjacent land uses that apply and add details in the comment box."
                       },
                       "watershed_code": {
                         "type": "string",
@@ -2461,6 +2475,13 @@
         "properties": {
           "shoreline_type": {
             "type": "string",
+            "x-enum-code": {
+              "x-enum-code-category-name": "invasives",
+              "x-enum-code-header-name": "shoreline_type_code",
+              "x-enum-code-name": "code_name",
+              "x-enum-code-text": "code_description",
+              "x-enum-code-sort-order": "code_sort_order"
+            },
             "title": "Shoreline Type",
             "x-tooltip-text": "Describe shoreline composition adjacent to observation (e.g. rip rap, road/parking lot, overhanging natural riparian veg, turf, fence, etc)"
           },
@@ -2910,7 +2931,7 @@
                     "title": "Invasive Plant",
                     "x-enum-code": {
                       "x-enum-code-category-name": "invasives",
-                      "x-enum-code-header-name": "invasive_plant_code",
+                      "x-enum-code-header-name": "invasive_plant_aquatic_code",
                       "x-enum-code-name": "code_name",
                       "x-enum-code-text": "code_description",
                       "x-enum-code-sort-order": "code_sort_order"
@@ -5530,17 +5551,6 @@
           }
         ],
         "properties": {
-          "biological_agent_code": {
-            "type": "string",
-            "title": "Biological Agent",
-            "x-enum-code": {
-              "x-enum-code-category-name": "invasives",
-              "x-enum-code-header-name": "biological_agent_code",
-              "x-enum-code-name": "code_name",
-              "x-enum-code-text": "code_description",
-              "x-enum-code-sort-order": "code_sort_order"
-            }
-          },
           "collection_date": {
             "type": "string",
             "title": "Collection Date"

--- a/app/src/rjsf/uiSchema/BaseUISchemaComponents.ts
+++ b/app/src/rjsf/uiSchema/BaseUISchemaComponents.ts
@@ -101,7 +101,7 @@ const AquaticAnimals = {
     'ui:widget': 'single-select-autocomplete'
   },
   early_detection_rapid_resp_ind: {},
-  negative_obs_ind: {},
+  observation_type: {},
   life_stage: {
     'ui:widget': 'single-select-autocomplete'
   },
@@ -155,7 +155,7 @@ const AquaticPlants = {
   e_dna_sample: {},
   genetic_structure_collected: {},
   genetic_sample_id: {},
-  negative_obs_ind: {}
+  observation_type: {}
 };
 
 const WaterbodyData = {
@@ -164,7 +164,9 @@ const WaterbodyData = {
   waterbody_type: {
     'ui:widget': 'single-select-autocomplete'
   },
-  waterbody_use: {}
+  waterbody_use: {
+    'ui:widget': 'multi-select-autocomplete'
+  }
 };
 
 const ProjectData = {

--- a/app/src/rjsf/uiSchema/BaseUISchemaComponents.ts
+++ b/app/src/rjsf/uiSchema/BaseUISchemaComponents.ts
@@ -862,7 +862,9 @@ const Observation_PlantAquatic = {
   },
   terrain_characteristics: {
     ...ThreeColumnStyle,
-    adjacent_land_use: {},
+    adjacent_land_use: {
+      'ui:widget': 'multi-select-autocomplete'
+    },
     inflow_permanent: {},
     inflow_other: {},
     outflow: {},

--- a/app/src/rjsf/uiSchema/UISchemaComponents.ts
+++ b/app/src/rjsf/uiSchema/UISchemaComponents.ts
@@ -99,6 +99,9 @@ const Activity = {
   reported_area: {
     'ui:readonly': true
   },
+  employer_code: {
+    'ui:widget': 'single-select-autocomplete'
+  },
   invasive_species_agency_code: {
     'ui:widget': 'single-select-autocomplete'
   },
@@ -108,6 +111,9 @@ const Activity = {
     }
   },
   general_comment: {},
+  location_description: {
+    'ui:widget': 'textarea'
+  },
   access_description: {
     'ui:widget': 'textarea'
   },

--- a/app/src/rjsf/widgets/MultiSelectAutoComplete.tsx
+++ b/app/src/rjsf/widgets/MultiSelectAutoComplete.tsx
@@ -72,7 +72,7 @@ const MultiSelectAutoComplete = (props: WidgetProps) => {
   const handleOnChange = (event: React.ChangeEvent<{}>, value: AutoCompleteMultiSelectOption[]): void => {
     const newValue: any[] = [];
     value.forEach((item) => newValue.push(item.value));
-    props.onChange(newValue);
+    props.onChange(newValue.toString());
   };
 
   /**

--- a/database/src/seeds/data/invasives/business_codes.csv
+++ b/database/src/seeds/data/invasives/business_codes.csv
@@ -1276,3 +1276,60 @@ invasive_plant_code_withbiocontrol,SJ,St. John's wort/Saint John's wort/ Goatwee
 invasive_plant_code_withbiocontrol,TR,Tansy ragwort (SENE JAC Senecio jacobaea),35
 invasive_plant_code_withbiocontrol,WP,Whiplash hawkweed (HIER FLA Hieracium flagellare),36
 invasive_plant_code_withbiocontrol,YT,Yellow/common toadflax (LINA VUL Linaria vulgaris),37
+employer_code,SIGD,Sechelt Indian Government District,1
+employer_code,DOSicamous,District of Sicamous,2
+employer_code,TOSidney,Town of Sidney,3
+employer_code,VOSilverton,Village of Silverton,4
+employer_code,VOSlocan,Village of Slocan,5
+employer_code,TOSmithers,Town of Smithers,6
+employer_code,DOSooke,District of Sooke,7
+employer_code,TOSpallumcheen,Township of Spallumcheen,8
+employer_code,DOSparwood,District of Sparwood,9
+employer_code,DOSquamish,District of Squamish,10
+employer_code,DOStewart,District of Stewart,11
+employer_code,DOSummerland,District of Summerland,12
+employer_code,MRMOSP,Mountain Resort Municipality of Sun Peaks,13
+employer_code,COSurrey,City of Surrey,14
+employer_code,VOTahsis,Village of Tahsis,15
+employer_code,DOTaylor,District of Taylor,16
+employer_code,VOTelkwa,Village of Telkwa,17
+employer_code,COTerrace,City of Terrace,18
+employer_code,DOTofino,District of Tofino,19
+employer_code,COTrail,City of Trail,20
+employer_code,DTTR,District of Tumbler Ridge,21
+employer_code,DOUcluelet,District of Ucluelet,22
+employer_code,VOValemount,Village of Valemount,23
+employer_code,COVancouver,City of Vancouver,24
+employer_code,DOVanderhoof,District of Vanderhoof,25
+employer_code,COVernon,City of Vernon,26
+employer_code,COVictoria,City of Victoria,27
+employer_code,TVN ,Town of View Royal,28
+employer_code,VOWarfield,Village of Warfield,29
+employer_code,CWY ,City of West Kelowna,30
+employer_code,DWTR,District of West Vancouver,31
+employer_code,RMOR,Resort Municipality of Whistler,32
+employer_code,CWY ,City of White Rock,33
+employer_code,CWY ,City of Williams Lake,34
+employer_code,VOZeballos,Village of Zeballos,35
+employer_code,BSND,Boundary Invasive Species Society,36
+employer_code,CCCIPC,Cariboo Chilcotin Coast Invasive Plant Committee Society,37
+employer_code,CCCIIC,Central Kootenay Invasive Species Society,38
+employer_code,CCCISC,Coastal Invasive Species Committee Society,39
+employer_code,CCCIIC,Columbia Shuswap Invasive Species Society,40
+employer_code,EEUNIE,East Kootenay Invasive Species Council,41
+employer_code,FFCIIF,Fraser Valley Invasive Species Society,42
+employer_code,IICIBI,Invasive Species Council of British Columbia Society,43
+employer_code,IICIMI,Invasive Species Council of Metro Vancouver Society,44
+employer_code,LLCIIL,Lillooet Regional Invasive Species Society,45
+employer_code,NPTH,Northwest Invasive Plant Council,46
+employer_code,OOCIIO,Okanagan and Similkameen Invasive Species Society,47
+employer_code,SSUNIS,Sea to Sky Invasive Species Council,48
+waterbody_use_code,R,recreation,1
+waterbody_use_code,F,fishing,2
+waterbody_use_code,B,boating,3
+waterbody_use_code,S,swimming,4
+waterbody_use_code,AI,agricultural intake,5
+waterbody_use_code,IU,industrial discharge,6
+waterbody_use_code,SW,spawning channel,7
+waterbody_use_code,CWI,community water intake,8
+waterbody_use_code,O,other,9

--- a/database/src/seeds/data/invasives/business_codes.csv
+++ b/database/src/seeds/data/invasives/business_codes.csv
@@ -1303,19 +1303,19 @@ employer_code,COVancouver,City of Vancouver,24
 employer_code,DOVanderhoof,District of Vanderhoof,25
 employer_code,COVernon,City of Vernon,26
 employer_code,COVictoria,City of Victoria,27
-employer_code,TVN ,Town of View Royal,28
+employer_code,TVN,Town of View Royal,28
 employer_code,VOWarfield,Village of Warfield,29
-employer_code,CWY ,City of West Kelowna,30
+employer_code,COWKelowna ,City of West Kelowna,30
 employer_code,DWTR,District of West Vancouver,31
 employer_code,RMOR,Resort Municipality of Whistler,32
-employer_code,CWY ,City of White Rock,33
-employer_code,CWY ,City of Williams Lake,34
+employer_code,COWhiteRock,City of White Rock,33
+employer_code,COWWilliamsLake,City of Williams Lake,34
 employer_code,VOZeballos,Village of Zeballos,35
 employer_code,BSND,Boundary Invasive Species Society,36
-employer_code,CCCIPC,Cariboo Chilcotin Coast Invasive Plant Committee Society,37
-employer_code,CCCIIC,Central Kootenay Invasive Species Society,38
-employer_code,CCCISC,Coastal Invasive Species Committee Society,39
-employer_code,CCCIIC,Columbia Shuswap Invasive Species Society,40
+employer_code,CCCIPCS,Cariboo Chilcotin Coast Invasive Plant Committee Society,37
+employer_code,CKISS,Central Kootenay Invasive Species Society,38
+employer_code,CISCS,Coastal Invasive Species Committee Society,39
+employer_code,CSISS,Columbia Shuswap Invasive Species Society,40
 employer_code,EEUNIE,East Kootenay Invasive Species Council,41
 employer_code,FFCIIF,Fraser Valley Invasive Species Society,42
 employer_code,IICIBI,Invasive Species Council of British Columbia Society,43
@@ -1324,12 +1324,32 @@ employer_code,LLCIIL,Lillooet Regional Invasive Species Society,45
 employer_code,NPTH,Northwest Invasive Plant Council,46
 employer_code,OOCIIO,Okanagan and Similkameen Invasive Species Society,47
 employer_code,SSUNIS,Sea to Sky Invasive Species Council,48
-waterbody_use_code,R,recreation,1
-waterbody_use_code,F,fishing,2
-waterbody_use_code,B,boating,3
-waterbody_use_code,S,swimming,4
-waterbody_use_code,AI,agricultural intake,5
-waterbody_use_code,IU,industrial discharge,6
-waterbody_use_code,SW,spawning channel,7
-waterbody_use_code,CWI,community water intake,8
-waterbody_use_code,O,other,9
+waterbody_use_code,R,Recreation,1
+waterbody_use_code,F,Fishing,2
+waterbody_use_code,B,Boating,3
+waterbody_use_code,S,Swimming,4
+waterbody_use_code,AI,Agricultural Intake,5
+waterbody_use_code,IU,Industrial Discharge,6
+waterbody_use_code,SW,Spawning Channel,7
+waterbody_use_code,CWI,Community Water Intake,8
+waterbody_use_code,O,Other,9
+adjacent_land_use_code,AO,Agricultural Operation,1
+adjacent_land_use_code,RP,Recreational Property,2
+adjacent_land_use_code,PL,Private Land,3
+adjacent_land_use_code,IS,Industrial Site,4
+adjacent_land_use_code,SF,Small Farms,5
+adjacent_land_use_code,L,Livestock,6
+adjacent_land_use_code,P,Parkland,7
+adjacent_land_use_code,RES,Residential,8
+adjacent_land_use_code,PPL,Provincial Public Lands,9
+adjacent_land_use_code,RW,Railway,10
+adjacent_land_use_code,H,Highway,11
+adjacent_land_use_code,O,Other,12
+shoreline_type_code,RR,Riprap,1
+shoreline_type_code,RPL,Road/Parking Lot,2
+shoreline_type_code,BLoDI,Boat Launch or Dock Infrastructure,3
+shoreline_type_code,RRV,Riparian Vegetation,4
+shoreline_type_code,T,Turf,5
+shoreline_type_code,F,Fence,6
+shoreline_type_code,LGA,Livestock Grazing Access,7
+shoreline_type_code,O,Other,8


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

# From Issue 870

- [x] build a new code table called "employer_code" with the content in the attached spreadsheet.  This code table will eventually be updated with new employers added by users during their request for access to the database.  (Government agency names have been confirmed as accurate and company names included so far for the invasive species committees have been checked against this: https://www.orgbook.gov.bc.ca/en/home )
- [x] review all plant forms and make sure there is a mandatory field called "employer" right before the field called "agency" in every form (observation forms, treatment forms, efficacy monitoring and transect forms - for both aquatic and terrestrial plants) with a drop down list linked to the new "employer_code" table.
[employer_code content to develop a code table july 22 2021.xlsx](https://github.com/bcgov/invasivesbc/files/6865748/employer_code.content.to.develop.a.code.table.july.22.2021.xlsx)
- [x] this will be a huge "drop down" list so need to enable the user to start typing in and then it shows options, rather than scrolling through the list.

# From Issue 869

- [x] remove check form for errors and copy form data buttons from the top of the form.... they are already at the bottom of the form which is a better place.  A button should show up that says "paste copied information" IF you have copied info from another form.
- [x] move the zone field ahead of the easting field so the order is zone, easting, northing.
- [x] add field called "employer" right before the existing "Agency" field and use a new "employer_code" code table that needs to be created in ticket #870 .
- [x] add new text field called "location description" before access description.
- [x] move comment field to be after project code
- [x] change tooltips/helptext on the Project code field to be "User defined identifier that can be used to filter or sort records".
- [x] change the waterbody use field to be a drop down that enables multiple options to be chosen (biohub has this if you need to steal code) with a new code table created with the following options: recreation, fishing, boating, swimming, agricultural intake, industrial discharge, spawning channel, community water intake, other.   Update the help text for this field to say "Choose all observed uses of waterbody that apply.  If other is chosen, add details in the comments".
- [x] change the field called "surveyors" to be called "observer(s)" and enable multiple people to be entered similar to the terrestrial observation form
- [x] change the Adjacent land use field to be a drop down that allows multiple options to be chosen with a new code table created with the following options: agricultural operation, recreational property, private land, industrial site, small farms, livestock, parkland, residential, Provincial public lands, railway, highway, other.  and update the helptext for this field to just say "Select all adjacent land uses that apply and add details in the comment box."
- [x] change the name of "inflow (other)" to be "inflow (Temp. or seasonal)
- [x] add a dropdown to shoreline types so people have to choose from a list and then add percentage.  New code table needed with the following options: riprap, road/parking lot, boat launch or dock infrastructure, riparian vegetation, turf, fence, livestock grazing access, other.
- [x] change the name of the field currently called water depth (m) to be "Average depth of waterbody (m)"
- [x] add the following onto the end of the existing help text for the Secchi depth field: "The secchi depth is the depth of water beyond which a high-contrast pattern on a submerged disk is no longer visible."
- [x] use the "invasive_plant_aquatic_code" for the drop down for invasive plant species instead of invasive_plant_code" (For this form only).
- [x] remove the field called provincial EDRR
- [x] move negative observation field up beside the invasive plant field and change the name of the field to be "observation type" and make it a mandatory field.  Options should be positive observation and negative observation (see the terrestrial form for how it should work).  If negative observation is chosen then all other fields in this section should disappear.  
- [x] ensure help text for observation type and life stage are the same as the terrestrial plant observation form.
- [x] remove the health and seed stage fields.
- [x] make the "voucher specimen collected" field mandatory, with help text: "Ideal to collect entire plant structure for verification purposes". 
- [x] if a user chooses yes to "Voucher specimen collected, the following optional fields show up (if they choose no, none of these show up):
o	Voucher Sample ID – text (help text: Unique identifier for each voucher collected. Helpful to include abbreviation of waterbody name.)
o	Date voucher collected
o	Exact UTM coordinates of voucher collection site (xone, easting, northing: user entered)
o	Voucher verification completed by (name and organization)
o	Date voucher verified 
o	Accession number (name of herbarium and accession number)
- [x] edit the "eDNA sample" field to be mandatory with the choices to be – Y/N (help text: Genetic material that can be extracted from bulk environmental samples such as water and soil).   If they choose yes, then the "eDNA sample ID" and "genetic structure collected" fields should pop up, but if they choose "no", it should not show those fields.  Default should be "no".  
- [ ] once all the tasks above have been completed, @CrystalChadburn to determine whether we need the presence and extent survey field and how to address any difference in those fields and what data is collected for each plant depending on the type of survey.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
