### PR TITLE
Clearing tables before seeding

### DIFF
--- a/api/test/sql/spatial-link-treatments.sql
+++ b/api/test/sql/spatial-link-treatments.sql
@@ -79,10 +79,12 @@ alter table treatments_by_species add primary key (gid);
 
 
 -- Temp query
-select
-  created_timestamp
-from
-  activity_incoming_data
-order by
-  created_timestamp desc
-;
+-- select
+--   count(created_timestamp)
+-- from
+--   activity_incoming_data
+-- where
+--   ''
+-- order by
+--   created_timestamp desc
+-- ;

--- a/api/test/sql/spatial-link-treatments.sql
+++ b/api/test/sql/spatial-link-treatments.sql
@@ -76,3 +76,13 @@ create index treatments_by_species_geom_gist on treatments_by_species using gist
 
 alter table treatments_by_species add column gid serial;
 alter table treatments_by_species add primary key (gid);
+
+
+-- Temp query
+select
+  created_timestamp
+from
+  activity_incoming_data
+order by
+  created_timestamp desc
+;

--- a/database/src/seeds/05_riso.ts
+++ b/database/src/seeds/05_riso.ts
@@ -7,5 +7,9 @@ export async function seed(knex: Knex): Promise<void> {
   const { data } = await axios.get(url, { responseType: 'arraybuffer' });
   const sql = await ungzip(data);
 
+  // Clear the table
+  const clear = 'truncate table public.regional_invasive_species_organization_areas;';
+  await knex.raw(clear);
+
   await knex.raw(sql.toString());
 }

--- a/database/src/seeds/06_ipma.ts
+++ b/database/src/seeds/06_ipma.ts
@@ -7,5 +7,9 @@ export async function seed(knex: Knex): Promise<void> {
   const { data } = await axios.get(url, { responseType: 'arraybuffer' });
   const sql = await ungzip(data);
 
+  // Clear the table
+  const clear = 'truncate table public.invasive_plant_management_areas;';
+  await knex.raw(clear);
+
   await knex.raw(sql.toString());
 }

--- a/database/src/seeds/07_aggregate.ts
+++ b/database/src/seeds/07_aggregate.ts
@@ -7,5 +7,9 @@ export async function seed(knex: Knex): Promise<void> {
   const { data } = await axios.get(url, { responseType: 'arraybuffer' });
   const sql = await ungzip(data);
 
+  // Clear the table
+  const clear = 'truncate table public.aggregate;';
+  await knex.raw(clear);
+
   await knex.raw(sql.toString());
 }

--- a/database/src/seeds/08_jurisdiction.ts
+++ b/database/src/seeds/08_jurisdiction.ts
@@ -21,6 +21,10 @@ export async function seed(knex: Knex): Promise<void> {
   // Unzip to text
   const sql: string = await ungzip(data);
 
+  // Clear the table
+  const clear = 'truncate table public.jurisdiction;';
+  await knex.raw(clear);
+
   /**
    * This file is too big to run all at once.
    * Split up by lines.

--- a/database/src/seeds/09_pmp.ts
+++ b/database/src/seeds/09_pmp.ts
@@ -7,5 +7,9 @@ export async function seed(knex: Knex): Promise<void> {
   const { data } = await axios.get(url, { responseType: 'arraybuffer' });
   const sql = await ungzip(data);
 
+  // Clear the table
+  const clear = 'truncate table public.pest_management_plan_areas;';
+  await knex.raw(clear);
+
   await knex.raw(sql.toString());
 }


### PR DESCRIPTION
This fixes a bug where seeds were being appending to existing data during each pull request. Tables are now being truncated before this happens.