### PR TITLE
user shapes filter

### DIFF
--- a/api/src/paths/admin-defined-shapes.ts
+++ b/api/src/paths/admin-defined-shapes.ts
@@ -10,6 +10,8 @@ import { atob } from 'js-base64';
 import { QueryResult } from 'pg';
 import { FeatureCollection } from 'geojson';
 import { GeoJSONFromKML, KMZToKML, sanitizeGeoJSON } from '../utils/kml-import';
+import {InvasivesRequest} from "../utils/auth-utils";
+import { ALL_ROLES, SECURITY_ON } from '../constants/misc';
 
 const defaultLog = getLogger('admin-defined-shapes');
 
@@ -18,6 +20,13 @@ export const POST: Operation = [uploadShape()];
 
 GET.apiDoc = {
   description: 'Fetches a GeoJSON object to display boundaries of administratively-defined shapes (KML uploads)',
+  security: SECURITY_ON
+    ? [
+        {
+          Bearer: ALL_ROLES
+        }
+      ]
+    : [],
   responses: {
     200: {
       description: 'GeoJSON FeatureCollection',
@@ -84,8 +93,10 @@ POST.apiDoc = {
  * @return {RequestHandler}
  */
 function getAdministrativelyDefinedShapes(): RequestHandler {
-  return async (req, res) => {
-    const user_id = req.query.user_id.toString();
+  return async (req: InvasivesRequest, res) => {
+    const user_id = req.authContext.user.user_id;
+    console.log(user_id);
+    console.log("req with invasives", [req.authContext]);
 
     const connection = await getDBConnection();
 

--- a/api/src/queries/admin-defined-shapes.ts
+++ b/api/src/queries/admin-defined-shapes.ts
@@ -7,11 +7,11 @@ import { SQL, SQLStatement } from 'sql-template-strings';
  */
 export const getAdministrativelyDefinedShapesSQL = (user_id: string) => {
   const sqlStatement: SQLStatement = SQL`
-SELECT title, json_build_object(
+SELECT id, title, json_build_object(
              'type', 'FeatureCollection',
              'features', json_agg(ST_asGeoJSON(t.geog)::json)
              ) as geojson
-    FROM (select id, title, geog from invasivesbc.admin_defined_shapes where visible is true and created_by = $1) as t group by title;
+    FROM (select id, title, geog from invasivesbc.admin_defined_shapes where visible is true and created_by = $1) as t group by title, id;
   `;
 
   sqlStatement.values = [user_id];

--- a/app/src/components/dialog/GeneralDialog.tsx
+++ b/app/src/components/dialog/GeneralDialog.tsx
@@ -1,7 +1,8 @@
 import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 export interface IGeneralDialog {
+  children?: ReactNode;
   dialogTitle: String;
   dialogContentText?: String;
   dialogOpen: boolean;
@@ -47,6 +48,7 @@ export const GeneralDialog = (props: IGeneralDialog) => {
           }
         })}
       </DialogActions>
+      {props.children}
     </Dialog>
   );
 };

--- a/app/src/components/map-buddy-components/KMLShapesUpload.tsx
+++ b/app/src/components/map-buddy-components/KMLShapesUpload.tsx
@@ -59,6 +59,7 @@ export const KMLShapesUpload: React.FC<any> = (props) => {
       setUploadLayersFlag(Math.random());
       setTimeout(() => {
         setResultMessage('');
+        if (props?.callback) props.callback();
       }, 2000);
     } catch (err) {
       setUploadRequests([]);

--- a/app/src/components/map/LayerPicker/LayerPicker.tsx
+++ b/app/src/components/map/LayerPicker/LayerPicker.tsx
@@ -43,7 +43,7 @@ export const LayerPicker = React.memo(
         return;
       }
       const fetchUploadedLayers = () => {
-        invasivesApi.getAdminUploadGeoJSONLayers(user_id).then((data) => {
+        invasivesApi.getAdminUploadGeoJSONLayers().then((data) => {
           if (data.length > 0) {
             setLayers((prev: any) => {
               let newLayers = [...prev];
@@ -147,10 +147,6 @@ export const LayerPicker = React.memo(
             }}>
             Load
           </Button>
-          <Accordion id="admin-shape-upload-accordion">
-            <AccordionSummary>Shape Upload (KML/KMZ)</AccordionSummary>
-            <KMLShapesUpload />
-          </Accordion>
         </Popover>
         <ListItem disableGutters>
           <ListItemButton id="layer-picker-btn" onClick={handlePopoverClick}>

--- a/app/src/components/map/MapContainer.tsx
+++ b/app/src/components/map/MapContainer.tsx
@@ -32,6 +32,7 @@ import OfflineMap from './OfflineMap';
 import { MapRequestContextProvider } from 'contexts/MapRequestsContext';
 import Layers from './Layers/Layers';
 import MapLocationControlGroup from './Tools/ToolTypes/Nav/MapLocationControlGroup';
+import { NamedBoundaryMenu } from './NamedBoundaryMenu';
 
 const DefaultIcon = L.icon({
   iconUrl: icon,
@@ -242,6 +243,12 @@ const MapContainer: React.FC<IMapContainerProps> = (props) => {
                 />
               );
             }, [mapMaxNativeZoom, setMapMaxNativeZoom, props.geometryState.geometry, props.activityId, map])}
+            <NamedBoundaryMenu
+              position="topleft"
+              id={props.activityId}
+              map={map}
+              inputGeo={props.geometryState.geometry}
+            />
 
             <MapResizer />
             {/* <MapRecordsDataGrid /> */}

--- a/app/src/components/map/MapContainer.tsx
+++ b/app/src/components/map/MapContainer.tsx
@@ -108,6 +108,7 @@ export interface IMapContainerProps {
   classes?: any;
   mapId: string;
   showDrawControls: boolean;
+  setShowDrawControls: React.Dispatch<boolean>;
   zoom?: any;
   center?: any;
   isPlanPage?: boolean;
@@ -244,6 +245,7 @@ const MapContainer: React.FC<IMapContainerProps> = (props) => {
               );
             }, [mapMaxNativeZoom, setMapMaxNativeZoom, props.geometryState.geometry, props.activityId, map])}
             <NamedBoundaryMenu
+              {...props}
               position="topleft"
               id={props.activityId}
               map={map}

--- a/app/src/components/map/NamedBoundaryMenu.tsx
+++ b/app/src/components/map/NamedBoundaryMenu.tsx
@@ -256,7 +256,7 @@ export const NamedBoundaryMenu = (props) => {
             </ListItemButton>
           </ListItem>
           {boundaries.map((b, index) => (
-            <JumpToTrip id={b.id} name={b.name} geos={b.geos} server_id={b.server_id} key={index} deleteBoundary={deleteBoundary}/>
+            <JumpToTrip boundary={b} id={b.id} name={b.name} geos={b.geos} server_id={b.server_id} key={index} deleteBoundary={deleteBoundary}/>
           ))}
         </List>
       </div>
@@ -270,7 +270,7 @@ export const NamedBoundaryMenu = (props) => {
         {showKMLUpload &&
           <Box>
             <Typography>Shape Upload (KML/KMZ)</Typography>
-            <KMLShapesUpload />
+            <KMLShapesUpload callback={getKMLs}/>
           </Box>
         }
       </GeneralDialog>

--- a/app/src/components/map/NamedBoundaryMenu.tsx
+++ b/app/src/components/map/NamedBoundaryMenu.tsx
@@ -87,7 +87,7 @@ export const NamedBoundaryMenu = (props) => {
   const [selectKMLDialog, setSelectKMLDialog] = useState<IGeneralDialog>({
     dialogActions: [],
     dialogOpen: false,
-    dialogTitle: 'Select which KML to add: ',
+    dialogTitle: 'Select which uploaded KML to add: ',
     dialogContentText: null
   });
 
@@ -118,7 +118,22 @@ export const NamedBoundaryMenu = (props) => {
 
   const getBoundaries = async () => {
     const boundaryResults = await dataAccess.getBoundaries();
-    setBoundaries(boundaryResults);
+    
+    if (Capacitor.getPlatform() !== 'web') {
+      const mappedBoundaries = boundaryResults.map((boundary) => {
+        const jsonObject = JSON.parse(boundary.json);
+        return {
+          id: boundary.id,
+          name: jsonObject.name,
+          geos: jsonObject.geos,
+          server_id: null
+        }
+      });
+
+      setBoundaries(mappedBoundaries);
+    } else {
+      setBoundaries(boundaryResults);
+    }
   };
 
   const getKMLs = async () => {
@@ -197,7 +212,7 @@ export const NamedBoundaryMenu = (props) => {
     });
   });
 
-  const addBoundary = ((geoArray) => {
+  const addBoundary = (async (geoArray) => {
     const name = prompt('Name:');
 
     if (name) {
@@ -208,8 +223,9 @@ export const NamedBoundaryMenu = (props) => {
         server_id: null
       };
   
-      dataAccess.addBoundary(tempBoundary);
-      setBoundaries([...boundaries, tempBoundary]);
+      await dataAccess.addBoundary(tempBoundary);
+      // setBoundaries([...boundaries, tempBoundary]);
+      getBoundaries();
     }
   });
 

--- a/app/src/components/map/NamedBoundaryMenu.tsx
+++ b/app/src/components/map/NamedBoundaryMenu.tsx
@@ -112,20 +112,29 @@ export const NamedBoundaryMenu = (props) => {
   const createBoundary = (() => {
     const dowe = window.confirm('Create new named boundary?');
     if (dowe) {
-      const name = prompt('Name:');
-      // setEdit(true);
-
-      const tempBoundary: Boundary = {
-        id: idCount,
-        name: name,
-        geos: [],
-        server_id: null
-      };
-
-      dataAccess.addBoundary(tempBoundary);
-      setBoundaries([...boundaries, tempBoundary]);
+      props.setShowDrawControls(true);
     }
   });
+
+  const addBoundary = ((geoArray) => {
+    const name = prompt('Name:');
+
+    const tempBoundary: Boundary = {
+      id: idCount,
+      name: name,
+      geos: geoArray,
+      server_id: null
+    };
+
+    dataAccess.addBoundary(tempBoundary);
+    setBoundaries([...boundaries, tempBoundary]);
+  });
+
+  useEffect(() => {
+    if (props?.geometryState?.geometry?.length > 0) {
+      addBoundary(props?.geometryState?.geometry);
+    }
+  }, [props?.geometryState?.geometry]);
 
   const deleteBoundary = async (id: number) => {
     await dataAccess.deleteBoundary(id);
@@ -164,7 +173,7 @@ export const NamedBoundaryMenu = (props) => {
             </ListItemButton>
           </ListItem>
           {boundaries.map((b, index) => (
-            <JumpToTrip id={b.id} name={b.name} key={index} deleteBoundary={deleteBoundary}/>
+            <JumpToTrip id={b.id} name={b.name} geos={b.geos} key={index} deleteBoundary={deleteBoundary}/>
           ))}
         </List>
       </div>

--- a/app/src/components/map/NamedBoundaryMenu.tsx
+++ b/app/src/components/map/NamedBoundaryMenu.tsx
@@ -119,15 +119,17 @@ export const NamedBoundaryMenu = (props) => {
   const addBoundary = ((geoArray) => {
     const name = prompt('Name:');
 
-    const tempBoundary: Boundary = {
-      id: idCount,
-      name: name,
-      geos: geoArray,
-      server_id: null
-    };
-
-    dataAccess.addBoundary(tempBoundary);
-    setBoundaries([...boundaries, tempBoundary]);
+    if (name) {
+      const tempBoundary: Boundary = {
+        id: idCount,
+        name: name,
+        geos: geoArray,
+        server_id: null
+      };
+  
+      dataAccess.addBoundary(tempBoundary);
+      setBoundaries([...boundaries, tempBoundary]);
+    }
   });
 
   useEffect(() => {
@@ -173,7 +175,7 @@ export const NamedBoundaryMenu = (props) => {
             </ListItemButton>
           </ListItem>
           {boundaries.map((b, index) => (
-            <JumpToTrip id={b.id} name={b.name} geos={b.geos} key={index} deleteBoundary={deleteBoundary}/>
+            <JumpToTrip boundary={b} id={b.id} name={b.name} geos={b.geos} key={index} deleteBoundary={deleteBoundary}/>
           ))}
         </List>
       </div>

--- a/app/src/components/map/NamedBoundaryMenu.tsx
+++ b/app/src/components/map/NamedBoundaryMenu.tsx
@@ -58,13 +58,6 @@ const useToolbarContainerStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-interface Boundary {
-  id: number,
-  name: string,
-  geos: [],
-  server_id: number
-}
-
 export const NamedBoundaryMenu = (props) => {
   const dataAccess = useDataAccess();
   // style

--- a/app/src/components/map/NamedBoundaryMenu.tsx
+++ b/app/src/components/map/NamedBoundaryMenu.tsx
@@ -214,7 +214,7 @@ export const NamedBoundaryMenu = (props) => {
             </ListItemButton>
           </ListItem>
           {boundaries.map((b, index) => (
-            <JumpToTrip boundary={b} id={b.id} name={b.name} geos={b.geos} key={index} deleteBoundary={deleteBoundary}/>
+            <JumpToTrip id={b.id} name={b.name} geos={b.geos} server_id={b.server_id} key={index} deleteBoundary={deleteBoundary}/>
           ))}
         </List>
       </div>

--- a/app/src/components/map/NamedBoundaryMenu.tsx
+++ b/app/src/components/map/NamedBoundaryMenu.tsx
@@ -15,6 +15,7 @@ import List from '@mui/material/List';
 import makeStyles from '@mui/styles/makeStyles';
 import { Theme } from '@mui/material';
 import MeasureToolContainer from './Tools/ToolTypes/Misc/MeasureToolContainer';
+import TabUnselectedIcon from '@mui/icons-material/TabUnselected';
 
 const POSITION_CLASSES = {
   bottomleft: 'leaflet-bottom leaflet-left',
@@ -41,7 +42,7 @@ const useToolbarContainerStyles = makeStyles((theme: Theme) => ({
   toggleMenuBTN: {
     padding: 5,
     marginTop: 10,
-    marginRight: 10,
+    marginRight: 50,
     zIndex: 1500,
     width: 40,
     transition: 'all 200ms ease-in-out',
@@ -54,7 +55,7 @@ const useToolbarContainerStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-export const ToolbarContainer = (props) => {
+export const NamedBoundaryMenu = (props) => {
   const [measureToolContainerOpen, setMeasureToolContainerOpen] = useState(false);
 
   const positionClass = (props.position && POSITION_CLASSES[props.position]) || POSITION_CLASSES.topright;
@@ -75,38 +76,24 @@ export const ToolbarContainer = (props) => {
 
   return (
     <>
-      <div ref={divRef} key={'toolbar1'} className={positionClass + ' leaflet-control'} style={{ display: 'static' }}>
+      <div ref={divRef} key={'toolbar2'} className={positionClass + ' leaflet-control'} style={{ display: 'static' }}>
         <IconButton
           id="toolbar-drawer-button"
           onClick={() => {
             handleExpand();
           }}
           className={classes.toggleMenuBTN + ' leaflet-control'}>
-          {expanded ? <CloseIcon /> : <MenuIcon />}
+          {expanded ? <CloseIcon /> : <TabUnselectedIcon />}
         </IconButton>
         <List
           ref={divRef}
           key={'toolbar2'}
           className={classes.innerToolBarContainer + ' leaflet-control'}
-          style={{ transform: expanded ? 'translateX(5%)' : 'translateX(110%)' }}>
-          <LayerPicker inputGeo={props.inputGeo} />
+          style={{ transform: expanded ? 'translateX(5%)' : 'translateX(-110%)' }}>
           <Divider />
-          <SetPointOnClick map={props.map} />
-          <MeasureTool
-            setMeasureToolContainerOpen={setMeasureToolContainerOpen}
-            measureToolContainerOpen={measureToolContainerOpen}
-          />
-          <ZoomControl mapMaxNativeZoom={props.mapMaxNativeZoom} setMapMaxNativeZoom={props.setMapMaxNativeZoom} />
           <JumpToTrip />
-          {/* <NewRecord />
-        <EditRecord />
-        <MultiSelectOrEdit />
-        <DrawButtonList /> */}
-
-          <JumpToActivity id={props.id} />
         </List>
       </div>
-      <MeasureToolContainer measureToolContainerOpen={measureToolContainerOpen} />
     </>
   );
 };

--- a/app/src/components/map/NamedBoundaryMenu.tsx
+++ b/app/src/components/map/NamedBoundaryMenu.tsx
@@ -14,11 +14,13 @@ import ExploreIcon from '@mui/icons-material/Explore';
 import L from 'leaflet';
 import List from '@mui/material/List';
 import makeStyles from '@mui/styles/makeStyles';
-import { ListItem, ListItemButton, ListItemIcon, ListItemText, Theme, Typography } from '@mui/material';
+import { Accordion, AccordionSummary, Box, ListItem, ListItemButton, ListItemIcon, ListItemText, Theme, Typography } from '@mui/material';
 import MeasureToolContainer from './Tools/ToolTypes/Misc/MeasureToolContainer';
 import TabUnselectedIcon from '@mui/icons-material/TabUnselected';
 import { toolStyles } from './Tools/Helpers/ToolStyles';
 import { useDataAccess } from 'hooks/useDataAccess';
+import { GeneralDialog, IGeneralDialog } from 'components/dialog/GeneralDialog';
+import KMLShapesUpload from 'components/map-buddy-components/KMLShapesUpload';
 
 const POSITION_CLASSES = {
   bottomleft: 'leaflet-bottom leaflet-left',
@@ -70,6 +72,14 @@ export const NamedBoundaryMenu = (props) => {
   const divRef = useRef();
   const [boundaries, setBoundaries] = useState<Boundary[]>([]);
   const [idCount, setIdCount] = useState(0);
+  const [showKMLUpload, setShowKMLUpload] = useState<boolean>(false);
+
+  const [newBoundaryDialog, setNewBoundaryDialog] = useState<IGeneralDialog>({
+    dialogActions: [],
+    dialogOpen: false,
+    dialogTitle: '',
+    dialogContentText: null
+  });
 
   const handleExpand = () => {
     setExpanded((prev) => {
@@ -103,10 +113,46 @@ export const NamedBoundaryMenu = (props) => {
   };
 
   const createBoundary = (() => {
-    const dowe = window.confirm('Create new named boundary?');
-    if (dowe) {
-      props.setShowDrawControls(true);
-    }
+    setShowKMLUpload(false);
+    setNewBoundaryDialog({
+      dialogOpen: true,
+      dialogTitle: 'Create New User Boundary',
+      dialogContentText: 'How would you like to create a new user boundary?',
+      dialogActions: [
+        {
+          actionName: 'Draw Shape',
+          actionOnClick: async () => {
+            props.setShowDrawControls(true);
+
+            setNewBoundaryDialog({ ...newBoundaryDialog, dialogOpen: false });
+          }
+        },
+        {
+          actionName: 'Upload KML',
+          actionOnClick: async () => {
+            // setNewBoundaryDialog({ ...newBoundaryDialog, dialogOpen: false });
+
+            setShowKMLUpload(true);
+          }
+        },
+        {
+          actionName: 'Select KML',
+          actionOnClick: async () => {
+            setNewBoundaryDialog({ ...newBoundaryDialog, dialogOpen: false });
+            // recordStateContext.add('Activity');
+            alert("third class");
+          }
+        },
+        {
+          actionName: 'Cancel',
+          actionOnClick: async () => {
+            setShowKMLUpload(false);
+            setNewBoundaryDialog({ ...newBoundaryDialog, dialogOpen: false });
+          },
+          autoFocus: true
+        }
+      ]
+    });
   });
 
   const addBoundary = ((geoArray) => {
@@ -172,6 +218,20 @@ export const NamedBoundaryMenu = (props) => {
           ))}
         </List>
       </div>
+
+      <GeneralDialog
+        dialogOpen={newBoundaryDialog.dialogOpen}
+        dialogTitle={newBoundaryDialog.dialogTitle}
+        dialogActions={newBoundaryDialog.dialogActions}
+        dialogContentText={newBoundaryDialog.dialogContentText}
+      >
+        {showKMLUpload &&
+          <Box>
+            <Typography>Shape Upload (KML/KMZ)</Typography>
+            <KMLShapesUpload />
+          </Box>
+        }
+      </GeneralDialog>
     </>
   );
 };

--- a/app/src/components/map/Tools/ToolTypes/Nav/CurrentTrip.tsx
+++ b/app/src/components/map/Tools/ToolTypes/Nav/CurrentTrip.tsx
@@ -5,14 +5,11 @@ import { ListItemButton } from '@mui/material';
 import { DatabaseContext } from 'contexts/DatabaseContext';
 import { useDataAccess } from 'hooks/useDataAccess';
 import L from 'leaflet';
-import { FeatureGroup } from 'react-leaflet';
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import { useMapEvent } from 'react-leaflet';
 import { toolStyles } from '../../Helpers/ToolStyles';
 import { FlyToAndFadeItemTransitionType, IFlyToAndFadeItem, useFlyToAndFadeContext } from './FlyToAndFade';
 
-import CheckIcon from '@mui/icons-material/Check';
-import EditTools from '../Data/EditTools';
 /*
 
 - [ ] add ui button to let user add shapes
@@ -47,7 +44,6 @@ export const JumpToTrip = (props) => {
 
   const [IFlyToAndFadeItems, setIFlyToAndFadeItems] = useState<Array<IFlyToAndFadeItem>>([]);
   const [index, setIndex] = useState<number>(0);
-  const [edit, setEdit] = useState(false);
 
   // map Event subcriptions:
   const map = useMapEvent('dragend', () => {
@@ -84,30 +80,7 @@ export const JumpToTrip = (props) => {
         return JSON.parse(rawRecord.json);
       });
     } else {
-      tripObjects = [
-        {
-          id: 1,
-          name: 'trip a',
-          geometry: [
-            {
-              type: 'Feature',
-              properties: {},
-              geometry: {
-                type: 'Polygon',
-                coordinates: [
-                  [
-                    [-126.826171875, 51.876490970614775],
-                    [-123.70605468750001, 51.876490970614775],
-                    [-123.70605468750001, 53.68369534495075],
-                    [-126.826171875, 53.68369534495075],
-                    [-126.826171875, 51.876490970614775]
-                  ]
-                ]
-              }
-            }
-          ]
-        }
-      ];
+      return;
     }
 
     let items = new Array<IFlyToAndFadeItem>();
@@ -135,55 +108,20 @@ export const JumpToTrip = (props) => {
   };
 
   return (
-    <>
-      <ListItem disableGutters>
-        <ListItemButton
-          onClick={() => {
-            /* eslint-disable */
-            const dowe = confirm('Create new named boundary?');
-            if (dowe) {
-              const name = prompt('Name:');
-              setEdit(true);
-            }
-          }}
-          ref={divRef}
-          aria-label="Jump To Location"
-          style={{ padding: 10, borderBottomLeftRadius: 5, borderBottomRightRadius: 5 }}>
-          <ListItemIcon>
-            <ExploreIcon />
-          </ListItemIcon>
-          <ListItemText>
-            <Typography className={toolClass.Font}>New Boundary</Typography>
-          </ListItemText>
-        </ListItemButton>
-      </ListItem>
-      <ListItem
-        onClick={() => {
-          jump();
-        }}
-        disableGutters>
-        <ListItemText>
-          <Typography className={toolClass.Font}>Sunny infested areas</Typography>
-        </ListItemText>
+    <ListItem disableGutters>
+      <ListItemButton
+        ref={divRef}
+        aria-label="Jump To Location"
+        onClick={jump}
+        style={{ padding: 10, borderBottomLeftRadius: 5, borderBottomRightRadius: 5 }}>
         <ListItemIcon>
-          <CheckIcon />
+          <ExploreIcon />
         </ListItemIcon>
-      </ListItem>
-      <ListItem disableGutters>
         <ListItemText>
-          <Typography className={toolClass.Font}>Scenic infested areas</Typography>
+          <Typography className={toolClass.Font}></Typography>
         </ListItemText>
-      </ListItem>
-      {/*
-        <>
-          edit?
-          <FeatureGroup>
-            <EditTools />
-          </FeatureGroup>
-          : <></>
-        </>
-      */}
-    </>
+      </ListItemButton>
+    </ListItem>
   );
 };
 

--- a/app/src/components/map/Tools/ToolTypes/Nav/JumpToTrip.tsx
+++ b/app/src/components/map/Tools/ToolTypes/Nav/JumpToTrip.tsx
@@ -87,7 +87,8 @@ export const JumpToTrip = (props) => {
         }}
         disableGutters>
         <ListItemText>
-          <Typography className={toolClass.Font}>{props.name}</Typography>
+          
+          <Typography className={toolClass.Font}>{props.name}{props.server_id && <span> (kml)</span>}</Typography>
         </ListItemText>
         <ListItemIcon>
           {checked && <CheckIcon />}

--- a/app/src/components/map/Tools/ToolTypes/Nav/JumpToTrip.tsx
+++ b/app/src/components/map/Tools/ToolTypes/Nav/JumpToTrip.tsx
@@ -1,7 +1,5 @@
 import { Capacitor } from '@capacitor/core';
-import { Box, Button, ListItem, ListItemIcon, ListItemText, Typography } from '@mui/material';
-import ExploreIcon from '@mui/icons-material/Explore';
-import { ListItemButton } from '@mui/material';
+import { Button, ListItem, ListItemIcon, ListItemText, Typography } from '@mui/material';
 import { DatabaseContext } from 'contexts/DatabaseContext';
 import { useDataAccess } from 'hooks/useDataAccess';
 import L from 'leaflet';
@@ -13,7 +11,6 @@ import { FlyToAndFadeItemTransitionType, IFlyToAndFadeItem, useFlyToAndFadeConte
 
 import CheckIcon from '@mui/icons-material/Check';
 import DeleteIcon from '@mui/icons-material/Delete';
-import EditTools from '../Data/EditTools';
 /*
 
 - [ ] add ui button to let user add shapes
@@ -21,13 +18,6 @@ import EditTools from '../Data/EditTools';
 - [ ] or view existing in list
 - [ ] 
 */
-
-interface Boundary {
-  id: number,
-  name: string,
-  geos: [],
-  server_id: number
-}
 
 export const JumpToTrip = (props) => {
   // style
@@ -44,10 +34,9 @@ export const JumpToTrip = (props) => {
 
   // initial setup & events to block:
   useEffect(() => {
-    L.DomEvent.disableClickPropagation(divRef?.current);
-    L.DomEvent.disableScrollPropagation(divRef?.current);
-    getTripGeosAndInitialPosition();
-    getBoundaries();
+    // L.DomEvent.disableClickPropagation(divRef?.current);
+    // L.DomEvent.disableScrollPropagation(divRef?.current);
+    // getTripGeosAndInitialPosition();
   }, []);
 
   // What the button cycles through.
@@ -55,12 +44,10 @@ export const JumpToTrip = (props) => {
   const [IFlyToAndFadeItems, setIFlyToAndFadeItems] = useState<Array<IFlyToAndFadeItem>>([]);
   const [index, setIndex] = useState<number>(0);
   const [edit, setEdit] = useState(false);
-  const [boundaries, setBoundaries] = useState<Boundary[]>([]);
-  const [idCount, setIdCount] = useState(0);
 
   // map Event subcriptions:
   const map = useMapEvent('dragend', () => {
-    getTripGeosAndInitialPosition();
+    // getTripGeosAndInitialPosition();
   });
 
   //onclick:
@@ -81,175 +68,105 @@ export const JumpToTrip = (props) => {
   }, [index]);
 
   // can be replaced with a menu (later):
-  const getTripGeosAndInitialPosition = async () => {
-    let tripObjects;
-    //mobile only
-    if (Capacitor.getPlatform() === 'ios' || Capacitor.getPlatform() === 'android') {
-      const queryResults = await dataAccess.getTrips();
-      if (!queryResults.length) {
-        return;
-      }
-      tripObjects = queryResults.map((rawRecord) => {
-        return JSON.parse(rawRecord.json);
-      });
-    } else {
-      tripObjects = [
-        {
-          id: 1,
-          name: 'trip a',
-          geometry: [
-            {
-              type: 'Feature',
-              properties: {},
-              geometry: {
-                type: 'Polygon',
-                coordinates: [
-                  [
-                    [-126.826171875, 51.876490970614775],
-                    [-123.70605468750001, 51.876490970614775],
-                    [-123.70605468750001, 53.68369534495075],
-                    [-126.826171875, 53.68369534495075],
-                    [-126.826171875, 51.876490970614775]
-                  ]
-                ]
-              }
-            }
-          ]
-        }
-      ];
-    }
+  // const getTripGeosAndInitialPosition = async () => {
+  //   let tripObjects;
+  //   //mobile only
+  //   if (Capacitor.getPlatform() === 'ios' || Capacitor.getPlatform() === 'android') {
+  //     const queryResults = await dataAccess.getTrips();
+  //     if (!queryResults.length) {
+  //       return;
+  //     }
+  //     tripObjects = queryResults.map((rawRecord) => {
+  //       return JSON.parse(rawRecord.json);
+  //     });
+  //   } else {
+  //     tripObjects = [
+  //       {
+  //         id: 1,
+  //         name: 'trip a',
+  //         geometry: [
+  //           {
+  //             type: 'Feature',
+  //             properties: {},
+  //             geometry: {
+  //               type: 'Polygon',
+  //               coordinates: [
+  //                 [
+  //                   [-126.826171875, 51.876490970614775],
+  //                   [-123.70605468750001, 51.876490970614775],
+  //                   [-123.70605468750001, 53.68369534495075],
+  //                   [-126.826171875, 53.68369534495075],
+  //                   [-126.826171875, 51.876490970614775]
+  //                 ]
+  //               ]
+  //             }
+  //           }
+  //         ]
+  //       }
+  //     ];
+  //   }
 
-    let items = new Array<IFlyToAndFadeItem>();
+  //   let items = new Array<IFlyToAndFadeItem>();
 
-    //add current position as bounds to zoom to
-    items.push({
-      name: 'Original Position',
-      bounds: map.getBounds(),
-      colour: 'red',
-      transitionType: FlyToAndFadeItemTransitionType.zoomToBounds
-    });
-    //then add trips as geometries to show
-    for (const trip of tripObjects.sort((a, b) => (a.id < b.id ? 1 : -1))) {
-      if (trip.geometry.length > 0) {
-        items.push({
-          name: 'TRIP: ' + trip.name,
-          geometries: trip.geometry,
-          colour: 'red',
-          transitionType: FlyToAndFadeItemTransitionType.zoomToGeometries
-        });
-      }
-    }
+  //   //add current position as bounds to zoom to
+  //   items.push({
+  //     name: 'Original Position',
+  //     bounds: map.getBounds(),
+  //     colour: 'red',
+  //     transitionType: FlyToAndFadeItemTransitionType.zoomToBounds
+  //   });
+  //   //then add trips as geometries to show
+  //   for (const trip of tripObjects.sort((a, b) => (a.id < b.id ? 1 : -1))) {
+  //     if (trip.geometry.length > 0) {
+  //       items.push({
+  //         name: 'TRIP: ' + trip.name,
+  //         geometries: trip.geometry,
+  //         colour: 'red',
+  //         transitionType: FlyToAndFadeItemTransitionType.zoomToGeometries
+  //       });
+  //     }
+  //   }
 
-    setIFlyToAndFadeItems([...items]);
-  };
+  //   setIFlyToAndFadeItems([...items]);
+  // };
 
-  const setBoundaryIdCount = (() => {
-    if (boundaries && boundaries.length > 0) {
-      //ensures id is not repeated on client side
-      const max = Math.max(...boundaries.map(b => b.id));
-      setIdCount(max + 1);
-    }
-  });
-
-  useEffect(() => {
-    setBoundaryIdCount();
-  }, [boundaries]);
-
-  const getBoundaries = async () => {
-    const results = await dataAccess.getBoundaries();
-    if (results) {
-      setBoundaries(results);
-    }
-  };
-
-  const createBoundary = (() => {
-    const dowe = window.confirm('Create new named boundary?');
-    if (dowe) {
-      const name = prompt('Name:');
-      setEdit(true);
-
-      const tempBoundary: Boundary = {
-        id: idCount,
-        name: name,
-        geos: [],
-        server_id: null
-      };
-
-      dataAccess.addBoundary(tempBoundary);
-      setBoundaries([...boundaries, tempBoundary]);
-    }
-  });
-
-  const deleteBoundary = async (id: number) => {
-    await dataAccess.deleteBoundary(id);
-    getBoundaries();
-  }
 
   return (
-    <Box>
-      <ListItem disableGutters>
-        <ListItemButton
-          onClick={createBoundary}
-          ref={divRef}
-          aria-label="Jump To Location"
-          style={{ padding: 10, borderBottomLeftRadius: 5, borderBottomRightRadius: 5 }}>
-          <ListItemIcon>
-            <ExploreIcon />
-          </ListItemIcon>
-          <ListItemText>
-            <Typography className={toolClass.Font}>New Boundary</Typography>
-          </ListItemText>
-        </ListItemButton>
-      </ListItem>
-
-      {boundaries.map((boundary, index) => (
-        <ListItem
-          key={index}
-          onClick={() => {
-            jump();
-          }}
-          disableGutters>
-          <ListItemText>
-            <Typography className={toolClass.Font}>{boundary.name}</Typography>
-          </ListItemText>
-          <ListItemIcon>
-            <CheckIcon />
-          </ListItemIcon>
-          <ListItemIcon>
-            <Button onClick={() => deleteBoundary(boundary.id)}>
-              <DeleteIcon />
-            </Button>
-          </ListItemIcon>
-        </ListItem>
-      ))}
-      {/* <ListItem
-        onClick={() => {
-          jump();
-        }}
-        disableGutters>
-        <ListItemText>
-          <Typography className={toolClass.Font}>Sunny infested areas</Typography>
-        </ListItemText>
-        <ListItemIcon>
-          <CheckIcon />
-        </ListItemIcon>
-      </ListItem> */}
-      {/* <ListItem disableGutters>
-        <ListItemText>
-          <Typography className={toolClass.Font}>Scenic infested areas</Typography>
-        </ListItemText>
-      </ListItem> */}
-      {/*
-        <>
-          edit?
-          <FeatureGroup>
-            <EditTools />
-          </FeatureGroup>
-          : <></>
-        </>
-      */}
-    </Box>
+    <ListItem
+      onClick={() => {
+        jump();
+      }}
+      disableGutters>
+      <ListItemText>
+        <Typography className={toolClass.Font}>{props.name}</Typography>
+      </ListItemText>
+      <ListItemIcon>
+        <CheckIcon />
+      </ListItemIcon>
+      <ListItemIcon>
+        <Button onClick={() => props.deleteBoundary(props.id)}>
+          <DeleteIcon />
+        </Button>
+      </ListItemIcon>
+    </ListItem>
   );
 };
 
 export default JumpToTrip;
+
+
+/* 
+just for reference until a later commit 
+
+<ListItem
+  onClick={() => {
+    jump();
+  }}
+  disableGutters>
+  <ListItemText>
+    <Typography className={toolClass.Font}>Sunny infested areas</Typography>
+  </ListItemText>
+  <ListItemIcon>
+    <CheckIcon />
+  </ListItemIcon>
+</ListItem> */

--- a/app/src/components/map/Tools/ToolTypes/Nav/JumpToTrip.tsx
+++ b/app/src/components/map/Tools/ToolTypes/Nav/JumpToTrip.tsx
@@ -1,5 +1,5 @@
 import { Capacitor } from '@capacitor/core';
-import { Button, ListItem, ListItemIcon, ListItemText, Typography } from '@mui/material';
+import { Button, ClickAwayListener, ListItem, ListItemIcon, ListItemText, Typography } from '@mui/material';
 import { DatabaseContext } from 'contexts/DatabaseContext';
 import { useDataAccess } from 'hooks/useDataAccess';
 import L from 'leaflet';
@@ -36,6 +36,7 @@ export const JumpToTrip = (props) => {
   }, []);
 
   const [flyToAndFadeItem, setFlyToAndFadeItem] = useState<IFlyToAndFadeItem>(null);
+  const [checked, setChecked] = useState<boolean>(false);
 
   // map Event subcriptions:
   const map = useMapEvent('dragend', () => {
@@ -72,25 +73,32 @@ export const JumpToTrip = (props) => {
     setFlyToAndFadeItem(item);
   };
 
+  const unCheck = () => {
+    setChecked(false);
+  }
+
 
   return (
-    <ListItem
-      onClick={() => {
-        jump();
-      }}
-      disableGutters>
-      <ListItemText>
-        <Typography className={toolClass.Font}>{props.name}</Typography>
-      </ListItemText>
-      <ListItemIcon>
-        <CheckIcon />
-      </ListItemIcon>
-      <ListItemIcon>
-        <Button onClick={() => props.deleteBoundary(props.id)}>
-          <DeleteIcon />
-        </Button>
-      </ListItemIcon>
-    </ListItem>
+    <ClickAwayListener onClickAway={unCheck}>
+      <ListItem
+        onClick={() => {
+          jump();
+          setChecked(true);
+        }}
+        disableGutters>
+        <ListItemText>
+          <Typography className={toolClass.Font}>{props.name}</Typography>
+        </ListItemText>
+        <ListItemIcon>
+          {checked && <CheckIcon />}
+        </ListItemIcon>
+        <ListItemIcon>
+          <Button onClick={() => props.deleteBoundary(props.id)}>
+            <DeleteIcon />
+          </Button>
+        </ListItemIcon>
+      </ListItem>
+    </ClickAwayListener>
   );
 };
 

--- a/app/src/components/map/Tools/ToolTypes/Nav/JumpToTrip.tsx
+++ b/app/src/components/map/Tools/ToolTypes/Nav/JumpToTrip.tsx
@@ -46,6 +46,7 @@ export const JumpToTrip = (props) => {
     L.DomEvent.disableClickPropagation(divRef?.current);
     L.DomEvent.disableScrollPropagation(divRef?.current);
     getTripGeosAndInitialPosition();
+    getBoundaries();
   }, []);
 
   // What the button cycles through.
@@ -76,6 +77,13 @@ export const JumpToTrip = (props) => {
       flyToContext.go([IFlyToAndFadeItems[index]]);
     }
   }, [index]);
+
+  const getBoundaries = async () => {
+    const results = await dataAccess.getBoundaries();
+    if (results) {
+      setBoundaries([results]);
+    }
+  };
 
   // can be replaced with a menu (later):
   const getTripGeosAndInitialPosition = async () => {

--- a/app/src/components/map/Tools/ToolTypes/Nav/JumpToTrip.tsx
+++ b/app/src/components/map/Tools/ToolTypes/Nav/JumpToTrip.tsx
@@ -160,12 +160,10 @@ export const JumpToTrip = (props) => {
         geos: [],
         server_id: null
       };
-      // const temp = [...boundaries, tempBoundary];
-  
+
+      dataAccess.addBoundary(tempBoundary);
       setBoundaries([...boundaries, tempBoundary]);
-      console.log(boundaries);
     }
-    
   });
 
   return (

--- a/app/src/components/map/Tools/ToolTypes/Nav/JumpToTrip.tsx
+++ b/app/src/components/map/Tools/ToolTypes/Nav/JumpToTrip.tsx
@@ -1,5 +1,5 @@
 import { Capacitor } from '@capacitor/core';
-import { ListItem, ListItemIcon, ListItemText, Typography } from '@mui/material';
+import { Box, ListItem, ListItemIcon, ListItemText, Typography } from '@mui/material';
 import ExploreIcon from '@mui/icons-material/Explore';
 import { ListItemButton } from '@mui/material';
 import { DatabaseContext } from 'contexts/DatabaseContext';
@@ -19,9 +19,14 @@ import EditTools from '../Data/EditTools';
 - [ ]  shapes persist - where?
 - [ ] or view existing in list
 - [ ] 
-
-
 */
+
+interface Boundary {
+  id: Number,
+  name: String,
+  geos: [],
+  server_id: Number
+}
 
 export const JumpToTrip = (props) => {
   // style
@@ -48,6 +53,7 @@ export const JumpToTrip = (props) => {
   const [IFlyToAndFadeItems, setIFlyToAndFadeItems] = useState<Array<IFlyToAndFadeItem>>([]);
   const [index, setIndex] = useState<number>(0);
   const [edit, setEdit] = useState(false);
+  const [boundaries, setBoundaries] = useState<Boundary[]>([]);
 
   // map Event subcriptions:
   const map = useMapEvent('dragend', () => {
@@ -134,18 +140,31 @@ export const JumpToTrip = (props) => {
     setIFlyToAndFadeItems([...items]);
   };
 
+  const updateBoundary = (() => {
+    const dowe = window.confirm('Create new named boundary?');
+    if (dowe) {
+      const name = prompt('Name:');
+      setEdit(true);
+
+      const tempBoundary: Boundary = {
+        id: null,
+        name: name,
+        geos: [],
+        server_id: null
+      };
+      // const temp = [...boundaries, tempBoundary];
+  
+      setBoundaries([...boundaries, tempBoundary]);
+      console.log(boundaries);
+    }
+    
+  });
+
   return (
-    <>
+    <Box>
       <ListItem disableGutters>
         <ListItemButton
-          onClick={() => {
-            /* eslint-disable */
-            const dowe = confirm('Create new named boundary?');
-            if (dowe) {
-              const name = prompt('Name:');
-              setEdit(true);
-            }
-          }}
+          onClick={updateBoundary}
           ref={divRef}
           aria-label="Jump To Location"
           style={{ padding: 10, borderBottomLeftRadius: 5, borderBottomRightRadius: 5 }}>
@@ -157,7 +176,23 @@ export const JumpToTrip = (props) => {
           </ListItemText>
         </ListItemButton>
       </ListItem>
-      <ListItem
+
+      {boundaries.map((boundary, index) => (
+        <ListItem
+          key={index}
+          onClick={() => {
+            jump();
+          }}
+          disableGutters>
+          <ListItemText>
+            <Typography className={toolClass.Font}>{boundary.name}</Typography>
+          </ListItemText>
+          <ListItemIcon>
+            <CheckIcon />
+          </ListItemIcon>
+        </ListItem>
+      ))}
+      {/* <ListItem
         onClick={() => {
           jump();
         }}
@@ -168,12 +203,12 @@ export const JumpToTrip = (props) => {
         <ListItemIcon>
           <CheckIcon />
         </ListItemIcon>
-      </ListItem>
-      <ListItem disableGutters>
+      </ListItem> */}
+      {/* <ListItem disableGutters>
         <ListItemText>
           <Typography className={toolClass.Font}>Scenic infested areas</Typography>
         </ListItemText>
-      </ListItem>
+      </ListItem> */}
       {/*
         <>
           edit?
@@ -183,7 +218,7 @@ export const JumpToTrip = (props) => {
           : <></>
         </>
       */}
-    </>
+    </Box>
   );
 };
 

--- a/app/src/components/map/Tools/ToolTypes/Nav/JumpToTrip.tsx
+++ b/app/src/components/map/Tools/ToolTypes/Nav/JumpToTrip.tsx
@@ -26,109 +26,51 @@ export const JumpToTrip = (props) => {
   // Is this needed? Copied from DisplayPosition
   const divRef = useRef(null);
 
-  // DB: MOBILE ONLY!
-  const databaseContext = useContext(DatabaseContext);
-  const dataAccess = useDataAccess();
-
   const flyToContext = useFlyToAndFadeContext();
 
   // initial setup & events to block:
   useEffect(() => {
     // L.DomEvent.disableClickPropagation(divRef?.current);
     // L.DomEvent.disableScrollPropagation(divRef?.current);
-    // getTripGeosAndInitialPosition();
+    getTripGeosAndInitialPosition();
   }, []);
 
-  // What the button cycles through.
-
-  const [IFlyToAndFadeItems, setIFlyToAndFadeItems] = useState<Array<IFlyToAndFadeItem>>([]);
-  const [index, setIndex] = useState<number>(0);
-  const [edit, setEdit] = useState(false);
+  const [flyToAndFadeItem, setFlyToAndFadeItem] = useState<IFlyToAndFadeItem>(null);
 
   // map Event subcriptions:
   const map = useMapEvent('dragend', () => {
-    // getTripGeosAndInitialPosition();
+    getTripGeosAndInitialPosition();
   });
 
   //onclick:
   const jump = () => {
-    // cycle through trips for now, later we can do a popup menu
-    const next = index == IFlyToAndFadeItems.length - 1 ? 0 : index + 1;
-    setIndex(next);
-  };
-
-  //
-  useEffect(() => {
-    if (!(IFlyToAndFadeItems.length > 0)) {
+    // popup menu style
+    if (!flyToAndFadeItem) {
       return;
     }
-    if (IFlyToAndFadeItems[index]?.geometries) {
-      flyToContext.go([IFlyToAndFadeItems[index]]);
+
+    if (flyToAndFadeItem.geometries) {
+      flyToContext.go([flyToAndFadeItem]);
     }
-  }, [index]);
 
-  // can be replaced with a menu (later):
-  // const getTripGeosAndInitialPosition = async () => {
-  //   let tripObjects;
-  //   //mobile only
-  //   if (Capacitor.getPlatform() === 'ios' || Capacitor.getPlatform() === 'android') {
-  //     const queryResults = await dataAccess.getTrips();
-  //     if (!queryResults.length) {
-  //       return;
-  //     }
-  //     tripObjects = queryResults.map((rawRecord) => {
-  //       return JSON.parse(rawRecord.json);
-  //     });
-  //   } else {
-  //     tripObjects = [
-  //       {
-  //         id: 1,
-  //         name: 'trip a',
-  //         geometry: [
-  //           {
-  //             type: 'Feature',
-  //             properties: {},
-  //             geometry: {
-  //               type: 'Polygon',
-  //               coordinates: [
-  //                 [
-  //                   [-126.826171875, 51.876490970614775],
-  //                   [-123.70605468750001, 51.876490970614775],
-  //                   [-123.70605468750001, 53.68369534495075],
-  //                   [-126.826171875, 53.68369534495075],
-  //                   [-126.826171875, 51.876490970614775]
-  //                 ]
-  //               ]
-  //             }
-  //           }
-  //         ]
-  //       }
-  //     ];
-  //   }
+  };
 
-  //   let items = new Array<IFlyToAndFadeItem>();
+  const getTripGeosAndInitialPosition = async () => {
+    const trip = await props?.boundary;
 
-  //   //add current position as bounds to zoom to
-  //   items.push({
-  //     name: 'Original Position',
-  //     bounds: map.getBounds(),
-  //     colour: 'red',
-  //     transitionType: FlyToAndFadeItemTransitionType.zoomToBounds
-  //   });
-  //   //then add trips as geometries to show
-  //   for (const trip of tripObjects.sort((a, b) => (a.id < b.id ? 1 : -1))) {
-  //     if (trip.geometry.length > 0) {
-  //       items.push({
-  //         name: 'TRIP: ' + trip.name,
-  //         geometries: trip.geometry,
-  //         colour: 'red',
-  //         transitionType: FlyToAndFadeItemTransitionType.zoomToGeometries
-  //       });
-  //     }
-  //   }
+    if (!trip || !trip?.geos?.length) {
+      return;
+    }
 
-  //   setIFlyToAndFadeItems([...items]);
-  // };
+    const item : IFlyToAndFadeItem = {
+      name: 'TRIP: ' + trip.name,
+      geometries: trip.geos,
+      colour: 'red',
+      transitionType: FlyToAndFadeItemTransitionType.zoomToGeometries
+    };
+
+    setFlyToAndFadeItem(item);
+  };
 
 
   return (
@@ -153,20 +95,3 @@ export const JumpToTrip = (props) => {
 };
 
 export default JumpToTrip;
-
-
-/* 
-just for reference until a later commit 
-
-<ListItem
-  onClick={() => {
-    jump();
-  }}
-  disableGutters>
-  <ListItemText>
-    <Typography className={toolClass.Font}>Sunny infested areas</Typography>
-  </ListItemText>
-  <ListItemIcon>
-    <CheckIcon />
-  </ListItemIcon>
-</ListItem> */

--- a/app/src/contexts/DatabaseContext.tsx
+++ b/app/src/contexts/DatabaseContext.tsx
@@ -409,7 +409,7 @@ export const upsert = async (upsertConfigs: Array<IUpsert>, databaseContext: any
           break;
         // no ID present therefore these are inserts
         case UpsertType.DOC_TYPE_AND_ID_DELETE:
-          batchUpdate += `delete from ` + upsertConfig.docType + ` where id=` + upsertConfig.ID;
+          batchUpdate += `delete from ` + upsertConfig.docType + ` where id=` + upsertConfig.ID + `;\n`;
           break;
         case UpsertType.DOC_TYPE:
           batchUpdate +=

--- a/app/src/features/home/activities/ActivitiesPage.tsx
+++ b/app/src/features/home/activities/ActivitiesPage.tsx
@@ -83,6 +83,7 @@ const PageContainer = (props) => {
   const history = useHistory();
   const recordStateContext = useContext(RecordSetContext);
   const [geometry, setGeometry] = useState<any[]>([]);
+  const [showDrawControls, setShowDrawControls] = useState<boolean>(false);
   const classes = useStyles();
   const [recordsExpanded, setRecordsExpanded] = useState(false);
   const [width, setWidth] = React.useState(window.innerWidth);
@@ -217,7 +218,8 @@ const PageContainer = (props) => {
         <MapRecordsContextProvider>
           <MapContainer
             classes={classes}
-            showDrawControls={false}
+            showDrawControls={showDrawControls}
+            setShowDrawControls={setShowDrawControls}
             center={[55, -128]}
             zoom={5}
             mapId={'mainMap'}

--- a/app/src/hooks/useDataAccess.tsx
+++ b/app/src/hooks/useDataAccess.tsx
@@ -307,16 +307,16 @@ export const useDataAccess = () => {
   /**
    * Delete boundary object (trip currently) record
    *
-   * @param {any} id
+   * @param {number} id
    * @return {*}  {Promise<any>}
    */
-   const deleteBoundary = async (id) => {
+   const deleteBoundary = async (id: number) => {
     if (isMobile()) {
-      // return databaseContext.asyncQueue({
-      //   asyncTask: () => {
-      //     return upsert([{ type: UpsertType.DOC_TYPE, docType: DocType.TRIP, json: newBoundaryObj }], databaseContext);
-      //   }
-      // });
+      return databaseContext.asyncQueue({
+        asyncTask: () => {
+          return upsert([{ type: UpsertType.DOC_TYPE_AND_ID_DELETE, docType: DocType.TRIP, ID: String(id) }], databaseContext);
+        }
+      });
     } else {
       const boundaries = await getBoundaries();
       const newBoundaries = boundaries.filter((b) => {

--- a/app/src/hooks/useDataAccess.tsx
+++ b/app/src/hooks/useDataAccess.tsx
@@ -295,7 +295,12 @@ export const useDataAccess = () => {
       });
     } else {
       //cache in localStorage
-      localStorage.setItem("boundaries", JSON.stringify(newBoundaryObj));
+      const boundaries = [];
+      const currBoundaries = await getBoundaries();
+      if (currBoundaries) boundaries.push(...currBoundaries);
+      boundaries.push(newBoundaryObj);
+
+      localStorage.setItem("boundaries", JSON.stringify(boundaries));
     }
   };
 

--- a/app/src/hooks/useDataAccess.tsx
+++ b/app/src/hooks/useDataAccess.tsx
@@ -258,6 +258,47 @@ export const useDataAccess = () => {
     });
   };
 
+  /**
+   * Get all the boundary (trip currently) records
+   *
+   * @return {*}  {Promise<any>}
+   */
+  const getBoundaries = async () => {
+    if (isMobile()) {
+      return databaseContext.asyncQueue({
+        asyncTask: () => {
+          return query({ type: QueryType.DOC_TYPE, docType: DocType.TRIP }, databaseContext);
+        }
+      });
+    } else {
+      const result = localStorage.getItem("boundaries");
+      return new Promise((resolve, reject) => {
+        resolve(JSON.parse(result));
+        //no reject for now so it fails gracefully and returns a null to be handled in jumptotrip
+      });
+    }
+    
+  };
+  
+  /**
+   * Add new boundary object (triip currenntly) record
+   *
+   * @param {any} newBoundaryObj
+   * @return {*}  {Promise<any>}
+   */
+  const addBoundary = async (newBoundaryObj: any) => {
+    if (isMobile()) {
+      return databaseContext.asyncQueue({
+        asyncTask: () => {
+          return upsert([{ type: UpsertType.DOC_TYPE, docType: DocType.TRIP, json: newBoundaryObj }], databaseContext);
+        }
+      });
+    } else {
+      //cache in localStorage
+      localStorage.setItem("boundaries", JSON.stringify(newBoundaryObj));
+    }
+  };
+
   const getApplicationUsers = async (): Promise<any> => {
     return databaseContext.asyncQueue({
       asyncTask: async () => {
@@ -857,6 +898,8 @@ export const useDataAccess = () => {
     updateActivity,
     getTrips,
     addTrip,
+    getBoundaries,
+    addBoundary,
     getActivities,
     getActivitiesLean,
     createActivity,

--- a/app/src/hooks/useDataAccess.tsx
+++ b/app/src/hooks/useDataAccess.tsx
@@ -277,16 +277,15 @@ export const useDataAccess = () => {
         //no reject for now so it fails gracefully and returns a null to be handled in jumptotrip
       });
     }
-    
   };
-  
+
   /**
-   * Add new boundary object (triip currenntly) record
+   * Add new boundary object (trip currently) record
    *
    * @param {any} newBoundaryObj
    * @return {*}  {Promise<any>}
    */
-  const addBoundary = async (newBoundaryObj: any) => {
+   const addBoundary = async (newBoundaryObj: any) => {
     if (isMobile()) {
       return databaseContext.asyncQueue({
         asyncTask: () => {
@@ -297,10 +296,34 @@ export const useDataAccess = () => {
       //cache in localStorage
       const boundaries = [];
       const currBoundaries = await getBoundaries();
+
       if (currBoundaries) boundaries.push(...currBoundaries);
       boundaries.push(newBoundaryObj);
 
       localStorage.setItem("boundaries", JSON.stringify(boundaries));
+    }
+  };
+
+  /**
+   * Delete boundary object (trip currently) record
+   *
+   * @param {any} id
+   * @return {*}  {Promise<any>}
+   */
+   const deleteBoundary = async (id) => {
+    if (isMobile()) {
+      // return databaseContext.asyncQueue({
+      //   asyncTask: () => {
+      //     return upsert([{ type: UpsertType.DOC_TYPE, docType: DocType.TRIP, json: newBoundaryObj }], databaseContext);
+      //   }
+      // });
+    } else {
+      const boundaries = await getBoundaries();
+      const newBoundaries = boundaries.filter((b) => {
+        return b.id !== id;
+      });
+
+      localStorage.setItem("boundaries", JSON.stringify(newBoundaries));
     }
   };
 
@@ -905,6 +928,7 @@ export const useDataAccess = () => {
     addTrip,
     getBoundaries,
     addBoundary,
+    deleteBoundary,
     getActivities,
     getActivitiesLean,
     createActivity,

--- a/app/src/hooks/useInvasivesApi.ts
+++ b/app/src/hooks/useInvasivesApi.ts
@@ -1137,12 +1137,12 @@ export const useInvasivesApi = () => {
    * @param {string[]} species
    * @return {*}  {Promise<any>}
    */
-  const getAdminUploadGeoJSONLayers = async (user_id: string): Promise<any> => {
+  const getAdminUploadGeoJSONLayers = async (): Promise<any> => {
     const options = await getRequestOptions();
     const { data } = await Http.request({
       headers: { ...options.headers },
       method: 'GET',
-      url: options.baseUrl + `/api/admin-defined-shapes?user_id=${user_id}`
+      url: options.baseUrl + `/api/admin-defined-shapes`
     });
     checkForErrors(data);
     if (LOGVERBOSE) {

--- a/app/src/interfaces/tripBoundary-interfaces.ts
+++ b/app/src/interfaces/tripBoundary-interfaces.ts
@@ -1,0 +1,6 @@
+interface Boundary {
+    id: number,
+    name: string,
+    geos: [],
+    server_id: number
+}


### PR DESCRIPTION
- wip named boundary workflow
- Add boundaries to list on new boundary click
- Add getter for locally stored boundary objects
- Add setter to store and update local boundaries
- Implement delete button and proper ID count for boundary list
- Move boundary list functionality into parent namedBoundaryMenu
- Store geo points into boundary objects for later access
- Allow flyToFade functionality on individual boundary item click and require name on creation
- Add check icon if trip boundary clicked
- Moved Boundary interface into separate file for DRY instances
- Change create boundary alert to dialog options and allow dialog children
- Setup authcontext using invasivesRequest and differentiate boundary from KML server_id
- Add dialog box for new boundaries, uploading kml, and adding selected kml to boundaries
- Fix flytofade and update select on KML upload
- Refactor getBoundary code and related to match now working mobile local db

# Overview

This PR includes the following proposed change(s):

- {List all the changes, if possible add the linked issue/ticket #}
- #1659
- Create, read, and delete functionality for Boundaries
- Can create trip boundaries from KML
- Functionality also works on mobile now

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- Manually tested in Chrome, safari and simulated Ipad in XCode

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
