### PR TITLE
Current IAPP Site tab

### DIFF
--- a/api/src/utils/iapp-json-utils.ts
+++ b/api/src/utils/iapp-json-utils.ts
@@ -213,6 +213,14 @@ const mapSitesRowsToJSON = async (site_extract_table_response: any) => {
       }
     );
 
+    // monitored flag
+    const monitored = (
+      row['has_biological_treatment_monitorings'] ||
+      row['has_chemical_treatment_monitorings'] ||
+      row['has_mechanical_treatment_monitorings']) ? 'Yes' : 'No';
+
+    (iapp_site as any).point_of_interest_payload.form_data.monitored = monitored;
+
     return iapp_site;
   });
 };

--- a/app/src/components/activities-list/Tables/POITablesHelpers.tsx
+++ b/app/src/components/activities-list/Tables/POITablesHelpers.tsx
@@ -48,10 +48,10 @@ export const point_of_interest_iapp_default_headers = [
     key: 'bio_dispersal',
     name: 'Biocontrol Dispersal'
   },
-  // {
-  //   key: 'monitored',
-  //   name: 'Monitored'
-  // },
+  {
+    key: 'monitored',
+    name: 'Monitored'
+  },
 ];
 
 export const mapPOI_IAPP_ToDataGridRows = (activities) => {
@@ -63,7 +63,6 @@ export const mapPOI_IAPP_ToDataGridRows = (activities) => {
   }
 
   return activities?.rows?.map((record, index) => {
-    // console.log(record);
     const jurisdictions = new Set();
     let lastSurveyed = new Date(record?.point_of_interest_payload?.form_data?.point_of_interest_data?.date_created);
     let agencies = new Set();
@@ -74,6 +73,7 @@ export const mapPOI_IAPP_ToDataGridRows = (activities) => {
     const chemTreatment = record?.point_of_interest_payload?.form_data?.chemical_treatments?.length ? "Yes" : "No";
     const mechTreatment = record?.point_of_interest_payload?.form_data?.mechanical_treatments?.length ? "Yes" : "No";
     const bioDispersal = record?.point_of_interest_payload?.form_data?.biological_dispersals?.length ? "Yes" : "No";
+    const monitored = record?.point_of_interest_payload?.form_data?.monitored;
 
     for (const survey of record?.point_of_interest_payload?.form_data?.surveys) {
       // jurisdictions
@@ -105,7 +105,7 @@ export const mapPOI_IAPP_ToDataGridRows = (activities) => {
       chem_treatment: chemTreatment,
       mech_treatment: mechTreatment,
       bio_dispersal: bioDispersal,
-      // monitored: ""
+      monitored: monitored
     };
   });
 };

--- a/app/src/components/activities-list/Tables/Plant/ActivityGrid.tsx
+++ b/app/src/components/activities-list/Tables/Plant/ActivityGrid.tsx
@@ -310,7 +310,7 @@ const ActivityGrid = (props) => {
     }
   }, [activitiesSelected]);
 
-  // set selected record to
+  // set selected record to poi
   useEffect(() => {
     if (poiSelected && props.setSelectedRecord && poiSelected.point_of_interest_id) {
       props.setSelectedRecord({

--- a/app/src/components/tabs/TabsContainer.tsx
+++ b/app/src/components/tabs/TabsContainer.tsx
@@ -303,6 +303,14 @@ const TabsContainer: React.FC<ITabsContainerProps> = (props: any) => {
           });
         }
 
+        if (isAuthorized() && process.env.REACT_APP_REAL_NODE_ENV !== 'production') {
+          tabsUserHasAccessTo.push({
+            label: 'Current IAPP Site',
+            path: '/home/iapp/',
+            icon: <img src={process.env.PUBLIC_URL + '/assets/iapp.gif'} style={{maxWidth: '3.8rem', marginBottom: '6px'}} />
+          });
+        }
+
         /*
         if (isAuthorized() && isMobile() && process.env.REACT_APP_REAL_NODE_ENV !== 'production') {
           tabsUserHasAccessTo.push({

--- a/app/src/contexts/recordSetContext.tsx
+++ b/app/src/contexts/recordSetContext.tsx
@@ -82,9 +82,14 @@ export const RecordSetProvider = (props) => {
   const updateState = async () => {
     const oldState = dataAccess.getAppState();
     const oldRecordSets = oldState?.recordSets;
-    if (oldRecordSets && recordSetState && JSON.stringify(oldRecordSets) !== JSON.stringify(recordSetState)) {
+    console.log((selectedRecord?.id));
+    if (oldRecordSets && recordSetState && ( JSON.stringify(oldRecordSets) !== JSON.stringify(recordSetState) || (oldState?.activeActivity !== selectedRecord?.id && oldState?.activeIappSite !== selectedRecord?.id) )) {
       if (selectedRecord?.id) {
-        dataAccess.setAppState({ recordSets: { ...recordSetState }, activeActivity: selectedRecord.id });
+        if (selectedRecord?.isIAPP) {
+          dataAccess.setAppState({ recordSets: { ...recordSetState }, activeIappSite: selectedRecord.id });
+        } else {
+          dataAccess.setAppState({ recordSets: { ...recordSetState }, activeActivity: selectedRecord.id });
+        }
       } else {
         dataAccess.setAppState({ recordSets: { ...recordSetState } });
       }

--- a/app/src/features/home/references/ReferenceIAPPSitePage.tsx
+++ b/app/src/features/home/references/ReferenceIAPPSitePage.tsx
@@ -2,27 +2,48 @@ import { IAPPSite } from 'components/points-of-interest/IAPP/IAPP-Site';
 import { useDataAccess } from 'hooks/useDataAccess';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
+import { Box, Typography } from '@mui/material';
 
 export const ReferenceIAPPSitePage: React.FC = (props) => {
   const urlParams: { id: string } = useParams();
   const dataAccess = useDataAccess();
+  let id: string = undefined;
 
   const [poi, setPOI] = useState(null);
 
+  // grabs id from appState if URL is empty, if both are empty - id is undefined and message shows up
+  if (urlParams.id === undefined) {
+    const appStateResults = dataAccess.getAppState();
+    id = appStateResults.activeIappSite
+  } else {
+    id = urlParams.id;
+  }
+
   useEffect(() => {
     const fetchPOI = async () => {
-      const poiData = await dataAccess.getPointsOfInterest({ iappSiteID: urlParams.id, isIAPP: true });
+      const poiData = await dataAccess.getPointsOfInterest({ iappSiteID: id, isIAPP: true });
       setPOI(poiData.rows[0]);
     };
 
     if (!poi) {
       fetchPOI();
     }
-  }, [poi, dataAccess, urlParams.id]);
+  }, [poi, dataAccess, urlParams.id, id]);
 
   return (
     <div id="iapp_site" style={{ marginTop: 30, marginBottom: 30 }}>
-      {poi && <IAPPSite record={poi} />}
+      {!id && (
+        <>
+          <Box m={3}>
+            <Typography variant="h4">Current IAPP Site </Typography>
+          </Box>
+          <Typography m={3}>
+            There is no current IAPP Site selected. When you select and IAPP record, it will become your current IAPP site and
+            show up in this tab.
+          </Typography>
+        </>
+      )}
+      {id && poi && <IAPPSite record={poi} />}
     </div>
   );
 };

--- a/app/src/features/home/references/ReferenceIAPPSitePage.tsx
+++ b/app/src/features/home/references/ReferenceIAPPSitePage.tsx
@@ -25,7 +25,7 @@ export const ReferenceIAPPSitePage: React.FC = (props) => {
       setPOI(poiData.rows[0]);
     };
 
-    if (!poi) {
+    if (!poi && id) {
       fetchPOI();
     }
   }, [poi, dataAccess, urlParams.id, id]);


### PR DESCRIPTION
- Add current IAPP site tab and allow optional access without id param in URL
- Include monitored column in IAPP record set and API
- Error check id variable on IAPP page to avoid fetching with undefined

# Overview

This PR includes the following proposed change(s):

- #1816
- New tab in header that brings user to current IAPP site
- IAPP site endpoint still functions without id in URL by grabbing id and type from application storage or displaying similar message to activity page

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

- Manually on local

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
