### PR TITLE
Cache Dropdowns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,5 +90,19 @@ api: ## Executes into the workspace container.
 	@echo "==============================================="
 	@docker-compose exec api bash
 
+build-ios: ## Builds the app for mobile
+	@echo "==============================================="
+	@echo "Make: build-mobile - building app for mobile"
+	@echo "==============================================="
+	@cd app && npm install && npm run build:ios && cd ..
+
+run-ios: ## Runs the app for mobile
+	@echo "==============================================="
+	@echo "Make: run-mobile - running app for mobile"
+	@echo "==============================================="
+	@cd app && npx cap sync ios && npx cap open ios && cd ..
+
+ios: | build-ios run-ios ## Builds and runs the app for mobile
+
 help:	## Display this help screen.
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/app/src/contexts/DatabaseContext.tsx
+++ b/app/src/contexts/DatabaseContext.tsx
@@ -143,7 +143,6 @@ export const DatabaseContextProvider = (props) => {
     for (const value of enumKeys(DocType)) {
       switch (value) {
         case 'CODE_TABLE':
-          setupSQL += `DROP TABLE IF EXISTS ${DocType[value]};`; // To wipe old table and get latest codes
           setupSQL += `create table if not exists  
             ${DocType[value]} 
              (

--- a/app/src/contexts/DatabaseContext.tsx
+++ b/app/src/contexts/DatabaseContext.tsx
@@ -143,10 +143,11 @@ export const DatabaseContextProvider = (props) => {
     for (const value of enumKeys(DocType)) {
       switch (value) {
         case 'CODE_TABLE':
+          setupSQL += `DROP TABLE IF EXISTS ${DocType[value]};`; // To wipe old table and get latest codes
           setupSQL += `create table if not exists  
             ${DocType[value]} 
              (
-              ID TEXT,
+              id TEXT PRIMARY KEY,
               json TEXT
             );`;
           break;

--- a/app/src/contexts/authStateContext.tsx
+++ b/app/src/contexts/authStateContext.tsx
@@ -140,6 +140,10 @@ export const AuthStateContextProvider: React.FC<any> = (props: any) => {
     await dataAccess.cacheFundingAgencies();
   };
 
+  const cacheCodeTables = async () => {
+    await dataAccess.cacheCodeTables();
+  };
+
   const cacheCurrentUserBCEID = async (bceid_userid) => {
     await dataAccess.cacheCurrentUserBCEID(bceid_userid);
   };
@@ -256,6 +260,7 @@ export const AuthStateContextProvider: React.FC<any> = (props: any) => {
             await cacheAllRoles();
             await cacheEmployers();
             await cacheFundingAgencies();
+            await cacheCodeTables();
           }
           const token = keycloak?.obj?.tokenParsed;
           if (token && token.idir_userid) {

--- a/app/src/hooks/useInvasivesApi.ts
+++ b/app/src/hooks/useInvasivesApi.ts
@@ -65,8 +65,7 @@ export const useInvasivesApi = () => {
   const [keycloakObject, keycloakReady] = useKeycloak();
 
   const getRequestOptions = async () => {
-    console.dir(keycloakObject);
-
+    // console.dir(keycloakObject);
     if (!keycloakObject) {
       console.error('Network request while keycloak object is not ready');
     }
@@ -1141,34 +1140,12 @@ export const useInvasivesApi = () => {
       headers: { ...options.headers },
       url: options.baseUrl + '/api/code_tables'
     });
-    cacheCodeTables(data);
     checkForErrors(data);
     if (LOGVERBOSE) {
       console.log('listCodeTables', data);
     }
 
     return data.result;
-  };
-
-  const cacheCodeTables = async (data) => {
-    if (data.result && data.result.length > 0) {
-      const upserts = data.result.map((codeTableJSON, index) => ({
-        type: UpsertType.DOC_TYPE_AND_ID,
-        docType: DocType.CODE_TABLE,
-        id: codeTableJSON.name,
-        json: codeTableJSON
-      }));
-      try {
-        await databaseContext.asyncQueue({
-          asyncTask: () => {
-            return upsert(upserts, databaseContext);
-          }
-        });
-      } catch (e) {
-        alert('unable to cache api spec');
-      }
-      return false;
-    }
   };
 
   const fetchCodeTable = async (codeHeaderName, csv = false): Promise<any> => {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Moved dropdown caching to useDataAccess.tsx, cache dropdowns on login since they are user-specific
- Fixed upsert where ID was not a primary key, drop code_tables table on login since different users see different tables.
- Tested blue dot tracking on mobile - working
- Tested browser cache clear - non-issue
- Updated makefile to make building and running ios simpler (`make ios`)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

Testing on mobile

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
