### PR TITLE
Add support for exporting metabase groups

### DIFF
--- a/api/src/admin/metabase_groups.ts
+++ b/api/src/admin/metabase_groups.ts
@@ -1,0 +1,20 @@
+import { getDBConnection } from '../database/db';
+import { getMetabaseGroupsSQL } from '../queries/role-queries';
+
+async function getMetabaseGroupMappings(req, res) {
+  const connection = await getDBConnection();
+  if (!connection) {
+    return res.status(503).json({ message: 'Database connection unavailable', request: req.body, code: 503 });
+  }
+  try {
+    const sqlStatement = getMetabaseGroupsSQL();
+    const result = await connection.query(sqlStatement.text, sqlStatement.values);
+    return res.status(200).json(result.rows);
+  } catch (error) {
+    return res.status(500).send();
+  } finally {
+    connection.release();
+  }
+}
+
+export { getMetabaseGroupMappings };

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -8,11 +8,14 @@ import { api_doc } from './openapi/api-doc/api-doc';
 import { applyApiDocSecurityFilters } from './utils/api-doc-security-filter';
 import { authenticate } from './utils/auth-utils';
 import { getLogger } from './utils/logger';
+import {getMetabaseGroupMappings} from "./admin/metabase_groups";
 
 const defaultLog = getLogger('app');
 
 const HOST = process.env.API_HOST || 'localhost';
 const PORT = Number(process.env.API_PORT || '3002');
+
+const ADMIN_PORT = 8500;
 
 export { HOST, PORT };
 
@@ -76,10 +79,16 @@ initialize({
   }
 });
 
+const adminApp: express.Express = express();
+adminApp.get('/metabase_groups', getMetabaseGroupMappings);
+
 // Start api
 try {
   app.listen(PORT, () => {
     defaultLog.info({ label: 'start api', message: `started api on ${HOST}:${PORT}/api` });
+  });
+  adminApp.listen(ADMIN_PORT, () => {
+    defaultLog.info({ label: 'start admin api', message: `started api on ${HOST}:${ADMIN_PORT}/admin` });
   });
 } catch (error) {
   defaultLog.error({ label: 'start api', message: 'error', error });

--- a/api/src/queries/role-queries.ts
+++ b/api/src/queries/role-queries.ts
@@ -60,17 +60,17 @@ export const getRolesForUserSQL = (user_id): SQLStatement => {
     return null;
   } else {
     const sql = SQL`
-      select 
-        user_access.role_id, 
-        user_role.role_name, 
-        user_role.role_description 
-      from 
-        user_access 
-      inner join 
-        user_role 
-      on 
-        user_access.role_id = user_role.role_id 
-      where 
+      select
+        user_access.role_id,
+        user_role.role_name,
+        user_role.role_description
+      from
+        user_access
+      inner join
+        user_role
+      on
+        user_access.role_id = user_role.role_id
+      where
         user_access.user_id=${user_id};
     `;
     return sql;
@@ -87,22 +87,22 @@ export const getUsersForRoleSQL = (role_id): SQLStatement => {
     return null;
   } else {
     const sql = SQL`
-      select 
-        user_access.user_id, 
-        application_user.first_name, 
-        application_user.last_name, 
-        application_user.email, 
-        application_user.preferred_username, 
-        application_user.account_status, 
-        application_user.activation_status, 
+      select
+        user_access.user_id,
+        application_user.first_name,
+        application_user.last_name,
+        application_user.email,
+        application_user.preferred_username,
+        application_user.account_status,
+        application_user.activation_status,
         application_user.activation_status
-      from 
-        user_access 
-      inner join 
-        application_user 
-      on 
-        user_access.user_id = application_user.user_id 
-      where 
+      from
+        user_access
+      inner join
+        application_user
+      on
+        user_access.user_id = application_user.user_id
+      where
         user_access.role_id=${role_id};
     `;
     return sql;
@@ -134,5 +134,19 @@ export const getAllRolesSQL = (): SQLStatement => {
   return SQL`
     SELECT *
     FROM user_role;
+  `;
+};
+
+/**
+ * SQL query to get metabase groups to be associated with each user
+ * @returns {SQLStatement} sql query object
+ */
+export const getMetabaseGroupsSQL = (): SQLStatement => {
+  return SQL`
+    select u.email,
+           array_remove(array_agg(distinct r.metabase_group),NULL) as metabase_groups
+    from user_access ua left join application_user u on ua.user_id=u.user_id inner join user_role r on ua.role_id = r.role_id
+    group by u.email
+    order by u.email asc;
   `;
 };

--- a/database/src/migrations/20220404145252_add_metabase_groups.ts
+++ b/database/src/migrations/20220404145252_add_metabase_groups.ts
@@ -1,0 +1,48 @@
+import * as Knex from 'knex';
+const DB_SCHEMA = 'invasivesbc';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    set schema '${DB_SCHEMA}';
+    set search_path=invasivesbc,public;
+
+    alter table user_role add column metabase_group varchar(100) null;
+`);
+
+  const metabaseUserRoles = [
+    'administrator_plants',
+    'administrator_animals',
+    'bcgov_staff_animals',
+    'bcgov_staff_plants',
+    'bcgov_staff_both',
+    'contractor_manager_animals',
+    'contractor_manager_plants',
+    'contractor_manager_both',
+    'contractor_staff_animals',
+    'contractor_staff_plants',
+    'contractor_staff_both',
+    'indigenous_riso_manager_animals',
+    'indigenous_riso_manager_plants',
+    'indigenous_riso_manager_both',
+    'indigenous_riso_staff_animals',
+    'indigenous_riso_staff_plants',
+    'indigenous_riso_staff_both'
+  ];
+  const metabaseAdminRoles = ['master_administrator'];
+
+  await knex(`${DB_SCHEMA}.user_role`)
+    .update({ metabase_group: 'standard_user' })
+    .whereIn('role_name', metabaseUserRoles);
+  await knex(`${DB_SCHEMA}.user_role`)
+    .update({ metabase_group: 'master_admin' })
+    .whereIn('role_name', metabaseAdminRoles);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    set schema '${DB_SCHEMA}';
+    set search_path=invasivesbc,public;
+
+    alter table user_role drop column metabase_group;
+`);
+}


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Adds an admin API (default port 8005) providing read-only access to user group membership information to be imported to metabase. This port should be exposed to local services only and not reachable via any routes.
- Associated database queries and migration to provide mapping between InvasivesBC role and Metabase groups 


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
