### PR TITLE
Bringing Back the Blue Dot

### DIFF
--- a/app/src/components/map/MapContainer.tsx
+++ b/app/src/components/map/MapContainer.tsx
@@ -244,13 +244,13 @@ const MapContainer: React.FC<IMapContainerProps> = (props) => {
 
             <MapResizer />
             {/* <MapRecordsDataGrid /> */}
-            {/*{useMemo(
-                () => (
-                  <MapLocationControlGroup {...props} />
-                ),
-                [props.geometryState.geometry]
-              )}
-                */}
+            {useMemo(
+              () => (
+                <MapLocationControlGroup {...props} />
+              ),
+              [props.geometryState.geometry]
+            )}
+
             {props.children}
           </MapRequestContextProvider>
         </FlyToAndFadeContextProvider>

--- a/app/src/components/map/Tools/ToolTypes/Nav/MapLocationControlGroup.tsx
+++ b/app/src/components/map/Tools/ToolTypes/Nav/MapLocationControlGroup.tsx
@@ -502,12 +502,12 @@ const MapLocationControlGroup: React.FC<IMapLocationControlGroupProps> = (props)
             {UTM[0] ? UTM[0] : couldNotCalcString}
           </p>
           <p>
-            <b>UTM Northing: </b>
-            {UTM[2] ? UTM[2] : couldNotCalcString}
-          </p>
-          <p>
             <b>UTM Easting: </b>
             {UTM[1] ? UTM[1] : couldNotCalcString}
+          </p>
+          <p>
+            <b>UTM Northing: </b>
+            {UTM[2] ? UTM[2] : couldNotCalcString}
           </p>
           <p>
             <b>Accuracy</b>: {Math.round(accuracy * 10) / 10}m

--- a/app/src/components/map/Tools/ToolTypes/Nav/MapLocationControlGroup.tsx
+++ b/app/src/components/map/Tools/ToolTypes/Nav/MapLocationControlGroup.tsx
@@ -486,7 +486,7 @@ const MapLocationControlGroup: React.FC<IMapLocationControlGroupProps> = (props)
             popupAnchor: [0, -20]
           })
         }>
-        <Popup>
+        <Popup closeButton={false}>
           <h2>You are here:</h2>
           <p>
             <b>Latitude: </b>


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Uncommented Map Tools in bottom right
- Refactored UTM Zone to ZEN Format
- Removed close button for popup which resulted in app refresh

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

### Big Blue is Back

<img width="1020" alt="Screen Shot 2022-05-12 at 9 43 52 AM" src="https://user-images.githubusercontent.com/52196460/168126580-77f5d527-a074-49be-8839-aee86afb9e15.png">

### Popup with Zen format and no close button

<img width="324" alt="Screen Shot 2022-05-12 at 9 44 01 AM" src="https://user-images.githubusercontent.com/52196460/168126619-8839d3aa-8fc2-4622-86b7-169d02cfeeb4.png">

### Accuracy circle

<img width="995" alt="Screen Shot 2022-05-12 at 9 44 17 AM" src="https://user-images.githubusercontent.com/52196460/168126624-0b1fb535-de70-471c-9a55-b151db7a4767.png">

### Topographical map Layer

<img width="1018" alt="Screen Shot 2022-05-12 at 9 44 26 AM" src="https://user-images.githubusercontent.com/52196460/168126642-9f78b3f1-5a60-4b07-a5aa-af6b6f2e3562.png">

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
