### PR TITLE
User Shape Spatial Filtering

### DIFF
--- a/app/src/components/activities-list/Tables/Plant/ActivityGrid.tsx
+++ b/app/src/components/activities-list/Tables/Plant/ActivityGrid.tsx
@@ -622,6 +622,20 @@ const ActivityGrid = (props) => {
                     );
                   }
                 })}
+              {recordSetContext?.recordSetState[props.setName]?.searchBoundary &&
+                <Chip
+                  label={`Boundary = ${recordSetContext?.recordSetState[props.setName]?.searchBoundary.name}`}
+                  variant="outlined"
+                  color="secondary"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                  }}
+                  onDelete={(e) => {
+                    e.stopPropagation();
+                    recordSetContext.removeBoundaryFromSet(props.setName);
+                  }}
+                />
+              }
             </List>
             <Box
               sx={{

--- a/app/src/components/activities-list/Tables/Plant/ActivityGrid.tsx
+++ b/app/src/components/activities-list/Tables/Plant/ActivityGrid.tsx
@@ -117,6 +117,11 @@ export const getSearchCriteriaFromFilters = (
   }
   */
 
+  //search_feature
+  if (recordSetContext.recordSetState[setName]?.searchBoundary) {
+    filter.search_feature = recordSetContext.recordSetState[setName]?.searchBoundary.geos[0];
+  }
+
   if (recordSetContext.recordSetState[setName]?.advancedFilters) {
     const currentAdvFilters = recordSetContext.recordSetState[setName]?.advancedFilters;
     const jurisdictions = [];

--- a/app/src/components/dialog/GeneralDialog.tsx
+++ b/app/src/components/dialog/GeneralDialog.tsx
@@ -25,7 +25,7 @@ export const GeneralDialog = (props: IGeneralDialog) => {
   }, [props.dialogOpen]);
 
   return (
-    <Dialog open={open} aria-labelledby="alert-dialog-title" aria-describedby="alert-dialog-description">
+    <Dialog onClick={(e) => e.stopPropagation()} open={open} aria-labelledby="alert-dialog-title" aria-describedby="alert-dialog-description">
       <DialogTitle id="alert-dialog-title">{props.dialogTitle}</DialogTitle>
       {props.dialogContentText && (
         <DialogContent>

--- a/app/src/components/map/MapContainer.tsx
+++ b/app/src/components/map/MapContainer.tsx
@@ -110,6 +110,7 @@ export interface IMapContainerProps {
   showDrawControls: boolean;
   setShowDrawControls: React.Dispatch<boolean>;
   showBoundaryMenu?: boolean;
+  setBoundaryMenu?: React.Dispatch<boolean>;
   zoom?: any;
   center?: any;
   isPlanPage?: boolean;

--- a/app/src/components/map/NamedBoundaryMenu.tsx
+++ b/app/src/components/map/NamedBoundaryMenu.tsx
@@ -1,5 +1,5 @@
 import { Capacitor } from '@capacitor/core';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import { LayerPicker } from './LayerPicker/LayerPicker';
 import { SetPointOnClick } from './Tools/ToolTypes/Data/InfoAreaDescription';
 import MeasureTool from './Tools/ToolTypes/Misc/MeasureTool';
@@ -34,6 +34,7 @@ import { useDataAccess } from 'hooks/useDataAccess';
 import { GeneralDialog, IGeneralDialog } from 'components/dialog/GeneralDialog';
 import KMLShapesUpload from 'components/map-buddy-components/KMLShapesUpload';
 import { useInvasivesApi } from 'hooks/useInvasivesApi';
+import { RecordSetContext } from 'contexts/recordSetContext';
 
 const POSITION_CLASSES = {
   bottomleft: 'leaflet-bottom leaflet-left',
@@ -84,7 +85,8 @@ export const NamedBoundaryMenu = (props) => {
   const classes = useToolbarContainerStyles();
   const [expanded, setExpanded] = useState<boolean>(false);
   const divRef = useRef();
-  const [boundaries, setBoundaries] = useState<Boundary[]>([]);
+  // const [boundaries, setBoundaries] = useState<Boundary[]>([]);
+  const recordSetContext = useContext(RecordSetContext);
   const [KMLs, setKMLs] = useState<Boundary[]>([]);
   const [idCount, setIdCount] = useState(0);
   const [showKMLUpload, setShowKMLUpload] = useState<boolean>(false);
@@ -115,17 +117,17 @@ export const NamedBoundaryMenu = (props) => {
     getKMLs();
   }, []);
 
-  const setBoundaryIdCount = () => {
-    if (boundaries && boundaries.length > 0) {
+  const setBoundaryIdCount = (() => {
+    if (recordSetContext.boundaries && recordSetContext.boundaries.length > 0) {
       //ensures id is not repeated on client side
-      const max = Math.max(...boundaries.map((b) => b.id));
+      const max = Math.max(...recordSetContext.boundaries.map(b => b.id));
       setIdCount(max + 1);
     }
-  };
+  });
 
   useEffect(() => {
     setBoundaryIdCount();
-  }, [boundaries]);
+  }, [recordSetContext.boundaries]);
 
   const getBoundaries = async () => {
     const boundaryResults = await dataAccess.getBoundaries();
@@ -141,9 +143,9 @@ export const NamedBoundaryMenu = (props) => {
         };
       });
 
-      setBoundaries(mappedBoundaries);
+      recordSetContext.setBoundaries(mappedBoundaries);
     } else {
-      if (boundaryResults) setBoundaries(boundaryResults);
+      recordSetContext.setBoundaries(boundaryResults);
     }
   };
 
@@ -287,16 +289,8 @@ export const NamedBoundaryMenu = (props) => {
               </ListItemText>
             </ListItemButton>
           </ListItem>
-          {boundaries?.map((b, index) => (
-            <JumpToTrip
-              boundary={b}
-              id={b.id}
-              name={b.name}
-              geos={b.geos}
-              server_id={b.server_id}
-              key={index}
-              deleteBoundary={deleteBoundary}
-            />
+          {recordSetContext.boundaries?.map((b, index) => (
+            <JumpToTrip boundary={b} id={b.id} name={b.name} geos={b.geos} server_id={b.server_id} key={index} deleteBoundary={deleteBoundary}/>
           ))}
         </List>
       </div>
@@ -334,7 +328,7 @@ export const NamedBoundaryMenu = (props) => {
             };
 
             dataAccess.addBoundary(boundaryFromKML);
-            setBoundaries([...boundaries, boundaryFromKML]);
+            recordSetContext.setBoundaries([...recordSetContext.boundaries, boundaryFromKML]);
             setSelectKMLDialog({ ...selectKMLDialog, dialogOpen: false });
             setNewBoundaryDialog({ ...newBoundaryDialog, dialogOpen: false });
           }}>

--- a/app/src/components/map/NamedBoundaryMenu.tsx
+++ b/app/src/components/map/NamedBoundaryMenu.tsx
@@ -118,16 +118,18 @@ export const NamedBoundaryMenu = (props) => {
   }, []);
 
   const setBoundaryIdCount = (() => {
-    if (recordSetContext.boundaries && recordSetContext.boundaries.length > 0) {
+    if (recordSetContext?.boundaries && recordSetContext?.boundaries?.length > 0) {
       //ensures id is not repeated on client side
       const max = Math.max(...recordSetContext.boundaries.map(b => b.id));
       setIdCount(max + 1);
+    } else {
+      setIdCount(idCount + 1);
     }
   });
 
   useEffect(() => {
     setBoundaryIdCount();
-  }, [recordSetContext.boundaries]);
+  }, [recordSetContext?.boundaries]);
 
   const getBoundaries = async () => {
     const boundaryResults = await dataAccess.getBoundaries();
@@ -289,7 +291,7 @@ export const NamedBoundaryMenu = (props) => {
               </ListItemText>
             </ListItemButton>
           </ListItem>
-          {recordSetContext.boundaries?.map((b, index) => (
+          {recordSetContext?.boundaries?.map((b, index) => (
             <JumpToTrip boundary={b} id={b.id} name={b.name} geos={b.geos} server_id={b.server_id} key={index} deleteBoundary={deleteBoundary}/>
           ))}
         </List>

--- a/app/src/contexts/recordSetContext.tsx
+++ b/app/src/contexts/recordSetContext.tsx
@@ -104,6 +104,13 @@ export const RecordSetProvider = (props) => {
     // dataAccess.setAppState({ recordSets: { ...recordSets } });
   }
 
+  const removeBoundaryFromSet = async (setName: string) => {
+    const oldState = dataAccess.getAppState();
+    delete oldState.recordSets[setName].searchBoundary;
+
+    setRecordSetState({ ...oldState.recordSets})
+  }
+
   useEffect(() => {
     getInitialState();
   }, []);
@@ -145,7 +152,8 @@ export const RecordSetProvider = (props) => {
           remove: remove,
           boundaries: boundaries,
           setBoundaries: setBoundaries,
-          addBoundaryToSet: addBoundaryToSet
+          addBoundaryToSet: addBoundaryToSet,
+          removeBoundaryFromSet: removeBoundaryFromSet
         }}>
         {props.children}
       </RecordSetContext.Provider>

--- a/app/src/contexts/recordSetContext.tsx
+++ b/app/src/contexts/recordSetContext.tsx
@@ -10,6 +10,7 @@ export const RecordSetContext = React.createContext(null);
 export const RecordSetProvider = (props) => {
   const [recordSetState, setRecordSetState] = useState(null);
   const [selectedRecord, setSelectedRecord] = useState(null);
+  const [boundaries, setBoundaries] = useState<Boundary[]>([]);
   const dataAccess = useDataAccess();
   const { userInfo } = useContext(AuthStateContext);
 
@@ -81,6 +82,24 @@ export const RecordSetProvider = (props) => {
     });
   };
 
+  const addBoundaryToSet = async (boundary: Boundary, setName: string) => {
+    const oldState = dataAccess.getAppState();
+    const recordSets = oldState?.recordSets;
+    const currentSet = recordSets[setName];
+
+    // add search boundary ID to given record set if doesn't exist
+    if (currentSet.searchBoundaryID) {
+      if (!currentSet.searchBoundaryID.includes(boundary.id)) {
+        currentSet.searchBoundaryID = [...currentSet.searchBoundaryID, boundary.id];
+      }
+    } else {
+      // create if not exists
+      currentSet.searchBoundaryID = [boundary.id];
+    }
+
+    dataAccess.setAppState({ recordSets: { ...recordSets } });
+  }
+
   useEffect(() => {
     getInitialState();
   }, []);
@@ -119,7 +138,10 @@ export const RecordSetProvider = (props) => {
           recordSetState: recordSetState,
           setRecordSetState: setRecordSetState,
           add: add,
-          remove: remove
+          remove: remove,
+          boundaries: boundaries,
+          setBoundaries: setBoundaries,
+          addBoundaryToSet: addBoundaryToSet
         }}>
         {props.children}
       </RecordSetContext.Provider>

--- a/app/src/contexts/recordSetContext.tsx
+++ b/app/src/contexts/recordSetContext.tsx
@@ -87,17 +87,21 @@ export const RecordSetProvider = (props) => {
     const recordSets = oldState?.recordSets;
     const currentSet = recordSets[setName];
 
-    // add search boundary ID to given record set if doesn't exist
-    if (currentSet.searchBoundaryID) {
-      if (!currentSet.searchBoundaryID.includes(boundary.id)) {
-        currentSet.searchBoundaryID = [...currentSet.searchBoundaryID, boundary.id];
-      }
-    } else {
-      // create if not exists
-      currentSet.searchBoundaryID = [boundary.id];
-    }
+    // add search boundary to given record set if doesn't exist
+    // if (currentSet.searchBoundary) {
+    //   if (!currentSet.searchBoundary.includes(boundary)) {
+    //     currentSet.searchBoundary = [...currentSet.searchBoundary, boundary];
+    //   }
+    // } else {
+    //   // create if not exists
+    //   currentSet.searchBoundary = [boundary];
+    // }
 
-    dataAccess.setAppState({ recordSets: { ...recordSets } });
+    // seems like only one geometry can be intersected at one time
+    currentSet.searchBoundary = boundary;
+
+    setRecordSetState({ ...recordSets });
+    // dataAccess.setAppState({ recordSets: { ...recordSets } });
   }
 
   useEffect(() => {

--- a/app/src/features/home/HomeLayout.tsx
+++ b/app/src/features/home/HomeLayout.tsx
@@ -17,7 +17,7 @@ const HomeLayout: React.FC<IHomeLayoutProps> = (props: any) => {
         {props.children}
       </Box>
       <Box
-        style={{ zIndex: 99999999999 }}
+        style={{ zIndex: 1 }}
         position="fixed"
         bottom="0px"
         left="0"

--- a/app/src/features/home/activities/activityRecordset/RecordSetAccordionSummary.tsx
+++ b/app/src/features/home/activities/activityRecordset/RecordSetAccordionSummary.tsx
@@ -8,6 +8,8 @@ import {
   Checkbox,
   Container,
   IconButton,
+  MenuItem,
+  Select,
   TextField,
   Typography
 } from '@mui/material';
@@ -22,6 +24,7 @@ import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import { RecordSetContext } from 'contexts/recordSetContext';
 import DownloadIcon from '@mui/icons-material/Download';
 import GrassIcon from '@mui/icons-material/Grass';
+import { GeneralDialog, IGeneralDialog } from 'components/dialog/GeneralDialog';
 
 const OrderSelector = (props) => {
   return (
@@ -54,8 +57,24 @@ const OrderSelector = (props) => {
 };
 
 const RecordSetAccordionSummary = (props) => {
+  const recordSetContext = useContext(RecordSetContext);
   const [newName, setNewName] = useState(props.recordSetName);
   const [nameEdit, setNameEdit] = useState(false);
+
+  const [boundaryFilterDialog, setBoundaryFilterDialog] = useState<IGeneralDialog>({
+    dialogActions: [
+      {
+        actionName: 'Cancel',
+        actionOnClick: async () => {
+          setBoundaryFilterDialog({ ...boundaryFilterDialog, dialogOpen: false });
+        }
+      }
+    ],
+    dialogOpen: false,
+    dialogTitle: 'Select boundary to filter: ',
+    dialogContentText: null
+  });
+
   // return useMemo(() => {
   return (
     <AccordionSummary>
@@ -122,6 +141,15 @@ const RecordSetAccordionSummary = (props) => {
         )}
       </Box>
       <AccordionActions sx={{ display: 'flex', justifyContent: 'end' }}>
+      <Button
+          onClick={(e) => {
+            e.stopPropagation();
+            setBoundaryFilterDialog({ ...boundaryFilterDialog, dialogOpen: true });
+          }}
+          variant="outlined">
+          Filter by boundary shape
+          <ArrowDropDownIcon />
+        </Button>
         <Button
           //className={classes.mainHeader}
           onClick={(e) => {
@@ -188,6 +216,25 @@ const RecordSetAccordionSummary = (props) => {
           <></>
         )}
       </AccordionActions>
+      <GeneralDialog
+        dialogOpen={boundaryFilterDialog.dialogOpen}
+        dialogTitle={boundaryFilterDialog.dialogTitle}
+        dialogActions={boundaryFilterDialog.dialogActions}
+        dialogContentText={boundaryFilterDialog.dialogContentText}
+      >
+        <Select
+          sx={{ minWidth: 150, mt: 3, mb: 3 }}
+          onChange={(e) => {
+            e.stopPropagation();
+            //add to the recordset filters
+            recordSetContext.addBoundaryToSet(e.target?.value, props?.setName);
+          }}
+        >
+          {recordSetContext.boundaries?.map((boundary) => {
+            return <MenuItem key={boundary.id} value={boundary}>{boundary.name}</MenuItem>
+          })}
+        </Select>
+      </GeneralDialog>
     </AccordionSummary>
   );
   // }, [JSON.stringify({ expanded: expanded, mapToggle: mapToggle, colour: colour, recordSetName: recordSetName })]);

--- a/app/src/features/home/activities/activityRecordset/RecordSetAccordionSummary.tsx
+++ b/app/src/features/home/activities/activityRecordset/RecordSetAccordionSummary.tsx
@@ -223,11 +223,12 @@ const RecordSetAccordionSummary = (props) => {
         dialogContentText={boundaryFilterDialog.dialogContentText}
       >
         <Select
-          sx={{ minWidth: 150, mt: 3, mb: 3 }}
+          sx={{ minWidth: 150, m: 3}}
           onChange={(e) => {
             e.stopPropagation();
             //add to the recordset filters
             recordSetContext.addBoundaryToSet(e.target?.value, props?.setName);
+            setBoundaryFilterDialog({ ...boundaryFilterDialog, dialogOpen: false });
           }}
         >
           {recordSetContext.boundaries?.map((boundary) => {


### PR DESCRIPTION
- [rebase] Add boundaries dropdown for each set to add to recordSetContext
- [rebase] Show namedBoundaryMenu only on activities page
- Allow filtering with boundary selected
- Add chip next to filter if boundary query is set + UX tweaks

# Overview

This PR includes the following proposed change(s):

- {List all the changes, if possible add the linked issue/ticket #}
- Half of #1819
- Adds a boundary drop down and filter chip to each accordion
- Implements spatial filtering through boundaries in record set context

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?
- Manually by Gabe
- Double checked activities returned match what was drawn around on map

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
