### PR TITLE
Fix advanced filter chip onDelete bug

### DIFF
--- a/app/src/components/activities-list/Tables/Plant/ActivityGrid.tsx
+++ b/app/src/components/activities-list/Tables/Plant/ActivityGrid.tsx
@@ -557,7 +557,8 @@ const ActivityGrid = (props) => {
             if (prev.length < 2) {
               return [];
             } else {
-              return prev.splice(props.key, 1);
+              prev.splice(props.id, 1);
+              return [...prev];
             }
           });
         }}
@@ -609,6 +610,7 @@ const ActivityGrid = (props) => {
                         filterValue={r.filterValue}
                         filterKey={r.filterKey}
                         key={i}
+                        id={i}
                       />
                     );
                   }


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Quick fix to bug where advanced filters would remove more than one filter/the opposite filters

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

- Manually tested by creating annd deleting filters, noting the results

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
