### PR TITLE
Mobile UI fix - buttons and layer picker

### DIFF
--- a/app/src/components/map/LayerPicker/SortableHelper.tsx
+++ b/app/src/components/map/LayerPicker/SortableHelper.tsx
@@ -38,7 +38,8 @@ import {
   CircularProgress,
   AccordionSummary,
   Accordion,
-  makeStyles
+  makeStyles,
+  Popover
 } from '@material-ui/core';
 import IMapContainerProps from '../MapContainer2';
 import { Feature, FeatureCollection, GeoJsonObject } from 'geojson';
@@ -93,6 +94,9 @@ export function LayerPicker(props: any) {
   const [menuState, setMenuState] = useState(false);
   const [checked, setChecked] = useState(false);
   const [radio, setRadio] = useState('default');
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+  const open = Boolean(anchorEl);
+  const id = open ? 'simple-popover' : undefined;
 
   const updateParent = (parentType: string, fieldsToUpdate: Object) => {
     let pIndex = getParentIndex(objectState, parentType);
@@ -251,21 +255,34 @@ export function LayerPicker(props: any) {
   const handleRadioChange = (event) => {
     setRadio(event.target.value);
   };
-  const toggleMenu = (event) => {
-    event.preventDefault();
-    setMenuState(!menuState);
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
   };
 
   return (
     <div style={{ zIndex: 1000 }}>
       <IconButton
         className={themeContext.themeType ? toolClass.toolBtnDark : toolClass.toolBtnLight}
-        onClick={toggleMenu}>
+        onClick={handleClick}>
         <LayersIcon />
       </IconButton>
-      {menuState ? (
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'left'
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right'
+        }}>
         <div
-          className={classes.root}
           onTouchStart={() => {
             map.dragging.disable();
             map.doubleClickZoom.disable();
@@ -319,7 +336,7 @@ export function LayerPicker(props: any) {
             lockAxis="y"
           />
         </div>
-      ) : null}
+      </Popover>
       {checked ? (
         <>
           {/*<TempPOILoader pointOfInterestFilter={props.pointOfInterestFilter} ></TempPOILoader>*/}

--- a/app/src/components/map/LayerPicker/SortableHelper.tsx
+++ b/app/src/components/map/LayerPicker/SortableHelper.tsx
@@ -1,15 +1,6 @@
-import React, { useState, useRef, useEffect, useContext } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
-import Accordion from '@material-ui/core/Accordion';
-import AccordionSummary from '@material-ui/core/AccordionSummary';
+import React, { useState, useEffect, useContext } from 'react';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import CircularProgress from '@material-ui/core/CircularProgress';
-import Checkbox from '@material-ui/core/Checkbox';
 import { SortableContainer, SortableElement, SortableHandle } from 'react-sortable-hoc';
-import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemIcon from '@material-ui/core/ListItemIcon';
-import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
 import DragHandleIcon from '@material-ui/icons/DragHandle';
 /* HelperFiles */
 import {
@@ -24,7 +15,6 @@ import {
   getChild,
   sortObject
 } from './LayerPickerHelper';
-import Grid from '@material-ui/core/Grid';
 import ColorPicker from 'material-ui-color-picker';
 import { TileLayer, useMap } from 'react-leaflet';
 import { Capacitor } from '@capacitor/core';
@@ -32,15 +22,30 @@ import { MapRequestContext } from 'contexts/MapRequestsContext';
 // for confirming loaded layers
 import DoneIcon from '@material-ui/icons/Done';
 import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline';
-import { IconButton } from '@material-ui/core';
 import LayersIcon from '@material-ui/icons/Layers';
-
-import { FormControl, FormControlLabel, Radio, RadioGroup } from '@material-ui/core';
+import {
+  Checkbox,
+  IconButton,
+  FormControl,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  Grid,
+  ListItemSecondaryAction,
+  ListItemIcon,
+  ListItem,
+  List,
+  CircularProgress,
+  AccordionSummary,
+  Accordion,
+  makeStyles
+} from '@material-ui/core';
 import IMapContainerProps from '../MapContainer2';
 import { Feature, FeatureCollection, GeoJsonObject } from 'geojson';
 import { GeoJSON } from 'react-leaflet';
 import TempPOILoader from '../LayerLoaderHelpers/TempPOILoader';
 import { ThemeContext } from 'contexts/themeContext';
+import { toolStyles } from '../Tools/ToolBtnStyles';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -73,29 +78,12 @@ const useStyles = makeStyles((theme) => ({
   },
   gridContainer: {
     position: 'relative'
-  },
-  iconButton: {
-    margin: '5px',
-    background: 'white',
-    borderRadius: '4px',
-    position: 'relative',
-    '&:hover': {
-      background: 'white'
-    }
-  },
-  iconButtonDark: {
-    margin: '5px',
-    background: '#424242',
-    borderRadius: '4px',
-    position: 'relative',
-    '&:hover': {
-      background: '#424242'
-    }
   }
 }));
 
 export function LayerPicker(props: any) {
   const classes = useStyles();
+  const toolClass = toolStyles();
   const mapLayersContext = useContext(MapRequestContext);
   const timeLeft = WithCounter();
   const map = useMap();
@@ -270,7 +258,9 @@ export function LayerPicker(props: any) {
 
   return (
     <div style={{ zIndex: 1000 }}>
-      <IconButton className={themeContext.themeType ? classes.iconButtonDark : classes.iconButton} onClick={toggleMenu}>
+      <IconButton
+        className={themeContext.themeType ? toolClass.toolBtnDark : toolClass.toolBtnLight}
+        onClick={toggleMenu}>
         <LayersIcon />
       </IconButton>
       {menuState ? (

--- a/app/src/components/map/MapContainer2.tsx
+++ b/app/src/components/map/MapContainer2.tsx
@@ -39,22 +39,14 @@ import { debounced } from 'utils/FunctionUtils';
 import { createPolygonFromBounds } from './LayerLoaderHelpers/LtlngBoundsToPoly';
 import { MapRequestContextProvider, MapRequestContext } from 'contexts/MapRequestsContext';
 import MeasureTool from './Tools/MeasureTool';
-import { makeStyles, Theme } from '@material-ui/core';
 import EditTools from './Tools/EditTools';
 import { RenderKeyFeaturesNearFeature } from './LayerLoaderHelpers/DataBCRenderFeaturesNearFeature';
+import { toolStyles } from './Tools/ToolBtnStyles';
 
 let DefaultIcon = L.icon({
   iconUrl: icon,
   shadowUrl: iconShadow
 });
-
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    position: 'relative',
-    height: '100%',
-    width: '100%'
-  }
-}));
 
 L.Marker.prototype.options.icon = DefaultIcon;
 
@@ -150,6 +142,7 @@ const interactiveGeometryStyle = () => {
 const MapContainer2: React.FC<IMapContainerProps> = (props) => {
   const databaseContext = useContext(DatabaseContext);
   const [map, setMap] = useState<any>(null);
+  const toolClass = toolStyles();
 
   const Offline = () => {
     const mapOffline = useMap();
@@ -254,14 +247,7 @@ const MapContainer2: React.FC<IMapContainerProps> = (props) => {
       whenCreated={setMap}>
       {/* <LayerComponentGoesHere></LayerComponentGoesHere> */}
       <MapRequestContextProvider>
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'flex-end',
-            alignItems: 'flex-end',
-            flexFlow: 'column wrap',
-            height: '45vh'
-          }}>
+        <div className={toolClass.toolBtnsLoc}>
           <LayerPicker data={data} />
           <DisplayPosition map={map} />
           <MeasureTool />
@@ -275,7 +261,7 @@ const MapContainer2: React.FC<IMapContainerProps> = (props) => {
         {/* Here is the offline component */}
         <Offline />
 
-        <ZoomControl position="bottomleft" />
+        <ZoomControl position="bottomright" />
 
         {/* Here are the editing tools */}
 

--- a/app/src/components/map/Tools/DisplayPosition.tsx
+++ b/app/src/components/map/Tools/DisplayPosition.tsx
@@ -2,10 +2,11 @@ import React, { useState, useEffect, useRef, useContext } from 'react';
 import LocationOnIcon from '@material-ui/icons/LocationOn';
 import { Marker, Popup } from 'react-leaflet';
 import { Geolocation } from '@capacitor/geolocation';
-import { CircularProgress, IconButton, makeStyles } from '@material-ui/core';
+import { CircularProgress, IconButton } from '@material-ui/core';
 import proj4 from 'proj4';
 import L from 'leaflet';
 import { ThemeContext } from 'contexts/themeContext';
+import { toolStyles } from './ToolBtnStyles';
 
 export const utm_zone = (longitude: number, latitude: number) => {
   let utmZone = ((Math.floor((longitude + 180) / 6) % 60) + 1).toString(); //getting utm zone
@@ -19,33 +20,8 @@ export const utm_zone = (longitude: number, latitude: number) => {
   return 'UTM  Zone:' + utmZone + ' UTM Easting:' + utmEasting + ' UTM Northing:' + utmNorthing;
 };
 
-const useStyles = makeStyles((theme) => ({
-  iconButton: {
-    width: 48,
-    height: 48,
-    margin: '5px',
-    zIndex: 1500,
-    background: 'white',
-    borderRadius: '15%',
-    '&:hover': {
-      background: 'white'
-    }
-  },
-  iconButtonDark: {
-    width: 48,
-    height: 48,
-    margin: '5px',
-    zIndex: 1500,
-    background: '#424242',
-    borderRadius: '15%',
-    '&:hover': {
-      background: '#424242'
-    }
-  }
-}));
-
 export default function DisplayPosition({ map }) {
-  const classes = useStyles();
+  const toolClass = toolStyles();
   const themeContext = useContext(ThemeContext);
   const [newPosition, setNewPosition] = useState(null);
   const [initialTime, setInitialTime] = useState(0);
@@ -93,7 +69,7 @@ export default function DisplayPosition({ map }) {
       ) : null}
       <IconButton
         ref={divRef}
-        className={themeContext.themeType ? classes.iconButtonDark : classes.iconButton}
+        className={themeContext.themeType ? toolClass.toolBtnDark : toolClass.toolBtnLight}
         disabled={startTimer}
         aria-label="my position"
         onClick={getLocation}>

--- a/app/src/components/map/Tools/EditTools.tsx
+++ b/app/src/components/map/Tools/EditTools.tsx
@@ -1,4 +1,4 @@
-import { IconButton, makeStyles } from '@material-ui/core';
+import { IconButton } from '@material-ui/core';
 import { useContext, useEffect, useRef, useState } from 'react';
 import { useLeafletContext } from '@react-leaflet/core';
 import { useMapEvent } from 'react-leaflet';
@@ -9,48 +9,10 @@ import single from '../Icons/square.png';
 import multi from '../Icons/trim.png';
 import { async } from 'q';
 import { ThemeContext } from 'contexts/themeContext';
-
-const useStyles = makeStyles((theme) => ({
-  image: {
-    height: 24,
-    width: 24
-  },
-  toolButton: {
-    margin: '5px',
-    background: 'white',
-    zIndex: 999,
-    height: '48px',
-    width: '48PX',
-    borderRadius: '4px',
-    '&:hover': {
-      background: 'white'
-    }
-  },
-  toolButtonDark: {
-    margin: '5px',
-    background: '#424242',
-    zIndex: 999,
-    height: '48px',
-    width: '48PX',
-    borderRadius: '4px',
-    '&:hover': {
-      background: '#424242'
-    }
-  },
-  typography: {
-    paddingLeft: theme.spacing(2),
-    fontSize: 16,
-    width: 150
-  },
-  button: {
-    display: 'flex',
-    justifyContent: 'flex-start',
-    width: 150
-  }
-}));
+import { toolStyles } from './ToolBtnStyles';
 
 const EditTools = (props: any) => {
-  const classes = useStyles();
+  const toolClass = toolStyles();
   const themeContext = useContext(ThemeContext);
   // This should get the 'FeatureGroup' connected to the tools
   const [multiMode, setMultiMode] = useState(false);
@@ -339,7 +301,7 @@ const EditTools = (props: any) => {
   return (
     <IconButton
       ref={divRef}
-      className={themeContext.themeType ? classes.toolButtonDark : classes.toolButton}
+      className={themeContext.themeType ? toolClass.toolBtnDark : toolClass.toolBtnLight}
       onClick={toggleMode}>
       {multiMode ? (
         <img src={multi} style={{ width: 32, height: 32 }} />

--- a/app/src/components/map/Tools/MeasureTool.tsx
+++ b/app/src/components/map/Tools/MeasureTool.tsx
@@ -1,42 +1,17 @@
 import React, { useState, useEffect, useRef, useContext } from 'react';
-import { useMapEvent, GeoJSON, Popup, Marker, useMapEvents } from 'react-leaflet';
+import { useMapEvent, GeoJSON, Popup, Marker } from 'react-leaflet';
 import { IconButton, Button, makeStyles, Popover, Grid, Typography } from '@material-ui/core';
 import RadioButtonUncheckedIcon from '@material-ui/icons/RadioButtonUnchecked';
 import RadioButtonCheckedIcon from '@material-ui/icons/RadioButtonChecked';
 import utm_zone from './DisplayPosition';
-import turf, { polygon, area } from '@turf/turf';
+import { polygon, area } from '@turf/turf';
 import L from 'leaflet';
 import dotMarker from '../Icons/dotMarker.png';
 import ruler from '../Icons/ruler.png';
 import { ThemeContext } from 'contexts/themeContext';
+import { toolStyles } from './ToolBtnStyles';
 
 const useStyles = makeStyles((theme) => ({
-  image: {
-    height: 24,
-    width: 24
-  },
-  rulerButton: {
-    margin: '5px',
-    background: 'white',
-    zIndex: 1500,
-    height: '48px',
-    width: '48px',
-    borderRadius: '4px',
-    '&:hover': {
-      background: 'white'
-    }
-  },
-  rulerButtonDark: {
-    margin: '5px',
-    background: '#424242',
-    zIndex: 1500,
-    height: '48px',
-    width: '48px',
-    borderRadius: '4px',
-    '&:hover': {
-      background: '#424242'
-    }
-  },
   typography: {
     paddingLeft: theme.spacing(2),
     fontSize: 16,
@@ -144,6 +119,7 @@ const finishPolygon = (geometryObj: any, polyObj: any, locArray: any) => {
 
 const MeasureTool = (props: any) => {
   const classes = useStyles();
+  const toolClass = toolStyles();
   const themeContext = useContext(ThemeContext);
   const [isMeasuringDistance, setIsMeasuringDistance] = useState(false);
   const [isMeasuringArea, setIsMeasuringArea] = useState(false);
@@ -219,9 +195,9 @@ const MeasureTool = (props: any) => {
     <>
       <IconButton
         ref={divRef}
-        className={themeContext.themeType ? classes.rulerButtonDark : classes.rulerButton}
+        className={themeContext.themeType ? toolClass.toolBtnDark : toolClass.toolBtnLight}
         onClick={handleClick}>
-        <img className={classes.image} src={ruler} />
+        <img className={toolClass.toolImg} src={ruler} />
       </IconButton>
       <Popover
         id={id}

--- a/app/src/components/map/Tools/MeasureTool.tsx
+++ b/app/src/components/map/Tools/MeasureTool.tsx
@@ -133,6 +133,8 @@ const MeasureTool = (props: any) => {
   const geometry = { aGeoJSON, setGeoJSON };
   const polyObj = { polyArea, setPolyArea };
   const distance = { totalDistance, setTotalDistance };
+  const open = Boolean(anchorEl);
+  const id = open ? 'simple-popover' : undefined;
 
   const markerIcon = L.icon({
     iconUrl: dotMarker,
@@ -188,8 +190,6 @@ const MeasureTool = (props: any) => {
   const handleClose = () => {
     setAnchorEl(null);
   };
-  const open = Boolean(anchorEl);
-  const id = open ? 'simple-popover' : undefined;
 
   return (
     <>

--- a/app/src/components/map/Tools/ToolBtnStyles.tsx
+++ b/app/src/components/map/Tools/ToolBtnStyles.tsx
@@ -1,12 +1,20 @@
-import { createTheme, makeStyles, ThemeOptions } from '@material-ui/core';
-import rjsfTheme from 'themes/rjsfTheme';
+import { makeStyles } from '@material-ui/core';
 
 export const toolStyles = makeStyles((theme) => ({
+  toolBtnsLoc: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    alignItems: 'flex-end',
+    flexFlow: 'column wrap',
+    height: '40vh'
+  },
   toolBtnLight: {
     height: 43,
     width: 43,
     zIndex: 1500,
     borderRadius: 4,
+    marginRight: 10,
+    marginBottom: 5,
     background: 'white',
     '&:hover': {
       background: 'white'
@@ -17,6 +25,8 @@ export const toolStyles = makeStyles((theme) => ({
     width: 43,
     zIndex: 1500,
     borderRadius: 4,
+    marginRight: 10,
+    marginBottom: 5,
     background: '#424242',
     '&:hover': {
       background: '#424242'

--- a/app/src/components/map/Tools/ToolBtnStyles.tsx
+++ b/app/src/components/map/Tools/ToolBtnStyles.tsx
@@ -1,0 +1,29 @@
+import { createTheme, makeStyles, ThemeOptions } from '@material-ui/core';
+import rjsfTheme from 'themes/rjsfTheme';
+
+export const toolStyles = makeStyles((theme) => ({
+  toolBtnLight: {
+    height: 43,
+    width: 43,
+    zIndex: 1500,
+    borderRadius: 4,
+    background: 'white',
+    '&:hover': {
+      background: 'white'
+    }
+  },
+  toolBtnDark: {
+    height: 43,
+    width: 43,
+    zIndex: 1500,
+    borderRadius: 4,
+    background: '#424242',
+    '&:hover': {
+      background: '#424242'
+    }
+  },
+  toolImg: {
+    height: 24,
+    width: 24
+  }
+}));


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Made tool buttons smaller
- Fixed zoom in/out buttons and positioned them bottom right
- Improved layer picker popover; adjusts size when accordions are opened
- Buttons on right (except zoom) are dark mode compatible
- Layer Picker is dark mode compatible

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
