### PR TITLE
Updated API Versions

### DIFF
--- a/api/openshift/api.dc.yaml
+++ b/api/openshift/api.dc.yaml
@@ -294,7 +294,7 @@ objects:
       wildcardPolicy: None
     status:
       ingress: null
-  - apiVersion: autoscaling/v1
+  - apiVersion: autoscaling/v2beta2
     kind: HorizontalPodAutoscaler
     metadata:
       annotations: {}
@@ -305,8 +305,13 @@ objects:
       maxReplicas: '${{REPLICA_MAX}}'
       minReplicas: '${{REPLICAS}}'
       scaleTargetRef:
-        apiVersion: v1
+        apiVersion: apps.openshift.io/v1
         kind: DeploymentConfig
         name: ${NAME}${SUFFIX}
-      cpuUtilization:
-        targetPercentage: 95
+      metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 95

--- a/app/openshift/app.dc.yaml
+++ b/app/openshift/app.dc.yaml
@@ -218,7 +218,7 @@ objects:
       wildcardPolicy: None
     status:
       ingress: null
-  - apiVersion: autoscaling/v1
+  - apiVersion: autoscaling/v2beta2
     kind: HorizontalPodAutoscaler
     metadata:
       annotations: {}
@@ -229,8 +229,13 @@ objects:
       maxReplicas: '${{REPLICA_MAX}}'
       minReplicas: '${{REPLICAS}}'
       scaleTargetRef:
-        apiVersion: v1
+        apiVersion: apps.openshift.io/v1
         kind: DeploymentConfig
         name: ${NAME}${SUFFIX}
-      cpuUtilization:
-        targetPercentage: 95
+      metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 95


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Updates to the DCs for API and APP - The horizontal scaler API Versions

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

You might have noticed errors for app and api HPA reported: **no matches for kind "DeploymentConfig" in group ""**

This has to do with OpenShift been upgraded and therefore some of the API version that we are using in the deploy are now deprecated. This change updates 2 api version in the HPA definition so it can properly operate again.