### PR TITLE
Biocontrol forms are done

### DIFF
--- a/api/src/openapi/api-doc/Activities/Plant/Monitorings.ts
+++ b/api/src/openapi/api-doc/Activities/Plant/Monitorings.ts
@@ -1,5 +1,5 @@
 import { Activity } from '../../Activity_Data_Components';
-import { Monitoring } from '../../Activity_Type_Data_Components';
+import { Monitoring, Monitoring_Biocontrol } from '../../Activity_Type_Data_Components';
 import {
   Subtype_Data_Monitoring_BiocontrolDispersal_TerrestrialPlant,
   Subtype_Data_Monitoring_BiocontrolRelease_TerrestrialPlant,
@@ -56,7 +56,7 @@ export const Activity_Monitoring_BiocontrolDispersal_TerrestrialPlant = {
       ...Activity
     },
     activity_type_data: {
-      ...Monitoring
+      ...Monitoring_Biocontrol
     },
     activity_subtype_data: {
       ...Subtype_Data_Monitoring_BiocontrolDispersal_TerrestrialPlant

--- a/api/src/openapi/api-doc/Activity_Type_Data_Components.ts
+++ b/api/src/openapi/api-doc/Activity_Type_Data_Components.ts
@@ -47,6 +47,23 @@ export const Monitoring = {
   }
 };
 
+export const Monitoring_Biocontrol = {
+  title: 'Monitoring Information',
+  type: 'object',
+  required: ['linked_id', 'activity_persons'],
+  properties: {
+    activity_persons: {
+      type: 'array',
+      default: [{}],
+      title: 'Monitoring Person(s)',
+      items: {
+        ...Persons
+      },
+      'x-tooltip-text': 'Name of person(s) doing monitoring'
+    }
+  }
+};
+
 export const Treatment = {
   title: 'Treatment Information',
   type: 'object',

--- a/api/src/openapi/api-doc/Components/General_Sub_Forms.ts
+++ b/api/src/openapi/api-doc/Components/General_Sub_Forms.ts
@@ -502,14 +502,15 @@ export const Spread_Results = {
               type: 'number',
               minimum: 0,
               maximum: 100,
-              'x-tooltip-text': '% Agent density is: Total # agents at the site ÷ total # plants with agents) x 100'
+              'x-tooltip-text': 'Total # of bioagents at the site ÷ total # of plants surveyed (or sweeps) x 100'
             },
             plant_attack: {
               title: 'Plant Attack (%)',
               type: 'number',
               minimum: 0,
               maximum: 100,
-              'x-tooltip-text': '% Attack is: Total # agents at the site ÷ total # plants with agents, x 100'
+              'x-tooltip-text':
+                'Total # of plants with bioagents at the site ÷ total # of plants surveyed (or sweeps) x 100'
             },
             max_spread_distance: {
               title: 'Max Spread Distance (m)',

--- a/api/src/openapi/api-doc/Components/Monitoring_Sub_Forms.ts
+++ b/api/src/openapi/api-doc/Components/Monitoring_Sub_Forms.ts
@@ -276,18 +276,6 @@ export const Monitoring_BiocontrolRelease_TerrestrialPlant_Information = {
       enum: ['Yes', 'No', 'Unknown'],
       default: 'No',
       'x-tooltip-text': 'Please indicate the presence of legacy IAPP records'
-    },
-    collection_history: {
-      type: 'number',
-      title: 'Collection History',
-      'x-tooltip-text':
-        'Enter the IAPP or InvasivesBC record number to indicate the location where the biocontrol agents were collected from'
-    },
-    collection_history_comments: {
-      type: 'string',
-      title: 'Collection History Comments',
-      'x-tooltip-text':
-        'Enter relevant information about where the biocontrol agents being released came from, how they were shipped, and any related information'
     }
   }
 };
@@ -302,9 +290,7 @@ export const Monitoring_BiocontrolDispersal_Information = {
     'invasive_plant_code',
     'start_time',
     'stop_time',
-    'total_bio_agent_quantity',
-    'collection_history',
-    'collection_history_comments'
+    'total_bio_agent_quantity'
   ],
   dependencies: {
     monitoring_method: {
@@ -375,7 +361,7 @@ export const Monitoring_BiocontrolDispersal_Information = {
               title: 'Location agent(s) found',
               'x-enum-code': {
                 'x-enum-code-category-name': 'invasives',
-                'x-enum-code-header-name': 'bio_agent_location_code',
+                'x-enum-code-header-name': 'location_agents_found_code',
                 'x-enum-code-name': 'code_name',
                 'x-enum-code-text': 'code_description',
                 'x-enum-code-sort-order': 'code_sort_order'

--- a/api/src/openapi/api-doc/Subtype_Data_Lists/Plant_Subtype_Data_Lists.ts
+++ b/api/src/openapi/api-doc/Subtype_Data_Lists/Plant_Subtype_Data_Lists.ts
@@ -127,7 +127,6 @@ export const Subtype_Data_Monitoring_BiocontrolDispersal_TerrestrialPlant = {
     Weather_Conditions: Weather_Conditions,
     Microsite_Conditions: Microsite_Conditions,
     Monitoring_BiocontrolDispersal_Information: Monitoring_BiocontrolDispersal_Information,
-    Spread_Results: Spread_Results,
     Target_Plant_Phenology: Target_Plant_Phenology
   }
 };

--- a/app/src/components/form/FormContainer.tsx
+++ b/app/src/components/form/FormContainer.tsx
@@ -65,7 +65,7 @@ export interface IFormContainerProps extends IFormControlsComponentProps {
 
 const FormContainer: React.FC<IFormContainerProps> = (props) => {
   const dataAccess = useDataAccess();
-
+  const [formData, setformData] = useState(props.activity?.formData);
   const [schemas, setSchemas] = useState<{ schema: any; uiSchema: any }>({ schema: null, uiSchema: null });
   const formRef = useRef(null);
   const [focusedFieldArgs, setFocusedFieldArgs] = useState(null);
@@ -112,7 +112,9 @@ const FormContainer: React.FC<IFormContainerProps> = (props) => {
         //revalidate formData after the setState is run
         $this.validate($this.state.formData);
         //update formData of the activity via onFormChange
-        props.onFormChange({ formData: formRef.current.state.formData }, formRef);
+        props.onFormChange({ formData: formRef.current.state.formData }, formRef, null, (updatedFormData) => {
+          setformData(updatedFormData);
+        });
       });
     }, 100);
     handleClose();
@@ -120,12 +122,16 @@ const FormContainer: React.FC<IFormContainerProps> = (props) => {
 
   //helper function to get field name from args
   const getFieldNameFromArgs = (args): string => {
+    console.log();
     let argumentFieldName = '';
     if (args[0].includes('root_activity_subtype_data_treatment_information_herbicide_0_')) {
       argumentFieldName = 'root_activity_subtype_data_treatment_information_herbicide_0_';
     } else if (args[0].includes('root_activity_subtype_data_Treatment_ChemicalPlant_Information_')) {
       argumentFieldName = 'root_activity_subtype_data_Treatment_ChemicalPlant_Information_';
-    } else if (args[0].includes('root_activity_subtype_data_Weather_Conditions_')) {
+    } else if (
+      args[0].includes('root_activity_subtype_data_Weather_Conditions_') &&
+      !props.activity.activitySubtype.toString().toLowerCase().includes('biocontrol')
+    ) {
       argumentFieldName = 'root_activity_subtype_data_Weather_Conditions_';
     } else if (args[0].includes('root_activity_data_')) {
       argumentFieldName = 'root_activity_data_';
@@ -318,7 +324,6 @@ const FormContainer: React.FC<IFormContainerProps> = (props) => {
     getApiSpec();
   }, [props.activity.activitySubtype, props.activity.activity_subtype]);
 
-  const [formData, setformData] = useState(props.activity?.formData);
   const isDisabled = props.isDisabled || props.activity?.sync?.status === ActivitySyncStatus.SAVE_SUCCESSFUL || false;
 
   if (!schemas.schema || !schemas.uiSchema) {
@@ -350,6 +355,7 @@ const FormContainer: React.FC<IFormContainerProps> = (props) => {
                 uiSchema={schemas.uiSchema}
                 formContext={{ suggestedJurisdictions: props.suggestedJurisdictions || [] }}
                 liveValidate={true}
+                validate={props.customValidation}
                 showErrorList={true}
                 transformErrors={props.customErrorTransformer}
                 autoComplete="off"

--- a/app/src/rjsf/uiSchema/BaseUISchemaComponents.ts
+++ b/app/src/rjsf/uiSchema/BaseUISchemaComponents.ts
@@ -194,8 +194,8 @@ const TransectData = {
 const Biological_Agent_Stage = {
   biological_agent_stage_code: { 'ui:widget': 'single-select-autocomplete' },
   release_quantity: {},
-  agent_location: {},
-  plant_position: {},
+  agent_location: {'ui:widget': 'single-select-autocomplete'},
+  plant_position: {'ui:widget': 'single-select-autocomplete'},
   'ui:order': ['biological_agent_stage_code', 'release_quantity','agent_location','plant_position']
 };
 
@@ -962,8 +962,6 @@ const Monitoring_BiocontrolRelease_TerrestrialPlant_Information = {
   total_bio_agent_quantity_estimated: { 'ui:readonly': true },
   count_duration: {},
   suitable_collection_site: {},
-  collection_history: {},
-  collection_history_comments: { 'ui:widget': 'textarea' },
   legacy_presence_ind: {},
   'ui:order': [
     'invasive_plant_code',
@@ -981,8 +979,6 @@ const Monitoring_BiocontrolRelease_TerrestrialPlant_Information = {
     'estimated_biological_agents',
     'total_bio_agent_quantity_actual',
     'total_bio_agent_quantity_estimated',
-    'collection_history',
-    'collection_history_comments',
     'suitable_collection_site',
     'legacy_presence_ind'
   ]

--- a/app/src/rjsf/uiSchema/RootUISchemas.ts
+++ b/app/src/rjsf/uiSchema/RootUISchemas.ts
@@ -262,13 +262,11 @@ const Activity_Monitoring_BiocontrolDispersal_TerrestrialPlant = {
     Microsite_Conditions:BaseUISchemaComponents.general_objects.Microsite_Conditions,
     Monitoring_BiocontrolDispersal_Information:BaseUISchemaComponents.activity_subtype_data_information_objects.Monitoring_BiocontrolDispersal_Information,
     Target_Plant_Phenology:BaseUISchemaComponents.general_objects.Target_Plant_Phenology,
-    Spread_Results: BaseUISchemaComponents.general_objects.Spread_Results,
     'ui:order':[
       'Weather_Conditions',
       'Microsite_Conditions',
       'Monitoring_BiocontrolDispersal_Information',
-      'Target_Plant_Phenology',
-      'Spread_Results']
+      'Target_Plant_Phenology']
   },
   'ui:order':['activity_data','activity_type_data','activity_subtype_data']
 };


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

Biocontrol release form
- [x] is it possible to make the Collection date field just a calendar with no time for this form?  Users will not know the time collected.  If not possible to change this, just make this field optional.
- [x] make the "wind aspect" form default to blank, not 0.  
- [x] add the plant phenology object that is currently in the release monitoring form into this form as well.  Keep all rules and fields the same (ie. make the user click "phenology details recorded" before the fields pop up.  Same help text etc.
- [x] Link the invasive_plant_code list to the existing "Plant Collected from" field and make it optional.  Add a new optional field directly after "Plant Collected From" called "Plant Collected from - unlisted" that will be text entered.  Users will either choose from the drop down, or if it's not on our list, then they will type it in.  Both of these fields need to report into a single field called "Plant collected from - this is similar to what Mike built for the PMP fields in the chemical treatment forms.
- [x] Add help text for the new "Plant collected from - unlisted" field that says "If the plant is not listed on the drop down in the previous field, type in the name of the plant the agents were collected from.  Scientific name is preferred, but can be common name if required.
- [x] add help text to the "Plant Collected From" field that says "If known, choose the species from the list that the agents were collected from".  Make this an optional field.
- [x] add the estimated table in so it matches the other biocontrol forms.  All 4 forms should have both estimate and actual objects, with users filling in only one or the other (via the add item function).
- [x] fix typo in help text of Agent Source field - Missing "D" at the start.  
- [x] Biological Agent Stage in the actual and estimated quantity objects are missing their drop down.  Link to biological_agent_stage_code code table.
- [x] update the help text for the "Actual Quantity...." object to be: The quantity of the biocontrol agent collected in the life stage it was collected (actual or calculated average/estimate). 

Biocontrol collection form
- [x]  (same as above) can we remove the temperature field warning for this form.  Keep the warning for the chemical treatment form.
- [x] (same as above) make the "wind aspect" form default to blank, not 0.  
- [x]  (same as above) add the plant phenology object that is currently in the release monitoring form into this form as well.  Keep all rules and fields the same (ie. make the user click "phenology details recorded" before the fields pop up.  Same help text etc.
- [x] plant position field is missing it's drop down - link to plant_position_code and add help text that says: Identify where the majority of the agents were found on the plant. 
- [x] Biological Agent Stage in the actual and estimated quantity objects are missing their drop down.  Link to biological_agent_stage_code code table.
- [x] update the help text for the "Actual Quantity...." object to be: The quantity of the biocontrol agent collected in the life stage it was collected. 

Release monitoring form
- [x]  (same as above) can we remove the temperature field warning for this form.  Keep the warning for the chemical treatment form.
- [x] (same as above) make the "wind aspect" form default to blank, not 0.  
- [x] Actual and Estimated objects do not work.  Red BUG text shows up when you click add item that says: Invalid root object field configuration:uiSchema order list does not contain properties 'agent_location', 'plant_position'
- [x]  Biological Agent Stage in the actual and estimated quantity objects are missing their drop down.  Link to biological_agent_stage_code code table.
- [x] check if plant position field is missing it's drop down - link to plant_position_code and add help text that says: Identify the overall general location from the drop down where the agent(s) were found on the plant.  Used in combination with the Agent Location field. 
- [x] check if agent location field is linked to it's drop down agent_location_code and add help text that says "Identify the precise location from the drop down where the agent(s) were located.  Used in combination with the Plant Position field. 
- [x] update the help text for the "Actual Quantity...." object to be: The quantity of the biocontrol agent collected in the life stage it was collected. 
- [x] Update the help text for the "% Attack" field to be: Total # of plants with bioagents at the site ÷ total # of plants surveyed (or sweeps) x 100
- [x] Update the help text for the "% Agent Density" field to be: Total # of bioagents at the site ÷ total # of plants surveyed (or sweeps) x 100
- [x] Remove "Collection history" and "Collection History Comments" fields from this form.

Biocontrol dispersal monitoring
- [x] (same as above) can we remove the temperature field warning for this form.  Keep the warning for the chemical treatment form.
- [x] (same as above) make the "wind aspect" form default to blank, not 0.  
- [x] (Same as above) Actual and Estimated objects do not work. Red BUG text shows up when you click add item that says: Invalid root object field configuration:uiSchema order list does not contain properties 'agent_location', 'plant_position'
- [x] (Same as above) check if plant position field is missing it's drop down - link to plant_position_code and add help text that says: Identify the overall general location from the drop down where the agent(s) were found on the plant.  Used in combination with the Agent Location field. 
- [x] (Same as above) check if agent location field is linked to it's drop down agent_location_code and add help text that says "Identify the precise location from the drop down where the agent(s) were located.  Used in combination with the Plant Position field. 
- [x] delete the "linked treatment ID" field (this field is only needed in the chemical, mechanical and release monitoring forms, not this one)
- [x] "Location Agent(s) Found" field is missing it's drop down.  Link to the location_agents_found_code code table.
- [x] Remove the "spread results" section from this form and all associated fields.
- [x] update the help text for the "Actual Quantity...." object to be: The quantity of the biocontrol agent collected in the life stage it was collected. 

closes #1571 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
