### PR TITLE
Duplicate layer data fix

### DIFF
--- a/api/src/queries/activity-queries.ts
+++ b/api/src/queries/activity-queries.ts
@@ -458,8 +458,8 @@ export const getOverlappingBCGridCellsSQL = (
       if (grid_item_ids.length < 1) {
         throw 'Error: looking for small grid items but the large grid item id array wasn\'t provided';
       } else {
-        const returnVal = SQL` 
-        SELECT id, public.st_asGeoJSON(geo) as geo
+        return SQL` 
+        SELECT id, public.st_asGeoJSON(geo) as geo, large_grid_item_id 
             FROM invasivesbc.bc_small_grid
             WHERE large_grid_item_id = ANY (${grid_item_ids}) AND public.ST_INTERSECTS(
               geo,
@@ -473,7 +473,6 @@ export const getOverlappingBCGridCellsSQL = (
               )
             );
         `;
-        return returnVal;
       }
       break;
   }

--- a/api/src/queries/activity-queries.ts
+++ b/api/src/queries/activity-queries.ts
@@ -459,7 +459,7 @@ export const getOverlappingBCGridCellsSQL = (
         throw 'Error: looking for small grid items but the large grid item id array wasn\'t provided';
       } else {
         const returnVal = SQL` 
-        SELECT public.st_asGeoJSON(geo) as geo
+        SELECT id, public.st_asGeoJSON(geo) as geo
             FROM invasivesbc.bc_small_grid
             WHERE large_grid_item_id = ANY (${grid_item_ids}) AND public.ST_INTERSECTS(
               geo,

--- a/app/capacitor.config.json
+++ b/app/capacitor.config.json
@@ -3,6 +3,9 @@
   "appName": "InvasivesBC-Ionic",
   "bundledWebRuntime": false,
   "npmClient": "npm",
+  "ios": {
+    "hideLogs": true
+  },
   "webDir": "build",
   "plugins": {
     "SplashScreen": {

--- a/app/ios/App/App/capacitor.config.json
+++ b/app/ios/App/App/capacitor.config.json
@@ -3,6 +3,9 @@
 	"appName": "InvasivesBC-Ionic",
 	"bundledWebRuntime": false,
 	"npmClient": "npm",
+	"ios": {
+		"hideLogs": true
+	},
 	"webDir": "build",
 	"plugins": {
 		"SplashScreen": {

--- a/app/src/components/map/LayerLoaderHelpers/DataBCRenderFeaturesNearFeature.tsx
+++ b/app/src/components/map/LayerLoaderHelpers/DataBCRenderFeaturesNearFeature.tsx
@@ -60,7 +60,7 @@ export const RenderKeyFeaturesNearFeature = (props: IRenderKeyFeaturesNearFeatur
           console.log('%cThe new extent does not overlap with and not inside of previous extent!', 'color:red');
           return true;
         }
-        if (!newArray.includes(worker.data.layer)) {
+        if (!newArray.includes(worker.data.BCGWcode)) {
           console.log('%cThe worker in a queue no longer needed as the layers have been changed!', 'color:red');
           return true;
         }
@@ -73,9 +73,7 @@ export const RenderKeyFeaturesNearFeature = (props: IRenderKeyFeaturesNearFeatur
   const startFetchingLayers = () => {
     const newArray = [];
     layersSelected.forEach((layer: any) => {
-      if (layer.enabled) {
-        newArray.push(layer.id);
-      }
+      newArray.push(layer.BCGWcode);
     });
 
     qRemove(lastRequestPushed, newArray);

--- a/app/src/components/map/LayerPicker/LayerPicker.tsx
+++ b/app/src/components/map/LayerPicker/LayerPicker.tsx
@@ -133,12 +133,6 @@ export function LayerPicker(props: any, { position }) {
     }
   });
 
-  //update context on ObjectState change
-  useEffect(() => {
-    setLayersSelected(objectState);
-    // check console.log(objectState);
-  }, [objectState]);
-
   const opacityText = (value: number) => {
     return `${value.toFixed(1)}`;
   };
@@ -248,8 +242,15 @@ export function LayerPicker(props: any, { position }) {
   ));
   //update context on ObjectState change
   useEffect(() => {
-    setLayersSelected(objectState);
-  }, [objectState]);
+    console.log(layers);
+    setLayersSelected(layers);
+  }, [layers]);
+
+  const toggleParentCheckbox = (parent) => {
+    updateParent(parent.id, {
+      enabled: !getParent(objectState, parent.id).enabled
+    });
+  };
 
   const SortableParentLayer = SortableElement(({ parent }) => {
     const onParentLayerAccordionChange = (event: any, expanded: any) => {
@@ -260,14 +261,9 @@ export function LayerPicker(props: any, { position }) {
         <Grid container spacing={1}>
           <Accordion expanded={parent.expanded} onChange={onParentLayerAccordionChange} className={classes.accordion}>
             <Grid container xs={12} justifyContent="space-between" alignItems="center">
-              {/* Turned off until later
               <Grid item xs>
-                <Checkbox
-                  checked={parent.enabled}
-                  name={parent.id}
-                  onChange={() => toggleParentCheckbox(parent, parent.children)}
-                />
-              </Grid>*/}
+                <Checkbox checked={parent.enabled} name={parent.id} onChange={() => toggleParentCheckbox(parent)} />
+              </Grid>
               {/* Info Dialog */}
               <Grid item xs={1}>
                 <Tooltip

--- a/app/src/components/trip/TripDataControls.tsx
+++ b/app/src/components/trip/TripDataControls.tsx
@@ -390,6 +390,25 @@ export const TripDataControls: React.FC<any> = (props) => {
           idArr.push(row.id);
         });
 
+        result.forEach(async (row) => {
+          await upsert(
+            [
+              {
+                type: UpsertType.RAW_SQL,
+                sql: `INSERT INTO LARGE_GRID_LAYER_DATA (id, featureArea,layerName) VALUES (${row.id},'${JSON.stringify(
+                  row.geo
+                )
+                  .split(`'`)
+                  .join(`''`)}','well')
+                  ON CONFLICT(id) 
+                  DO 
+                    UPDATE SET featureArea='${JSON.stringify(row.geo).split(`'`).join(`''`)}', layerName='well';`
+              }
+            ],
+            databaseContext
+          );
+        });
+
         const smallGridResult = await invasivesApi.getGridItemsThatOverlapPolygon(
           JSON.stringify(tripGeo.features[0].geometry),
           '0',
@@ -400,35 +419,27 @@ export const TripDataControls: React.FC<any> = (props) => {
 
         smallGridResult.forEach(async (gridResult) => {
           const feature = JSON.parse(gridResult.geo);
-          console.log('grid result');
-          console.log(gridResult);
           const gridId = gridResult.id;
           const bufferedGeo = turf.buffer(feature, 0);
           const wellsInside = await getDataFromDataBC('WHSE_WATER_MANAGEMENT.GW_WATER_WELLS_WRBC_SVW', bufferedGeo);
-          console.log(`INSERT INTO layer_data (id, featureArea, featuresInArea, layerName) VALUES (${gridId},'${JSON.stringify(
-                  bufferedGeo
-                )
-                  .split(`'`)
-                  .join(`''`)}','${JSON.stringify(wellsInside).split(`'`).join(`''`)}','well') 
-                  ON CONFLICT(id) 
-                  DO 
-                    UPDATE SET featureArea='${JSON.stringify(bufferedGeo)
-                  .split(`'`)
-                  .join(`''`)}', featuresInArea='${JSON.stringify(wellsInside).split(`'`).join(`''`)}', layerName='well';`);
           await upsert(
             [
               {
                 type: UpsertType.RAW_SQL,
-                sql: `INSERT INTO layer_data (id, featureArea, featuresInArea, layerName) VALUES (${gridId},'${JSON.stringify(
+                sql: `INSERT INTO SMALL_GRID_LAYER_DATA (id, featureArea, featuresInArea, layerName, largeGridID) VALUES (${gridId},'${JSON.stringify(
                   bufferedGeo
                 )
                   .split(`'`)
-                  .join(`''`)}','${JSON.stringify(wellsInside).split(`'`).join(`''`)}','well') 
+                  .join(`''`)}','${JSON.stringify(wellsInside).split(`'`).join(`''`)}','well',${
+                  gridResult.large_grid_item_id
+                }) 
                   ON CONFLICT(id) 
                   DO 
                     UPDATE SET featureArea='${JSON.stringify(bufferedGeo)
+                      .split(`'`)
+                      .join(`''`)}', featuresInArea='${JSON.stringify(wellsInside)
                   .split(`'`)
-                  .join(`''`)}', featuresInArea='${JSON.stringify(wellsInside).split(`'`).join(`''`)}', layerName='well';`
+                  .join(`''`)}', layerName='well', largeGridID=${gridResult.large_grid_item_id};`
               }
             ],
             databaseContext

--- a/app/src/components/trip/TripDataControls.tsx
+++ b/app/src/components/trip/TripDataControls.tsx
@@ -400,17 +400,35 @@ export const TripDataControls: React.FC<any> = (props) => {
 
         smallGridResult.forEach(async (gridResult) => {
           const feature = JSON.parse(gridResult.geo);
+          console.log('grid result');
+          console.log(gridResult);
+          const gridId = gridResult.id;
           const bufferedGeo = turf.buffer(feature, 0);
           const wellsInside = await getDataFromDataBC('WHSE_WATER_MANAGEMENT.GW_WATER_WELLS_WRBC_SVW', bufferedGeo);
+          console.log(`INSERT INTO layer_data (id, featureArea, featuresInArea, layerName) VALUES (${gridId},'${JSON.stringify(
+                  bufferedGeo
+                )
+                  .split(`'`)
+                  .join(`''`)}','${JSON.stringify(wellsInside).split(`'`).join(`''`)}','well') 
+                  ON CONFLICT(id) 
+                  DO 
+                    UPDATE SET featureArea='${JSON.stringify(bufferedGeo)
+                  .split(`'`)
+                  .join(`''`)}', featuresInArea='${JSON.stringify(wellsInside).split(`'`).join(`''`)}', layerName='well';`);
           await upsert(
             [
               {
                 type: UpsertType.RAW_SQL,
-                sql: `INSERT INTO layer_data (featureArea, featuresInArea, layerName) VALUES ('${JSON.stringify(
+                sql: `INSERT INTO layer_data (id, featureArea, featuresInArea, layerName) VALUES (${gridId},'${JSON.stringify(
                   bufferedGeo
                 )
                   .split(`'`)
-                  .join(`''`)}','${JSON.stringify(wellsInside).split(`'`).join(`''`)}','well');`
+                  .join(`''`)}','${JSON.stringify(wellsInside).split(`'`).join(`''`)}','well') 
+                  ON CONFLICT(id) 
+                  DO 
+                    UPDATE SET featureArea='${JSON.stringify(bufferedGeo)
+                  .split(`'`)
+                  .join(`''`)}', featuresInArea='${JSON.stringify(wellsInside).split(`'`).join(`''`)}', layerName='well';`
               }
             ],
             databaseContext

--- a/app/src/constants/database.ts
+++ b/app/src/constants/database.ts
@@ -12,7 +12,8 @@ export enum DocType {
   OFFLINE_EXTENT = 'offline_extent',
   OFFLINE_DATA = 'offline_data',
   PLAN_PAGE_EXTENT = 'plan_page_extent',
-  LAYER_DATA = 'layer_data'
+  LARGE_GRID_LAYER_DATA = 'large_grid_layer_data',
+  SMALL_GRID_LAYER_DATA = 'small_grid_layer_data'
 }
 
 // max and default db page row limit

--- a/app/src/contexts/DatabaseContext2.tsx
+++ b/app/src/contexts/DatabaseContext2.tsx
@@ -119,7 +119,7 @@ export const DatabaseContext2Provider = (props) => {
           setupSQL += `create table if not exists  
             ${DocType[value]} 
              (
-              id INTEGER PRIMARY KEY,
+              id INTEGER UNIQUE,
               featureArea TEXT,
               featuresInArea TEXT,
               layerName TEXT

--- a/app/src/contexts/DatabaseContext2.tsx
+++ b/app/src/contexts/DatabaseContext2.tsx
@@ -115,13 +115,23 @@ export const DatabaseContext2Provider = (props) => {
     let setupSQL = ``;
     for (const value of enumKeys(DocType)) {
       switch (value) {
-        case 'LAYER_DATA':
+        case 'SMALL_GRID_LAYER_DATA':
           setupSQL += `create table if not exists  
             ${DocType[value]} 
              (
               id INTEGER UNIQUE,
               featureArea TEXT,
               featuresInArea TEXT,
+              layerName TEXT,
+              largeGridID INTEGER
+            );\n`;
+          break;
+        case 'LARGE_GRID_LAYER_DATA':
+          setupSQL += `create table if not exists  
+            ${DocType[value]} 
+             (
+              id INTEGER UNIQUE,
+              featureArea TEXT,
               layerName TEXT
             );\n`;
           break;


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Made it so that there are 2 tables created and cached to when the new trip is created: large grid and small grid layer data.
- When extent changes, queries for large grid items, than for small ones.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
