### PR TITLE
Issue1543 utm fixes - ZEN format and zoom to UTM / Current location pin

### DIFF
--- a/app/src/components/activity/ActivityMapComponent.tsx
+++ b/app/src/components/activity/ActivityMapComponent.tsx
@@ -89,16 +89,6 @@ const ActivityMapComponent: React.FC<IMapContainerProps> = (props) => {
     if (!validZone) {
       return; // allow for cancel
     }
-    while (!validNorthing) {
-      northing = prompt('Enter a valid UTM Northing');
-      if (!isNaN(Number(northing))) {
-        validNorthing = true;
-        break;
-      }
-    }
-    if (!validNorthing) {
-      return; // allow for cancel
-    }
     while (!validEasting) {
       easting = prompt('Enter a valid UTM Easting');
       if (!isNaN(Number(easting))) {
@@ -109,6 +99,16 @@ const ActivityMapComponent: React.FC<IMapContainerProps> = (props) => {
     if (!validEasting) {
       //allow for cancel
       return;
+    }
+    while (!validNorthing) {
+      northing = prompt('Enter a valid UTM Northing');
+      if (!isNaN(Number(northing))) {
+        validNorthing = true;
+        break;
+      }
+    }
+    if (!validNorthing) {
+      return; // allow for cancel
     }
 
     let result = calc_lat_long_from_utm(Number(zone), Number(easting), Number(northing));
@@ -172,7 +172,15 @@ const ActivityMapComponent: React.FC<IMapContainerProps> = (props) => {
         </AccordionSummary>
         <AccordionDetails>
           <Grid justifyContent={'space-around'} container>
-            <Grid container justifyContent={'center'} alignItems={'stretch'} paddingBottom={'10px'} xs={3} item>
+            <Grid
+              sx={{ flexWrap: 'nowrap' }}
+              container
+              justifyContent={'center'}
+              alignItems={'stretch'}
+              paddingBottom={'10px'}
+              spacing={'space-evenly'}
+              xs={3}
+              item>
               <Button disabled={false} variant="contained" color="primary" onClick={manualUTMEntry}>
                 Enter UTM Manually
               </Button>

--- a/app/src/components/activity/ActivityMapComponent.tsx
+++ b/app/src/components/activity/ActivityMapComponent.tsx
@@ -122,7 +122,7 @@ const ActivityMapComponent: React.FC<IMapContainerProps> = (props) => {
     };
     // let the page validate the utm:
     props.geometryState.setGeometry([geo]);
-    map.setView([result[1], result[0]], 16);
+    map.setView([result[1], result[0]], 17);
   };
 
   const getGPSLocationEntry = async () => {
@@ -134,7 +134,7 @@ const ActivityMapComponent: React.FC<IMapContainerProps> = (props) => {
     timer({ initialTime, setInitialTime }, { startTimer, setStartTimer });
     props.geometryState.setGeometry([turf.point([position.coords.longitude, position.coords.latitude])]);
     draw.disable();
-    map.setView([position.coords.latitude, position.coords.longitude], 16);
+    map.setView([position.coords.latitude, position.coords.longitude], 17);
   };
 
   const endTrack = async () => {

--- a/app/src/components/activity/ActivityMapComponent.tsx
+++ b/app/src/components/activity/ActivityMapComponent.tsx
@@ -38,7 +38,7 @@ const ActivityMapComponent: React.FC<IMapContainerProps> = (props) => {
   const [isLoading, setIsLoading] = useState<boolean>(!props.activityId);
   const [initialTime, setInitialTime] = useState(0);
   const [startTimer, setStartTimer] = useState(false);
-  const [mapForButton, setMapForButton] = useState(null);
+  const [map, setMap] = useState(null);
   const [dialog, setDialog] = useState(false);
 
   useEffect(() => {
@@ -122,10 +122,11 @@ const ActivityMapComponent: React.FC<IMapContainerProps> = (props) => {
     };
     // let the page validate the utm:
     props.geometryState.setGeometry([geo]);
+    map.setView([result[1], result[0]], 16);
   };
 
   const getGPSLocationEntry = async () => {
-    const draw = new (L as any).Draw.Marker(mapForButton, {});
+    const draw = new (L as any).Draw.Marker(map, {});
     draw.enable();
     setInitialTime(3);
     setStartTimer(true);
@@ -133,6 +134,7 @@ const ActivityMapComponent: React.FC<IMapContainerProps> = (props) => {
     timer({ initialTime, setInitialTime }, { startTimer, setStartTimer });
     props.geometryState.setGeometry([turf.point([position.coords.longitude, position.coords.latitude])]);
     draw.disable();
+    map.setView([position.coords.latitude, position.coords.longitude], 16);
   };
 
   const endTrack = async () => {
@@ -199,7 +201,7 @@ const ActivityMapComponent: React.FC<IMapContainerProps> = (props) => {
                   </Button>
                   <Button
                     onClick={() => {
-                      new (L as any).Draw.Marker(mapForButton, {}).enable();
+                      new (L as any).Draw.Marker(map, {}).enable();
                       setDialog(false);
                     }}>
                     No
@@ -226,7 +228,7 @@ const ActivityMapComponent: React.FC<IMapContainerProps> = (props) => {
               </Button>
             </Grid> */}
             <Grid xs={12} className={props.classes.mapContainer} item>
-              <MapContainer {...props} activityId={props.activityId} setMapForButton={setMapForButton} />
+              <MapContainer {...props} activityId={props.activityId} setMapForActivityPage={setMap} />
             </Grid>
           </Grid>
         </AccordionDetails>

--- a/app/src/components/map/MapContainer.tsx
+++ b/app/src/components/map/MapContainer.tsx
@@ -130,7 +130,7 @@ const MapContainer: React.FC<IMapContainerProps> = (props) => {
 
   useEffect(() => {
     try {
-      props.setMapForButton(map);
+      props.setMapForActivityPage(map);
     } catch (e) {
       console.log('setMapForButton error', e);
     }

--- a/app/src/components/map/Tools/ToolTypes/Data/InfoAreaDescription.tsx
+++ b/app/src/components/map/Tools/ToolTypes/Data/InfoAreaDescription.tsx
@@ -231,7 +231,7 @@ function SetPointOnClick({ map }: any) {
 
   useEffect(() => {
     if (utm) {
-      setRows([createDataUTM('UTM', utm[0]), createDataUTM('Northing', utm[2]), createDataUTM('Easting', utm[1])]);
+      setRows([createDataUTM('UTM', utm[0]), createDataUTM('Easting', utm[1]), createDataUTM('Northing', utm[2])]);
     }
   }, [utm]);
 


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Changed input of UTM to ZEN format
- Changed position popup table to be ZEN format
- When UTM position is created the map zooms to that location
- When the users current location is used as a marker the map zooms to that locaiton

NOTE: Still need to zoom to location when marker created.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

On a new or old activity you will click the "Enter UTM Manually" button. It will prompt to enter the UTM Zone, then UTM Easting, and finally the UTM Northing.
Once entered you will notice the map change to that location.
I also added this to when you want to drop a pin at your location.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
