### PR TITLE
Mobile sync

### DIFF
--- a/app/src/components/activities-list/ActivitiesList.tsx
+++ b/app/src/components/activities-list/ActivitiesList.tsx
@@ -41,6 +41,7 @@ import { Sync } from '@material-ui/icons';
 import { IonAlert } from '@ionic/react';
 import { Capacitor } from '@capacitor/core';
 import { useDataAccess } from 'hooks/useDataAccess';
+import { NetworkContext } from 'contexts/NetworkContext';
 
 const useStyles = makeStyles((theme: Theme) => ({
   newActivityButtonsRow: {
@@ -222,6 +223,7 @@ const ActivitiesList: React.FC = () => {
   const [isDisabled, setIsDisable] = useState(false);
   const [workflowFunction, setWorkflowFunction] = useState('Plant');
   const [showAlert, setShowAlert] = useState(false);
+  const networkContext = useContext(NetworkContext);
 
   const syncCachedActivities = async () => {
     console.log('Syncing...');
@@ -345,7 +347,7 @@ const ActivitiesList: React.FC = () => {
               <MenuItem value="Batch Upload">Batch Upload</MenuItem>
             </Select>
           </FormControl>
-          {isMobile && (
+          {isMobile && networkContext.connected && (
             <Button onClick={showPrompt} key="sync" color="primary" variant="outlined" startIcon={<Sync />}>
               Sync Cached Records
             </Button>

--- a/app/src/components/activities-list/ActivitiesList.tsx
+++ b/app/src/components/activities-list/ActivitiesList.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Button,
   Checkbox,
   Divider,
   FormControl,
@@ -36,6 +37,10 @@ import {
 import { DatabaseContext2, query, QueryType } from '../../contexts/DatabaseContext2';
 import BatchUpload from '../../components/batch-upload/BatchUpload';
 import { ALL_ROLES, PLANT_ROLES, ANIMAL_ROLES, USER_ACCESS, User_Access } from 'constants/roles';
+import { Sync } from '@material-ui/icons';
+import { IonAlert } from '@ionic/react';
+import { Capacitor } from '@capacitor/core';
+import { useDataAccess } from 'hooks/useDataAccess';
 
 const useStyles = makeStyles((theme: Theme) => ({
   newActivityButtonsRow: {
@@ -184,6 +189,7 @@ interface IActivityList {
 
 const ActivitiesList: React.FC = () => {
   const classes = useStyles();
+  const dataAccess = useDataAccess();
 
   let hasPlantAccess = false;
   let hasAnimalAccess = false;
@@ -215,6 +221,24 @@ const ActivitiesList: React.FC = () => {
   const [syncing, setSyncing] = useState(false);
   const [isDisabled, setIsDisable] = useState(false);
   const [workflowFunction, setWorkflowFunction] = useState('Plant');
+  const [showAlert, setShowAlert] = useState(false);
+
+  const syncCachedActivities = async () => {
+    console.log('Syncing...');
+    try {
+      await dataAccess.syncCachedRecords();
+    } catch (e: any) {
+      console.log('Error syncing cached records: ', e);
+    }
+  };
+
+  const showPrompt = () => {
+    setShowAlert(true);
+  };
+
+  const isMobile = () => {
+    return Capacitor.getPlatform() !== 'web';
+  };
 
   // const syncActivities = async () => {
   //   setIsDisable(true);
@@ -288,6 +312,26 @@ const ActivitiesList: React.FC = () => {
 
   return (
     <>
+      <IonAlert
+        isOpen={showAlert}
+        onDidDismiss={() => setShowAlert(false)}
+        header={'Are you sure?'}
+        message={'If you choose to sync your cached records, you will no longer be able to edit them.'}
+        buttons={[
+          {
+            text: 'Cancel',
+            role: 'cancel',
+            cssClass: 'secondary',
+            handler: () => {}
+          },
+          {
+            text: 'Okay',
+            handler: () => {
+              syncCachedActivities();
+            }
+          }
+        ]}
+      />
       <Box>
         <Box mb={3} display="flex" justifyContent="space-between">
           <FormControl variant="outlined" className={classes.formControl}>
@@ -301,6 +345,11 @@ const ActivitiesList: React.FC = () => {
               <MenuItem value="Batch Upload">Batch Upload</MenuItem>
             </Select>
           </FormControl>
+          {isMobile && (
+            <Button onClick={showPrompt} key="sync" color="primary" variant="outlined" startIcon={<Sync />}>
+              Sync Cached Records
+            </Button>
+          )}
         </Box>
         <Box>
           {workflowFunction === 'Plant' && (


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Add sync button if on mobile and network connected
- Pressing sync button prompts user to confirm
- Cancelling does nothing
- Confirming will fetch all locally cached activities that have not yet been synced and create the activity in the invasivesbc database
- To be implemented: User should not be able to edit or delete activity after syncing. This is NOT DONE.
- Added two columns to local cache activity table

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Manual testing on mobile

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
