### PR TITLE
Fix broken point marker icons and align them to associated point

### DIFF
--- a/app/src/components/activity/ActivityMapComponent.tsx
+++ b/app/src/components/activity/ActivityMapComponent.tsx
@@ -21,6 +21,8 @@ import { calc_lat_long_from_utm } from 'components/map/Tools/ToolTypes/Nav/Displ
 import { MapRecordsContextProvider } from 'contexts/MapRecordsContext';
 import { Geolocation } from '@capacitor/geolocation';
 import L from 'leaflet';
+import icon from 'leaflet/dist/images/marker-icon.png';
+import iconShadow from 'leaflet/dist/images/marker-shadow.png';
 
 const timer = ({ initialTime, setInitialTime }, { startTimer, setStartTimer }) => {
   if (initialTime > 0) {
@@ -125,8 +127,15 @@ const ActivityMapComponent: React.FC<IMapContainerProps> = (props) => {
     map.setView([result[1], result[0]], 17);
   };
 
+  // define default marker icon to override src defined in leaflet.css
+  const DefaultIcon = L.icon({
+    iconUrl: icon,
+    shadowUrl: iconShadow,
+    iconAnchor: [12, 41],
+  });
+
   const getGPSLocationEntry = async () => {
-    const draw = new (L as any).Draw.Marker(map, {});
+    const draw = new (L as any).Draw.Marker(map, {icon: DefaultIcon});
     draw.enable();
     setInitialTime(3);
     setStartTimer(true);
@@ -206,7 +215,9 @@ const ActivityMapComponent: React.FC<IMapContainerProps> = (props) => {
                   </Button>
                   <Button
                     onClick={() => {
-                      new (L as any).Draw.Marker(map, {}).enable();
+                      new (L as any).Draw.Marker(map, {
+                        icon: DefaultIcon,
+                      }).enable();
                       setDialog(false);
                     }}>
                     No

--- a/app/src/components/map/MapContainer.tsx
+++ b/app/src/components/map/MapContainer.tsx
@@ -34,7 +34,8 @@ import MapLocationControlGroup from './Tools/ToolTypes/Nav/MapLocationControlGro
 
 const DefaultIcon = L.icon({
   iconUrl: icon,
-  shadowUrl: iconShadow
+  shadowUrl: iconShadow,
+  iconAnchor: [12, 41],
 });
 
 L.Marker.prototype.options.icon = DefaultIcon;

--- a/app/src/components/map/Tools/ToolTypes/Data/EditTools.tsx
+++ b/app/src/components/map/Tools/ToolTypes/Data/EditTools.tsx
@@ -5,6 +5,8 @@ import bbox from '@turf/bbox';
 import centroid from '@turf/centroid';
 import * as turf from '@turf/helpers';
 import L from 'leaflet';
+import icon from 'leaflet/dist/images/marker-icon.png';
+import iconShadow from 'leaflet/dist/images/marker-shadow.png';
 import React, { useEffect, useRef, useState } from 'react';
 import { useMapEvent } from 'react-leaflet';
 import { MobilePolylineDrawButton } from '../../Helpers/MobileDrawBtns';
@@ -170,6 +172,13 @@ const EditTools = (props: any) => {
     }
   };
 
+  // define default marker icon to override src defined in leaflet.css
+  const DefaultIcon = L.icon({
+    iconUrl: icon,
+    shadowUrl: iconShadow,
+    iconAnchor: [12, 41]
+  });
+
   const updateMapOnGeometryChange = () => {
     // upload from geometrystate props
     // updates drawnItems with the latest geo changes, attempting to only draw new geos and delete no-longer-present ones
@@ -291,6 +300,9 @@ const EditTools = (props: any) => {
         circlemarker: false,
         polyline: {
           disabled: true
+        },
+        marker: {
+          icon: DefaultIcon
         }
       },
       edit: {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- #1787
- Point marker icon is now specified on the draw call with proper alignment

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Manually clicking through the application and checking the points of error.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
