### PR TITLE
Activity Fuzzy Matching

### DIFF
--- a/api/src/models/activity.ts
+++ b/api/src/models/activity.ts
@@ -137,6 +137,8 @@ export class ActivitySearchCriteria {
 
   jurisdiction: string[];
 
+  grid_filters: any;
+
   order: string[];
   hideTreatmentsAndMonitoring: boolean;
 
@@ -177,6 +179,8 @@ export class ActivitySearchCriteria {
     this.species_treated = obj?.species_treated || [];
 
     this.jurisdiction = obj?.jurisdiction || [];
+
+    this.grid_filters = obj?.grid_filters || null;
 
     this.order = (obj && obj.order) || [];
     this.hideTreatmentsAndMonitoring = (obj && obj.hideTreatmentsAndMonitoring) || true;

--- a/api/src/queries/activity-queries.ts
+++ b/api/src/queries/activity-queries.ts
@@ -337,7 +337,7 @@ export const getActivitiesSQL = (searchCriteria: ActivitySearchCriteria, lean: b
         // DONE (Sammy) + confirmed
         console.log('\n[INVASIVE SPECIES AGENCY CODE]: ', gridFilters.agency, '\n');
         sqlStatement.append(
-          SQL` AND LOWER(a.activity_payload::jsonb->'form_data'->'activity_data'->>'invasive_species_agency_code') LIKE '%'||`
+          SQL` AND LOWER(a.agency) LIKE '%'||`
         );
         sqlStatement.append(SQL`LOWER(${gridFilters.agency})`);
         sqlStatement.append(SQL`||'%'`);

--- a/api/src/queries/activity-queries.ts
+++ b/api/src/queries/activity-queries.ts
@@ -270,72 +270,63 @@ export const getActivitiesSQL = (searchCriteria: ActivitySearchCriteria, lean: b
     const gridFilters = searchCriteria.grid_filters;
     if (gridFilters.enabled) {
       if (gridFilters.short_id) {
-        // DONE (Sammy) + confirmed + case ins
         sqlStatement.append(SQL` AND LOWER(a.activity_payload ->> 'short_id') LIKE '%'||`);
         sqlStatement.append(SQL`LOWER(${gridFilters.short_id})`);
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.type) {
-        // DONE (Sammy) + confirmed + case ins
         sqlStatement.append(SQL` AND LOWER(a.activity_type)::text LIKE '%'||`);
         sqlStatement.append(SQL`LOWER(${gridFilters.type})`);
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.subtype) {
-        // DONE (Sammy) + confirmed + case ins
         sqlStatement.append(SQL` AND LOWER(a.activity_subtype::text) LIKE '%'||`);
         sqlStatement.append(SQL`LOWER(${gridFilters.subtype})`);
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.received_timestamp) {
-        // DONE
-        console.log('\n[RECEIVED TIMESTAMP]: ', gridFilters.received_timestamp, '\n');
+        //console.log('\n[RECEIVED TIMESTAMP]: ', gridFilters.received_timestamp, '\n');
         sqlStatement.append(SQL` AND LOWER(to_char(a.received_timestamp at time zone 'UTC' at time zone 'America/Vancouver', 'Dy, Mon DD YYYY HH24:MI:SS')::text) LIKE '%'||`);
         sqlStatement.append(SQL`LOWER(${gridFilters.received_timestamp})`);
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.jurisdiction) {
-        // Note: "Jurisdiction" property of activity_payload is not the source of truth for jurisdiction.
-        // See: activity_payload.form_data.activity_data.jurisdictions for the source of truth.
-        // @@@@@@@@@!!    needs a restructure to include it within the activity incoming data   @@@@@@
-        console.log('\n[JURISDICTION]: ', gridFilters.jurisdiction, '\n');
+        sqlStatement.append(
+          SQL` AND LOWER(a.jurisdiction_display) LIKE '%'||`
+        );
+        sqlStatement.append(SQL`LOWER(${gridFilters.jurisdiction})`);
+        sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.species_positive) {
-        // DONE
-        console.log('\n[SPECIES POSITIVE]: ', gridFilters.species_positive, '\n');
+        // console.log('\n[SPECIES POSITIVE]: ', gridFilters.species_positive, '\n');
         sqlStatement.append(SQL` AND LOWER(a.species_positive_full) LIKE '%'||`);
         sqlStatement.append(SQL`LOWER(${gridFilters.species_positive})`);
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.species_negative) {
-        // DONE
-        console.log('\n[SPECIES NEGATIVE]: ', gridFilters.species_negative, '\n');
+        // console.log('\n[SPECIES NEGATIVE]: ', gridFilters.species_negative, '\n');
         sqlStatement.append(SQL` AND LOWER(a.species_negative_full) LIKE '%'||`);
         sqlStatement.append(SQL`LOWER(${gridFilters.species_negative})`);
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.species_treated) {
-        // DONE
-        console.log('\n[SPECIES TREATED]: ', gridFilters.species_treated, '\n');
+        // console.log('\n[SPECIES TREATED]: ', gridFilters.species_treated, '\n');
         sqlStatement.append(SQL` AND LOWER(a.species_treated_full) LIKE '%'||`);
         sqlStatement.append(SQL`LOWER(${gridFilters.species_treated})`);
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.created_by) {
-        // DONE (Sammy) + confirmed + case ins
         sqlStatement.append(SQL` AND LOWER(a.created_by)::text LIKE '%'||`);
         sqlStatement.append(SQL`LOWER(${gridFilters.created_by})`);
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.updated_by) {
-        // DONE + confirmed + case ins
         sqlStatement.append(SQL` AND LOWER(a.updated_by)::text LIKE '%'||`);
         sqlStatement.append(SQL`LOWER(${gridFilters.updated_by})`);
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.agency) {
-        // DONE (Sammy) + confirmed
-        console.log('\n[INVASIVE SPECIES AGENCY CODE]: ', gridFilters.agency, '\n');
+        // console.log('\n[INVASIVE SPECIES AGENCY CODE]: ', gridFilters.agency, '\n');
         sqlStatement.append(
           SQL` AND LOWER(a.agency) LIKE '%'||`
         );
@@ -343,12 +334,11 @@ export const getActivitiesSQL = (searchCriteria: ActivitySearchCriteria, lean: b
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.regional_invasive_species_organization_areas) {
-        // DONE
-        console.log(
-          '\n[REGIONAL INVASIVE SPECIES ORGANIZATION AREAS]: ',
-          gridFilters.regional_invasive_species_organization_areas,
-          '\n'
-        );
+        // console.log(
+        //   '\n[REGIONAL INVASIVE SPECIES ORGANIZATION AREAS]: ',
+        //   gridFilters.regional_invasive_species_organization_areas,
+        //   '\n'
+        // );
         sqlStatement.append(
           SQL` AND LOWER(a.regional_invasive_species_organization_areas) LIKE '%'||`
         );
@@ -356,21 +346,18 @@ export const getActivitiesSQL = (searchCriteria: ActivitySearchCriteria, lean: b
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.regional_districts) {
-        // DONE
-        console.log('\n[REGIONAL DISTRICTS]: ', gridFilters.regional_districts, '\n');
+        // console.log('\n[REGIONAL DISTRICTS]: ', gridFilters.regional_districts, '\n');
         sqlStatement.append(SQL` AND LOWER(a.regional_districts) LIKE '%'||`);
         sqlStatement.append(SQL`LOWER(${gridFilters.regional_districts})`);
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.biogeoclimatic_zones) {
-        // DONE
-        console.log('\n[BIOGEOCLIMATIC ZONES]: ', gridFilters.biogeoclimatic_zones, '\n');
+        // console.log('\n[BIOGEOCLIMATIC ZONES]: ', gridFilters.biogeoclimatic_zones, '\n');
         sqlStatement.append(SQL` AND LOWER(a.biogeoclimatic_zones) LIKE '%'||`);
         sqlStatement.append(SQL`LOWER(${gridFilters.biogeoclimatic_zones})`);
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.elevation) {
-        // DONE + case ins unnecessary 
         sqlStatement.append(SQL` AND a.elevation::text LIKE '%'||`);
         sqlStatement.append(SQL`${gridFilters.elevation}`);
         sqlStatement.append(SQL`||'%'`);

--- a/api/src/queries/activity-queries.ts
+++ b/api/src/queries/activity-queries.ts
@@ -269,95 +269,113 @@ export const getActivitiesSQL = (searchCriteria: ActivitySearchCriteria, lean: b
     console.log(searchCriteria.grid_filters);
     const gridFilters = searchCriteria.grid_filters;
     if (gridFilters.enabled) {
+      if (gridFilters.short_id) {
+        // DONE (Sammy) + confirmed + case ins
+        sqlStatement.append(SQL` AND LOWER(a.activity_payload ->> 'short_id') LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.short_id})`);
+        sqlStatement.append(SQL`||'%'`);
+      }
       if (gridFilters.type) {
-        // DONE (Sammy) + confirmed
-        sqlStatement.append(SQL` AND a.activity_type::text LIKE '%'||`);
-        sqlStatement.append(SQL`${gridFilters.type}`);
+        // DONE (Sammy) + confirmed + case ins
+        sqlStatement.append(SQL` AND LOWER(a.activity_type)::text LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.type})`);
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.subtype) {
-        // DONE (Sammy) + confirmed
-        sqlStatement.append(SQL` AND a.activity_subtype::text LIKE '%'||`);
-        sqlStatement.append(SQL`${gridFilters.subtype}`);
+        // DONE (Sammy) + confirmed + case ins
+        sqlStatement.append(SQL` AND LOWER(a.activity_subtype::text) LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.subtype})`);
+        sqlStatement.append(SQL`||'%'`);
+      }
+      if (gridFilters.received_timestamp) {
+        //
+        // @@@@@      Date formatting done in SQL, needs rethinking here       *****&&&&&&*******@@@@@@@@@@
+        //
+        console.log('\n[RECEIVED TIMESTAMP]: ', gridFilters.received_timestamp, '\n');
+        sqlStatement.append(SQL` AND LOWER(a.received_timestamp::text) LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.received_timestamp})`);
+        sqlStatement.append(SQL`||'%'`);
+      }
+      if (gridFilters.jurisdiction) {
+        // Note: "Jurisdiction" property of activity_payload is not the source of truth for jurisdiction.
+        // See: activity_payload.form_data.activity_data.jurisdictions for the source of truth.
+        // @@@@@@@@@!!    needs a restructure to include it within the activity incoming data   @@@@@@
+        console.log('\n[JURISDICTION]: ', gridFilters.jurisdiction, '\n');
+      }
+      if (gridFilters.species_positive) {
+        // DONE
+        console.log('\n[SPECIES POSITIVE]: ', gridFilters.species_positive, '\n');
+        sqlStatement.append(SQL` AND LOWER(a.species_positive_full) LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.species_positive})`);
+        sqlStatement.append(SQL`||'%'`);
+      }
+      if (gridFilters.species_negative) {
+        // DONE
+        console.log('\n[SPECIES NEGATIVE]: ', gridFilters.species_negative, '\n');
+        sqlStatement.append(SQL` AND LOWER(a.species_negative_full) LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.species_negative})`);
+        sqlStatement.append(SQL`||'%'`);
+      }
+      if (gridFilters.species_treated) {
+        // DONE
+        console.log('\n[SPECIES TREATED]: ', gridFilters.species_treated, '\n');
+        sqlStatement.append(SQL` AND LOWER(a.species_treated_full) LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.species_treated})`);
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.created_by) {
-        // DONE (Sammy) + confirmed
-        sqlStatement.append(SQL` AND a.created_by::text LIKE '%'||`);
-        sqlStatement.append(SQL`${gridFilters.created_by}`);
+        // DONE (Sammy) + confirmed + case ins
+        sqlStatement.append(SQL` AND LOWER(a.created_by)::text LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.created_by})`);
         sqlStatement.append(SQL`||'%'`);
       }
-      if (gridFilters.short_id) {
-        // DONE (Sammy) + confirmed
-        sqlStatement.append(SQL` AND a.activity_payload ->> 'short_id' LIKE '%'||`);
-        sqlStatement.append(SQL`${gridFilters.short_id}`);
-        sqlStatement.append(SQL`||'%'`);
-      }
-      if (gridFilters.elevation) {
-        // DONE
-        console.log('\n[ELEVATION]: ', gridFilters.elevation, '\n');
-        sqlStatement.append(SQL` AND a.elevation::text LIKE '%'||`);
-        sqlStatement.append(SQL`${gridFilters.elevation}`);
+      if (gridFilters.updated_by) {
+        // DONE + confirmed + case ins
+        sqlStatement.append(SQL` AND LOWER(a.updated_by)::text LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.updated_by})`);
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.agency) {
         // DONE (Sammy) + confirmed
         console.log('\n[INVASIVE SPECIES AGENCY CODE]: ', gridFilters.agency, '\n');
         sqlStatement.append(
-          SQL` AND a.activity_payload::jsonb->'form_data'->'activity_data'->>'invasive_species_agency_code' LIKE '%'||`
+          SQL` AND LOWER(a.activity_payload::jsonb->'form_data'->'activity_data'->>'invasive_species_agency_code') LIKE '%'||`
         );
-        sqlStatement.append(SQL`${gridFilters.agency}`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.agency})`);
         sqlStatement.append(SQL`||'%'`);
       }
-      if (gridFilters.regional_districts) {
-        // format: string array of codes NOT IMPLEMENTED
-        // source: activity_payload.regional_districts
-        console.log('\n[REGIONAL DISTRICTS]: ', gridFilters.regional_districts, '\n');
-      }
       if (gridFilters.regional_invasive_species_organization_areas) {
-        // Format: string array of codes NOT IMPLEMENTED
-        // source: activity_incoming_data.activity_payload.regional_invasive_species_organization_areas
+        // DONE
         console.log(
           '\n[REGIONAL INVASIVE SPECIES ORGANIZATION AREAS]: ',
           gridFilters.regional_invasive_species_organization_areas,
           '\n'
         );
-      }
-      if (gridFilters.jurisdiction) {
-        // Note: "Jurisdiction" property of activity_payload is not the source of truth for jurisdiction.
-        // See: activity_payload.form_data.activity_data.jurisdictions for the source of truth.
-        console.log('\n[JURISDICTION]: ', gridFilters.jurisdiction, '\n');
-      }
-      if (gridFilters.received_timestamp) {
-        // format: iso date string NOT IMPLEMENTED
-        // source: activity_incoming_data.received_timestamp
-        console.log('\n[RECEIVED TIMESTAMP]: ', gridFilters.received_timestamp, '\n');
-      }
-      if (gridFilters.species_positive) {
-        // DONE
-        console.log('\n[SPECIES POSITIVE]: ', gridFilters.species_positive, '\n');
-        sqlStatement.append(SQL` AND a.species_positive_full LIKE '%'||`);
-        sqlStatement.append(SQL`${gridFilters.species_positive}`);
+        sqlStatement.append(
+          SQL` AND LOWER(a.regional_invasive_species_organization_areas) LIKE '%'||`
+        );
+        sqlStatement.append(SQL`LOWER(${gridFilters.regional_invasive_species_organization_areas})`);
         sqlStatement.append(SQL`||'%'`);
       }
-      if (gridFilters.species_negative) {
+      if (gridFilters.regional_districts) {
         // DONE
-        console.log('\n[SPECIES NEGATIVE]: ', gridFilters.species_negative, '\n');
-        sqlStatement.append(SQL` AND a.species_negative_full LIKE '%'||`);
-        sqlStatement.append(SQL`${gridFilters.species_negative}`);
-        sqlStatement.append(SQL`||'%'`);
-      }
-      if (gridFilters.species_treated) {
-        // DONE
-        console.log('\n[SPECIES TREATED]: ', gridFilters.species_treated, '\n');
-        sqlStatement.append(SQL` AND a.species_treated_full LIKE '%'||`);
-        sqlStatement.append(SQL`${gridFilters.species_treated}`);
+        console.log('\n[REGIONAL DISTRICTS]: ', gridFilters.regional_districts, '\n');
+        sqlStatement.append(SQL` AND LOWER(a.regional_districts) LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.regional_districts})`);
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.biogeoclimatic_zones) {
-        // format: string array of codes NOT IMPLEMENTED
-        // source: activity_incoming_data.biogeoclimatic_zones
+        // DONE
         console.log('\n[BIOGEOCLIMATIC ZONES]: ', gridFilters.biogeoclimatic_zones, '\n');
+        sqlStatement.append(SQL` AND LOWER(a.biogeoclimatic_zones) LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.biogeoclimatic_zones})`);
+        sqlStatement.append(SQL`||'%'`);
+      }
+      if (gridFilters.elevation) {
+        // DONE + case ins unnecessary 
+        sqlStatement.append(SQL` AND a.elevation::text LIKE '%'||`);
+        sqlStatement.append(SQL`${gridFilters.elevation}`);
+        sqlStatement.append(SQL`||'%'`);
       }
     }
   }

--- a/api/src/queries/activity-queries.ts
+++ b/api/src/queries/activity-queries.ts
@@ -288,11 +288,9 @@ export const getActivitiesSQL = (searchCriteria: ActivitySearchCriteria, lean: b
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.received_timestamp) {
-        //
-        // @@@@@      Date formatting done in SQL, needs rethinking here       *****&&&&&&*******@@@@@@@@@@
-        //
+        // DONE
         console.log('\n[RECEIVED TIMESTAMP]: ', gridFilters.received_timestamp, '\n');
-        sqlStatement.append(SQL` AND LOWER(a.received_timestamp::text) LIKE '%'||`);
+        sqlStatement.append(SQL` AND LOWER(to_char(a.received_timestamp at time zone 'UTC' at time zone 'America/Vancouver', 'Dy, Mon DD YYYY HH24:MI:SS')::text) LIKE '%'||`);
         sqlStatement.append(SQL`LOWER(${gridFilters.received_timestamp})`);
         sqlStatement.append(SQL`||'%'`);
       }

--- a/api/src/queries/activity-queries.ts
+++ b/api/src/queries/activity-queries.ts
@@ -334,14 +334,25 @@ export const getActivitiesSQL = (searchCriteria: ActivitySearchCriteria, lean: b
         console.log('\n[RECEIVED TIMESTAMP]: ', gridFilters.received_timestamp, '\n');
       }
       if (gridFilters.species_positive) {
-        // format: string array of codes NOT IMPLEMENTED
-        // source: activity_incoming_data.species_positive
+        // DONE
         console.log('\n[SPECIES POSITIVE]: ', gridFilters.species_positive, '\n');
+        sqlStatement.append(SQL` AND a.species_positive_full LIKE '%'||`);
+        sqlStatement.append(SQL`${gridFilters.species_positive}`);
+        sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.species_negative) {
-        // format: string array of codes NOT IMPLEMENTED
-        // source: activity_incoming_data.species_negative
+        // DONE
         console.log('\n[SPECIES NEGATIVE]: ', gridFilters.species_negative, '\n');
+        sqlStatement.append(SQL` AND a.species_negative_full LIKE '%'||`);
+        sqlStatement.append(SQL`${gridFilters.species_negative}`);
+        sqlStatement.append(SQL`||'%'`);
+      }
+      if (gridFilters.species_treated) {
+        // DONE
+        console.log('\n[SPECIES TREATED]: ', gridFilters.species_treated, '\n');
+        sqlStatement.append(SQL` AND a.species_treated_full LIKE '%'||`);
+        sqlStatement.append(SQL`${gridFilters.species_treated}`);
+        sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.biogeoclimatic_zones) {
         // format: string array of codes NOT IMPLEMENTED

--- a/api/src/queries/activity-queries.ts
+++ b/api/src/queries/activity-queries.ts
@@ -294,9 +294,9 @@ export const getActivitiesSQL = (searchCriteria: ActivitySearchCriteria, lean: b
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.elevation) {
-        // DONE (Sammy) (( NEEDS WORK ))
+        // DONE
         console.log('\n[ELEVATION]: ', gridFilters.elevation, '\n');
-        sqlStatement.append(SQL` AND a.activity_payload ->> 'elevation' LIKE '%'||`);
+        sqlStatement.append(SQL` AND a.elevation::text LIKE '%'||`);
         sqlStatement.append(SQL`${gridFilters.elevation}`);
         sqlStatement.append(SQL`||'%'`);
       }

--- a/api/src/queries/activity-queries.ts
+++ b/api/src/queries/activity-queries.ts
@@ -263,6 +263,93 @@ export const getActivitiesSQL = (searchCriteria: ActivitySearchCriteria, lean: b
 
     sqlStatement.append(SQL`)`);
   }
+  console.log('$$$$ BEFORE IF GRID FILTERS STATEMENT, ', searchCriteria);
+  if (searchCriteria.grid_filters) {
+    console.log('$$$$ GRID FILTERS $$$$');
+    console.log(searchCriteria.grid_filters);
+    const gridFilters = searchCriteria.grid_filters;
+    if (gridFilters.enabled) {
+      if (gridFilters.type) {
+        // DONE (Sammy) + confirmed
+        sqlStatement.append(SQL` AND a.activity_type::text LIKE '%'||`);
+        sqlStatement.append(SQL`${gridFilters.type}`);
+        sqlStatement.append(SQL`||'%'`);
+      }
+      if (gridFilters.subtype) {
+        // DONE (Sammy) + confirmed
+        sqlStatement.append(SQL` AND a.activity_subtype::text LIKE '%'||`);
+        sqlStatement.append(SQL`${gridFilters.subtype}`);
+        sqlStatement.append(SQL`||'%'`);
+      }
+      if (gridFilters.created_by) {
+        // DONE (Sammy) + confirmed
+        sqlStatement.append(SQL` AND a.created_by::text LIKE '%'||`);
+        sqlStatement.append(SQL`${gridFilters.created_by}`);
+        sqlStatement.append(SQL`||'%'`);
+      }
+      if (gridFilters.short_id) {
+        // DONE (Sammy) + confirmed
+        sqlStatement.append(SQL` AND a.activity_payload ->> 'short_id' LIKE '%'||`);
+        sqlStatement.append(SQL`${gridFilters.short_id}`);
+        sqlStatement.append(SQL`||'%'`);
+      }
+      if (gridFilters.elevation) {
+        // DONE (Sammy) (( NEEDS WORK ))
+        console.log('\n[ELEVATION]: ', gridFilters.elevation, '\n');
+        sqlStatement.append(SQL` AND a.activity_payload ->> 'elevation' LIKE '%'||`);
+        sqlStatement.append(SQL`${gridFilters.elevation}`);
+        sqlStatement.append(SQL`||'%'`);
+      }
+      if (gridFilters.agency) {
+        // DONE (Sammy) + confirmed
+        console.log('\n[INVASIVE SPECIES AGENCY CODE]: ', gridFilters.agency, '\n');
+        sqlStatement.append(
+          SQL` AND a.activity_payload::jsonb->'form_data'->'activity_data'->>'invasive_species_agency_code' LIKE '%'||`
+        );
+        sqlStatement.append(SQL`${gridFilters.agency}`);
+        sqlStatement.append(SQL`||'%'`);
+      }
+      if (gridFilters.regional_districts) {
+        // format: string array of codes NOT IMPLEMENTED
+        // source: activity_payload.regional_districts
+        console.log('\n[REGIONAL DISTRICTS]: ', gridFilters.regional_districts, '\n');
+      }
+      if (gridFilters.regional_invasive_species_organization_areas) {
+        // Format: string array of codes NOT IMPLEMENTED
+        // source: activity_incoming_data.activity_payload.regional_invasive_species_organization_areas
+        console.log(
+          '\n[REGIONAL INVASIVE SPECIES ORGANIZATION AREAS]: ',
+          gridFilters.regional_invasive_species_organization_areas,
+          '\n'
+        );
+      }
+      if (gridFilters.jurisdiction) {
+        // Note: "Jurisdiction" property of activity_payload is not the source of truth for jurisdiction.
+        // See: activity_payload.form_data.activity_data.jurisdictions for the source of truth.
+        console.log('\n[JURISDICTION]: ', gridFilters.jurisdiction, '\n');
+      }
+      if (gridFilters.received_timestamp) {
+        // format: iso date string NOT IMPLEMENTED
+        // source: activity_incoming_data.received_timestamp
+        console.log('\n[RECEIVED TIMESTAMP]: ', gridFilters.received_timestamp, '\n');
+      }
+      if (gridFilters.species_positive) {
+        // format: string array of codes NOT IMPLEMENTED
+        // source: activity_incoming_data.species_positive
+        console.log('\n[SPECIES POSITIVE]: ', gridFilters.species_positive, '\n');
+      }
+      if (gridFilters.species_negative) {
+        // format: string array of codes NOT IMPLEMENTED
+        // source: activity_incoming_data.species_negative
+        console.log('\n[SPECIES NEGATIVE]: ', gridFilters.species_negative, '\n');
+      }
+      if (gridFilters.biogeoclimatic_zones) {
+        // format: string array of codes NOT IMPLEMENTED
+        // source: activity_incoming_data.biogeoclimatic_zones
+        console.log('\n[BIOGEOCLIMATIC ZONES]: ', gridFilters.biogeoclimatic_zones, '\n');
+      }
+    }
+  }
 
   if (searchCriteria.created_by && searchCriteria.created_by.length) {
     sqlStatement.append(SQL` AND created_by IN (`);

--- a/app/src/components/activities-list/Tables/ActivityTablesHelpers.tsx
+++ b/app/src/components/activities-list/Tables/ActivityTablesHelpers.tsx
@@ -124,7 +124,7 @@ export const mapActivitiesToDataGridRows = (activities) => {
       species_treated: activity?.species_treated_full,
       created_by: activity?.created_by,
       updated_by: activity?.updated_by,
-      agency: activity?.activity_payload?.form_data?.activity_data?.invasive_species_agency_code, // Not in payload atm
+      agency: activity?.agency,
       regional_invasive_species_organization_areas: activity?.regional_invasive_species_organization_areas,
       regional_districts: activity?.regional_districts,
       biogeoclimatic_zones: activity?.biogeoclimatic_zones,

--- a/app/src/components/activities-list/Tables/ActivityTablesHelpers.tsx
+++ b/app/src/components/activities-list/Tables/ActivityTablesHelpers.tsx
@@ -109,7 +109,7 @@ export const mapActivitiesToDataGridRows = (activities) => {
       short_id: activity?.activity_payload?.short_id,
       type: activity?.activity_payload?.activity_type,
       subtype: ActivitySubtypeShortLabels[activity?.activity_payload?.activity_subtype],
-      received_timestamp: new Date(activity?.activity_payload?.received_timestamp).toString(),
+      received_timestamp: new Date(activity?.received_timestamp).toString(),
       jurisdiction: activity?.activity_payload?.jurisdiction
         ? activity?.activity_payload?.jurisdiction
         : activity?.activity_payload?.form_data?.activity_data?.jurisdictions?.map((jurisdiction, index) => {

--- a/app/src/components/activities-list/Tables/ActivityTablesHelpers.tsx
+++ b/app/src/components/activities-list/Tables/ActivityTablesHelpers.tsx
@@ -1,23 +1,22 @@
 import { ActivitySubtypeShortLabels } from 'constants/activities';
 
 export interface ActivityRow {
-  activity_id: string;
-  short_id: string;
-  type: string;
-  sub_type: string;
-  received_timestamp: string;
-  jurisdiction: string[];
-  species_positive: string;
-  species_negative: string;
-  species_treated: string;
-  created_by: string;
+  activity_id: string; // activity_incoming_data.activity_id
+  short_id: string; // activity_incoming_data.activity_payload.short_id
+  type: string; // activity_incoming_data.activity_type
+  subtype: string; // activity_incoming_data.activity_subtype
+  received_timestamp: string; // activity_incoming_data.received_timestamp
+  jurisdiction: string[]; // activity_incoming_data.jurisdiction
+  species_positive: string[]; // activity_incoming_data.species_positive ***
+  species_negative: string[]; // activity_incoming_data.species_negative ***
+  species_treated: string[];
+  created_by: string; // activity_incoming_data.created_by
   updated_by: string;
-  agency: string;
-  regional_invasive_species_organization_areas: string;
-  regional_districts: string;
-  biogeoclimatic_zones: string;
-  elevation: string;
-  // date_modified: string; // Not on csv from crystals outline
+  agency: string; // activity_incoming_data.activity_payload.form_data.activity_data.invasive_species_agency_code
+  regional_invasive_species_organization_areas: string; // activity_incoming_data.activity_payload.regional_invasive_species_organization_areas
+  regional_districts: string; // activity_payload.regional_districts
+  biogeoclimatic_zones: string; // activity_payload.biogeoclimatic_zones
+  elevation: string; // activity_payload.form_data.activity_data.elevation
 }
 
 export const activites_default_headers = [
@@ -30,7 +29,7 @@ export const activites_default_headers = [
     name: 'Activity Type'
   },
   {
-    key: 'activity_subtype',
+    key: 'subtype',
     name: 'Activity Sub Type'
   },
   {
@@ -103,24 +102,32 @@ export const mapActivitiesToDataGridRows = (activities) => {
   }
 
   return activities?.rows?.map((activity, index) => {
+    console.log("activity row: ", activity);
     return {
       // id: index,
       activity_id: activity?.activity_id,
       short_id: activity?.activity_payload?.short_id,
       type: activity?.activity_payload?.activity_type,
-      activity_type: activity?.activity_payload?.activity_type,
-      activity_subtype: ActivitySubtypeShortLabels[activity?.activity_payload?.activity_subtype],
+      subtype: ActivitySubtypeShortLabels[activity?.activity_payload?.activity_subtype],
       received_timestamp: new Date(activity?.activity_payload?.received_timestamp).toString(),
-      jurisdiction: activity?.activity_payload?.jurisdiction,
-      species_positive: activity?.species_positive_full,
-      species_negative: activity?.species_negative_full,
-      species_treated: activity?.species_treated_full,
+      jurisdiction: activity?.activity_payload?.jurisdiction
+        ? activity?.activity_payload?.jurisdiction
+        : activity?.activity_payload?.form_data?.activity_data?.jurisdictions?.map((jurisdiction, index) => {
+            if (index === activity?.activity_payload?.form_data?.activity_data?.jurisdictions?.length - 1) {
+              return jurisdiction?.jurisdiction_code;
+            } else {
+              return jurisdiction?.jurisdiction_code + ', ';
+            }
+          }),
+      species_positive: activity?.activity_payload?.species_positive,
+      species_negative: activity?.activity_payload?.species_negative,
+      species_treated: activity?.activity_payload?.species_treated,
       created_by: activity?.created_by,
       updated_by: activity?.updated_by,
       agency: activity?.activity_payload?.form_data?.activity_data?.invasive_species_agency_code, // Not in payload atm
       regional_invasive_species_organization_areas: activity?.regional_invasive_species_organization_areas,
-      regional_districts: activity?.regional_districts,
-      biogeoclimatic_zones: activity?.biogeoclimatic_zones,
+      regional_districts: activity?.activity_payload?.regional_districts?.join(', ') || '',
+      biogeoclimatic_zones: activity?.activity_payload?.biogeoclimatic_zones?.join(', ') || '',
       elevation: activity?.elevation
       // date_modified: new Date(activity?.activity_payload?.created_timestamp).toString(),
       // reported_area: activity?.activity_payload?.form_data?.activity_data?.reported_area,

--- a/app/src/components/activities-list/Tables/ActivityTablesHelpers.tsx
+++ b/app/src/components/activities-list/Tables/ActivityTablesHelpers.tsx
@@ -119,9 +119,9 @@ export const mapActivitiesToDataGridRows = (activities) => {
               return jurisdiction?.jurisdiction_code + ', ';
             }
           }),
-      species_positive: activity?.activity_payload?.species_positive,
-      species_negative: activity?.activity_payload?.species_negative,
-      species_treated: activity?.activity_payload?.species_treated,
+      species_positive: activity?.species_positive_full,
+      species_negative: activity?.species_negative_full,
+      species_treated: activity?.species_treated_full,
       created_by: activity?.created_by,
       updated_by: activity?.updated_by,
       agency: activity?.activity_payload?.form_data?.activity_data?.invasive_species_agency_code, // Not in payload atm

--- a/app/src/components/activities-list/Tables/ActivityTablesHelpers.tsx
+++ b/app/src/components/activities-list/Tables/ActivityTablesHelpers.tsx
@@ -126,8 +126,8 @@ export const mapActivitiesToDataGridRows = (activities) => {
       updated_by: activity?.updated_by,
       agency: activity?.activity_payload?.form_data?.activity_data?.invasive_species_agency_code, // Not in payload atm
       regional_invasive_species_organization_areas: activity?.regional_invasive_species_organization_areas,
-      regional_districts: activity?.activity_payload?.regional_districts?.join(', ') || '',
-      biogeoclimatic_zones: activity?.activity_payload?.biogeoclimatic_zones?.join(', ') || '',
+      regional_districts: activity?.regional_districts,
+      biogeoclimatic_zones: activity?.biogeoclimatic_zones,
       elevation: activity?.elevation
       // date_modified: new Date(activity?.activity_payload?.created_timestamp).toString(),
       // reported_area: activity?.activity_payload?.form_data?.activity_data?.reported_area,

--- a/app/src/components/activities-list/Tables/ActivityTablesHelpers.tsx
+++ b/app/src/components/activities-list/Tables/ActivityTablesHelpers.tsx
@@ -110,15 +110,7 @@ export const mapActivitiesToDataGridRows = (activities) => {
       type: activity?.activity_payload?.activity_type,
       subtype: ActivitySubtypeShortLabels[activity?.activity_payload?.activity_subtype],
       received_timestamp: new Date(activity?.received_timestamp).toString(),
-      jurisdiction: activity?.activity_payload?.jurisdiction
-        ? activity?.activity_payload?.jurisdiction
-        : activity?.activity_payload?.form_data?.activity_data?.jurisdictions?.map((jurisdiction, index) => {
-            if (index === activity?.activity_payload?.form_data?.activity_data?.jurisdictions?.length - 1) {
-              return jurisdiction?.jurisdiction_code;
-            } else {
-              return jurisdiction?.jurisdiction_code + ', ';
-            }
-          }),
+      jurisdiction: activity?.jurisdiction_display,
       species_positive: activity?.species_positive_full,
       species_negative: activity?.species_negative_full,
       species_treated: activity?.species_treated_full,

--- a/app/src/components/activities-list/Tables/Plant/ActivityGrid.tsx
+++ b/app/src/components/activities-list/Tables/Plant/ActivityGrid.tsx
@@ -320,9 +320,6 @@ const ActivityGrid = (props) => {
       0,
       20
     );
-    console.log("get activities, gimme the filters enabled and then filters");
-    console.log(filters.enabled);
-    console.log(filters);
 
     const act_list = await dataAccess.getActivities(filter);
     if (act_list && !act_list.count) {
@@ -722,7 +719,8 @@ const ActivityGrid = (props) => {
       filterDialog,
       advancedFilterRows,
       filters,
-      activities
+      activities,
+      sortedRows
     ]
   );
 };

--- a/app/src/features/home/activity/ActivityPage.tsx
+++ b/app/src/features/home/activity/ActivityPage.tsx
@@ -291,7 +291,7 @@ const ActivityPage: React.FC<IActivityPageProps> = (props) => {
     let userNameInject = '';
     let applicatorLicenseInject = '';
     let employerInject = '';
-    let agenciesInject = '';
+    let agenciesInject = [];
     let psnInject = '';
 
     if (activity_type_data?.activity_persons) {

--- a/database/src/migrations/0012_agency_full_name_update_trigger.ts
+++ b/database/src/migrations/0012_agency_full_name_update_trigger.ts
@@ -1,0 +1,94 @@
+import { Knex } from 'knex';
+
+const table_name = 'admin_defined_shapes';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+
+  --      migration     --
+
+  set search_path=invasivesbc,public;
+
+  -- Add column to pull agencies from
+  ALTER TABLE activity_incoming_data DROP COLUMN IF EXISTS agency, ADD COLUMN agency TEXT;
+
+  -- Get mapping table of agencies
+  WITH codes AS 
+    (SELECT * FROM code WHERE code_header_id = 181),
+  -- Get rows of the listed agencies
+  payload AS 
+    (SELECT 
+      activity_incoming_data_id AS id,
+      string_to_array(activity_payload->'form_data'->'activity_data'->>'invasive_species_agency_code', ',') AS acronym 
+    FROM activity_incoming_data),
+  -- Map unnested rows to proper. full code_description names
+  mapped AS 
+    (SELECT id, unnested_code_name, code_description 
+    FROM 
+      (SELECT id, UNNEST(acronym) AS unnested_code_name FROM payload) AS foo, 
+      codes
+    WHERE code_name = unnested_code_name),
+  -- Collect mapped descriptions by their id
+  collected AS
+    (SELECT id, array_to_string(ARRAY_AGG(code_description), ', ') AS agency_list FROM mapped GROUP BY id)
+  -- Update column
+  UPDATE activity_incoming_data
+  SET agency = agency_list
+  FROM collected
+  WHERE activity_incoming_data_id = collected.id;
+
+
+
+  CREATE OR REPLACE FUNCTION agency_mapping()
+      RETURNS TRIGGER
+      LANGUAGE PLPGSQL
+      AS  
+  $$
+  BEGIN
+    set search_path=invasivesbc,public;
+    
+    -- Get mapping table of agencies
+    WITH codes AS 
+      (SELECT * FROM code WHERE code_header_id = 181),
+    -- Get rows of the listed agencies
+    payload AS 
+      (SELECT 
+        activity_incoming_data_id AS id,
+        string_to_array(activity_payload->'form_data'->'activity_data'->>'invasive_species_agency_code', ',') AS acronym 
+      FROM activity_incoming_data),
+    -- Map unnested rows to proper. full code_description names
+    mapped AS 
+      (SELECT id, unnested_code_name, code_description 
+      FROM 
+        (SELECT id, UNNEST(acronym) AS unnested_code_name FROM payload) AS foo, 
+        codes
+      WHERE code_name = unnested_code_name),
+    -- Collect mapped descriptions by their id
+    collected AS
+      (SELECT id, array_to_string(ARRAY_AGG(code_description), ', ') AS agency_list FROM mapped GROUP BY id)
+    
+    -- Update column
+    UPDATE activity_incoming_data
+    SET agency = agency_list
+    FROM collected
+    WHERE activity_incoming_data_id = collected.id AND activity_incoming_data_id = NEW.activity_incoming_data_id;
+
+      RETURN NEW;
+  END
+  $$;
+
+  DROP TRIGGER IF EXISTS agency_full_name ON activity_incoming_data;
+  CREATE TRIGGER agency_full_name 
+  AFTER INSERT 
+  ON activity_incoming_data
+  FOR EACH ROW 
+  EXECUTE PROCEDURE agency_mapping();
+  END
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`set schema 'invasivesbc';
+    set search_path = invasivesbc,public;
+    DROP TRIGGER IF EXISTS agency_full_name ON activity_incoming_data;`);
+}

--- a/database/src/migrations/0012_agency_full_name_update_trigger.ts
+++ b/database/src/migrations/0012_agency_full_name_update_trigger.ts
@@ -4,17 +4,16 @@ const table_name = 'admin_defined_shapes';
 
 export async function up(knex: Knex): Promise<void> {
   await knex.raw(`
-
-  --      migration     --
-
   set search_path=invasivesbc,public;
 
   -- Add column to pull agencies from
   ALTER TABLE activity_incoming_data DROP COLUMN IF EXISTS agency, ADD COLUMN agency TEXT;
-
+  
   -- Get mapping table of agencies
   WITH codes AS 
-    (SELECT * FROM code WHERE code_header_id = 181),
+    (SELECT * FROM code WHERE code_header_id = (
+      SELECT code_header_id FROM code_header WHERE code_header_description = 'invasive_species_agency_code')
+    ),
   -- Get rows of the listed agencies
   payload AS 
     (SELECT 
@@ -49,7 +48,9 @@ export async function up(knex: Knex): Promise<void> {
     
     -- Get mapping table of agencies
     WITH codes AS 
-      (SELECT * FROM code WHERE code_header_id = 181),
+      (SELECT * FROM code WHERE code_header_id = (
+        SELECT code_header_id FROM code_header WHERE code_header_description = 'invasive_species_agency_code')
+      ),
     -- Get rows of the listed agencies
     payload AS 
       (SELECT 

--- a/database/src/migrations/0013_jurisdiction_full_name_update_trigger.ts
+++ b/database/src/migrations/0013_jurisdiction_full_name_update_trigger.ts
@@ -1,0 +1,93 @@
+import { Knex } from 'knex';
+
+const table_name = 'admin_defined_shapes';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+  --				migration				--
+
+  set search_path=invasivesbc,public;
+
+  ALTER TABLE activity_incoming_data DROP COLUMN IF EXISTS jurisdiction_display, ADD COLUMN jurisdiction_display TEXT;
+
+  -- Get mapping table
+  WITH codes AS
+    (SELECT * FROM code WHERE code_header_id = (
+      SELECT code_header_id FROM code_header WHERE code_header_description = 'jurisdiction_code')
+    ),
+  -- Get jurisdiction codes
+  mapped AS
+    (SELECT activity_id, jurisdiction_percentage, code_description
+  FROM activity_jurisdictions, codes
+  WHERE jurisdiction_code = code_name),
+  -- Collect jurisdiction codes into strings 
+  stringified AS
+    (SELECT 
+      activity_id, 
+      STRING_AGG(code_description::text || ' (' || jurisdiction_percentage::TEXT || '%)', ', ') AS jurisdictions
+    FROM mapped
+    GROUP BY activity_id)
+    
+
+  UPDATE activity_incoming_data 
+  SET jurisdiction_display = s.jurisdictions
+  FROM stringified s
+  WHERE activity_incoming_data.activity_id = s.activity_id;
+    
+
+  --				trigger				--
+    
+
+  CREATE OR REPLACE FUNCTION jurisdiction_mapping()
+      RETURNS TRIGGER
+      LANGUAGE PLPGSQL
+      AS
+  $$
+  BEGIN
+    set search_path=invasivesbc,public;
+
+    -- Get mapping table
+    WITH codes AS 
+      (SELECT * FROM code WHERE code_header_id = (
+        SELECT code_header_id FROM code_header WHERE code_header_description = 'jurisdiction_code')
+      ),
+    -- Get jurisdiction codes
+    mapped AS 
+      (SELECT activity_id, jurisdiction_percentage, code_description
+    FROM activity_jurisdictions, codes
+    WHERE jurisdiction_code = code_name),
+    -- Collect jurisdiction codes into strings
+    stringified AS
+      (SELECT
+        activity_id,
+        STRING_AGG(code_description::text || ' (' || jurisdiction_percentage::TEXT || '%)', ', ') AS jurisdictions
+      FROM mapped
+      GROUP BY activity_id)
+
+
+    UPDATE activity_incoming_data
+    SET jurisdiction_display = s.jurisdictions
+    FROM stringified s
+    WHERE activity_incoming_data.activity_id = s.activity_id
+    AND activity_incoming_data.activity_id = NEW.activity_id;
+
+    RETURN NEW;
+  END
+  $$;
+
+  DROP TRIGGER IF EXISTS jurisdiction_full_name ON activity_incoming_data;
+  CREATE TRIGGER jurisdiction_full_name 
+  AFTER INSERT 
+  ON activity_incoming_data
+  FOR EACH ROW 
+  EXECUTE PROCEDURE jurisdiction_mapping();
+  END
+
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`set schema 'invasivesbc';
+    set search_path = invasivesbc,public;
+    DROP TRIGGER IF EXISTS jurisdiction_full_name ON activity_incoming_data;`);
+}


### PR DESCRIPTION
- Apply Sam's previous work in activity_partial_filtering and disabled javascript filtering
- Allow filtering with elevation
- Allow fuzzy matching and proper display for species positive, negative, and treated
- Fuzzy match remaining columns except timestamp and juris
- Allow filtering on recieved_timestamp
- Create migration and trigger for agency full names
- Display and allow filtering on full agency names
- Fix migration and trigger error with code header id
- Add migration and trigger for jurisdiction descriptions
- Replace jurisdiction code with full name and percentage in activity grid
- Add fuzzy matching capability for jurisdiction column
- Fix input letter delay when fetching activities

# Overview

This PR includes the following proposed change(s):

- {List all the changes, if possible add the linked issue/ticket #}
- #1838 partially
- #2045 partially
- Added migrations and triggers for jurisdiction, agency, and species names
- Allowed fuzzy matching for each column in grid data table including date received
- Fixed the input delay on column filtering

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- Manual tested by me Gabe

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
