### PR TITLE
Just in case we need to switch client_id

### DIFF
--- a/.config/config.json
+++ b/.config/config.json
@@ -36,17 +36,17 @@
   "sso": {
     "dev": {
       "url": "https://dev.oidc.gov.bc.ca",
-      "clientId": "invasives-bc-1948",
+      "clientId": "invasives-bc-1849",
       "realm": "onestopauth-business"
     },
     "test": {
       "url": "https://test.oidc.gov.bc.ca",
-      "clientId": "invasives-bc-1948",
+      "clientId": "invasives-bc-1849",
       "realm": "onestopauth-business"
     },
     "prod": {
       "url": "https://oidc.gov.bc.ca",
-      "clientId": "invasives-bc-1948",
+      "clientId": "invasives-bc-1849",
       "realm": "onestopauth-business"
     }
   }

--- a/api/src/utils/auth-utils.ts
+++ b/api/src/utils/auth-utils.ts
@@ -14,7 +14,7 @@ const APP_CERTIFICATE_URL =
   process.env.APP_CERTIFICATE_URL ||
   'https://dev.oidc.gov.bc.ca/auth/realms/onestopauth-business/protocol/openid-connect/certs';
 
-const KEYCLOAK_CLIENT_ID = 'invasives-bc-1948';
+const KEYCLOAK_CLIENT_ID = 'invasives-bc-1849';
 
 const TOKEN_IGNORE_EXPIRATION: boolean =
   process.env.TOKEN_IGNORE_EXPIRATION === 'true' ||

--- a/app/openshift/app.dc.yaml
+++ b/app/openshift/app.dc.yaml
@@ -43,7 +43,7 @@ parameters:
     value: 'https://oidc.gov.bc.ca'
   - name: SSO_CLIENT_ID
     description: Client Id for application
-    value: 'invasives-bc-1948'
+    value: 'invasives-bc-1849'
   - name: SSO_REALM
     description: Realm identifier or name
     value: onestopauth-business

--- a/app/public/keycloak.json
+++ b/app/public/keycloak.json
@@ -4,5 +4,5 @@
   "realm": "onestopauth-business",
   "ssl-required": "external",
   "public-client": true,
-  "resource": "invasives-bc-1948"
+  "resource": "invasives-bc-1849"
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -56,7 +56,7 @@ const App: React.FC<IAppProps> = (props) => {
   const keycloakInstanceConfig: KeycloakConfig = {
     realm: 'onestopauth-business',
     url: SSO_URL,
-    clientId: 'invasives-bc-1948'
+    clientId: 'invasives-bc-1849'
   };
 
   //@ts-ignore

--- a/testing/integration/postman/invasives_api_dev.environment.json
+++ b/testing/integration/postman/invasives_api_dev.environment.json
@@ -39,7 +39,7 @@
 		},
 		{
 			"key": "KEYCLOAK_CLIENT_ID",
-			"value": "invasives-bc-1948",
+			"value": "invasives-bc-1849",
 			"enabled": true
 		},
 		{


### PR DESCRIPTION
Our IDIM approval is for client id 1849, but we need to use public type which is 1948.  If they can approve 1948 this can be closed, if they decide to change the type of 1849 then we need to merge this.

UPDATE:  Ok they were able to just update our client type in 1849 and we can forget about 1948 (so we need this PR).