### PR TITLE
Issue1145

### DIFF
--- a/api/src/openapi/api-doc.json
+++ b/api/src/openapi/api-doc.json
@@ -880,6 +880,7 @@
           "observation_persons": {
             "type": "array",
             "default": [{}],
+            "minItems": 1,
             "title": "Observation Person(s)",
             "items": {
               "$ref": "#/components/schemas/Persons"
@@ -909,6 +910,7 @@
             "type": "array",
             "default": [{}],
             "title": "Terrestrial Invasive Plants",
+            "minItems": 1,
             "items": {
               "$ref": "#/components/schemas/TerrestrialPlants"
             },
@@ -1001,6 +1003,7 @@
           "invasive_plants": {
             "type": "array",
             "default": [{}],
+            "minItems": 1,
             "title": "Aquatic Invasive Plant Information",
             "items": {
               "$ref": "#/components/schemas/AquaticPlants"
@@ -2000,6 +2003,7 @@
               "invasive_plants_information": {
                 "title": "Invasive Plants",
                 "type": "array",
+                "minItems": 1,
                 "default": [{}],
                 "items": {
                   "properties": {
@@ -2021,42 +2025,31 @@
                       "x-tooltip-text": "Check if there is a mix of herbicides in the tank"
                     }
                   },
-                  "dependencies": {
-                    "tank_mix": {
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "tank_mix": {
-                              "enum": [true]
-                            },
-                            "herbicide": {
-                              "type": "array",
-                              "default": [{}],
-                              "title": "Herbicide",
-                              "items": {
-                                "$ref": "#/components/schemas/Herbicide_with_tank_volume"
-                              },
-                              "x-tooltip-text": "Herbicide information for the treatment"
-                            }
-                          }
+                  "if": {
+                    "properties": {
+                      "tank_mix": {
+                        "enum": [true]
+                      }
+                    }
+                  },
+                  "then": {
+                    "properties": {
+                      "herbicide": {
+                        "type": "array",
+                        "default": [{}],
+                        "title": "Herbicide",
+                        "items": {
+                          "$ref": "#/components/schemas/Herbicide_with_tank_volume"
                         },
-                        {
-                          "properties": {
-                            "tank_mix": {
-                              "enum": [false]
-                            },
-                            "herbicide": {
-                              "type": "array",
-                              "default": [{}],
-                              "title": "Herbicide",
-                              "items": {
-                                "$ref": "#/components/schemas/Herbicide"
-                              },
-                              "x-tooltip-text": "Herbicide information for the treatment"
-                            }
-                          }
-                        }
-                      ]
+                        "x-tooltip-text": "Herbicide information for the treatment"
+                      }
+                    }
+                  },
+                  "else": {
+                    "properties": {
+                      "tank_mix": {
+                        "enum": [false]
+                      }
                     }
                   },
                   "required": ["invasive_plant_code"]
@@ -2194,6 +2187,7 @@
               "invasive_plants_information": {
                 "title": "Invasive Plants",
                 "type": "array",
+                "minItems": 1,
                 "default": [{}],
                 "items": {
                   "properties": {
@@ -3819,32 +3813,27 @@
             "x-tooltip-text": "Capacity of tank measured in litres"
           }
         },
-        "dependencies": {
-          "herbicide_type": {
-            "oneOf": [
-              {
-                "properties": {
-                  "herbicide_type": {
-                    "enum": ["liquid"]
-                  },
-                  "herbicide_information": {
-                    "title": " ",
-                    "$ref": "#/components/schemas/Herbicide_Liquid_Object"
-                  }
-                }
-              },
-              {
-                "properties": {
-                  "herbicide_type": {
-                    "enum": ["granular"]
-                  },
-                  "herbicide_information": {
-                    "title": " ",
-                    "$ref": "#/components/schemas/Herbicide_Granular_Object"
-                  }
-                }
-              }
-            ]
+        "if": {
+          "properties": {
+            "herbicide_type": {
+              "enum": ["liquid"]
+            }
+          }
+        },
+        "then": {
+          "properties": {
+            "herbicide_information": {
+              "title": " ",
+              "$ref": "#/components/schemas/Herbicide_Liquid_Object"
+            }
+          }
+        },
+        "else": {
+          "properties": {
+            "herbicide_information": {
+              "title": " ",
+              "$ref": "#/components/schemas/Herbicide_Granular_Object"
+            }
           }
         }
       },
@@ -4622,6 +4611,7 @@
             "type": "array",
             "default": [{}],
             "title": "Invasive Plants",
+            "minItems": 1,
             "items": {
               "$ref": "#/components/schemas/InvasivePlants"
             },
@@ -4638,6 +4628,7 @@
             "type": "array",
             "default": [{}],
             "title": "Invasive Plants",
+            "minItems": 1,
             "items": {
               "type": "object",
               "required": ["invasive_plant_code", "number_plants"],
@@ -4702,6 +4693,7 @@
             "type": "array",
             "default": [{}],
             "title": "Invasive Plants",
+            "minItems": 1,
             "items": {
               "type": "object",
               "required": ["invasive_plant_code", "daubenmire_classification"],
@@ -4766,6 +4758,7 @@
             "type": "array",
             "default": [{}],
             "title": "Invasive Plants",
+            "minItems": 1,
             "items": {
               "type": "object",
               "required": ["invasive_plant_code", "percent_covered"],

--- a/api/src/openapi/api-doc.json
+++ b/api/src/openapi/api-doc.json
@@ -3604,102 +3604,6 @@
           }
         }
       },
-      "Herbicide_Liquid_Object": {
-        "type": "object",
-        "required": [
-          "area_treated_liquid",
-          "application_rate_liquid",
-          "herbicide_amount_liquid",
-          "mix_delivery_rate_liquid"
-        ],
-        "properties": {
-          "area_treated_liquid": {
-            "type": "string",
-            "title": "Area Treated (Ha)"
-          },
-          "application_rate_liquid": {
-            "type": "number",
-            "title": "Application Rate (L/ha)",
-            "format": "float",
-            "minimum": 0,
-            "x-tooltip-text": "Recommended label rate for herbicide (L/ha) used for this treatment"
-          },
-          "herbicide_amount_liquid": {
-            "type": "number",
-            "title": "Amount of Mix Used (L)",
-            "format": "float",
-            "minimum": 0,
-            "x-tooltip-text": "Volume in litres (ie 5.1 L) of herbicide and water mix"
-          },
-          "mix_delivery_rate_liquid": {
-            "type": "number",
-            "title": "Delivery Rate of Mix (L/ha)",
-            "format": "float",
-            "minimum": 0,
-            "x-tooltip-text": "Calibrated delivery rate of the device used to apply herbicide in L/ha"
-          },
-          "dilution_liquid": {
-            "type": "number",
-            "title": "Dilution %",
-            "minimum": 0,
-            "x-tooltip-text": "Percent (%) of product in the mix"
-          },
-          "specific_treatment_area_liquid": {
-            "type": "number",
-            "title": "Specific Treatment Area (ha)",
-            "minimum": 0,
-            "x-tooltip-text": "Area of the chemical treatment (ha) automatically calculated from the application and delivery rates used during chemical treatment"
-          }
-        }
-      },
-      "Herbicide_Granular_Object": {
-        "type": "object",
-        "required": [
-          "area_treated_granular",
-          "application_rate_granular",
-          "herbicide_amount_granular",
-          "mix_delivery_rate_granular"
-        ],
-        "properties": {
-          "area_treated_granular": {
-            "type": "string",
-            "title": "Area Treated (Ha)"
-          },
-          "application_rate_granular": {
-            "type": "number",
-            "title": "Application Rate (g/ha)",
-            "format": "float",
-            "minimum": 0,
-            "x-tooltip-text": "Recommended label rate for herbicide (G/ha) used for this treatment"
-          },
-          "herbicide_amount_granular": {
-            "type": "number",
-            "title": "Amount of Mix Used (g)",
-            "format": "float",
-            "minimum": 0,
-            "x-tooltip-text": "Volume in granules (ie 5.1 g) of herbicide and water mix"
-          },
-          "mix_delivery_rate_granular": {
-            "type": "number",
-            "title": "Delivery Rate of Mix (g/ha)",
-            "format": "float",
-            "minimum": 0,
-            "x-tooltip-text": "Calibrated delivery rate of the device used to apply herbicide in g/ha"
-          },
-          "dilution_granular": {
-            "type": "number",
-            "title": "Dilution %",
-            "minimum": 0,
-            "x-tooltip-text": "Percent (%) of product in the mix"
-          },
-          "specific_treatment_area_granular": {
-            "type": "number",
-            "title": "Specific Treatment Area (ha)",
-            "minimum": 0,
-            "x-tooltip-text": "Area of the chemical treatment (ha) automatically calculated from the application and delivery rates used during chemical treatment"
-          }
-        }
-      },
       "Invasive_Plant": {
         "properties": {
           "invasive_plant_code": {
@@ -3776,7 +3680,14 @@
       },
       "Herbicide": {
         "type": "object",
-        "required": ["herbicide_code", "herbicide_type"],
+        "required": [
+          "herbicide_code",
+          "herbicide_type",
+          "area_treated",
+          "application_rate",
+          "herbicide_amount",
+          "mix_delivery_rate"
+        ],
         "properties": {
           "herbicide_code": {
             "type": "string",
@@ -3794,6 +3705,43 @@
             "type": "string",
             "enum": ["liquid", "granular"],
             "x-tooltip-text": "Choose whether the herbicide being used is liquid or granular"
+          },
+          "area_treated": {
+            "type": "string",
+            "title": "Area Treated (Ha)"
+          },
+          "application_rate": {
+            "type": "number",
+            "title": "Application Rate (L/ha)",
+            "format": "float",
+            "minimum": 0,
+            "x-tooltip-text": "Recommended label rate for herbicide (L/ha) used for this treatment"
+          },
+          "herbicide_amount": {
+            "type": "number",
+            "title": "Amount of Mix Used (L)",
+            "format": "float",
+            "minimum": 0,
+            "x-tooltip-text": "Volume in litres (ie 5.1 L) of herbicide and water mix"
+          },
+          "mix_delivery_rate": {
+            "type": "number",
+            "title": "Delivery Rate of Mix (L/ha)",
+            "format": "float",
+            "minimum": 0,
+            "x-tooltip-text": "Calibrated delivery rate of the device used to apply herbicide in L/ha"
+          },
+          "dilution": {
+            "type": "number",
+            "title": "Dilution %",
+            "minimum": 0,
+            "x-tooltip-text": "Percent (%) of product in the mix"
+          },
+          "specific_treatment_area": {
+            "type": "number",
+            "title": "Specific Treatment Area (ha)",
+            "minimum": 0,
+            "x-tooltip-text": "Area of the chemical treatment (ha) automatically calculated from the application and delivery rates used during chemical treatment"
           }
         },
         "dependencies": {
@@ -3803,10 +3751,6 @@
                 "properties": {
                   "herbicide_type": {
                     "enum": ["liquid"]
-                  },
-                  "herbicide_information_liquid": {
-                    "title": " ",
-                    "$ref": "#/components/schemas/Herbicide_Liquid_Object"
                   }
                 }
               },
@@ -3815,9 +3759,14 @@
                   "herbicide_type": {
                     "enum": ["granular"]
                   },
-                  "herbicide_information_granular": {
-                    "title": " ",
-                    "$ref": "#/components/schemas/Herbicide_Granular_Object"
+                  "application_rate": {
+                    "title": "Application Rate (g/ha)"
+                  },
+                  "herbicide_amount": {
+                    "title": "Amount of Mix Used (g)"
+                  },
+                  "mix_delivery_rate": {
+                    "title": "Delivery Rate of Mix (g/ha)"
                   }
                 }
               }

--- a/api/src/openapi/api-doc.json
+++ b/api/src/openapi/api-doc.json
@@ -2047,8 +2047,14 @@
                   },
                   "else": {
                     "properties": {
-                      "tank_mix": {
-                        "enum": [false]
+                      "herbicide": {
+                        "type": "array",
+                        "default": [{}],
+                        "title": "Herbicide",
+                        "items": {
+                          "$ref": "#/components/schemas/Herbicide"
+                        },
+                        "x-tooltip-text": "Herbicide information for the treatment"
                       }
                     }
                   },

--- a/api/src/openapi/api-doc.json
+++ b/api/src/openapi/api-doc.json
@@ -3689,6 +3689,12 @@
           "mix_delivery_rate"
         ],
         "properties": {
+          "herbicide_type": {
+            "title": "Herbicide Type",
+            "type": "string",
+            "enum": ["liquid", "granular"],
+            "x-tooltip-text": "Choose whether the herbicide being used is liquid or granular"
+          },
           "herbicide_code": {
             "type": "string",
             "title": "Herbicide",
@@ -3699,12 +3705,6 @@
               "x-enum-code-text": "code_description",
               "x-enum-code-sort-order": "code_sort_order"
             }
-          },
-          "herbicide_type": {
-            "title": "Herbicide Type",
-            "type": "string",
-            "enum": ["liquid", "granular"],
-            "x-tooltip-text": "Choose whether the herbicide being used is liquid or granular"
           },
           "area_treated": {
             "type": "string",

--- a/api/src/openapi/api-doc.json
+++ b/api/src/openapi/api-doc.json
@@ -3606,40 +3606,45 @@
       },
       "Herbicide_Liquid_Object": {
         "type": "object",
-        "required": ["area_treated", "application_rate", "herbicide_amount", "mix_delivery_rate"],
+        "required": [
+          "area_treated_liquid",
+          "application_rate_liquid",
+          "herbicide_amount_liquid",
+          "mix_delivery_rate_liquid"
+        ],
         "properties": {
-          "area_treated": {
+          "area_treated_liquid": {
             "type": "string",
             "title": "Area Treated (Ha)"
           },
-          "application_rate": {
+          "application_rate_liquid": {
             "type": "number",
             "title": "Application Rate (L/ha)",
             "format": "float",
             "minimum": 0,
             "x-tooltip-text": "Recommended label rate for herbicide (L/ha) used for this treatment"
           },
-          "herbicide_amount": {
+          "herbicide_amount_liquid": {
             "type": "number",
             "title": "Amount of Mix Used (L)",
             "format": "float",
             "minimum": 0,
             "x-tooltip-text": "Volume in litres (ie 5.1 L) of herbicide and water mix"
           },
-          "mix_delivery_rate": {
+          "mix_delivery_rate_liquid": {
             "type": "number",
             "title": "Delivery Rate of Mix (L/ha)",
             "format": "float",
             "minimum": 0,
             "x-tooltip-text": "Calibrated delivery rate of the device used to apply herbicide in L/ha"
           },
-          "dilution": {
+          "dilution_liquid": {
             "type": "number",
             "title": "Dilution %",
             "minimum": 0,
             "x-tooltip-text": "Percent (%) of product in the mix"
           },
-          "specific_treatment_area": {
+          "specific_treatment_area_liquid": {
             "type": "number",
             "title": "Specific Treatment Area (ha)",
             "minimum": 0,
@@ -3649,40 +3654,45 @@
       },
       "Herbicide_Granular_Object": {
         "type": "object",
-        "required": ["area_treated", "application_rate", "herbicide_amount", "mix_delivery_rate"],
+        "required": [
+          "area_treated_granular",
+          "application_rate_granular",
+          "herbicide_amount_granular",
+          "mix_delivery_rate_granular"
+        ],
         "properties": {
-          "area_treated": {
+          "area_treated_granular": {
             "type": "string",
             "title": "Area Treated (Ha)"
           },
-          "application_rate": {
+          "application_rate_granular": {
             "type": "number",
             "title": "Application Rate (g/ha)",
             "format": "float",
             "minimum": 0,
             "x-tooltip-text": "Recommended label rate for herbicide (G/ha) used for this treatment"
           },
-          "herbicide_amount": {
+          "herbicide_amount_granular": {
             "type": "number",
             "title": "Amount of Mix Used (g)",
             "format": "float",
             "minimum": 0,
             "x-tooltip-text": "Volume in granules (ie 5.1 g) of herbicide and water mix"
           },
-          "mix_delivery_rate": {
+          "mix_delivery_rate_granular": {
             "type": "number",
             "title": "Delivery Rate of Mix (g/ha)",
             "format": "float",
             "minimum": 0,
             "x-tooltip-text": "Calibrated delivery rate of the device used to apply herbicide in g/ha"
           },
-          "dilution": {
+          "dilution_granular": {
             "type": "number",
             "title": "Dilution %",
             "minimum": 0,
             "x-tooltip-text": "Percent (%) of product in the mix"
           },
-          "specific_treatment_area": {
+          "specific_treatment_area_granular": {
             "type": "number",
             "title": "Specific Treatment Area (ha)",
             "minimum": 0,
@@ -3719,7 +3729,7 @@
                   "tank_mix": {
                     "enum": [true]
                   },
-                  "herbicide": {
+                  "herbicide_with_tank_volume": {
                     "type": "array",
                     "default": [{}],
                     "title": "Herbicide",
@@ -3794,7 +3804,7 @@
                   "herbicide_type": {
                     "enum": ["liquid"]
                   },
-                  "herbicide_information": {
+                  "herbicide_information_liquid": {
                     "title": " ",
                     "$ref": "#/components/schemas/Herbicide_Liquid_Object"
                   }
@@ -3805,7 +3815,7 @@
                   "herbicide_type": {
                     "enum": ["granular"]
                   },
-                  "herbicide_information": {
+                  "herbicide_information_granular": {
                     "title": " ",
                     "$ref": "#/components/schemas/Herbicide_Granular_Object"
                   }

--- a/api/src/openapi/api-doc.json
+++ b/api/src/openapi/api-doc.json
@@ -367,7 +367,7 @@
             "$ref": "#/components/schemas/Activity"
           },
           "activity_subtype_data": {
-            "$ref": "#/components/schemas/Dispersal_BiologicalDispersal"
+            "$ref": "#/components/schemas/Monitoring_BiologicalDispersal"
           }
         }
       },
@@ -975,15 +975,6 @@
                     "title": "Outflow",
                     "x-tooltip-text": "Permanent, year-round water outflow(s) adjacent to observation (e.g. river, downstream culvert, etc)"
                   },
-                  "shoreline_types": {
-                    "type": "array",
-                    "default": [{}],
-                    "title": "Shoreline Types",
-                    "items": {
-                      "$ref": "#/components/schemas/ShorelineTypes"
-                    },
-                    "x-tooltip-text": "Specify shoreline types with their respective percentages"
-                  },
                   "comment": {
                     "type": "string",
                     "title": "Comment",
@@ -994,6 +985,15 @@
                 "required": ["substrate_type", "tidal_influence"]
               }
             ]
+          },
+          "shoreline_types": {
+            "type": "array",
+            "default": [{}],
+            "title": "Shoreline Types",
+            "items": {
+              "$ref": "#/components/schemas/ShorelineTypes"
+            },
+            "x-tooltip-text": "Specify shoreline types with their respective percentages"
           },
           "water_quality": {
             "type": "object",
@@ -1555,7 +1555,7 @@
           }
         }
       },
-      "Dispersal_BiologicalDispersal": {
+      "Monitoring_BiologicalDispersal": {
         "title": "Biological Dispersal Information",
         "type": "object",
         "required": [
@@ -1606,17 +1606,24 @@
           },
           "applicator1_name": {
             "type": "string",
-            "title": "Primary Applicator Name",
+            "title": "Primary Observer Name",
             "x-tooltip-text": "Name of primary applicator"
           },
           "applicator2_name": {
             "type": "string",
-            "title": "Secondary Applicator Name",
+            "title": "Secondary Observer Name",
             "x-tooltip-text": "Name of secondary applicator"
           },
           "monitoring_organization": {
             "type": "string",
-            "title": "Monitoring Organization",
+            "title": "Employer",
+            "x-enum-code": {
+              "x-enum-code-category-name": "invasives",
+              "x-enum-code-header-name": "employer_code",
+              "x-enum-code-name": "code_name",
+              "x-enum-code-text": "code_description",
+              "x-enum-code-sort-order": "code_sort_order"
+            },
             "x-tooltip-text": "The organization or company doing the monitoring"
           },
           "biological_agent_presence_code": {
@@ -1842,20 +1849,20 @@
                     "type": "string",
                     "title": "Outflow",
                     "x-tooltip-text": "Permanent, year-round water outflow(s) adjacent to observation (e.g. river, downstream culvert, etc)"
-                  },
-                  "shoreline_types": {
-                    "type": "array",
-                    "default": [{}],
-                    "title": "Shoreline Types",
-                    "items": {
-                      "$ref": "#/components/schemas/ShorelineTypes"
-                    },
-                    "x-tooltip-text": "Specify shoreline types with their respective percentages"
                   }
                 },
                 "required": ["substrate_type", "tidal_influence"]
               }
             ]
+          },
+          "shoreline_types": {
+            "type": "array",
+            "default": [{}],
+            "title": "Shoreline Types",
+            "items": {
+              "$ref": "#/components/schemas/ShorelineTypes"
+            },
+            "x-tooltip-text": "Specify shoreline types with their respective percentages"
           },
           "water_quality": {
             "type": "object",
@@ -2006,59 +2013,7 @@
                 "minItems": 1,
                 "default": [{}],
                 "items": {
-                  "properties": {
-                    "invasive_plant_code": {
-                      "type": "string",
-                      "title": "Invasive Plant",
-                      "x-enum-code": {
-                        "x-enum-code-category-name": "invasives",
-                        "x-enum-code-header-name": "invasive_plant_code",
-                        "x-enum-code-name": "code_name",
-                        "x-enum-code-text": "code_description",
-                        "x-enum-code-sort-order": "code_sort_order"
-                      },
-                      "x-tooltip-text": "Target invasive plant species being treated at this location"
-                    },
-                    "tank_mix": {
-                      "type": "boolean",
-                      "title": "Tank Mix",
-                      "x-tooltip-text": "Check if there is a mix of herbicides in the tank"
-                    }
-                  },
-                  "if": {
-                    "properties": {
-                      "tank_mix": {
-                        "enum": [true]
-                      }
-                    }
-                  },
-                  "then": {
-                    "properties": {
-                      "herbicide": {
-                        "type": "array",
-                        "default": [{}],
-                        "title": "Herbicide",
-                        "items": {
-                          "$ref": "#/components/schemas/Herbicide_with_tank_volume"
-                        },
-                        "x-tooltip-text": "Herbicide information for the treatment"
-                      }
-                    }
-                  },
-                  "else": {
-                    "properties": {
-                      "herbicide": {
-                        "type": "array",
-                        "default": [{}],
-                        "title": "Herbicide",
-                        "items": {
-                          "$ref": "#/components/schemas/Herbicide"
-                        },
-                        "x-tooltip-text": "Herbicide information for the treatment"
-                      }
-                    }
-                  },
-                  "required": ["invasive_plant_code"]
+                  "$ref": "#/components/schemas/Invasive_Plant"
                 }
               }
             },
@@ -2196,65 +2151,8 @@
                 "minItems": 1,
                 "default": [{}],
                 "items": {
-                  "properties": {
-                    "invasive_plant_code": {
-                      "type": "string",
-                      "title": "Invasive Plant",
-                      "x-enum-code": {
-                        "x-enum-code-category-name": "invasives",
-                        "x-enum-code-header-name": "invasive_plant_code",
-                        "x-enum-code-name": "code_name",
-                        "x-enum-code-text": "code_description",
-                        "x-enum-code-sort-order": "code_sort_order"
-                      },
-                      "x-tooltip-text": "Target invasive plant species being treated at this location"
-                    },
-                    "tank_mix": {
-                      "type": "boolean",
-                      "title": "Tank Mix",
-                      "x-tooltip-text": "Check if there is a mix of herbicides in the tank"
-                    }
-                  },
-                  "dependencies": {
-                    "tank_mix": {
-                      "oneOf": [
-                        {
-                          "properties": {
-                            "tank_mix": {
-                              "enum": [true]
-                            },
-                            "herbicide": {
-                              "type": "array",
-                              "default": [{}],
-                              "title": "Herbicide",
-                              "items": {
-                                "$ref": "#/components/schemas/Herbicide_with_tank_volume"
-                              },
-                              "x-tooltip-text": "Herbicide information for the treatment"
-                            }
-                          }
-                        },
-                        {
-                          "properties": {
-                            "tank_mix": {
-                              "enum": [false]
-                            },
-                            "herbicide": {
-                              "type": "array",
-                              "default": [{}],
-                              "title": "Herbicide",
-                              "items": {
-                                "$ref": "#/components/schemas/Herbicide"
-                              },
-                              "x-tooltip-text": "Herbicide information for the treatment"
-                            }
-                          }
-                        }
-                      ]
-                    }
-                  }
-                },
-                "required": ["invasive_plant_code"]
+                  "$ref": "#/components/schemas/Invasive_Plant"
+                }
               }
             },
             "required": ["invasive_plants_information"]
@@ -2343,6 +2241,7 @@
         "type": "array",
         "title": "Mechanical Treatment Information",
         "default": [{}],
+        "minItems": 1,
         "items": {
           "$ref": "#/components/schemas/Treatment_MechanicalPlant_Information_Item"
         }
@@ -2926,14 +2825,13 @@
                 },
                 "start_time": {
                   "type": "string",
-                  "format": "time",
-                  "minimum": 1,
-                  "title": "Start time collecting (mins)"
+                  "format": "date-time",
+                  "title": "Start time collecting"
                 },
                 "stop_time": {
                   "type": "string",
-                  "format": "time",
-                  "title": "Stop time collecting (mins)"
+                  "format": "date-time",
+                  "title": "Stop time collecting"
                 },
                 "total_time": {
                   "type": "number",
@@ -3708,6 +3606,7 @@
       },
       "Herbicide_Liquid_Object": {
         "type": "object",
+        "required": ["area_treated", "application_rate", "herbicide_amount", "mix_delivery_rate"],
         "properties": {
           "area_treated": {
             "type": "string",
@@ -3746,11 +3645,11 @@
             "minimum": 0,
             "x-tooltip-text": "Area of the chemical treatment (ha) automatically calculated from the application and delivery rates used during chemical treatment"
           }
-        },
-        "required": ["area_treated", "application_rate", "herbicide_amount", "mix_delivery_rate"]
+        }
       },
       "Herbicide_Granular_Object": {
         "type": "object",
+        "required": ["area_treated", "application_rate", "herbicide_amount", "mix_delivery_rate"],
         "properties": {
           "area_treated": {
             "type": "string",
@@ -3789,59 +3688,81 @@
             "minimum": 0,
             "x-tooltip-text": "Area of the chemical treatment (ha) automatically calculated from the application and delivery rates used during chemical treatment"
           }
-        },
-        "required": ["application_rate", "herbicide_amount", "mix_delivery_rate", "area_treated"]
+        }
       },
-      "Herbicide_with_tank_volume": {
-        "type": "object",
-        "required": ["herbicide_code", "herbicide_type"],
+      "Invasive_Plant": {
         "properties": {
-          "herbicide_code": {
+          "invasive_plant_code": {
             "type": "string",
-            "title": "Herbicide",
+            "title": "Invasive Plant",
             "x-enum-code": {
               "x-enum-code-category-name": "invasives",
-              "x-enum-code-header-name": "liquid_herbicide_code",
+              "x-enum-code-header-name": "invasive_plant_code",
               "x-enum-code-name": "code_name",
               "x-enum-code-text": "code_description",
               "x-enum-code-sort-order": "code_sort_order"
-            }
+            },
+            "x-tooltip-text": "Target invasive plant species being treated at this location"
           },
-          "herbicide_type": {
-            "title": "Herbicide Type",
-            "type": "string",
-            "enum": ["liquid", "granular"],
-            "x-tooltip-text": "Choose whether the herbicide being used is liquid or granular"
-          },
-          "tank_volume": {
-            "title": "Tank Volume (L)",
-            "type": "number",
-            "x-tooltip-text": "Capacity of tank measured in litres"
+          "tank_mix": {
+            "type": "boolean",
+            "title": "Tank Mix",
+            "default": false,
+            "x-tooltip-text": "Check if there is a mix of herbicides in the tank"
           }
         },
-        "if": {
-          "properties": {
-            "herbicide_type": {
-              "enum": ["liquid"]
-            }
+        "dependencies": {
+          "tank_mix": {
+            "oneOf": [
+              {
+                "properties": {
+                  "tank_mix": {
+                    "enum": [true]
+                  },
+                  "herbicide": {
+                    "type": "array",
+                    "default": [{}],
+                    "title": "Herbicide",
+                    "items": {
+                      "allOf": [
+                        {
+                          "properties": {
+                            "tank_volume": {
+                              "title": "Tank Volume (L)",
+                              "type": "number",
+                              "x-tooltip-text": "Capacity of tank measured in litres"
+                            }
+                          }
+                        },
+                        {
+                          "$ref": "#/components/schemas/Herbicide"
+                        }
+                      ]
+                    },
+                    "x-tooltip-text": "Herbicide information for the treatment"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "tank_mix": {
+                    "enum": [false]
+                  },
+                  "herbicide": {
+                    "type": "array",
+                    "default": [{}],
+                    "title": "Herbicide",
+                    "items": {
+                      "$ref": "#/components/schemas/Herbicide"
+                    },
+                    "x-tooltip-text": "Herbicide information for the treatment"
+                  }
+                }
+              }
+            ]
           }
         },
-        "then": {
-          "properties": {
-            "herbicide_information": {
-              "title": " ",
-              "$ref": "#/components/schemas/Herbicide_Liquid_Object"
-            }
-          }
-        },
-        "else": {
-          "properties": {
-            "herbicide_information": {
-              "title": " ",
-              "$ref": "#/components/schemas/Herbicide_Granular_Object"
-            }
-          }
-        }
+        "required": ["invasive_plant_code"]
       },
       "Herbicide": {
         "type": "object",
@@ -5495,7 +5416,7 @@
         "properties": {
           "water_sample_depth": {
             "type": "number",
-            "title": "Average depth of waterbody (m)",
+            "title": "Maximum depth (m)",
             "x-tooltip-text": "Enter the water depth in metres"
           },
           "secchi_depth": {

--- a/app/src/components/activity/ActivityComponent.tsx
+++ b/app/src/components/activity/ActivityComponent.tsx
@@ -11,7 +11,6 @@ import { useDataAccess } from 'hooks/useDataAccess';
 import { Geolocation } from '@capacitor/geolocation';
 //import { useCurrentPosition, useWatchPosition } from '@ionic/react-hooks/geolocation';
 import * as turf from '@turf/turf';
-import { Feature } from 'geojson';
 import MapContainer, { IMapContainerProps } from 'components/map/MapContainer';
 import { useHistory } from 'react-router-dom';
 import KMLUpload from 'components/map-buddy-components/KMLUpload';

--- a/app/src/components/common/RecordTables.tsx
+++ b/app/src/components/common/RecordTables.tsx
@@ -908,7 +908,7 @@ export const MonitoringTable: React.FC<IActivitiesTable> = (props) => {
           ActivitySubtype.Monitoring_ChemicalTerrestrialAquaticPlant,
           ActivitySubtype.Monitoring_MechanicalTerrestrialAquaticPlant,
           ActivitySubtype.Monitoring_BiologicalTerrestrialPlant,
-          ActivitySubtype.Activity_BiologicalDispersal
+          ActivitySubtype.Monitoring_BiologicalDispersal
         ]}
         tableSchemaType={[
           'Monitoring',
@@ -996,7 +996,7 @@ export const GeneralBiologicalControlTable: React.FC<IActivitiesTable> = (props)
           ActivitySubtype.Treatment_BiologicalPlant,
           ActivitySubtype.Transect_BiocontrolEfficacy,
           ActivitySubtype.Monitoring_BiologicalTerrestrialPlant,
-          ActivitySubtype.Activity_BiologicalDispersal
+          ActivitySubtype.Monitoring_BiologicalDispersal
         ]}
         {...props}
       />

--- a/app/src/components/form/FormContainer.tsx
+++ b/app/src/components/form/FormContainer.tsx
@@ -239,7 +239,6 @@ const FormContainer: React.FC<IFormContainerProps> = (props) => {
       let components = response.components;
       let uiSchema = RootUISchemas[subtype];
       const subtypeSchema = components?.schemas?.[subtype];
-
       // Handle activity_id linking fetches
       try {
         if (props.activity?.activityType === 'Monitoring') {
@@ -281,8 +280,8 @@ const FormContainer: React.FC<IFormContainerProps> = (props) => {
                 properties: {
                   ...modifiedSchema?.properties,
                   linked_id: {
-                    ...modifiedSchema?.properties?.linked_id,
-                    anyOf: treatments
+                    ...modifiedSchema?.properties?.linked_id
+                    // anyOf: treatments
                   }
                 }
               };

--- a/app/src/components/form/FormContainer.tsx
+++ b/app/src/components/form/FormContainer.tsx
@@ -29,7 +29,7 @@ import MultiSelectAutoComplete from '../../rjsf/widgets/MultiSelectAutoComplete'
 import SingleSelectAutoComplete from '../../rjsf/widgets/SingleSelectAutoComplete';
 import rjsfTheme from '../../themes/rjsfTheme';
 import FormControlsComponent, { IFormControlsComponentProps } from './FormControlsComponent';
-
+// import './aditionalFormStyles.css';
 export interface IFormContainerProps extends IFormControlsComponentProps {
   classes?: any;
   activity: any;

--- a/app/src/components/form/aditionalFormStyles.css
+++ b/app/src/components/form/aditionalFormStyles.css
@@ -1,0 +1,8 @@
+/* ----------Show just 1 error at a time for the field-------------*/
+#invasivesbc-activity-form ul li .Mui-error {
+  display: none;
+}
+
+#invasivesbc-activity-form ul li:first-child .Mui-error {
+  display: block;
+}

--- a/app/src/constants/activities.ts
+++ b/app/src/constants/activities.ts
@@ -31,7 +31,7 @@ export enum ActivitySubtype {
   Monitoring_ChemicalTerrestrialAquaticPlant = 'Activity_Monitoring_ChemicalTerrestrialAquaticPlant',
   Monitoring_MechanicalTerrestrialAquaticPlant = 'Activity_Monitoring_MechanicalTerrestrialAquaticPlant',
   Monitoring_BiologicalTerrestrialPlant = 'Activity_Monitoring_BiologicalTerrestrialPlant',
-  Activity_BiologicalDispersal = 'Activity_Dispersal_BiologicalDispersal',
+  Monitoring_BiologicalDispersal = 'Activity_Monitoring_BiologicalDispersal',
 
   Transect_FireMonitoring = 'Activity_Transect_FireMonitoring',
   Transect_Vegetation = 'Activity_Transect_Vegetation',
@@ -62,7 +62,7 @@ export enum ActivitySubtypeShortLabels {
   Activity_Monitoring_ChemicalTerrestrialAquaticPlant = 'Chemical',
   Activity_Monitoring_MechanicalTerrestrialAquaticPlant = 'Mechanical',
   Activity_Monitoring_BiologicalTerrestrialPlant = 'Biocontrol Release Monitoring',
-  Activity_Dispersal_BiologicalDispersal = 'Biocontrol Dispersal Monitoring',
+  Activity_Monitoring_BiologicalDispersal = 'Biocontrol Dispersal Monitoring',
 
   // Transects:
   Activity_Transect_FireMonitoring = 'Wildfire & Prescribed Burn Monitoring',
@@ -84,8 +84,8 @@ export enum ActivityMonitoringLinks {
   Activity_Monitoring_MechanicalTerrestrialAquaticPlant = 'Activity_Treatment_MechanicalPlant',
   Activity_Monitoring_BiologicalTerrestrialPlant = 'Activity_Treatment_BiologicalPlant',
 
-  Activity_Dispersal_BiologicalDispersal = 'Activity_Collection_Biocontrol',
-  Activity_Collection_Biocontrol = 'Activity_Dispersal_BiologicalDispersal'
+  Activity_Monitoring_BiologicalDispersal = 'Activity_Collection_Biocontrol',
+  Activity_Collection_Biocontrol = 'Activity_Collection_Biocontrol'
 }
 
 export const ActivityTypeIcon: { [key: string]: SvgIconComponent } = {
@@ -119,7 +119,7 @@ export enum ActivityLetter {
   Activity_Monitoring_ChemicalTerrestrialAquaticPlant = 'C',
   Activity_Monitoring_MechanicalTerrestrialAquaticPlant = 'P', // Aquatic?
   Activity_Monitoring_BiologicalTerrestrialPlant = 'P',
-  Activity_Dispersal_BiologicalDispersal = 'D',
+  Activity_Monitoring_BiologicalDispersal = 'D',
 
   // Transects:
   Activity_Transect_FireMonitoring = 'T',

--- a/app/src/constants/activities.ts
+++ b/app/src/constants/activities.ts
@@ -49,7 +49,7 @@ export enum ActivitySubtypeShortLabels {
   Activity_AnimalActivity_AnimalAquatic = 'Animal Aquatic',
 
   // Treatments:
-  Activity_Treatment_ChemicalPlant = 'Terrestrial Invasive Plant Chemical Treatment:',
+  Activity_Treatment_ChemicalPlant = 'Terrestrial Invasive Plant Chemical Treatment',
   Activity_Treatment_ChemicalPlant_BulkEdit = 'Terrestrial Invasive Plant Chemical Treatment',
   Activity_Treatment_ChemicalPlantAquatic = 'Aquatic Invasive Plant Chemical Treatment',
   Activity_Treatment_MechanicalPlant = 'Terrestrial Invasive Plant Mechanical Treatment',

--- a/app/src/contexts/DatabaseContext2.tsx
+++ b/app/src/contexts/DatabaseContext2.tsx
@@ -244,7 +244,7 @@ export const DatabaseContext2Provider = (props) => {
   return null;
 };
 
-function enumKeys<O extends object, K extends keyof O = keyof O>(obj: O): K[] {
+export function enumKeys<O extends object, K extends keyof O = keyof O>(obj: O): K[] {
   return Object.keys(obj).filter((k) => Number.isNaN(+k)) as K[];
 }
 

--- a/app/src/features/home/activity/ActivityPage.tsx
+++ b/app/src/features/home/activity/ActivityPage.tsx
@@ -119,10 +119,6 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
     if (doc?.docType === DocType.REFERENCE_ACTIVITY) {
       return;
     }
-    console.log(' - - - -  update doc - ...doc');
-    console.log(doc);
-    console.log(' - - - -  update doc - ...updates');
-    console.log(updates);
     let updatedDoc = {
       ...doc,
       ...updates,
@@ -172,8 +168,6 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
           ...oldActivity,
           ...mapDocToDBActivity(updated)
         };
-        console.log('***********NEW activity (line 180)');
-        console.log(newActivity);
 
         if (!oldActivity) await dataAccess.createActivity(newActivity, databaseContext);
         else await dataAccess.updateActivity(newActivity, databaseContext);
@@ -259,7 +253,7 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
    * @param {*} extent The leaflet bounds object
    */
   const saveExtent = async (newExtent: any) => {
-    // await updateDoc({ extent: newExtent });
+     await updateDoc({ extent: newExtent });
   };
 
   /**
@@ -268,7 +262,7 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
    * @param {IPhoto} photosArr An array of photo objects.
    */
   const savePhotos = async (photosArr: IPhoto[]) => {
-    // await updateDoc({ photos: photosArr, dateUpdated: new Date() });
+     await updateDoc({ photos: photosArr, dateUpdated: new Date() });
   };
 
   /*
@@ -372,12 +366,12 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
    * Update the doc (activity) with the latest form data and store it in DB
    */
   const pasteFormData = async () => {
-    // await updateDoc({
-    //   formData: retrieveFormDataFromSession(doc),
-    //   status: ActivityStatus.EDITED,
-    //   dateUpdated: new Date(),
-    //   formStatus: FormValidationStatus.NOT_VALIDATED
-    // });
+    await updateDoc({
+      formData: retrieveFormDataFromSession(doc),
+      status: ActivityStatus.EDITED,
+      dateUpdated: new Date(),
+      formStatus: FormValidationStatus.NOT_VALIDATED
+    });
   };
 
   /**
@@ -406,8 +400,6 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
         databaseContext,
         false
       );
-      console.dir('activityResults - - -- -- ---');
-      console.dir(activityResults);
     } else {
       try {
         activityResults = await dataAccess.getActivityById(

--- a/app/src/features/home/activity/ActivityPage.tsx
+++ b/app/src/features/home/activity/ActivityPage.tsx
@@ -87,7 +87,6 @@ interface IActivityPageProps {
 const ActivityPage: React.FC<IActivityPageProps> = (props) => {
   const classes = useStyles();
   const dataAccess = useDataAccess();
-  console.log(GetUserAccessLevel());
 
   const databaseContextPouch = useContext(DatabaseContext);
   const databaseContext = useContext(DatabaseContext2);
@@ -207,7 +206,6 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
       const { latitude, longitude } = calculateLatLng(geom) || {};
       var utm = calc_utm(longitude, latitude);
       let utm_zone = utm[0];
-      console.dir('activityPage', utm_zone);
       let utm_easting = utm[1];
       let utm_northing = utm[2];
       /*****exported DisplayPosition utm_zone function
@@ -351,7 +349,8 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
    */
   const onFormChange = debounced(100, async (event: any, ref: any, lastField: any) => {
     let updatedFormData = event.formData;
-
+    console.log('EVENT');
+    console.log(event);
     updatedFormData.activity_subtype_data = populateHerbicideDilutionAndArea(updatedFormData.activity_subtype_data);
     updatedFormData.activity_subtype_data = populateTransectLineAndPointData(updatedFormData.activity_subtype_data);
 

--- a/app/src/features/home/activity/ActivityPage.tsx
+++ b/app/src/features/home/activity/ActivityPage.tsx
@@ -30,6 +30,7 @@ import {
   getHerbicideApplicationRateValidator,
   getTransectOffsetDistanceValidator,
   getPosAndNegObservationValidator,
+  getShorelineTypesPercentValidator,
   getHerbicideMixValidation,
   getVegTransectPointsPercentCoverValidator,
   getDurationCountAndPlantCountValidation,
@@ -303,18 +304,23 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
       return formData;
     }
 
-    formData.activity_subtype_data.collections.forEach((collection) => {
-      if (collection.start_time && collection.stop_time) {
-        const arrStart = collection.start_time.split(':');
-        const arrStop = collection.stop_time.split(':');
-        const minutesStart = +arrStart[0] * 60 + +arrStart[1];
-        const minutesStop = +arrStop[0] * 60 + +arrStop[1];
+    const collections = [...formData.activity_subtype_data.collections];
 
-        const total = minutesStop - minutesStart;
-        collection.total_time = total;
+    collections.forEach((collection) => {
+      if (collection.start_time && collection.stop_time) {
+        const start_time = new Date(collection.start_time);
+        const stop_time = new Date(collection.stop_time);
+
+        const diffMs = stop_time.getTime() - start_time.getTime();
+        const diffMins = Math.round(diffMs / 1000 / 60);
+        console.log(diffMins);
+        collection.total_time = diffMins;
       }
     });
-    return formData;
+    return {
+      ...formData,
+      activity_subtype_data: { ...formData.activity_subtype_data, collections: collections }
+    };
   };
 
   const autoFillSlopeAspect = (formData: any, lastField: string) => {
@@ -728,10 +734,15 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
             </Typography>
           </Box>
           <Box display="flex" flexDirection="row" justifyContent="space-between" padding={1} mb={3}>
-            <Typography align="center">Activity ID: {doc.activityId ? doc.activityId : 'unknown'}</Typography>
+            <Typography
+              onClick={() => {
+                console.log(doc);
+              }}
+              align="center">
+              Activity ID: {doc.shortId ? doc.shortId : 'unknown'}
+            </Typography>
             <Typography align="center">
-              {/*
-              Date created: {doc.dateCreated ? doc.dateCreated : 'unknown'}*/}
+              Date created: {doc.dateCreated ? new Date(doc.dateCreated).toString() : 'unknown'}
             </Typography>
           </Box>
           <ActivityComponent
@@ -745,6 +756,7 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
               getDuplicateInvasivePlantsValidator(doc.activitySubtype),
               getHerbicideApplicationRateValidator(),
               getTransectOffsetDistanceValidator(),
+              getShorelineTypesPercentValidator(),
               getHerbicideMixValidation(),
               getVegTransectPointsPercentCoverValidator(),
               getDurationCountAndPlantCountValidation(),

--- a/app/src/hooks/useDataAccess.tsx
+++ b/app/src/hooks/useDataAccess.tsx
@@ -180,7 +180,7 @@ export const useDataAccess = () => {
     }
   ): Promise<any> => {
     if (Capacitor.getPlatform() === 'web') {
-      //TODO: implement getting old version from derver and making new with overwritten props
+      //TODO: implement getting old version from server and making new with overwritten props
       // IN USEINVASIVES API
       return api.updateActivity(activity);
     } else {

--- a/app/src/rjsf/business-rules/customValidation.ts
+++ b/app/src/rjsf/business-rules/customValidation.ts
@@ -169,9 +169,10 @@ export function getShorelineTypesPercentValidator(): rjsfValidator {
     if (!formData || !formData.activity_subtype_data || !formData.activity_subtype_data.shoreline_types) {
       return errors;
     }
-    console.log(formData);
 
     const { shoreline_types } = formData.activity_subtype_data;
+
+    console.log('I shouldnt be here');
 
     let totalPercent = 0;
 
@@ -495,7 +496,6 @@ export function getHerbicideApplicationRateValidator(): rjsfValidator {
       let herbicideIndex = 0;
       invPlant.herbicide?.forEach((herbicide: any) => {
         if (!herbicide.herbicide_information?.application_rate || !herbicide.herbicide_code) {
-          console.log('no herbicide information found');
         } else if (
           herbicide.herbicide_information.application_rate &&
           herbicide.herbicide_information.application_rate > HerbicideApplicationRates[herbicide.herbicide_code]

--- a/app/src/rjsf/business-rules/customValidation.ts
+++ b/app/src/rjsf/business-rules/customValidation.ts
@@ -164,6 +164,35 @@ export function getVegTransectPointsPercentCoverValidator(): rjsfValidator {
 /*
   Function to validate that the total percent value of all jurisdictions combined = 100
 */
+export function getShorelineTypesPercentValidator(): rjsfValidator {
+  return (formData: any, errors: FormValidation): FormValidation => {
+    if (!formData || !formData.activity_subtype_data || !formData.activity_subtype_data.shoreline_types) {
+      return errors;
+    }
+    console.log(formData);
+
+    const { shoreline_types } = formData.activity_subtype_data;
+
+    let totalPercent = 0;
+
+    shoreline_types.forEach((shoreline_type: any) => {
+      totalPercent += shoreline_type.percent_covered;
+    });
+
+    errors.activity_subtype_data['shoreline_types'].__errors = [];
+    if (totalPercent !== 100) {
+      errors.activity_subtype_data['shoreline_types'].addError(
+        'Total percentage of area covered by jurisdictions must equal 100%'
+      );
+    }
+
+    return errors;
+  };
+}
+
+/*
+  Function to validate that the total percent value of all jurisdictions combined = 100
+*/
 export function getJurisdictionPercentValidator(): rjsfValidator {
   return (formData: any, errors: FormValidation): FormValidation => {
     if (!formData || !formData.activity_data || !formData.activity_data.jurisdictions) {
@@ -221,7 +250,7 @@ export function getAreaValidator(activitySubtype: string): rjsfValidator {
       'Activity_Monitoring_ChemicalTerrestrialAquaticPlant',
       'Activity_Monitoring_MechanicalTerrestrialAquaticPlant',
       'Activity_Monitoring_BiologicalTerrestrialPlant',
-      'Activity_Dispersal_BiologicalDispersal',
+      'Activity_Monitoring_BiologicalDispersal',
       'Activity_AnimalActivity_AnimalTerrestrial',
       'Activity_AnimalActivity_AnimalAquatic',
       'Activity_Transect_FireMonitoring',

--- a/app/src/rjsf/business-rules/customValidation.ts
+++ b/app/src/rjsf/business-rules/customValidation.ts
@@ -494,15 +494,18 @@ export function getHerbicideApplicationRateValidator(): rjsfValidator {
     let invPlantIndex = 0;
     formData.activity_subtype_data.treatment_information.invasive_plants_information.forEach((invPlant: any) => {
       let herbicideIndex = 0;
-      invPlant.herbicide?.forEach((herbicide: any) => {
-        if (!herbicide.herbicide_information?.application_rate || !herbicide.herbicide_code) {
+
+      const herbicideName = !invPlant.tank_mix ? 'herbicide' : 'herbicide_with_tank_volume';
+
+      invPlant[herbicideName].forEach((herbicide: any) => {
+        if (!herbicide.application_rate || !herbicide.herbicide_code) {
         } else if (
-          herbicide.herbicide_information.application_rate &&
-          herbicide.herbicide_information.application_rate > HerbicideApplicationRates[herbicide.herbicide_code]
+          herbicide.application_rate &&
+          herbicide.application_rate > HerbicideApplicationRates[herbicide.herbicide_code]
         ) {
           errors.activity_subtype_data['treatment_information']['invasive_plants_information'][invPlantIndex][
-            'herbicide'
-          ][herbicideIndex]['herbicide_information']['application_rate'].addError(
+            herbicideName
+          ][herbicideIndex]['application_rate'].addError(
             `Application rate exceeds maximum applicable rate of ${
               HerbicideApplicationRates[herbicide.herbicide_code]
             } L/ha for this herbicide`
@@ -511,8 +514,8 @@ export function getHerbicideApplicationRateValidator(): rjsfValidator {
         //if user clicked proceed in the warning dialog, remove the error
         if (formData.forceNoValidationFields && formData.forceNoValidationFields.includes('application_rate')) {
           errors.activity_subtype_data['treatment_information']['invasive_plants_information'][invPlantIndex][
-            'herbicide'
-          ][herbicideIndex]['herbicide_information']['application_rate'].__errors.pop();
+            herbicideName
+          ][herbicideIndex]['application_rate'].__errors.pop();
         }
 
         herbicideIndex++;

--- a/app/src/rjsf/business-rules/customValidation.ts
+++ b/app/src/rjsf/business-rules/customValidation.ts
@@ -166,13 +166,16 @@ export function getVegTransectPointsPercentCoverValidator(): rjsfValidator {
 */
 export function getShorelineTypesPercentValidator(): rjsfValidator {
   return (formData: any, errors: FormValidation): FormValidation => {
-    if (!formData || !formData.activity_subtype_data || !formData.activity_subtype_data.shoreline_types) {
+    if (
+      !formData ||
+      !formData.activity_subtype_data ||
+      !formData.activity_subtype_data.shoreline_types ||
+      formData.activity_subtype_data.shoreline_types.length < 1
+    ) {
       return errors;
     }
 
     const { shoreline_types } = formData.activity_subtype_data;
-
-    console.log('I shouldnt be here');
 
     let totalPercent = 0;
 

--- a/app/src/rjsf/uiSchema/BaseUISchemaComponents.ts
+++ b/app/src/rjsf/uiSchema/BaseUISchemaComponents.ts
@@ -65,10 +65,10 @@ const Weather_Conditions = {
 };
 
 const Herbicide = {
+    'herbicide_type':{},
   'herbicide_code':{
     'ui:widget': 'single-select-autocomplete'
   },
-  'herbicide_type':{},
   'tank_volume':{},
   'herbicide_information':{
     'area_treated':{},
@@ -85,7 +85,7 @@ const Herbicide = {
     },
     'ui:order':['area_treated','application_rate','herbicide_amount','mix_delivery_rate','dilution','specific_treatment_area']
   },
-  'ui:order':['herbicide_code','herbicide_type','tank_volume','herbicide_information']
+  'ui:order':['herbicide_type','herbicide_code','tank_volume','herbicide_information']
 };
 
 const ProjectCode = {
@@ -140,7 +140,6 @@ const TerrestrialPlants = {
     'enda_sample_information',
     'invasive_plant_density_code',
     'invasive_plant_distribution_code',
-    'plant_life_stage_code',
     'plant_life_stage_code',
     'voucher_specimen_collected',
     'voucher_specimen_collection_information']
@@ -1216,7 +1215,7 @@ const Observation_PlantAquatic = {
     'inflow_permanent':{},
     'inflow_other':{},
     'outflow':{},
-    'shoreline_types':{},
+    
     'comment': {
       'ui:widget': 'textarea'
     },
@@ -1233,10 +1232,10 @@ const Observation_PlantAquatic = {
       'inflow_permanent',
       'inflow_other',
       'outflow',
-      'shoreline_types',
       'comment'
     ]
   },
+  'shoreline_types':{},
   'water_quality':{},
   'invasive_plants': {
     items: {
@@ -1244,7 +1243,7 @@ const Observation_PlantAquatic = {
       ...AquaticPlants
     }
   },
-  'ui:order':['waterbody_data','water_quality','invasive_plants']
+  'ui:order':['waterbody_data','shoreline_types','water_quality','invasive_plants']
 };
 
 /* 
@@ -1275,8 +1274,12 @@ const Biocontrol_Collection_Details = {
   'collection_method': {
     'ui:widget': 'single-select-autocomplete'
   },
-  'start_time': {},
-  'stop_time': {},
+  'start_time': {
+    'ui:widget': 'datetime'
+  },
+  'stop_time': {
+    'ui:widget': 'datetime'
+  },
   'total_time': {
     'ui:readonly': true
   },
@@ -1472,10 +1475,10 @@ const Activity_AnimalAquatic = {
   Dispersal
 */
 
-const Dispersal_BiologicalDispersal = {
+const Monitoring_BiologicalDispersal = {
   'monitoring_organization': {},
   'biological_agent_presence_code': {
-    'ui:widget': 'single-select-autocomplete'
+    'ui:widget': 'multi-select-autocomplete'
   },
   'count_duration': {},
   'biological_agent_code': {
@@ -1517,7 +1520,7 @@ const Dispersal_BiologicalDispersal = {
   },
   'ui:order':[
     'invasive_plant_code',
-        'applicator1_name',
+    'applicator1_name',
     'applicator2_name',
     'monitoring_organization',
     'biological_agent_presence_code',
@@ -1774,7 +1777,7 @@ const BaseUISchemaComponents = {
   Transect_FireMonitoring,
   Transect_Vegetation,
   Transect_BiocontrolEfficacy,
-  Dispersal_BiologicalDispersal,
+  Monitoring_BiologicalDispersal,
   Treatment,
   Treatment_MechanicalPlant,
   Treatment_MechanicalPlantAquatic,

--- a/app/src/rjsf/uiSchema/RootUISchemas.ts
+++ b/app/src/rjsf/uiSchema/RootUISchemas.ts
@@ -101,14 +101,14 @@ const Activity_Transect_BiocontrolEfficacy = {
   'ui:order':['activity_data','activity_subtype_data']
 };
 
-const Activity_Dispersal_BiologicalDispersal = {
+const Activity_Monitoring_BiologicalDispersal = {
   'activity_data': {
     ...BaseUISchemaComponents.ThreeColumnStyle,
     ...UISchemaComponents.Activity
   },
   'activity_subtype_data': {
     ...BaseUISchemaComponents.ThreeColumnStyle,
-    ...BaseUISchemaComponents.Dispersal_BiologicalDispersal
+    ...BaseUISchemaComponents.Monitoring_BiologicalDispersal
   },
   'ui:order':['activity_data','activity_subtype_data']
 };
@@ -287,7 +287,7 @@ const RootUISchemas = {
   Activity_Transect_FireMonitoring,
   Activity_Transect_Vegetation,
   Activity_Transect_BiocontrolEfficacy,
-  Activity_Dispersal_BiologicalDispersal,
+  Activity_Monitoring_BiologicalDispersal,
   Activity_Treatment_ChemicalPlant,
   Activity_Treatment_ChemicalPlant_BulkEdit,
   Activity_Treatment_ChemicalPlantAquatic,

--- a/app/src/rjsf/uiSchema/UISchemaComponents.ts
+++ b/app/src/rjsf/uiSchema/UISchemaComponents.ts
@@ -143,11 +143,6 @@ const Treatment_ChemicalPlantAquatic = {
     'invasive_plant_code': {
       'ui:widget': 'single-select-autocomplete'
     },
-    'herbicide': {
-      items: {
-        ...BaseUISchemaComponents.Herbicide
-      }
-    },
     'wind_speed': {
       validateOnBlur: true
     },
@@ -157,6 +152,7 @@ const Treatment_ChemicalPlantAquatic = {
     'pesticide_use_permit_PUP': {},
     'signage_on_site': {}
   },
+  'shoreline_types':{},
   'waterbody_data': {
     ...BaseUISchemaComponents.TwoColumnStyle
   },
@@ -169,6 +165,7 @@ const Treatment_ChemicalPlantAquatic = {
         'herbicide': {
           items: {
             herbicide_type: { 'ui:widget': 'single-select-autocomplete' },
+            
             herbicide_information: {
               ...BaseUISchemaComponents.TwoColumnStyle
             }
@@ -177,7 +174,7 @@ const Treatment_ChemicalPlantAquatic = {
       }
     }
   },
-  'ui:order':['treatment_chemicalplant_information','waterbody_data','water_quality','treatment_information']
+  'ui:order':['treatment_chemicalplant_information','shoreline_types','waterbody_data','water_quality','treatment_information']
 };
 
 const Activity = {

--- a/app/src/rjsf/widgets/MultiSelectAutoComplete.tsx
+++ b/app/src/rjsf/widgets/MultiSelectAutoComplete.tsx
@@ -3,8 +3,10 @@ import TextField from '@material-ui/core/TextField';
 import CheckBoxIcon from '@material-ui/icons/CheckBox';
 import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
 import Autocomplete, { createFilterOptions } from '@material-ui/lab/Autocomplete';
-import { WidgetProps } from '@rjsf/core';
+import { UiSchema, WidgetProps } from '@rjsf/core';
+import { enumKeys } from 'contexts/DatabaseContext2';
 import React from 'react';
+import { MultipleSelect } from 'react-select-material-ui';
 
 const icon = <CheckBoxOutlineBlankIcon fontSize="small" />;
 const checkedIcon = <CheckBoxIcon fontSize="small" />;
@@ -60,8 +62,10 @@ export type AutoCompleteMultiSelectOption = { label: string; value: any };
  */
 const MultiSelectAutoComplete = (props: WidgetProps) => {
   const enumDisabled = props.options.enumDisabled;
-  const enumOptions = (props.options.enumOptions as AutoCompleteMultiSelectOption[]) || [];
-
+  const enumOptions = props.options.enumOptions as any[];
+  console.log(enumOptions);
+  // const [current, setCurrent] = useState(null);
+  // const [currentValue, setCurrentValue] = useState([]);
   /**
    * On a value selected or un-selected, call the parents onChange event to inform the form of the new value of the
    * widget.
@@ -69,82 +73,103 @@ const MultiSelectAutoComplete = (props: WidgetProps) => {
    * @param {React.ChangeEvent<{}>} event
    * @param {AutoCompleteMultiSelectOption[]} value
    */
-  const handleOnChange = (event: React.ChangeEvent<{}>, value: AutoCompleteMultiSelectOption[]): void => {
+  const handleOnChange = (value: any[]): void => {
     const newValue: any[] = [];
-    value.forEach((item) => newValue.push(item.value));
+    value.forEach((item) => {
+      newValue.push(item.value);
+    });
     props.onChange(newValue.toString());
   };
 
-  /**
-   * Custom comparator to determine if a given option is selected.
-   *
-   * @param {AutoCompleteMultiSelectOption} option
-   * @param {AutoCompleteMultiSelectOption} value
-   * @return {*}  {boolean}
-   */
-  const handleGetOptionSelected = (
-    option: AutoCompleteMultiSelectOption,
-    value: AutoCompleteMultiSelectOption
-  ): boolean => {
-    if (!option?.value || !value?.value) {
-      return false;
-    }
-
-    return option.value === value.value;
-  };
+  // /**
+  //  * Custom comparator to determine if a given option is selected.
+  //  *
+  //  * @param {AutoCompleteMultiSelectOption} option
+  //  * @param {AutoCompleteMultiSelectOption} value
+  //  * @return {*}  {boolean}
+  //  */
+  // const handleGetOptionSelected = (
+  //   option: AutoCompleteMultiSelectOption,
+  //   value: AutoCompleteMultiSelectOption
+  // ): boolean => {
+  //   if (!option?.value || !value?.value) {
+  //     return false;
+  //   }
+  //   return option.value === value.value;
+  // };
 
   /**
    * Parses an existing array of values into an array of options.
    *
    * @return {*}  {AutoCompleteMultiSelectOption[]}
    */
-  const getExistingValue = (): AutoCompleteMultiSelectOption[] => {
+  const getExistingValue = (): string[] => {
     if (!props.value) {
       return [];
     }
-
-    return enumOptions.filter((option) => props.value.includes(option.value));
+    let retVal;
+    retVal = enumOptions.filter((option) => props.value.includes(option.value));
+    return retVal;
   };
 
+  // const getOptions = () => {
+  //   const optionArr: string[] = [];
+
+  //   for (const key of enumKeys(enumOptions)) {
+  //     optionArr.push(enumOptions[key]);
+  //   }
+
+  //   return optionArr;
+  // };
+  let optionArr: NonNullable<UiSchema['ui:options']>;
+  enumOptions.forEach(({ value, label }) => {
+    optionArr.push({ value: label });
+  });
+
+  // const handleSelection = (values, name) => this.setState({ [name]: values });
+
+  const dataSourceNodes = enumOptions.map(({ value, label }) => <div key={value}>{label}</div>);
+
   return (
-    <Autocomplete
-      multiple
-      autoHighlight={true}
-      id={props.id}
-      value={getExistingValue()}
-      getOptionSelected={handleGetOptionSelected}
-      disabled={props.disabled}
-      options={enumOptions}
-      disableCloseOnSelect
-      filterOptions={createFilterOptions({ limit: 50 })}
-      getOptionLabel={(option) => option.label}
-      onChange={handleOnChange}
-      renderOption={(option, { selected }) => {
-        const disabled: any = enumDisabled && (enumDisabled as any).indexOf(option.value) !== -1;
-        return (
-          <>
-            <Checkbox
-              icon={icon}
-              checkedIcon={checkedIcon}
-              style={{ marginRight: 8 }}
-              checked={selected}
-              disabled={disabled}
-              value={option.value}
-            />
-            {option.label}
-          </>
-        );
-      }}
-      renderInput={(params) => (
-        <TextField
-          {...params}
-          variant="outlined"
-          required={props.required}
-          label={props.label || props.schema.title}
-          placeholder={'Begin typing to filter results...'}
-        />
-      )}
-    />
+    <MultiSelectAutoComplete onChange={handleOnChange} value={getExistingValue} options={optionArr} />
+    // <Autocomplete
+    //   multiple
+    //   autoHighlight={true}
+    //   id={props.id}
+    //   value={getExistingValue()}
+    //   getOptionSelected={handleGetOptionSelected}
+    //   disabled={props.disabled}
+    //   options={enumOptions}
+    //   disableCloseOnSelect
+    //   filterOptions={createFilterOptions({ limit: 50 })}
+    //   getOptionLabel={(option) => option.label}
+    //   onChange={handleOnChange}
+    //   renderOption={(option, { selected }) => {
+    //     const disabled: any = enumDisabled && (enumDisabled as any).indexOf(option.value) !== -1;
+    //     return (
+    //       <>
+    //         <Checkbox
+    //           icon={icon}
+    //           checkedIcon={checkedIcon}
+    //           style={{ marginRight: 8 }}
+    //           checked={selected}
+    //           disabled={disabled}
+    //           value={option.value}
+    //         />
+    //         {option.label}
+    //       </>
+    //     );
+    //   }}
+    //   renderInput={(params) => (
+    //     <TextField
+    //       {...params}
+    //       variant="outlined"
+    //       required={props.required}
+    //       label={props.label || props.schema.title}
+    //       placeholder={'Begin typing to filter results...'}
+    //     />
+    //   )}
+    // />
   );
 };
 

--- a/app/src/utils/addActivity.ts
+++ b/app/src/utils/addActivity.ts
@@ -508,7 +508,7 @@ export function populateSpeciesArrays(record) {
     case ActivitySubtype.Monitoring_ChemicalTerrestrialAquaticPlant:
     case ActivitySubtype.Monitoring_MechanicalTerrestrialAquaticPlant:
     case ActivitySubtype.Monitoring_BiologicalTerrestrialPlant:
-    case ActivitySubtype.Activity_BiologicalDispersal:
+    case ActivitySubtype.Monitoring_BiologicalDispersal:
       species_positive = [subtypeData?.invasive_plant_code];
       break;
 

--- a/app/src/utils/addActivity.ts
+++ b/app/src/utils/addActivity.ts
@@ -248,15 +248,18 @@ export const sanitizeRecord = (input: any) => {
   naming variables differently in different contexts was a good idea.
   Note for future refactoring: favor DB representation.
 */
-export const mapDocToDBActivity = (doc: any) => ({
-  ...mapKeys(doc, snakeCase),
-  _id: doc._id || doc.activity_id,
-  sync_status: doc.sync?.status,
-  media: doc.photos?.map((photo) => ({
-    file_name: photo.filepath,
-    encoded_file: photo.dataUrl
-  }))
-});
+export const mapDocToDBActivity = (doc: any) => {
+  const retVal = {
+    ...mapKeys(doc, snakeCase),
+    _id: doc._id || doc.activity_id,
+    sync_status: doc.sync?.status,
+    media: doc.photos?.map((photo) => ({
+      file_name: photo.filepath,
+      encoded_file: photo.dataUrl
+    }))
+  };
+  return retVal;
+};
 
 /*
   Function to temporarily deal with a grievous oversight by initial devs who thought 

--- a/app/src/utils/addActivity.ts
+++ b/app/src/utils/addActivity.ts
@@ -543,7 +543,6 @@ export function populateSpeciesArrays(record) {
     default:
       break;
   }
-  console.log(3333, species_positive, species_negative);
   return {
     ...record,
     species_positive:


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

IN PROGRESS. branch name - issue1145
ALL FORMS (except transects):
- [x] ensure "Adjacent land use" field is able to allow for multiple choices in all forms.
- [x] ensure all forms must have at least one invasive plant chosen to be submitted **(minItems property)**
- [x] Many fields in the have red “this is a required property” message duplicated.  fix so it only shows once.
**this is the RJSF problem try changing oneOf to if-then-else format**
https://json-schema.org/understanding-json-schema/reference/conditionals.html
- [x] For Funding Agency field : When clicking on some agencies from the list it will add that agency plus another agency  Ex. Alberni-Clayoquot RD will also add Capital RD, CCCIPC also adds ISCBC, Central Coast RD also adds ISCBC.  
**this is the problem with multi-select-autocomplete widget**
- [x] For Observation Person(s) field on multiple forms - If you add a person and then remove them the field doesn’t show the “is a required property” message anymore.  Might be the same for all mandatory fields?? can we test and fix this?
- [x] In all forms the date and time are autofilled BUT, if a user tries to change date it won’t let you enter anything and says “should be string” – also once you’ve removed the auto timestamp the field is stuck being empty.   Allow users to override the date and time in the proper format if they need to.
- [x] When making Terrestrial Observation or Chemical Treatment.  Some forms don’t show an errors but remain invalid - are there hidden validation rules?
- [x] for all numerical fields (like Pesticide applicator number or buffer distance when drawing a line) is there a way to have it bring up the number keyboard instead of the letters in your ipad?  No worries if not.
**there is no way to do this.**

Biocontrol Dispersal Monitoring form
- [x] Has two fields for Primary and Secondary Applicator edit to be called Observer Name(s)
- [x]  “Monitoring Organization” should be renamed as employer and linked to the same employer code table as all the rest of the forms.
- [x] There is a Biological Agent Presence field where you can select 1 option from a list of Adults, Larvae, Eggs, Foliar Feeding, Root Feeding, etc. – edit this field so that you can choose multiple selections from the drop down.  
- [ ] @CrystalChadburn to add something else here about the collection history and collection history comments fields and phenology fields after susan reviews.

Biocontrol Collection form
- [x] Start time and stop time says “(mins)” – need a clock to be able to choose the time

Aquatic observation, mechanical and chemical treatment forms:
- [x] Aquatic observation form: Shoreline type requires 100% cover but allows to enter more than 100%.  Limit this to 100%
- [x] Change the name of the "average depth of waterbody" to "maximum depth"
- [ ] @CrystalChadburn to add something here about inflow/outflow fields 


Terrestrial observation form:
- [x] Terrestrial plant observation form has two fields for life stage.

Chemical forms (aquatic and terrestrial)
- [x] when user clicked on a well it showed UTM zone 39 and had wrong coordinates **(latlong reversed)**
- [x] In Terrestrial Chemical Treatment form, the  Application Start Time field can’t enter any info – says “should be string”.  this needs a time clock to enable users to pick a time in the same standardized format as all time fields.


Monitoring forms
- [x] all monitoring forms have two access description fields.  Reduce to 1.



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [x] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
