### PR TITLE
Change activity queries to use one function and same sql

### DIFF
--- a/api/src/paths/activities-lean.ts
+++ b/api/src/paths/activities-lean.ts
@@ -8,7 +8,7 @@ import { ALL_ROLES, SEARCH_LIMIT_MAX, SEARCH_LIMIT_DEFAULT, SECURITY_ON } from '
 import { getDBConnection } from '../database/db';
 import { ActivitySearchCriteria } from '../models/activity';
 import geoJSON_Feature_Schema from '../openapi/geojson-feature-doc.json';
-import { getActivitiesLeanSQL, deleteActivitiesSQL } from '../queries/activity-queries';
+import { getActivitiesSQL, deleteActivitiesSQL } from '../queries/activity-queries';
 import { getLogger } from '../utils/logger';
 
 const defaultLog = getLogger('activity');
@@ -227,12 +227,12 @@ function getActivitiesBySearchFilterCriteria(): RequestHandler {
     }
 
     try {
-      const sqlStatement: SQLStatement = getActivitiesLeanSQL(sanitizedSearchCriteria);
+      const sqlStatement: SQLStatement = getActivitiesSQL(sanitizedSearchCriteria, true);
 
       // Check for sql and role:
       // console.log('========================= activities-lean.ts 232', sqlStatement.text);
       // console.log('========================= activities-lean.ts 232 roleName', roleName);
-      
+
       if (!sqlStatement) {
         return res.status(500).json({
           message: 'Error generating SQL statement',

--- a/api/src/paths/activities.ts
+++ b/api/src/paths/activities.ts
@@ -260,7 +260,7 @@ function getActivitiesBySearchFilterCriteria(): RequestHandler {
     }
 
     try {
-      const sqlStatement: SQLStatement = getActivitiesSQL(sanitizedSearchCriteria);
+      const sqlStatement: SQLStatement = getActivitiesSQL(sanitizedSearchCriteria, false);
 
       if (!sqlStatement) {
         return res
@@ -318,7 +318,7 @@ function deleteActivitiesByIds(): RequestHandler {
     }
 
     if (isAdmin === false) {
-      const sqlStatement = getActivitiesSQL(sanitizedSearchCriteria);
+      const sqlStatement = getActivitiesSQL(sanitizedSearchCriteria, false);
 
       if (!sqlStatement) {
         return res


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Modify activity-queries to amalgamate getActivities and getActivitiesLean to one function that decides the return type based on a parameter

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Web tested

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
