### PR TITLE
Layout Hotfix

### DIFF
--- a/app/src/features/home/HomeLayout.tsx
+++ b/app/src/features/home/HomeLayout.tsx
@@ -8,12 +8,22 @@ export interface IHomeLayoutProps {
 }
 
 const HomeLayout: React.FC<IHomeLayoutProps> = (props: any) => {
+  const [bottomPadding, setBottomPadding] = React.useState(10);
+
+  React.useEffect(() => {
+    if (props?.children[1]?.type?.name === 'LandingPage') {
+      setBottomPadding(10);
+    } else {
+      setBottomPadding(5);
+    }
+  }, [props]);
+
   return (
     <Box width="100%" height="100%" display="flex" flex="1" flexDirection="column">
       <Box height="80px">
         <TabsContainer isMobileNoNetwork={props?.children.props?.isMobileNoNetwork} />
       </Box>
-      <Box height="100%" width="100%" overflow="auto">
+      <Box height="100%" width="100%" paddingBottom={bottomPadding} overflow="auto">
         {props.children}
       </Box>
       <Box


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Bug caused buttons to not be clickable due to being behind footer
- Fixed where everywhere, but the map page has a padding of 10 for the bottom
- Map Page has pading bottom of 5

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

I would look at the bottom page of each page and compare how the map page renders compared to the other pages

## Screenshots

### Home Page

<img width="1275" alt="Screen Shot 2022-05-09 at 1 35 06 PM" src="https://user-images.githubusercontent.com/52196460/167493321-86e74d1c-4885-435d-8d03-4a45dd7f7bb3.png">

### Map Page

<img width="652" alt="Screen Shot 2022-05-09 at 1 35 13 PM" src="https://user-images.githubusercontent.com/52196460/167493325-eb4ddebd-acf3-4cec-85fc-faaa37955f10.png">

### Map Page - Records Tab open

<img width="1062" alt="Screen Shot 2022-05-09 at 1 35 20 PM" src="https://user-images.githubusercontent.com/52196460/167493343-d8f38683-edda-4055-a87e-f44a04734f02.png">


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
