### PR TITLE
Caching layer_data the correct way.

### DIFF
--- a/app/src/hooks/useInvasivesApi.ts
+++ b/app/src/hooks/useInvasivesApi.ts
@@ -225,6 +225,25 @@ export const useInvasivesApi = () => {
     return data.options;
   };
 
+  const getGridItemsThatOverlapPolygon = async (
+    geometry: string,
+    largeGrid: string,
+    largeGrid_item_ids?: number[]
+  ): Promise<any> => {
+    const { data } = await Http.request({
+      headers: { ...options.headers, 'Content-Type': 'application/json' },
+      method: 'POST',
+      data: {
+        geometry: geometry,
+        largeGrid: largeGrid,
+        largeGrid_item_ids: largeGrid_item_ids ? largeGrid_item_ids : []
+      },
+      url: options.baseUrl + `/api/bc-grid/bcGrid`
+    });
+
+    return data;
+  };
+
   /**
    * Fetch a signle activity by its id.
    *
@@ -437,6 +456,7 @@ export const useInvasivesApi = () => {
     updateActivity,
     getApiSpec,
     getCachedApiSpec,
+    getGridItemsThatOverlapPolygon,
     getPointsOfInterest,
     getMetabaseQueryResults,
     getMetabaseQueryOptions,

--- a/database/src/migrations/bcGrid.ts
+++ b/database/src/migrations/bcGrid.ts
@@ -149,7 +149,6 @@ export async function up(knex: Knex): Promise<void> {
           smallGridItemIndex++;
         }
         await knex.raw(sqlInsertSm);
-        // console.log(sqlInsertSm + '\n');
 
         largeGridItemIndex++;
       }


### PR DESCRIPTION

# Overview

This PR includes the following proposed change(s):

- [x] BC Large grid migration created
- [x] BC Small Grid migration created
- [x] When a user creates a trip, Polygon created is getting compared with large grid items, then small grid items. Resulted small grid items are pushed to layer_data sqllite table. 
- [x] If the app is offline and a user creates a polygon on the activity page, wells are cached from layer_data sqllite table.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
