### PR TITLE
SD / HD (low & high res) map toggle

### DIFF
--- a/app/src/components/map/MapContainer.tsx
+++ b/app/src/components/map/MapContainer.tsx
@@ -1,19 +1,17 @@
 import { MapContextMenuData } from '../../features/home/map/MapContextMenu';
 import { Feature, GeoJsonObject } from 'geojson';
+<<<<<<< HEAD
 import React, { useState, useEffect } from 'react';
+=======
+import React, { useState, useRef, useEffect } from 'react';
+>>>>>>> dd02ba9 (hd / sd zoom toggle works - needs style)
 import * as L from 'leaflet';
 import 'leaflet-draw';
 import 'leaflet-draw/dist/leaflet.draw.css';
 import './MapContainer.css';
-import {
-  MapContainer as ReactLeafletMapContainer,
-  useMap,
-  FeatureGroup,
-  ZoomControl,
-  Marker,
-  Tooltip
-} from 'react-leaflet';
+import { MapContainer as ReactLeafletMapContainer, useMap, FeatureGroup, Marker, Tooltip } from 'react-leaflet';
 import Spinner from '../../components/spinner/Spinner';
+import ZoomControl from 'components/map/Tools/ZoomControl';
 
 // Offline dependencies
 import 'leaflet.offline';
@@ -125,6 +123,11 @@ export interface IMapContainerProps {
 }
 
 const MapContainer: React.FC<IMapContainerProps> = (props) => {
+  //to support the zoom control component controlling the parent map container:
+  const [mapZoom, setMapZoom] = useState<number>(5);
+  const [mapMaxZoom, setMapMaxZoom] = useState<number>(25);
+  const [mapMaxNativeZoom, setMapMaxNativeZoom] = useState<number>(20);
+
   const [poiMarker, setPoiMarker] = useState(null);
   const [map, setMap] = useState<any>(null);
   const toolClass = toolStyles();
@@ -135,6 +138,16 @@ const MapContainer: React.FC<IMapContainerProps> = (props) => {
   });
 
   const Offline = (props) => {
+<<<<<<< HEAD
+=======
+    useEffect(() => {
+      console.log('max zoom: ', mapMaxZoom);
+      console.log('max native zoom: ', mapMaxNativeZoom);
+      console.log('map zoom: ', mapZoom);
+      console.dir(props);
+    }, [mapMaxNativeZoom, mapMaxZoom, props]);
+
+>>>>>>> dd02ba9 (hd / sd zoom toggle works - needs style)
     const mapOffline = useMap();
     const offlineLayer = (L.tileLayer as any).offline(
       // 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
@@ -145,6 +158,10 @@ const MapContainer: React.FC<IMapContainerProps> = (props) => {
         subdomains: 'abc',
         // minZoom: 13,
         // maxZoom: 19,
+        maxZoom: mapMaxZoom,
+        //maxZoom: 25,
+        maxNativeZoom: props.maxNativeZoom,
+        //maxNativeZoom: 20,
         crossOrigin: true
       }
     );
@@ -205,7 +222,10 @@ const MapContainer: React.FC<IMapContainerProps> = (props) => {
   return (
     <ReactLeafletMapContainer
       center={[55, -128]}
-      zoom={5}
+      zoom={mapZoom}
+      bounceAtZoomLimits={true}
+      maxZoom={mapMaxZoom}
+      //maxZoom={25}
       style={{ height: '100%', width: '100%' }}
       zoomControl={false}
       whenCreated={setMap}
@@ -216,6 +236,7 @@ const MapContainer: React.FC<IMapContainerProps> = (props) => {
           <SetPointOnClick map={map} setPoiMarker={setPoiMarker} />
           <DisplayPosition map={map} setPoiMarker={setPoiMarker} />
           <MeasureTool />
+          <ZoomControl mapMaxNativeZoom={mapMaxNativeZoom} setMapMaxNativeZoom={setMapMaxNativeZoom} />
           {props.showDrawControls && (
             <FeatureGroup>
               <EditTools isPlanPage={props.isPlanPage} geometryState={props.geometryState} />
@@ -225,9 +246,8 @@ const MapContainer: React.FC<IMapContainerProps> = (props) => {
         </div>
 
         {/* Here is the offline component */}
-        <Offline {...props} />
+        <Offline {...props} maxNativeZoom={mapMaxNativeZoom}  />
 
-        <ZoomControl position="bottomright" />
         <LayerPicker
           position="topright"
           map={map}

--- a/app/src/components/map/MapContainer.tsx
+++ b/app/src/components/map/MapContainer.tsx
@@ -1,10 +1,6 @@
 import { MapContextMenuData } from '../../features/home/map/MapContextMenu';
 import { Feature, GeoJsonObject } from 'geojson';
-<<<<<<< HEAD
-import React, { useState, useEffect } from 'react';
-=======
 import React, { useState, useRef, useEffect } from 'react';
->>>>>>> dd02ba9 (hd / sd zoom toggle works - needs style)
 import * as L from 'leaflet';
 import 'leaflet-draw';
 import 'leaflet-draw/dist/leaflet.draw.css';
@@ -138,16 +134,6 @@ const MapContainer: React.FC<IMapContainerProps> = (props) => {
   });
 
   const Offline = (props) => {
-<<<<<<< HEAD
-=======
-    useEffect(() => {
-      console.log('max zoom: ', mapMaxZoom);
-      console.log('max native zoom: ', mapMaxNativeZoom);
-      console.log('map zoom: ', mapZoom);
-      console.dir(props);
-    }, [mapMaxNativeZoom, mapMaxZoom, props]);
-
->>>>>>> dd02ba9 (hd / sd zoom toggle works - needs style)
     const mapOffline = useMap();
     const offlineLayer = (L.tileLayer as any).offline(
       // 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
@@ -246,7 +232,7 @@ const MapContainer: React.FC<IMapContainerProps> = (props) => {
         </div>
 
         {/* Here is the offline component */}
-        <Offline {...props} maxNativeZoom={mapMaxNativeZoom}  />
+        <Offline {...props} maxNativeZoom={mapMaxNativeZoom} />
 
         <LayerPicker
           position="topright"

--- a/app/src/components/map/Tools/ZoomControl.tsx
+++ b/app/src/components/map/Tools/ZoomControl.tsx
@@ -1,0 +1,47 @@
+import { Button, IconButton } from '@mui/material';
+import React, { useContext, useEffect, useRef } from 'react';
+import { toolStyles } from './Helpers/ToolBtnStyles';
+import L from 'leaflet';
+import { ThemeContext } from 'contexts/themeContext';
+import HdIcon from '@mui/icons-material/Hd';
+import SdIcon from '@mui/icons-material/Sd';
+
+export const ZoomControl = (props) => {
+  const LOW_RES = 17;
+  const HIGH_RES = 25;
+  const toolClass = toolStyles();
+  const themeContext = useContext(ThemeContext);
+  const divRef = useRef(null);
+
+  //block click propogation
+  useEffect(() => {
+    L.DomEvent.disableClickPropagation(divRef?.current);
+    L.DomEvent.disableScrollPropagation(divRef?.current);
+  });
+
+  //onclick
+  const toggle = () => {
+    props.setMapMaxNativeZoom((prevState) => {
+      if (prevState === LOW_RES) {
+        return HIGH_RES;
+      } else {
+        return LOW_RES;
+      }
+    });
+  };
+  return (
+    <>
+      <IconButton
+        //todo add this attribution:
+        //<div>Icons made by <a href="https://www.flaticon.com/authors/wahya" title="wahya">wahya</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a></div>
+        ref={divRef}
+        className={themeContext.themeType ? toolClass.toolBtnDark : toolClass.toolBtnLight}
+        aria-label="toggle max zoom resolution"
+        onClick={toggle}>
+        {props.maxNativeZoom === HIGH_RES ? <HdIcon /> : <SdIcon />}
+      </IconButton>
+    </>
+  );
+};
+
+export default ZoomControl;

--- a/app/src/components/map/Tools/ZoomControl.tsx
+++ b/app/src/components/map/Tools/ZoomControl.tsx
@@ -1,5 +1,5 @@
-import { Button, IconButton } from '@mui/material';
-import React, { useContext, useEffect, useRef } from 'react';
+import { Button, IconButton } from '@material-ui/core';
+import React, { useContext, useEffect, useState, useRef } from 'react';
 import { toolStyles } from './Helpers/ToolBtnStyles';
 import L from 'leaflet';
 import { ThemeContext } from 'contexts/themeContext';
@@ -19,12 +19,16 @@ export const ZoomControl = (props) => {
     L.DomEvent.disableScrollPropagation(divRef?.current);
   });
 
+  const [isHighRes, setIsHighRes] = useState(false);
+
   //onclick
   const toggle = () => {
     props.setMapMaxNativeZoom((prevState) => {
       if (prevState === LOW_RES) {
+        setIsHighRes(true);
         return HIGH_RES;
       } else {
+        setIsHighRes(false);
         return LOW_RES;
       }
     });
@@ -38,7 +42,7 @@ export const ZoomControl = (props) => {
         className={themeContext.themeType ? toolClass.toolBtnDark : toolClass.toolBtnLight}
         aria-label="toggle max zoom resolution"
         onClick={toggle}>
-        {props.maxNativeZoom === HIGH_RES ? <HdIcon /> : <SdIcon />}
+        {isHighRes ? <HdIcon fontSize={'large'} /> : <SdIcon fontSize={'large'} />}
       </IconButton>
     </>
   );


### PR DESCRIPTION
Allow the user to toggle between 'High Def' and 'Standard Definition' to take advantage of better imaging in urban areas, while not forcing them to look at a grey screen in rural areas.  Takes advantage of leaflet tile zoom interpolation, and works around its lack of ability to dynamically set the interpolation based on what is available.