### PR TITLE
save a preset & Layer Picker Fix/refactor

### DIFF
--- a/app/src/components/map/LayerPicker/LayerPicker.tsx
+++ b/app/src/components/map/LayerPicker/LayerPicker.tsx
@@ -150,7 +150,9 @@ export function LayerPicker(props: any, { position }) {
   const [newLayers, setNewLayers] = useState([]);
 
   useEffect(() => {
-    if (objectState) setNewLayers(sanitizedLayers(objectState));
+    if (objectState) {
+      setNewLayers(sanitizedLayers(objectState));
+    }
   }, [objectState]);
 
   useEffect(() => {
@@ -458,6 +460,18 @@ export function LayerPicker(props: any, { position }) {
                   useDragHandle={true}
                   lockAxis="y"
                 />
+                <Button
+                  onClick={() => {
+                    localStorage.setItem('mySave', JSON.stringify(objectState));
+                  }}>
+                  Save
+                </Button>
+                <Button
+                  onClick={() => {
+                    setObjectState(JSON.parse(localStorage.getItem('mySave')));
+                  }}>
+                  Load
+                </Button>
               </Popover>
             </div>
           )}


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- refactor layer picker code
- can save 1 preset and load a preset to the layer picker

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
