### PR TITLE
chem treatment form fixes mar31

### DIFF
--- a/api/src/openapi/api-doc/Activities/Plant/Treatments.ts
+++ b/api/src/openapi/api-doc/Activities/Plant/Treatments.ts
@@ -27,6 +27,9 @@ export const Activity_Treatment_ChemicalPlantAquatic = {
     activity_data: {
       ...Activity
     },
+    activity_type_data: {
+      ...Treatment_Chemical
+    },
     activity_subtype_data: {
       ...Subtype_Data_Treatment_ChemicalPlantAquatic
     }

--- a/app/src/components/form/ChemicalTreatmentDetailsForm/Components/single-objects/CalculationResultsTable.tsx
+++ b/app/src/components/form/ChemicalTreatmentDetailsForm/Components/single-objects/CalculationResultsTable.tsx
@@ -91,6 +91,7 @@ function Row(props: { name: string; row: ReturnType<typeof createData> }) {
                   <TableHead>
                     <TableCell style={{ fontWeight: 'bold' }}>#</TableCell>
                     {Object.keys(row[0]).map((key) => {
+                      if (key === 'index') return <></>;
                       return (
                         <TableCell key={key} style={{ fontWeight: 'bold' }}>
                           {key
@@ -111,6 +112,7 @@ function Row(props: { name: string; row: ReturnType<typeof createData> }) {
                         <TableRow key={Math.random()}>
                           <TableCell>{index + 1}</TableCell>
                           {Object.keys(plant).map((key) => {
+                            if (key === 'index') return <></>;
                             return (
                               <TableCell key={key}>
                                 {Array.isArray(plant[key]) ? (

--- a/app/src/components/form/ChemicalTreatmentDetailsForm/Components/single-objects/Herbicide.tsx
+++ b/app/src/components/form/ChemicalTreatmentDetailsForm/Components/single-objects/Herbicide.tsx
@@ -22,6 +22,18 @@ const Herbicide: React.FC<IHerbicideComponent> = ({ herbicide, index, classes, i
   const chemicalApplicationMethod = formDetails.formData.chemical_application_method;
   const tankMixOn = formDetails.formData.tank_mix;
 
+  const [product_application_rate_g_ha, setproduct_application_rate_g_ha] = useState(0);
+  useEffect(() => {
+    if (!product_application_rate_g_ha || isNaN(product_application_rate_g_ha)) {
+      return;
+    } else {
+      setCurrentHerbicide((prevFields) => ({
+        ...prevFields,
+        product_application_rate: Number(product_application_rate_g_ha) / 1000
+      }));
+    }
+  }, [product_application_rate_g_ha]);
+
   //get arrays for spray and direct chemical methods
   const chemical_method_direct_code_values = businessCodes['chemical_method_direct'].map((code) => {
     return code.value;
@@ -284,7 +296,7 @@ const Herbicide: React.FC<IHerbicideComponent> = ({ herbicide, index, classes, i
               className={classes.inputField}
               type="number"
               label="Dilution (%)"
-              value={herbicide?.dilution || ''}
+              value={herbicide?.dilution}
               variant="outlined"
               onChange={(event) => {
                 if (event.target.value === null) {
@@ -310,7 +322,7 @@ const Herbicide: React.FC<IHerbicideComponent> = ({ herbicide, index, classes, i
               className={classes.inputField}
               type="number"
               label="Area Treated (sqm)"
-              value={herbicide.area_treated_sqm || ''}
+              value={herbicide.area_treated_sqm}
               variant="outlined"
               onChange={(event) => {
                 if (event.target.value === null) {
@@ -338,7 +350,7 @@ const Herbicide: React.FC<IHerbicideComponent> = ({ herbicide, index, classes, i
               type="number"
               id="delivery-rate-of-mix"
               label="Delivery Rate of Mix (L/ha)"
-              value={herbicide.delivery_rate_of_mix || ''}
+              value={herbicide.delivery_rate_of_mix}
               variant="outlined"
               onChange={(event) => {
                 if (event.target.value === null) {
@@ -355,7 +367,7 @@ const Herbicide: React.FC<IHerbicideComponent> = ({ herbicide, index, classes, i
             <Tooltip
               style={{ float: 'right', marginBottom: 5, color: 'rgb(170, 170, 170)' }}
               placement="left"
-              title="Recommended label rate for herbicide (L/ha) used for this treatment">
+              title="Recommended label rate for herbicide (g/ha) used for this treatment">
               <HelpOutlineIcon />
             </Tooltip>
             <TextField
@@ -363,10 +375,35 @@ const Herbicide: React.FC<IHerbicideComponent> = ({ herbicide, index, classes, i
               className={classes.inputField}
               type="number"
               id="product-application-rate"
-              // error={currentHerbicideErrorSchema?.application_rate?.__errors?.length > 0}
+              label="Product Application Rate (g/ha)"
+              value={product_application_rate_g_ha}
+              variant="outlined"
+              onChange={(event) => {
+                if (event.target.value === null) {
+                  return;
+                }
+                setproduct_application_rate_g_ha(Number(event.target.value));
+                // setCurrentHerbicide((prevFields) => ({
+                //   ...prevFields,
+                //   product_application_rate: Number(event.target.value) / 1000
+                // }));
+              }}
+              defaultValue={undefined}
+            />
+
+            <Tooltip
+              style={{ float: 'right', marginBottom: 5, color: 'rgb(170, 170, 170)' }}
+              placement="left"
+              title="Recommended label rate for herbicide (L/ha) used for this treatment">
+              <HelpOutlineIcon />
+            </Tooltip>
+            <TextField
+              disabled={formDetails.disabled || true}
+              className={classes.inputField}
+              type="number"
+              id="product-application-rate"
               label="Product Application Rate (L/ha)"
-              // helperText={currentHerbicideErrorSchema?.application_rate?.__errors[0] || ''}
-              value={herbicide.product_application_rate || ''}
+              value={herbicide.product_application_rate}
               variant="outlined"
               onChange={(event) => {
                 if (event.target.value === null) {

--- a/app/src/components/map/LayerLoaderHelpers/JurisdictionsLayer.tsx
+++ b/app/src/components/map/LayerLoaderHelpers/JurisdictionsLayer.tsx
@@ -66,7 +66,7 @@ export const JurisdictionsLayer = (props) => {
   }, []);
 
   const fetchData = async () => {
-    const jurisdictionsData = await dataAccess.getJurisdictions({ search_feature: mapBounds }, databaseContext);
+    const jurisdictionsData = await dataAccess.getJurisdictions({ search_feature: mapBounds });
     let jurisdictionsFeatureArray = [];
     jurisdictionsData?.forEach((row) => {
       jurisdictionsFeatureArray.push(row.geojson ? row.geojson : row);

--- a/app/src/components/map/Tools/ToolTypes/Data/InfoAreaDescription.tsx
+++ b/app/src/components/map/Tools/ToolTypes/Data/InfoAreaDescription.tsx
@@ -172,36 +172,38 @@ function SetPointOnClick({ map }: any) {
   // }, [position]);
 
   useMapEvent('click', (e) => {
-    if (clickMode) {
-      console.log('mousedown ding');
-      if (positionOne === null) {
-        setPositionOne(e.latlng);
+    if (drawnGeo) {
+      if (clickMode) {
+        console.log('mousedown ding');
+        if (positionOne === null) {
+          setPositionOne(e.latlng);
+        } else {
+          const coords = center(drawnGeo).geometry.coordinates;
+          const result = calc_utm(coords[0], coords[1]);
+          setClickMode(false);
+          setPositionOne(null);
+          setUTM([
+            createDataUTM('Zone', result[0]),
+            createDataUTM('Easting', result[1]),
+            createDataUTM('Northing', result[2])
+          ]);
+        }
       } else {
+        const temp = e.latlng;
+        const val = 0.003;
+        const latlng1 = [temp.lng + val, temp.lat - val / 2];
+        const latlng3 = [temp.lng - val, temp.lat + val / 2];
+        const latlng2 = [temp.lng + val, temp.lat + val / 2];
+        const latlng4 = [temp.lng - val, temp.lat - val / 2];
+        setDrawnGeo(polygon([[latlng1, latlng2, latlng3, latlng4, latlng1]]));
         const coords = center(drawnGeo).geometry.coordinates;
         const result = calc_utm(coords[0], coords[1]);
-        setClickMode(false);
-        setPositionOne(null);
         setUTM([
           createDataUTM('Zone', result[0]),
           createDataUTM('Easting', result[1]),
           createDataUTM('Northing', result[2])
         ]);
       }
-    } else {
-      const temp = e.latlng;
-      const val = 0.003;
-      const latlng1 = [temp.lng + val, temp.lat - val / 2];
-      const latlng3 = [temp.lng - val, temp.lat + val / 2];
-      const latlng2 = [temp.lng + val, temp.lat + val / 2];
-      const latlng4 = [temp.lng - val, temp.lat - val / 2];
-      setDrawnGeo(polygon([[latlng1, latlng2, latlng3, latlng4, latlng1]]));
-      const coords = center(drawnGeo).geometry.coordinates;
-      const result = calc_utm(coords[0], coords[1]);
-      setUTM([
-        createDataUTM('Zone', result[0]),
-        createDataUTM('Easting', result[1]),
-        createDataUTM('Northing', result[2])
-      ]);
     }
   });
 

--- a/app/src/rjsf/uiSchema/RootUISchemas.ts
+++ b/app/src/rjsf/uiSchema/RootUISchemas.ts
@@ -139,6 +139,10 @@ const Activity_Treatment_ChemicalPlantAquatic = {
     ...BaseUISchemaComponents.column_styles.ThreeColumnStyle,
     ...BaseUISchemaComponents.activity_data_objects.Activity
   },
+  activity_type_data: {
+    ...BaseUISchemaComponents.column_styles.TwoColumnStyle,
+    ...BaseUISchemaComponents.activity_type_data_objects.Treatment_Chemical
+  },
   activity_subtype_data: {
     Well_Information: {
       ...BaseUISchemaComponents.general_objects.Well_Information
@@ -151,7 +155,7 @@ const Activity_Treatment_ChemicalPlantAquatic = {
     },
     'ui:order': ['Well_Information', 'Treatment_ChemicalPlant_Information', 'Pest_Injury_Threshold_Determination']
   },
-  'ui:order': ['activity_data', 'activity_subtype_data']
+  'ui:order': ['activity_data', 'activity_type_data', 'activity_subtype_data']
 };
 
 const Activity_Treatment_MechanicalPlantTerrestrial = {

--- a/app/src/rjsf/widgets/SingleSelectAutoComplete.tsx
+++ b/app/src/rjsf/widgets/SingleSelectAutoComplete.tsx
@@ -137,7 +137,6 @@ const SingleSelectAutoComplete = (props: WidgetProps) => {
   return (
     <div>
       <Autocomplete
-        autoComplete
         autoHighlight
         autoSelect={props.required}
         blurOnSelect
@@ -203,6 +202,7 @@ const SingleSelectAutoComplete = (props: WidgetProps) => {
         renderInput={(params) => (
           <TextField
             {...params}
+            autoComplete="new-password"
             variant="outlined"
             required={props.required}
             label={props.label || props.schema.title}

--- a/database/src/seeds/08_jurisdiction.ts
+++ b/database/src/seeds/08_jurisdiction.ts
@@ -8,12 +8,12 @@ export async function seed(knex: Knex): Promise<void> {
    * speeding up the development life cycle.
    */
   const env: string = process.env.REACT_APP_REAL_NODE_ENV;
-  let url: string;
-  if (env.match(/dev/i) || env.match(/local/i)) {
-    url = 'https://nrs.objectstore.gov.bc.ca/seeds/jurisdiction_vancouver_island.sql.gz';
-  } else {
-    url = 'https://nrs.objectstore.gov.bc.ca/seeds/jurisdiction.sql.gz';
-  }
+  const url = 'https://nrs.objectstore.gov.bc.ca/seeds/jurisdiction.sql.gz';
+  // if (env.match(/dev/i) || env.match(/local/i)) {
+  //   url = 'https://nrs.objectstore.gov.bc.ca/seeds/jurisdiction_vancouver_island.sql.gz';
+  // } else {
+  //   url = 'https://nrs.objectstore.gov.bc.ca/seeds/jurisdiction.sql.gz';
+  // }
 
   // Fetch data
   const { data } = await axios.get(url, { responseType: 'arraybuffer' });


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

closes #1756  

On both terrestrial and aquatic chemical treatment forms:

- [x] hide the "index" column that shows currently in the calculation output section 
- [x] add a new field called Product Application Rate g/Ha for the granular and product application rate scenario that the user will enter in grams (like 230g), that then gets converted by the system into L/ha into the existing "product application rate l/ha" field and lock that field so users do not enter in it.   That should allow users to enter in g/Ha and have the calculations work to output in l of undiluted herbicide (scenario 5).  Ensure the help text for the new g/ha product application rate field says "Recommended label rate for herbicide (g/ha) used for this treatment"
- [x] when a user chooses granular and then dilution, the dilution % field must allow decimal points, up to 5 decimals (ie. 0.0230%) (scenario 6)

On the aquatic chemical treatment form only:
- [x] treatment person and PAC fields are missing.  Please add to match the terrestrial form.
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
