### PR TITLE
getSimplified and DataBC Table Fix (Can't merge until I can verify on Mobile)

### DIFF
--- a/app/src/components/map/Tools/ToolTypes/Data/InfoAreaDescription.tsx
+++ b/app/src/components/map/Tools/ToolTypes/Data/InfoAreaDescription.tsx
@@ -13,7 +13,8 @@ import {
 import AdjustIcon from '@material-ui/icons/Adjust';
 import FolderIcon from '@material-ui/icons/Folder';
 import LocationOnIcon from '@material-ui/icons/LocationOn';
-import StorageIcon from '@material-ui/icons/Storage';
+// Removed Temporarily until we figure out databc Table:
+// import StorageIcon from '@material-ui/icons/Storage';
 import { Stack } from '@mui/material';
 import * as turf from '@turf/turf';
 import { DatabaseContext } from 'contexts/DatabaseContext';
@@ -29,7 +30,8 @@ import { getDataFromDataBC } from '../../../WFSConsumer';
 import {
   createDataUTM,
   RenderTableActivity,
-  RenderTableDataBC,
+  // Removed Temporarily until we figure out databc Table:
+  // RenderTableDataBC,
   RenderTablePOI,
   RenderTablePosition
 } from '../../Helpers/StyledTable';
@@ -59,7 +61,8 @@ export const GeneratePopup = (props) => {
   const [section, setSection] = useState('position');
   const [pointMode, setPointMode] = useState(true);
   const [showRadius, setShowRadius] = useState(false);
-  const [databc, setDataBC] = useState(null);
+  // (NOSONAR)'d Temporarily until we figure out databc Table:
+  const [databc, setDataBC] = useState(null); // NOSONAR
   const [radius, setRadius] = useState(3);
   const [pois, setPOIs] = useState([]);
   const [rows, setRows] = useState([]);

--- a/app/src/components/map/Tools/ToolTypes/Data/InfoAreaDescription.tsx
+++ b/app/src/components/map/Tools/ToolTypes/Data/InfoAreaDescription.tsx
@@ -18,6 +18,7 @@ import { Stack } from '@mui/material';
 import * as turf from '@turf/turf';
 import { DatabaseContext } from 'contexts/DatabaseContext';
 import { ThemeContext } from 'contexts/themeContext';
+import { useInvasivesApi } from 'hooks/useInvasivesApi';
 import L, { DomEvent } from 'leaflet';
 import React, { useCallback, useContext, useEffect, useRef, useState } from 'react';
 // Leaflet and React-Leaflet
@@ -66,6 +67,7 @@ export const GeneratePopup = (props) => {
   const popupElRef = useRef(null);
   const dbContext = useContext(DatabaseContext);
   var activities;
+  const invasivesApi = useInvasivesApi();
 
   useEffect(() => {
     if (popupElRef?.current) {
@@ -87,7 +89,11 @@ export const GeneratePopup = (props) => {
 
   useEffect(() => {
     if (bufferedGeo) {
-      getDataFromDataBC('WHSE_WATER_MANAGEMENT.GW_WATER_WELLS_WRBC_SVW', bufferedGeo).then((returnVal) => {
+      getDataFromDataBC(
+        'WHSE_WATER_MANAGEMENT.GW_WATER_WELLS_WRBC_SVW',
+        bufferedGeo,
+        invasivesApi.getSimplifiedGeoJSON
+      ).then((returnVal) => {
         setDataBC(returnVal);
       }, []);
     }

--- a/app/src/components/map/Tools/ToolTypes/Data/InfoAreaDescription.tsx
+++ b/app/src/components/map/Tools/ToolTypes/Data/InfoAreaDescription.tsx
@@ -220,7 +220,7 @@ export const GeneratePopup = (props) => {
                 setRows={setRows}
               />
             )}
-            {section == 'databc' && <RenderTableDataBC rows={databc} />}
+            {/*section == 'databc' && <RenderTableDataBC rows={databc} />*/}
             {section == 'poi' && (
               <RenderTablePOI map={props.map} rows={poiTableRows} setPoiMarker={props.setPoiMarker} />
             )}
@@ -232,7 +232,7 @@ export const GeneratePopup = (props) => {
               onChange={handleChange}>
               <BottomNavigationAction value="position" label="Position" icon={<LocationOnIcon />} />
               <BottomNavigationAction value="activity" label="Activity" icon={<FolderIcon />} />
-              <BottomNavigationAction value="databc" label="Data BC" icon={<StorageIcon />} />
+              {/*<BottomNavigationAction value="databc" label="Data BC" icon={<StorageIcon />} />*/}
               <BottomNavigationAction value="poi" label="POI" icon={<AdjustIcon />} />
             </BottomNavigation>
           </Grid>

--- a/app/src/components/trip/TripDataControls.tsx
+++ b/app/src/components/trip/TripDataControls.tsx
@@ -656,7 +656,7 @@ export const TripDataControls: React.FC<any> = (props) => {
               }
               break;
             default:
-              featuresInArea = await getDataFromDataBC(layerName, bufferedGeo);
+              featuresInArea = await getDataFromDataBC(layerName, bufferedGeo, invasivesApi.getSimplifiedGeoJSON);
               break;
           }
 


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- getSimplified function crash fix
- Removed DataBC Table to prevent app from crashing and because it only used Water Wells

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

#### Map Page Test
Went onto map page > Zoomed onto my position > clicked circle marker > opened Activity Record Tables > opened POI Record Tables

#### Activity Page Test
Went onto My Records Page > Opened a random activity > Zoomed onto my position > clicked circle marker > opened Activity Record Tables > opened POI Record Tables

## Screenshots

<img width="1496" alt="Screen Shot 2021-12-30 at 12 42 03 PM" src="https://user-images.githubusercontent.com/52196460/147791784-950fe7e4-a965-46c4-b074-0f9c94afd01c.png">

<img width="1367" alt="Screen Shot 2021-12-30 at 12 42 45 PM" src="https://user-images.githubusercontent.com/52196460/147791794-a30e37ee-20d5-458b-bca6-ed1c61662f0d.png">

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
