### PR TITLE
Error Context Timeout

### DIFF
--- a/app/src/components/error/ErrorBanner.tsx
+++ b/app/src/components/error/ErrorBanner.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { IErrorBanner, ErrorContext } from 'contexts/ErrorContext';
-import { Alert, AlertTitle, Box } from '@mui/material';
+import { Alert, AlertColor, AlertTitle, Box } from '@mui/material';
 import { useContext, useEffect } from 'react';
 
 export const ErrorBanner = (props: IErrorBanner) => {
   const errorContext = useContext(ErrorContext);
+  const [severity, setSeverity]: AlertColor = useState('error');
 
   const triggerOnClose = () => {
     errorContext.clearError({
@@ -13,6 +14,16 @@ export const ErrorBanner = (props: IErrorBanner) => {
       namespace: props.namespace
     });
   };
+
+  useEffect(() => {
+    switch (props.code) {
+      case 401:
+        setSeverity('warning');
+        break;
+      default:
+        setSeverity('error');
+    }
+  });
 
   useEffect(() => {
     if (errorContext) {
@@ -26,7 +37,7 @@ export const ErrorBanner = (props: IErrorBanner) => {
 
   return (
     <Box margin={2}>
-      <Alert variant="filled" severity="error" onClose={triggerOnClose}>
+      <Alert variant="filled" severity={severity} onClose={triggerOnClose}>
         <AlertTitle>{message}</AlertTitle>
         {props.message}
       </Alert>

--- a/app/src/components/error/ErrorBanner.tsx
+++ b/app/src/components/error/ErrorBanner.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { IErrorBanner, ErrorContext } from 'contexts/ErrorContext';
 import { Alert, AlertTitle, Box } from '@mui/material';
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 
 export const ErrorBanner = (props: IErrorBanner) => {
   const errorContext = useContext(ErrorContext);
@@ -13,6 +13,14 @@ export const ErrorBanner = (props: IErrorBanner) => {
       namespace: props.namespace
     });
   };
+
+  useEffect(() => {
+    if (errorContext) {
+      setTimeout(() => {
+        triggerOnClose();
+      }, 5000);
+    }
+  }, [errorContext]);
 
   const message = process.env.REACT_APP_REAL_NODE_ENV !== 'production' && props.code + ' - ' + props.namespace;
 


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Timeout added to error context so the banner doesn't take stay at the top

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

`Step 1`: Make sure you're logged out or an unauthorized user.
`Step 2`: Go to Map Page
`Step 3`: Click on record geometry
> Should be only Observation that shows

`Step 4`: Open InvasivesBC or IAPP Tables from Popup
`Step 5`: Should see Error banner that is orange and only last 5 seconds

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
