### PR TITLE
update height of show records button

### DIFF
--- a/app/src/components/Footer/Footer.tsx
+++ b/app/src/components/Footer/Footer.tsx
@@ -40,8 +40,8 @@ const Footer: React.FC<IFooterProps> = () => {
       <Toolbar
         style={{
           position: 'relative',
-          minHeight: '2.5vh',
-          maxHeight: '5vh',
+          minHeight: '50px',
+          maxHeight: '50px',
           fontSize: '1rem',
           justifyContent: 'flex-start'
         }}>

--- a/app/src/features/home/activities/ActivitiesPage.tsx
+++ b/app/src/features/home/activities/ActivitiesPage.tsx
@@ -206,17 +206,13 @@ const PageContainer = (props) => {
     ]);
   }, [recordStateContext?.recordSetState?.length, recordStateContext?.selectedRecord?.id]);
 
-  const recordsClosedHeight = () => {
-    return width > 900 ? 'calc(100% - 5vh)' : 'calc(100vh - env(safe-area-inset-bottom) - 12.5vh)';
-  };
-
   /* set up main menu bar options: */
   return (
     <>
       {/*the main list of record sets:*/}
       <Box
         style={{
-          height: recordsExpanded ? 'calc(100% - 400px)' : recordsClosedHeight()
+          height: recordsExpanded ? 'calc(100% - 400px)' : '91.5%'
         }}>
         <MapRecordsContextProvider>
           <MapContainer


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

Move "Show Records" button up so that it's visible on safari on iOS and iPad
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

## How Has This Been Tested?

Manual testing on mobile and web

## Screenshots

<img width="1180" alt="Screen Shot 2022-05-30 at 1 02 14 PM" src="https://user-images.githubusercontent.com/35615145/171053948-8d044560-e203-42e6-b921-2bc28f2d9be8.png">
<img width="603" alt="Screen Shot 2022-05-30 at 1 02 03 PM" src="https://user-images.githubusercontent.com/35615145/171053969-4e0fa0a1-5053-40ed-97ea-baebfe6577cb.png">

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
