### PR TITLE
Deployment tuning

### DIFF
--- a/.github/workflows/deploy_dev_app.yml
+++ b/.github/workflows/deploy_dev_app.yml
@@ -1,0 +1,184 @@
+# Static Deploy
+# Builds and Deploys merged PR's to persistent pods/services/routes/etc in the OpenShift Dev, Test, or Prod environments.
+name: Static Deploy - DEV APP
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - dev
+    paths:
+      - 'app/*'
+
+concurrency:
+  group: db_app-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Print variables for logging and debugging purposes
+  checkEnv:
+    name: Check Env variables
+    runs-on: ubuntu-20.04
+    if: ${{ github.event.pull_request.merged == true }}
+    env:
+      LABELS: ${{ toJson(github.event.pull_request.labels) }}
+    steps:
+      - name: Print Env Vars
+        run: |
+          echo OC CLI Version: $(oc version)
+          echo Git Base Ref: ${{ github.base_ref }}
+          echo Git Change ID: ${{ github.event.number }}
+          echo Git Pull Request Ref: ${{ github.event.pull_request.head.sha }}
+          echo GIt Event Name: ${{ github.event_name }}
+          echo GIt Event Action: ${{ github.event.action }}
+          echo Git Labels: "$LABELS"
+            # Build the web frontend app
+
+  buildAPP:
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: false
+    name: Build App Image
+    runs-on: ubuntu-20.04
+    env:
+      BUILD_ID: ${{ github.event.number }}
+      BRANCH: ${{ github.base_ref }}
+      REACT_APP_REAL_NODE_ENV: production
+    steps:
+      # Checkout the PR branch
+      - name: Checkout Target Branch
+        uses: actions/checkout@v2
+
+      # Install Node - for `node` and `npm` commands
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.3.1
+
+      # Log in to OpenShift.
+      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
+      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
+      - name: Log in to OpenShift
+        run: oc login --token=${{ secrets.TOOLS_SA_TOKEN }} --server=https://api.silver.devops.gov.bc.ca:6443
+
+      # Build the app image
+      - name: Build APP Image
+        working-directory: './app/.pipeline/'
+        run: |
+          npm ci
+          DEBUG=* npm run build -- --pr=$BUILD_ID --branch=$BRANCH --type=static
+
+  # Deploy App image
+  deployAPP:
+    name: Deploy App Image
+    runs-on: ubuntu-20.04
+    if: ${{ github.event.pull_request.merged == true }}
+    env:
+      BUILD_ID: ${{ github.event.number }}
+      BRANCH: ${{ github.base_ref }}
+    needs:
+      - buildAPP
+    steps:
+      # Checkout the PR branch
+      - name: Checkout Target Branch
+        uses: actions/checkout@v2
+
+      # Install Node - for `node` and `npm` commands
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.3.1
+
+      # Log in to OpenShift.
+      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
+      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
+      - name: Log in to OpenShift
+        run: oc login --token=${{ secrets.TOOLS_SA_TOKEN }} --server=https://api.silver.devops.gov.bc.ca:6443
+
+      # Deploy the app image
+      - name: Deploy App Image
+        working-directory: './app/.pipeline'
+        run: |
+          npm ci
+          DEBUG=* npm run deploy -- --pr=$BUILD_ID --env=$BRANCH --branch=$BRANCH --type=static
+
+  purgeTags:
+    name: Clean stale Openshift ImageStream tags
+    runs-on: ubuntu-20.04
+    if: ${{ github.event.pull_request.merged == true }}
+    needs:
+      - deployAPP
+    steps:
+      # Checkout the PR branch
+      - name: Checkout Target Branch
+        uses: actions/checkout@v2
+
+      # Log in to OpenShift.
+      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
+      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
+      - name: Log in to OpenShift
+        run: oc login --token=${{ secrets.TOOLS_SA_TOKEN }} --server=https://api.silver.devops.gov.bc.ca:6443
+
+      # Deploy the app image
+      - name: Deploy App Image
+        working-directory: './.github'
+        run: |
+          ./purge-old-tags.sh
+
+  # Clean any artifacts created by the deploy-pr workflow (if it ran, see comments at the top of `deploy-pr.yml`)
+  clean:
+    name: Clean Merged PR Build and Deploy Artifacts
+    runs-on: ubuntu-20.04
+    # Only clean if the PR was merged (but not closed) and was marked as a PR-DEPLOY
+    if: |
+      ${{ github.event.pull_request.merged == true &&
+        ( contains(github.event.pull_request.labels.*.name, 'PR-DEPLOY') ||
+          contains(github.event.pull_request.title, 'PR-DEPLOY') ) }}
+    needs:
+      - deployDatabase
+      - deployDatabaseSetup
+      - deployAPI
+      - deployAPP
+    env:
+      BUILD_ID: ${{ github.event.number }}
+      BRANCH: ${{ github.base_ref }}
+    steps:
+      # Checkout the PR branch
+      - name: Checkout Target Branch
+        uses: actions/checkout@v2
+
+      # Install Node - for `node` and `npm` commands
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.3.1
+
+      # Log in to OpenShift.
+      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
+      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
+      - name: Log in to OpenShift
+        run: oc login --token=${{ secrets.TOOLS_SA_TOKEN }} --server=https://api.silver.devops.gov.bc.ca:6443
+
+      # Clean the database build/deployment artifacts
+      - name: Clean Database Artifacts
+        working-directory: './database/.pipeline/'
+        run: |
+          npm ci
+          DEBUG=* npm run clean -- --pr=$BUILD_ID --env=build
+          DEBUG=* npm run clean -- --pr=$BUILD_ID --env=$BRANCH
+
+      # Clean the api build/deployment artifacts
+      - name: Clean API Artifacts
+        working-directory: './api/.pipeline/'
+        run: |
+          npm ci
+          DEBUG=* npm run clean -- --pr=$BUILD_ID --env=build
+          DEBUG=* npm run clean -- --pr=$BUILD_ID --env=$BRANCH
+
+      # Clean the app build/deployment artifacts
+      - name: Clean APP Artifacts
+        working-directory: './app/.pipeline/'
+        run: |
+          npm ci
+          DEBUG=* npm run clean -- --pr=$BUILD_ID --env=build
+          DEBUG=* npm run clean -- --pr=$BUILD_ID --env=$BRANCH

--- a/.github/workflows/deploy_dev_db_api.yml
+++ b/.github/workflows/deploy_dev_db_api.yml
@@ -1,12 +1,19 @@
 # Static Deploy
 # Builds and Deploys merged PR's to persistent pods/services/routes/etc in the OpenShift Dev, Test, or Prod environments.
-name: Static Deploy - DEV
+name: Static Deploy - DEV API & DB
 
 on:
   pull_request:
     types: [closed]
     branches:
       - dev
+    paths:
+      - 'api/*'
+      - 'database/*'
+
+concurrency:
+  group: db_api-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # Print variables for logging and debugging purposes
@@ -29,6 +36,9 @@ jobs:
 
   # Build the Database image
   buildDatabase:
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: false
     name: Build Database Image
     runs-on: ubuntu-20.04
     if: ${{ github.event.pull_request.merged == true }}
@@ -63,14 +73,15 @@ jobs:
 
   # Build the Database Setup image
   buildDatabaseSetup:
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: false
     name: Build Database Setup Image
     runs-on: ubuntu-20.04
     if: ${{ github.event.pull_request.merged == true }}
     env:
       BUILD_ID: ${{ github.event.number }}
       BRANCH: ${{ github.base_ref }}
-    needs:
-      - buildAPP
     steps:
       # Checkout the PR branch
       - name: Checkout Target Branch
@@ -97,6 +108,9 @@ jobs:
 
   # Build the API image
   buildAPI:
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: false
     name: Build API Image
     runs-on: ubuntu-20.04
     if: ${{ github.event.pull_request.merged == true }}
@@ -104,7 +118,7 @@ jobs:
       BUILD_ID: ${{ github.event.number }}
       BRANCH: ${{ github.base_ref }}
     needs:
-      - buildAPP
+      - buildDatabaseSetup
 
     steps:
       # Checkout the PR branch
@@ -126,39 +140,6 @@ jobs:
       # Build the api image
       - name: Build API Image
         working-directory: './api/.pipeline/'
-        run: |
-          npm ci
-          DEBUG=* npm run build -- --pr=$BUILD_ID --branch=$BRANCH --type=static
-
-  # Build the web frontend app
-  buildAPP:
-    name: Build App Image
-    runs-on: ubuntu-20.04
-    if: ${{ github.event.pull_request.merged == true }}
-    env:
-      BUILD_ID: ${{ github.event.number }}
-      BRANCH: ${{ github.base_ref }}
-      REACT_APP_REAL_NODE_ENV: development
-    steps:
-      # Checkout the PR branch
-      - name: Checkout Target Branch
-        uses: actions/checkout@v2
-
-      # Install Node - for `node` and `npm` commands
-      - name: Setup Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12.3.1
-
-      # Log in to OpenShift.
-      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
-      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
-      - name: Log in to OpenShift
-        run: oc login --token=${{ secrets.TOOLS_SA_TOKEN }} --server=https://api.silver.devops.gov.bc.ca:6443
-
-      # Build the app image
-      - name: Build APP Image
-        working-directory: './app/.pipeline/'
         run: |
           npm ci
           DEBUG=* npm run build -- --pr=$BUILD_ID --branch=$BRANCH --type=static
@@ -267,41 +248,10 @@ jobs:
           npm ci
           DEBUG=* npm run deploy -- --pr=$BUILD_ID --env=$BRANCH --branch=$BRANCH --type=static
 
-  # Deploy App image
-  deployAPP:
-    name: Deploy App Image
-    runs-on: ubuntu-20.04
-    if: ${{ github.event.pull_request.merged == true }}
-    env:
-      BUILD_ID: ${{ github.event.number }}
-      BRANCH: ${{ github.base_ref }}
-    needs:
-      - buildAPP
-    steps:
-      # Checkout the PR branch
-      - name: Checkout Target Branch
-        uses: actions/checkout@v2
-
-      # Install Node - for `node` and `npm` commands
-      - name: Setup Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12.3.1
-
-      # Log in to OpenShift.
-      # Note: The secrets needed to log in are NOT available if the PR comes from a FORK.
-      # PR's must originate from a branch off the original repo or else all openshift `oc` commands will fail.
-      - name: Log in to OpenShift
-        run: oc login --token=${{ secrets.TOOLS_SA_TOKEN }} --server=https://api.silver.devops.gov.bc.ca:6443
-
-      # Deploy the app image
-      - name: Deploy App Image
-        working-directory: './app/.pipeline'
-        run: |
-          npm ci
-          DEBUG=* npm run deploy -- --pr=$BUILD_ID --env=$BRANCH --branch=$BRANCH --type=static
-
   purgeTags:
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: false
     name: Clean stale Openshift ImageStream tags
     runs-on: ubuntu-20.04
     if: ${{ github.event.pull_request.merged == true }}


### PR DESCRIPTION
Attempt to control deployments using path specifiers and concurrency rules in gh actions.
Should only allow for one build at a time, and only build api & db (together) AND/OR app if applicable.
Should cancel only the in progress builds that make sense to, e.g, if there is a new api PR it should cancel the other one, but not the in progress app build.
