### PR TITLE
everything is done for issues 945 and 948 except removing headings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,5 @@ dist
 app/buildArchive
 .vscode
 mingw-w64-x86_64-github-cli-1.13.1-1-any.pkg.tar.zst
+
+app/ios/DerivedData

--- a/api/src/openapi/api-doc.json
+++ b/api/src/openapi/api-doc.json
@@ -381,10 +381,12 @@
           "activity_date_time",
           "latitude",
           "longitude",
+          "utm_zone",
           "employer_code",
           "utm_easting",
           "utm_northing",
-          "reported_area"
+          "reported_area",
+          "location_description"
         ],
         "properties": {
           "activity_date_time": {
@@ -434,11 +436,11 @@
               "x-enum-code-text": "code_description",
               "x-enum-code-sort-order": "code_sort_order"
             },
-            "x-tooltip-text": "Employer of an agent"
+            "x-tooltip-text": "The company or agency that the person(s) completing the activity is directly employed by"
           },
           "invasive_species_agency_code": {
             "type": "string",
-            "title": "Agency",
+            "title": "Funding Agency",
             "x-enum-code": {
               "x-enum-code-category-name": "invasives",
               "x-enum-code-header-name": "invasive_species_agency_code",
@@ -446,7 +448,7 @@
               "x-enum-code-text": "code_description",
               "x-enum-code-sort-order": "code_sort_order"
             },
-            "x-tooltip-text": "Organization that is paying to have this work done"
+            "x-tooltip-text": "Choose the organization that is paying for the work to be done. If multiple funders exist or in cases when an agency has been hired to manage the work on behalf of the primary funding agency, multiple Funding Agencies may be chosen."
           },
           "location_description": {
             "type": "string",
@@ -602,7 +604,7 @@
       "Observation": {
         "title": "Observation Information",
         "type": "object",
-        "required": ["observation_type_code", "observation_persons"],
+        "required": ["observation_type_code", "observation_persons", "survey_type"],
         "properties": {
           "observation_type_code": {
             "type": "string",
@@ -624,6 +626,12 @@
               "$ref": "#/components/schemas/Persons"
             },
             "x-tooltip-text": "Name of person(s) doing the observation"
+          },
+          "survey_type": {
+            "type": "string",
+            "title": "Survey Type",
+            "enum": ["Presence Survey", "Extent Survey"],
+            "x-tooltip-text": "Presence survey used to determine general presence of invasive species in waterbody. Extent survey used to delineate each point and polygon of a target species prior to treatment"
           }
         }
       },
@@ -678,77 +686,51 @@
                     "enum": ["Yes", "No", "Unknown"],
                     "x-tooltip-text": "Indicate if the water level at the observation point is influenced by tides"
                   },
+                  "adjacent_land_use": {
+                    "type": "string",
+                    "title": "Adjacent Land Use",
+                    "x-enum-code": {
+                      "x-enum-code-category-name": "invasives",
+                      "x-enum-code-header-name": "adjacent_land_use_code",
+                      "x-enum-code-name": "code_name",
+                      "x-enum-code-text": "code_description",
+                      "x-enum-code-sort-order": "code_sort_order"
+                    },
+                    "x-tooltip-text": "Select all adjacent land uses that apply and add details in the comment box."
+                  },
+                  "inflow_permanent": {
+                    "type": "string",
+                    "title": "Inflow (Permanent)",
+                    "x-tooltip-text": "Permanent, year round water inflow(s) adjacent to observation (e.g. river)"
+                  },
+                  "inflow_other": {
+                    "type": "string",
+                    "title": "Inflow (Temp. or seasonal)",
+                    "x-tooltip-text": "Temporary or seasonal water inflow(s) adjacent to observation (e.g. overland flow)"
+                  },
+                  "outflow": {
+                    "type": "string",
+                    "title": "Outflow",
+                    "x-tooltip-text": "Permanent, year-round water outflow(s) adjacent to observation (e.g. river, downstream culvert, etc)"
+                  },
+                  "shoreline_types": {
+                    "type": "array",
+                    "title": "Shoreline Types",
+                    "items": {
+                      "$ref": "#/components/schemas/ShorelineTypes"
+                    },
+                    "x-tooltip-text": "Specify shoreline types with their respective percentages"
+                  },
                   "comment": {
                     "type": "string",
                     "title": "Comment",
                     "maxLength": 300,
                     "x-tooltip-text": "Add a comment"
                   }
-                }
+                },
+                "required": ["substrate_type", "tidal_influence"]
               }
             ]
-          },
-          "project_data": {
-            "type": "object",
-            "title": "Project Data",
-            "properties": {
-              "surveyors": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/Persons"
-                },
-                "x-tooltip-text": "Name of person(s) doing the observation",
-
-                "title": "Observer(s)"
-              },
-              "survey_type": {
-                "type": "string",
-                "title": "Survey Type",
-                "enum": ["Presence Survey", "Extent Survey"],
-                "x-tooltip-text": "Presence survey used to determine general presence of invasive species in waterbody. Extent survey used to delineate each point and polygon of a target species prior to treatment"
-              }
-            }
-          },
-          "terrain_characteristics": {
-            "type": "object",
-            "title": "Terrain Characteristics",
-            "properties": {
-              "adjacent_land_use": {
-                "type": "string",
-                "title": "Adjacent Land Use",
-                "x-enum-code": {
-                  "x-enum-code-category-name": "invasives",
-                  "x-enum-code-header-name": "adjacent_land_use_code",
-                  "x-enum-code-name": "code_name",
-                  "x-enum-code-text": "code_description",
-                  "x-enum-code-sort-order": "code_sort_order"
-                },
-                "x-tooltip-text": "Select all adjacent land uses that apply and add details in the comment box."
-              },
-              "inflow_permanent": {
-                "type": "string",
-                "title": "Inflow (Permanent)",
-                "x-tooltip-text": "Permanent, year round water inflow(s) adjacent to observation (e.g. river)"
-              },
-              "inflow_other": {
-                "type": "string",
-                "title": "Inflow (Temp. or seasonal)",
-                "x-tooltip-text": "Temporary or seasonal water inflow(s) adjacent to observation (e.g. overland flow)"
-              },
-              "outflow": {
-                "type": "string",
-                "title": "Outflow",
-                "x-tooltip-text": "Permanent, year-round water outflow(s) adjacent to observation (e.g. river, downstream culvert, etc)"
-              },
-              "shoreline_types": {
-                "type": "array",
-                "title": "Shoreline Types",
-                "items": {
-                  "$ref": "#/components/schemas/ShorelineTypes"
-                },
-                "x-tooltip-text": "Specify shoreline types with their respective percentages"
-              }
-            }
           },
           "water_quality": {
             "type": "object",
@@ -757,7 +739,7 @@
           },
           "invasive_plants": {
             "type": "array",
-            "title": "Aquatic Plants",
+            "title": "Aquatic Invasive Plant Information",
             "items": {
               "$ref": "#/components/schemas/AquaticPlants"
             }
@@ -2506,14 +2488,7 @@
       },
       "ObservationPlantTerrestrialData": {
         "type": "object",
-        "required": [
-          "specific_use_code",
-          "slope_code",
-          "aspect_code",
-          "research_detection_ind",
-          "well_ind",
-          "special_care_ind"
-        ],
+        "required": ["specific_use_code", "slope_code", "aspect_code", "research_detection_ind", "well_ind"],
         "properties": {
           "soil_texture_code": {
             "type": "string",
@@ -2576,13 +2551,6 @@
             "enum": ["Yes", "No", "Unknown"],
             "default": "No",
             "x-tooltip-text": "Is there a visible well nearby? Indicate the distance from the observation in the comments"
-          },
-          "special_care_ind": {
-            "type": "string",
-            "title": "Special Care",
-            "enum": ["Yes", "No", "Unknown"],
-            "default": "No",
-            "x-tooltip-text": "Designation to flag the potential for unique circumstances prior to treatment of the observation area"
           }
         }
       },
@@ -2608,107 +2576,9 @@
             "enum": ["Positive occurrence", "Negative occurrence"],
             "default": "Positive occurrence",
             "x-tooltip-text": "The observation describes the presence or absence of target invasive plants within a defined area"
-          },
-          "voucher_specimen_collected": {
-            "type": "string",
-            "title": "Voucher Specimen Collected",
-            "enum": ["Yes", "No"],
-            "default": "No",
-            "x-tooltip-text": "Ideal to collect entire plant structure for verification purposes."
           }
         },
         "dependencies": {
-          "voucher_specimen_collected": {
-            "oneOf": [
-              {
-                "properties": {
-                  "voucher_specimen_collected": {
-                    "enum": ["Yes"]
-                  },
-                  "voucher_specimen_collection_information": {
-                    "type": "object",
-                    "title": "Voucher Specimen Collection Information",
-                    "required": [
-                      "voucher_sample_id",
-                      "date_voucher_collected",
-                      "accession_number",
-                      "name_of_herbarium",
-                      "voucher_verification_completed_by",
-                      "exact_utm_coords",
-                      "date_voucher_verified"
-                    ],
-                    "properties": {
-                      "voucher_sample_id": {
-                        "title": "Voucher Sample ID",
-                        "type": "string",
-                        "x-tooltip-text": "Unique identifier for each voucher collected."
-                      },
-                      "date_voucher_collected": {
-                        "title": "Date Voucher Collected",
-                        "type": "string",
-                        "format": "date"
-                      },
-                      "date_voucher_verified": {
-                        "title": "Date voucher verified",
-                        "type": "string",
-                        "format": "date"
-                      },
-                      "name_of_herbarium": {
-                        "title": "Name of Herbarium",
-                        "type": "string"
-                      },
-                      "accession_number": {
-                        "title": "Accession number",
-                        "type": "string"
-                      },
-                      "voucher_verification_completed_by": {
-                        "type": "object",
-                        "title": "Voucher verification completed by",
-                        "required": ["person_name", "organization"],
-                        "properties": {
-                          "person_name": {
-                            "type": "string",
-                            "title": "Name"
-                          },
-                          "organization": {
-                            "type": "string",
-                            "title": "Organization"
-                          }
-                        }
-                      },
-                      "exact_utm_coords": {
-                        "title": "Exact UTM coordinates of voucher collection site",
-                        "type": "object",
-                        "required": ["utm_zone", "utm_easting", "utm_northing"],
-                        "properties": {
-                          "utm_zone": {
-                            "title": "UTM Zone",
-                            "type": "number"
-                          },
-                          "utm_easting": {
-                            "title": "UTM Easting",
-                            "type": "number"
-                          },
-                          "utm_northing": {
-                            "title": "UTM Northing",
-                            "type": "number"
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "required": ["voucher_specimen_collection_information"]
-              },
-              {
-                "properties": {
-                  "voucher_specimen_collected": {
-                    "enum": ["No"]
-                  }
-                }
-              }
-            ]
-          },
           "occurrence": {
             "oneOf": [
               {
@@ -2758,9 +2628,107 @@
                       "x-enum-code-sort-order": "code_sort_order"
                     },
                     "x-tooltip-text": "Average phenological stage of plant; rosette, flowering, etc"
+                  },
+                  "voucher_specimen_collected": {
+                    "type": "string",
+                    "title": "Voucher Specimen Collected",
+                    "enum": ["Yes", "No"],
+                    "default": "No",
+                    "x-tooltip-text": "Ideal to collect entire plant structure for verification purposes."
                   }
                 },
                 "dependencies": {
+                  "voucher_specimen_collected": {
+                    "oneOf": [
+                      {
+                        "properties": {
+                          "voucher_specimen_collected": {
+                            "enum": ["Yes"]
+                          },
+                          "voucher_specimen_collection_information": {
+                            "type": "object",
+                            "title": "Voucher Specimen Collection Information",
+                            "required": [
+                              "voucher_sample_id",
+                              "date_voucher_collected",
+                              "accession_number",
+                              "name_of_herbarium",
+                              "voucher_verification_completed_by",
+                              "exact_utm_coords",
+                              "date_voucher_verified"
+                            ],
+                            "properties": {
+                              "voucher_sample_id": {
+                                "title": "Voucher Sample ID",
+                                "type": "string",
+                                "x-tooltip-text": "Unique identifier for each voucher collected."
+                              },
+                              "date_voucher_collected": {
+                                "title": "Date Voucher Collected",
+                                "type": "string",
+                                "format": "date"
+                              },
+                              "date_voucher_verified": {
+                                "title": "Date voucher verified",
+                                "type": "string",
+                                "format": "date"
+                              },
+                              "name_of_herbarium": {
+                                "title": "Name of Herbarium",
+                                "type": "string"
+                              },
+                              "accession_number": {
+                                "title": "Accession number",
+                                "type": "string"
+                              },
+                              "voucher_verification_completed_by": {
+                                "type": "object",
+                                "title": "Voucher verification completed by",
+                                "required": ["person_name", "organization"],
+                                "properties": {
+                                  "person_name": {
+                                    "type": "string",
+                                    "title": "Name"
+                                  },
+                                  "organization": {
+                                    "type": "string",
+                                    "title": "Organization"
+                                  }
+                                }
+                              },
+                              "exact_utm_coords": {
+                                "title": "Exact UTM coordinates of voucher collection site",
+                                "type": "object",
+                                "required": ["utm_zone", "utm_easting", "utm_northing"],
+                                "properties": {
+                                  "utm_zone": {
+                                    "title": "UTM Zone",
+                                    "type": "number"
+                                  },
+                                  "utm_easting": {
+                                    "title": "UTM Easting",
+                                    "type": "number"
+                                  },
+                                  "utm_northing": {
+                                    "title": "UTM Northing",
+                                    "type": "number"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "required": ["voucher_specimen_collection_information"]
+                      },
+                      {
+                        "properties": {
+                          "voucher_specimen_collected": {
+                            "enum": ["No"]
+                          }
+                        }
+                      }
+                    ]
+                  },
                   "edna_sample": {
                     "oneOf": [
                       {
@@ -2796,7 +2764,12 @@
                     ]
                   }
                 },
-                "required": ["invasive_plant_density_code", "invasive_plant_distribution_code", "plant_life_stage_code"]
+                "required": [
+                  "invasive_plant_density_code",
+                  "invasive_plant_distribution_code",
+                  "plant_life_stage_code",
+                  "voucher_specimen_collected"
+                ]
               },
               {
                 "properties": {
@@ -2916,12 +2889,24 @@
       },
       "AquaticPlants": {
         "type": "object",
-        "required": ["observation_type"],
+        "required": ["observation_type", "invasive_plant_code"],
         "properties": {
           "sample_point_id": {
             "type": "string",
             "title": "Sample Point ID",
             "x-tooltip-text": "For Presence Surveys. Number each sample point in the same waterbody (e.g. 001, 002, 003, etc). Do not use for Extent Surveys"
+          },
+          "invasive_plant_code": {
+            "type": "string",
+            "title": "Invasive Plant",
+            "x-enum-code": {
+              "x-enum-code-category-name": "invasives",
+              "x-enum-code-header-name": "invasive_plant_aquatic_code",
+              "x-enum-code-name": "code_name",
+              "x-enum-code-text": "code_description",
+              "x-enum-code-sort-order": "code_sort_order"
+            },
+            "x-tooltip-text": "For Presence survey: select species observed at coordinates. For Extent Survey: select target species for survey"
           },
           "observation_type": {
             "type": "string",
@@ -2938,18 +2923,13 @@
                 "properties": {
                   "observation_type": {
                     "enum": ["Negative Observation"]
-                  },
-                  "invasive_plant_code": {
-                    "type": "string",
-                    "title": "Invasive Plant",
-                    "x-enum-code": {
-                      "x-enum-code-category-name": "invasives",
-                      "x-enum-code-header-name": "invasive_plant_aquatic_code",
-                      "x-enum-code-name": "code_name",
-                      "x-enum-code-text": "code_description",
-                      "x-enum-code-sort-order": "code_sort_order"
-                    },
-                    "x-tooltip-text": "For Presence survey: select species observed at coordinates. For Extent Survey: select target species for survey"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "observation_type": {
+                    "enum": ["Positive Observation"]
                   },
                   "invasive_plant_density_code": {
                     "type": "string",
@@ -3002,137 +2982,6 @@
                     "type": "string",
                     "title": "Genetic Structure Collected",
                     "x-tooltip-text": "Describe plant parts collected. Ideal to collect entire plant structure for verification purposes"
-                  }
-                },
-                "required": ["voucher_specimen_collected"],
-                "dependencies": {
-                  "edna_sample": {
-                    "oneOf": [
-                      {
-                        "properties": {
-                          "edna_sample": {
-                            "enum": ["Yes"]
-                          },
-                          "enda_sample_information": {
-                            "type": "object",
-                            "title": "eDNA Sample Information",
-                            "properties": {
-                              "edna_sample_id": {
-                                "title": "eDNA sample ID",
-                                "type": "number"
-                              },
-                              "genetic_structure_collected": {
-                                "title": "Genetic Structure Collected",
-                                "type": "string"
-                              }
-                            },
-                            "required": ["edna_sample_id", "genetic_structure_collected"]
-                          }
-                        },
-                        "required": ["enda_sample_information"]
-                      },
-                      {
-                        "properties": {
-                          "edna_sample": {
-                            "enum": ["No"]
-                          }
-                        }
-                      }
-                    ]
-                  },
-                  "voucher_specimen_collected": {
-                    "oneOf": [
-                      {
-                        "properties": {
-                          "voucher_specimen_collected": {
-                            "enum": ["Yes"]
-                          },
-                          "voucher_specimen_collection_information": {
-                            "type": "object",
-                            "title": "Voucher Specimen Collection Information",
-                            "required": [
-                              "voucher_sample_id",
-                              "date_voucher_collected",
-                              "accession_number",
-                              "name_of_herbarium",
-                              "voucher_verification_completed_by",
-                              "exact_utm_coords",
-                              "date_voucher_verified"
-                            ],
-                            "properties": {
-                              "voucher_sample_id": {
-                                "title": "Voucher Sample ID",
-                                "type": "string",
-                                "x-tooltip-text": "Unique identifier for each voucher collected."
-                              },
-                              "date_voucher_collected": {
-                                "title": "Date Voucher Collected",
-                                "type": "string",
-                                "format": "date"
-                              },
-                              "date_voucher_verified": {
-                                "title": "Date voucher verified",
-                                "type": "string",
-                                "format": "date"
-                              },
-                              "accession_number": {
-                                "title": "Accession number",
-                                "type": "string"
-                              },
-                              "voucher_verification_completed_by": {
-                                "type": "object",
-                                "title": "Voucher verification completed by",
-                                "required": ["person_name", "organization"],
-                                "properties": {
-                                  "person_name": {
-                                    "type": "string",
-                                    "title": "Name"
-                                  },
-                                  "organization": {
-                                    "type": "string",
-                                    "title": "Organization"
-                                  }
-                                }
-                              },
-                              "exact_utm_coords": {
-                                "title": "Exact UTM coordinates of voucher collection site",
-                                "type": "object",
-                                "required": ["utm_zone", "utm_easting", "utm_northing"],
-                                "properties": {
-                                  "utm_zone": {
-                                    "title": "UTM Zone",
-                                    "type": "number"
-                                  },
-                                  "utm_easting": {
-                                    "title": "UTM Easting",
-                                    "type": "number"
-                                  },
-                                  "utm_northing": {
-                                    "title": "UTM Northing",
-                                    "type": "number"
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "required": ["voucher_specimen_collection_information"]
-                      },
-                      {
-                        "properties": {
-                          "voucher_specimen_collected": {
-                            "enum": ["No"]
-                          }
-                        }
-                      }
-                    ]
-                  }
-                }
-              },
-              {
-                "properties": {
-                  "observation_type": {
-                    "enum": ["Positive Observation"]
                   },
                   "edna_sample": {
                     "type": "string",
@@ -3142,7 +2991,15 @@
                     "x-tooltip-text": "Genetic material that can be extracted from bulk environmental samples such as water and soil"
                   }
                 },
-                "required": ["edna_sample"],
+                "required": [
+                  "edna_sample",
+                  "invasive_plant_density_code",
+                  "voucher_specimen_collected",
+                  "genetic_structure_collected",
+                  "genetic_sample_id",
+                  "plant_life_stage_code",
+                  "invasive_plant_distribution_code"
+                ],
                 "dependencies": {
                   "edna_sample": {
                     "oneOf": [
@@ -4916,6 +4773,7 @@
         }
       },
       "WaterbodyData": {
+        "required": ["waterbody_type"],
         "properties": {
           "waterbody_type": {
             "type": "string",

--- a/api/src/openapi/api-doc.json
+++ b/api/src/openapi/api-doc.json
@@ -3206,7 +3206,7 @@
       },
       "TransectData": {
         "type": "object",
-        "title": "Transect Information",
+        "title": " ",
         "required": [
           "utm_zone",
           "transect_start_date_time",

--- a/api/src/openapi/api-doc.json
+++ b/api/src/openapi/api-doc.json
@@ -636,7 +636,7 @@
         }
       },
       "Observation_PlantTerrestrial": {
-        "title": "Terrestrial Plant Information",
+        "title": " ",
         "type": "object",
         "required": ["observation_plant_terrestrial_data", "invasive_plants"],
         "properties": {
@@ -657,7 +657,7 @@
         }
       },
       "Observation_PlantAquatic": {
-        "title": "Aquatic Plant Information",
+        "title": "‎‎‎‏‏‎ ‎",
         "type": "object",
         "required": ["waterbody_data", "invasive_plants"],
         "properties": {

--- a/app/src/features/home/activity/ActivityPage.tsx
+++ b/app/src/features/home/activity/ActivityPage.tsx
@@ -32,6 +32,7 @@ import {
   getHerbicideMixValidation,
   getVegTransectPointsPercentCoverValidator,
   getDurationCountAndPlantCountValidation,
+  getPersonNameNoNumbersValidator,
   getJurisdictionPercentValidator,
   getSlopeAspectBothFlatValidator,
   getInvasivePlantsValidator,
@@ -549,6 +550,7 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
             getHerbicideMixValidation(),
             getVegTransectPointsPercentCoverValidator(),
             getDurationCountAndPlantCountValidation(),
+            getPersonNameNoNumbersValidator(),
             getJurisdictionPercentValidator(),
             getInvasivePlantsValidator(linkedActivity)
           ])}

--- a/app/src/rjsf/business-rules/customValidation.ts
+++ b/app/src/rjsf/business-rules/customValidation.ts
@@ -345,12 +345,38 @@ export function getInvasivePlantsValidator(linkedActivity: any): rjsfValidator {
   };
 }
 /*
+  Function to validate that the person field does not contain any numbers
+*/
+export function getPersonNameNoNumbersValidator(): rjsfValidator {
+  return (formData: any, errors: FormValidation): FormValidation => {
+    if (
+      !formData ||
+      !formData.activity_type_data ||
+      !formData.activity_type_data.observation_persons ||
+      !formData.activity_type_data.observation_persons ||
+      formData.activity_type_data.observation_persons.length < 1
+    ) {
+      return errors;
+    }
+    let index = 0;
+    formData.activity_type_data.observation_persons.forEach((person) => {
+      if (person?.person_name)
+        if (person.person_name.match(/\d+/g) != null) {
+          errors['activity_type_data']['observation_persons'][index]['person_name'].addError(
+            'Name field must not contain any numbers'
+          );
+        }
+      index++;
+    });
+    return errors;
+  };
+}
+/*
   Function to validate that if the herbicide mix is set to true,
   there must be 2 or more herbicides chosen
 */
 export function getHerbicideMixValidation(): rjsfValidator {
   return (formData: any, errors: FormValidation): FormValidation => {
-    console.log(formData);
     if (
       !formData ||
       !formData.activity_subtype_data ||


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

## Issue945

- [x] all fields under "basic information" need to be mandatory EXCEPT project code and comment.
- [x] Edit the help text for the "Employer" field to say "The company or agency that the person(s) completing the activity is directly employed by".
- [x] change the name of "Agency" field to "Funding Agency" and update the help text to say "Choose the organization that is paying for the work to be done.  If multiple funders exist or in cases when an agency has been hired to manage the work on behalf of the primary funding agency, multiple Funding Agencies may be chosen."
- [x] remove the "special care" field
- [x] restrict "observation person(s)" to text only (no numbers)
- [x] remove the heading that says "Aquatic Plant Information" as it has nothing under it and confuses users.
- [x] make the "Waterbody type", "Substrate type" and "Tidal influence" fields mandatory
- [x] move the fields currently under the "terrain characteristics" up under the Waterbody Data heading between "tidal influence" and "comment", and delete the "terrain characteristics" heading.
- [x] Under the "project data" heading, delete the observer(s) field and move the "survey type" field up under "Observation information" to sit between "type" and "observation person(s)".  This leaves nothing under project data, so delete this heading.
- [x] edit "Aquatic plants" heading to be "Aquatic Invasive Plant Information"
- [x] all fields under the Aquatic Plants heading should be mandatory, except for "Sample Point ID". 
- [x] the fields that show up when you choose positive and negative observation are backwards.  Fix this so that a user FIRST enters the sample point ID, then picks invasive plant, then either positive or negative observation (put fields in that order).  Then, if they choose positive observation, the following fields show up in this order (Density, Distribution, Life stage, voucher specimen collected, eDNA sample) but when you choose negative observation, no other fields show up.  Double check this matches the plant terrestrial observation form.  
- [x] make invasive plant and observation type mandatory fields, as well as all the fields that show up when you choose positive observation.  Sample point ID remains optional.

## Issue948

- [x] all fields under "basic information" need to be mandatory EXCEPT project code and comment.
- [x] Edit the help text for the "Employer" field to say "The company or agency that the person(s) completing the activity is directly employed by".
- [x] change the name of "Agency" field to "Funding Agency" and update the help text to say "Choose the organization that is paying for the work to be done.  If multiple funders exist or in cases when an agency has been hired to manage the work on behalf of the primary funding agency, multiple Funding Agencies may be chosen."
- [x] restrict "observation person(s)" to text only (no numbers)
- [x] remove the "special care" field
- [x] remove the heading that says "Terrestrial Plant Information" as it has nothing under it and confuses users.  I know this was on a previous ticket and was unable to be done - double check with @micheal-w-wells to see if we can remove it.
- [x] if negative observation is chosen all of the following fields are hidden and only show if positive observation is chosen (Density, Distribution, Life stage, Voucher specimen collected, eDNA sample).  It is still showing Voucher Specimen collected for negative occurance.
- [x] make invasive plant and observation type mandatory fields, as well as all the fields that show up when you choose positive observation.  

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
