### PR TITLE
iapp fuzzy matching

### DIFF
--- a/api/src/models/point-of-interest.ts
+++ b/api/src/models/point-of-interest.ts
@@ -86,6 +86,8 @@ export class PointOfInterestSearchCriteria {
   date_range_start: Date;
   date_range_end: Date;
 
+  grid_filters: any;
+
   point_of_interest_ids: string[];
 
   search_feature: GeoJSON.FeatureCollection;
@@ -119,6 +121,8 @@ export class PointOfInterestSearchCriteria {
 
     this.date_range_start = (obj && obj.date_range_start) || null;
     this.date_range_end = (obj && obj.date_range_end) || null;
+
+    this.grid_filters = (obj && obj.grid_filters) || null;
 
     this.search_feature = (obj && obj.search_feature) || null;
 

--- a/api/src/queries/iapp-queries.ts
+++ b/api/src/queries/iapp-queries.ts
@@ -118,20 +118,39 @@ export const getSitesBasedOnSearchCriteriaSQL = (searchCriteria: PointOfInterest
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.bio_release) {
-        // blocked
+        sqlStatement.append(SQL` AND has_biological_treatments = CASE
+        WHEN LOWER('Yes') LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.bio_release})`);
+        sqlStatement.append(SQL`||'%'`);
+        sqlStatement.append(SQL`THEN TRUE ELSE FALSE END`);
       }
       if (gridFilters.chem_treatment) {
-        // blocked
+        sqlStatement.append(SQL` AND has_chemical_treatments = CASE
+        WHEN LOWER('Yes') LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.chem_treatment})`);
+        sqlStatement.append(SQL`||'%'`);
+        sqlStatement.append(SQL`THEN TRUE ELSE FALSE END`);
       }
       if (gridFilters.mech_treatment) {
-        // blocked
+        sqlStatement.append(SQL` AND has_mechanical_treatments = CASE
+        WHEN LOWER('Yes') LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.mech_treatment})`);
+        sqlStatement.append(SQL`||'%'`);
+        sqlStatement.append(SQL`THEN TRUE ELSE FALSE END`);
       }
       if (gridFilters.bio_dispersal) {
-        // blocked
+        sqlStatement.append(SQL` AND has_biological_dispersals = CASE
+        WHEN LOWER('Yes') LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.bio_dispersal})`);
+        sqlStatement.append(SQL`||'%'`);
+        sqlStatement.append(SQL`THEN TRUE ELSE FALSE END`);
       }
       if (gridFilters.monitored) {
-        // everything is true, does this even matter
-        // 
+        // sqlStatement.append(SQL` AND has_biological_treatments = CASE
+        // WHEN LOWER('Yes') LIKE '%'||`);
+        // sqlStatement.append(SQL`LOWER(${gridFilters.monitored})`);
+        // sqlStatement.append(SQL`||'%'`);
+        // sqlStatement.append(SQL`THEN TRUE ELSE FALSE END`);
       }
 
     }

--- a/api/src/queries/iapp-queries.ts
+++ b/api/src/queries/iapp-queries.ts
@@ -20,7 +20,7 @@ export const getSitesBasedOnSearchCriteriaSQL = (searchCriteria: PointOfInterest
     ) AS anything) `);
   }
 
-  if (searchCriteria.grid_filters.jurisdictions) {
+  if (searchCriteria?.grid_filters?.jurisdictions) {
     if (searchCriteria.search_feature) sqlStatement.append(SQL`, `);
     sqlStatement.append(SQL`WITH strings AS (SELECT site_id, array_to_string(jurisdictions, ', ') AS j_string FROM iapp_site_summary_and_geojson) `);
   }
@@ -34,7 +34,7 @@ export const getSitesBasedOnSearchCriteriaSQL = (searchCriteria: PointOfInterest
     //   ON i.site_id = p.point_of_interest_incoming_id WHERE 1=1`
   );
 
-  if (searchCriteria.grid_filters.jurisdictions) {
+  if (searchCriteria?.grid_filters?.jurisdictions) {
     sqlStatement.append(SQL` INNER JOIN strings j ON i.site_id = j.site_id`);
   }
 
@@ -88,14 +88,14 @@ export const getSitesBasedOnSearchCriteriaSQL = (searchCriteria: PointOfInterest
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.paper_file_id) {
-        //gonna be difficult, comes from extract
+        sqlStatement.append(SQL` AND LOWER(i.site_paper_file_id::text) LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.paper_file_id})`);
+        sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.jurisdictions) {
         sqlStatement.append(SQL` AND LOWER(j.j_string) LIKE '%'||`);
         sqlStatement.append(SQL`LOWER(${gridFilters.jurisdictions})`);
         sqlStatement.append(SQL`||'%'`);
-
-        //gonna have to do the same thing as activity with its array checking...
       }
       if (gridFilters.date_created) {
         sqlStatement.append(SQL` AND LOWER(i.min_survey::text) LIKE '%'||`);
@@ -113,7 +113,9 @@ export const getSitesBasedOnSearchCriteriaSQL = (searchCriteria: PointOfInterest
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.agencies) {
-        // can't find, difficult
+        sqlStatement.append(SQL` AND LOWER(i.agencies::text) LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.agencies})`);
+        sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.bio_release) {
         // blocked
@@ -129,6 +131,7 @@ export const getSitesBasedOnSearchCriteriaSQL = (searchCriteria: PointOfInterest
       }
       if (gridFilters.monitored) {
         // everything is true, does this even matter
+        // 
       }
 
     }

--- a/api/src/queries/iapp-queries.ts
+++ b/api/src/queries/iapp-queries.ts
@@ -63,6 +63,72 @@ export const getSitesBasedOnSearchCriteriaSQL = (searchCriteria: PointOfInterest
     }
   }
 
+  // grid filtering
+  console.log('\n\n%%%%%%%%%%%%%%%%%%%%%%% GRID FILTERS @@@@@@@\n\n\n\n\n\n\n\n\n\n\n\n');
+  if (searchCriteria.grid_filters) {
+    console.log('$$$$ GRID FILTERS @@@@@@@');
+    console.log(searchCriteria.grid_filters);
+
+    const gridFilters = searchCriteria.grid_filters;
+    if (gridFilters.enabled) {
+      if (gridFilters.point_of_interest_id) {
+        sqlStatement.append(SQL` AND i.site_id::text LIKE '%'||`);
+        sqlStatement.append(SQL`${gridFilters.point_of_interest_id}`);
+        sqlStatement.append(SQL`||'%'`);
+      }
+      if (gridFilters.paper_file_id) {
+        //gonna be difficult, comes from extract
+      }
+      if (gridFilters.jurisdictions) {
+        // sqlStatement.append(
+        //   SQL` AND LOWER(i.jurisdictions) LIKE '%'||`
+        // );
+        // sqlStatement.append(SQL`LOWER(${gridFilters.jurisdictions})`);
+        // sqlStatement.append(SQL`||'%'`);
+
+        //gonna have to do the same thing as activity with its array checking...
+      }
+      if (gridFilters.date_created) {
+        // doesn't work fully because of mismatches
+
+        // sqlStatement.append(SQL` AND LOWER(i.min_survey::text) LIKE '%'||`);
+        // sqlStatement.append(SQL`LOWER(${gridFilters.date_created})`);
+        // sqlStatement.append(SQL`||'%'`);
+      }
+      if (gridFilters.species_on_site) {
+        sqlStatement.append(SQL` AND LOWER(i.all_species_on_site) LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.species_on_site})`);
+        sqlStatement.append(SQL`||'%'`);
+      }
+      if (gridFilters.date_last_surveyed) {
+        // doesn't work either same reason
+
+        // sqlStatement.append(SQL` AND LOWER(i.max_survey::text) LIKE '%'||`);
+        // sqlStatement.append(SQL`LOWER(${gridFilters.date_last_surveyed})`);
+        // sqlStatement.append(SQL`||'%'`);
+      }
+      if (gridFilters.agencies) {
+        // can't find, difficult
+      }
+      if (gridFilters.bio_release) {
+        // blocked
+      }
+      if (gridFilters.chem_treatment) {
+        // blocked
+      }
+      if (gridFilters.mech_treatment) {
+        // blocked
+      }
+      if (gridFilters.bio_dispersal) {
+        // blocked
+      }
+      if (gridFilters.monitored) {
+        // everything is true, does this even matter
+      }
+
+    }
+  }
+
   // search intersects with positive or negative species
   if ((searchCriteria.species_positive && searchCriteria.species_positive.length) || 
       (searchCriteria.species_negative && searchCriteria.species_negative.length)) {

--- a/api/src/queries/iapp-queries.ts
+++ b/api/src/queries/iapp-queries.ts
@@ -98,11 +98,9 @@ export const getSitesBasedOnSearchCriteriaSQL = (searchCriteria: PointOfInterest
         //gonna have to do the same thing as activity with its array checking...
       }
       if (gridFilters.date_created) {
-        // doesn't work fully because of mismatches
-
-        // sqlStatement.append(SQL` AND LOWER(i.min_survey::text) LIKE '%'||`);
-        // sqlStatement.append(SQL`LOWER(${gridFilters.date_created})`);
-        // sqlStatement.append(SQL`||'%'`);
+        sqlStatement.append(SQL` AND LOWER(i.min_survey::text) LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.date_created})`);
+        sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.species_on_site) {
         sqlStatement.append(SQL` AND LOWER(i.all_species_on_site) LIKE '%'||`);
@@ -110,11 +108,9 @@ export const getSitesBasedOnSearchCriteriaSQL = (searchCriteria: PointOfInterest
         sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.date_last_surveyed) {
-        // doesn't work either same reason
-
-        // sqlStatement.append(SQL` AND LOWER(i.max_survey::text) LIKE '%'||`);
-        // sqlStatement.append(SQL`LOWER(${gridFilters.date_last_surveyed})`);
-        // sqlStatement.append(SQL`||'%'`);
+        sqlStatement.append(SQL` AND LOWER(i.max_survey::text) LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.date_last_surveyed})`);
+        sqlStatement.append(SQL`||'%'`);
       }
       if (gridFilters.agencies) {
         // can't find, difficult

--- a/api/src/queries/iapp-queries.ts
+++ b/api/src/queries/iapp-queries.ts
@@ -75,11 +75,7 @@ export const getSitesBasedOnSearchCriteriaSQL = (searchCriteria: PointOfInterest
   }
 
   // grid filtering
-  console.log('\n\n%%%%%%%%%%%%%%%%%%%%%%% GRID FILTERS @@@@@@@\n\n\n\n\n\n\n\n\n\n\n\n');
   if (searchCriteria.grid_filters) {
-    console.log('$$$$ GRID FILTERS @@@@@@@');
-    console.log(searchCriteria.grid_filters);
-
     const gridFilters = searchCriteria.grid_filters;
     if (gridFilters.enabled) {
       if (gridFilters.point_of_interest_id) {

--- a/api/src/queries/iapp-queries.ts
+++ b/api/src/queries/iapp-queries.ts
@@ -146,11 +146,15 @@ export const getSitesBasedOnSearchCriteriaSQL = (searchCriteria: PointOfInterest
         sqlStatement.append(SQL`THEN TRUE ELSE FALSE END`);
       }
       if (gridFilters.monitored) {
-        // sqlStatement.append(SQL` AND has_biological_treatments = CASE
-        // WHEN LOWER('Yes') LIKE '%'||`);
-        // sqlStatement.append(SQL`LOWER(${gridFilters.monitored})`);
-        // sqlStatement.append(SQL`||'%'`);
-        // sqlStatement.append(SQL`THEN TRUE ELSE FALSE END`);
+        sqlStatement.append(SQL` AND (
+          (has_biological_treatment_monitorings = TRUE 
+          OR has_chemical_treatment_monitorings = TRUE 
+          OR has_mechanical_treatment_monitorings = TRUE
+          )
+        AND LOWER('Yes') LIKE '%'||`);
+        sqlStatement.append(SQL`LOWER(${gridFilters.monitored})`);
+        sqlStatement.append(SQL`||'%'`);
+        sqlStatement.append(SQL`)`);
       }
 
     }

--- a/api/src/utils/iapp-json-utils.ts
+++ b/api/src/utils/iapp-json-utils.ts
@@ -295,6 +295,8 @@ const getIAPPjson = (row: any, extract: any) => {
         moti_districts: '', // Could not find
         media_keys: '', // Could not find
         jurisdictions: row.jurisdictions,
+        date_created: row.min_survey,
+        date_last_surveyed: row.max_survey,
         species_positive: [], // Could not find
         species_negative: [] // Could not find
       }

--- a/app/src/components/activities-list/Tables/POITablesHelpers.tsx
+++ b/app/src/components/activities-list/Tables/POITablesHelpers.tsx
@@ -67,7 +67,6 @@ export const mapPOI_IAPP_ToDataGridRows = (activities) => {
   }
 
   return activities?.rows?.map((record, index) => {
-    let lastSurveyed = new Date(record?.point_of_interest_payload?.form_data?.point_of_interest_data?.date_created);
     let agencies = new Set();
     let species = new Set();
     const jurisdictions = record?.point_of_interest_payload?.jurisdictions;
@@ -81,10 +80,6 @@ export const mapPOI_IAPP_ToDataGridRows = (activities) => {
     const monitored = record?.point_of_interest_payload?.form_data?.monitored;
 
     for (const survey of surveys) {
-      // last survey date
-      const survey_date = new Date(survey?.survey_date);
-      if (survey_date > lastSurveyed) lastSurveyed = survey_date;
-
       // agency
       agencies.add(survey?.invasive_species_agency_code);
 
@@ -96,11 +91,9 @@ export const mapPOI_IAPP_ToDataGridRows = (activities) => {
       point_of_interest_id: record?.point_of_interest_id,
       paper_file_id: record?.point_of_interest_payload?.form_data?.point_of_interest_data?.project_code[0]?.description,
       jurisdictions: jurisdictions ? jurisdictions : null,
-      date_created: new Date(record?.point_of_interest_payload?.form_data?.point_of_interest_data?.date_created)
-        .toISOString()
-        .substring(0, 10),
+      date_created: new Date(record?.point_of_interest_payload?.date_created).toISOString().substring(0, 10),
       species_on_site: Array.from(species).join(', '),
-      date_last_surveyed: lastSurveyed.toISOString().substring(0, 10),
+      date_last_surveyed: new Date(record?.point_of_interest_payload?.date_last_surveyed).toISOString().substring(0, 10),
       agencies: Array.from(agencies).join(', '),
       bio_release: bioRelease,
       chem_treatment: chemTreatment,

--- a/app/src/components/activities-list/Tables/Plant/ActivityGrid.tsx
+++ b/app/src/components/activities-list/Tables/Plant/ActivityGrid.tsx
@@ -345,7 +345,7 @@ const ActivityGrid = (props) => {
       userSettings?.recordSets,
       props.setName,
       true,
-      null,
+      filters.enabled ? filters : null,
       0,
       20
     );

--- a/database/src/migrations/0014_iapp_extra_fuzzy_columns.ts
+++ b/database/src/migrations/0014_iapp_extra_fuzzy_columns.ts
@@ -1,0 +1,115 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  // Creates columns for jurisdiction and species, recalls Brian's ...02 migration, then creates/fills iapp_invbc_mapping mapping table
+  await knex.raw(`
+  	set search_path=invasivesbc,public;
+
+    drop materialized VIEW IF EXISTS invasivesbc.iapp_site_summary_and_geojson;
+    drop materialized view IF EXISTS invasivesbc.iapp_site_summary;
+
+    CREATE MATERIALIZED VIEW invasivesbc.iapp_site_summary
+      TABLESPACE pg_default
+      AS WITH jurisdiction_data AS (
+              SELECT DISTINCT regexp_split_to_array(survey_extract.jurisdictions::text, '($1<=)(, )'::text) AS jurisdictions,
+                  survey_extract.estimated_area_hectares,
+                  survey_extract.site_id
+                FROM invasivesbc.survey_extract
+              ),
+      paper_file_list AS (SELECT DISTINCT(se.site_paper_file_id), se.site_id 
+              FROM survey_extract se 
+              GROUP BY se.site_id, se.site_paper_file_id),
+	    agencies AS (SELECT sea.site_id, string_agg(DISTINCT(sea.survey_agency), ', ') AS agency_agg
+              FROM survey_extract sea 
+              GROUP BY sea.site_id)
+      SELECT i.site_id,
+        i.all_species_on_site,
+        i.decimal_longitude,
+        i.decimal_latitude,
+        i.min_survey,
+        i.max_survey,
+        i.min_chemical_treatment_dates,
+        i.max_chemical_treatment_dates,
+        i.min_chemical_treatment_monitoring_dates,
+        i.max_chemical_treatment_monitoring_dates,
+        i.min_bio_dispersal_dates,
+        i.max_bio_dispersal_dates,
+        i.min_bio_treatment_dates,
+        i.max_bio_treatment_dates,
+        i.min_bio_treatment_monitoring_dates,
+        i.max_bio_treatment_monitoring_dates,
+        i.min_mechanical_treatment_dates,
+        i.max_mechanical_treatment_dates,
+        i.min_mechanical_treatment_monitoring_dates,
+        i.max_mechanical_treatment_monitoring_dates,
+        i.has_surveys,
+        i.has_biological_treatment_monitorings,
+        i.has_biological_treatments,
+        i.has_biological_dispersals,
+        i.has_chemical_treatment_monitorings,
+        i.has_chemical_treatments,
+        i.has_mechanical_treatments,
+        i.has_mechanical_treatment_monitorings,
+        jd.jurisdictions,
+        jd.estimated_area_hectares AS reported_area,
+        string_to_array(i.all_species_on_site::text, ', '::text) AS all_species_on_site_as_array,
+        p.site_paper_file_id,
+        a.agency_agg AS agencies
+      FROM invasivesbc.iapp_site_summary_slow i
+        JOIN jurisdiction_data jd ON i.site_id = jd.site_id
+        JOIN paper_file_list p ON jd.site_id = p.site_id
+        JOIN agencies a ON p.site_id = a.site_id
+      WHERE 1 = 1
+    WITH DATA;
+    
+    
+    CREATE MATERIALIZED VIEW invasivesbc.iapp_site_summary_and_geojson
+    TABLESPACE pg_default
+    AS SELECT i.site_id,
+        i.all_species_on_site,
+        i.decimal_longitude,
+        i.decimal_latitude,
+        i.min_survey,
+        i.max_survey,
+        i.min_chemical_treatment_dates,
+        i.max_chemical_treatment_dates,
+        i.min_chemical_treatment_monitoring_dates,
+        i.max_chemical_treatment_monitoring_dates,
+        i.min_bio_dispersal_dates,
+        i.max_bio_dispersal_dates,
+        i.min_bio_treatment_dates,
+        i.max_bio_treatment_dates,
+        i.min_bio_treatment_monitoring_dates,
+        i.max_bio_treatment_monitoring_dates,
+        i.min_mechanical_treatment_dates,
+        i.max_mechanical_treatment_dates,
+        i.min_mechanical_treatment_monitoring_dates,
+        i.max_mechanical_treatment_monitoring_dates,
+        i.has_surveys,
+        i.has_biological_treatment_monitorings,
+        i.has_biological_treatments,
+        i.has_biological_dispersals,
+        i.has_chemical_treatment_monitorings,
+        i.has_chemical_treatments,
+        i.has_mechanical_treatments,
+        i.has_mechanical_treatment_monitorings,
+        i.jurisdictions,
+        i.reported_area,
+        i.all_species_on_site_as_array,
+        i.site_paper_file_id,
+        i.agencies, 
+        json_build_object('type', 'Feature', 'properties', json_build_object('site_id', i.site_id, 'species', i.all_species_on_site, 'has_surveys', i.has_surveys, 'has_biological_treatments', i.has_biological_treatments, 'has_biological_monitorings', i.has_biological_treatment_monitorings, 'has_biological_dispersals', i.has_biological_dispersals, 'has_chemical_treatments', i.has_chemical_treatments, 'has_chemical_monitorings', i.has_chemical_treatment_monitorings, 'has_mechanical_treatments', i.has_mechanical_treatments, 'has_mechanical_monitorings', i.has_mechanical_treatment_monitorings, 'earliest_survey', i.min_survey, 'latest_survey', i.max_survey, 'earliest_chemical_treatment', i.min_chemical_treatment_dates, 'latest_chemical_treatment', i.max_chemical_treatment_dates, 'earliest_chemical_monitoring', i.min_chemical_treatment_monitoring_dates, 'latest_chemical_monitoring', i.max_chemical_treatment_monitoring_dates, 'earliest_bio_dispersal', i.min_bio_dispersal_dates, 'latest_bio_dispersal', i.max_bio_dispersal_dates, 'earliest_bio_treatment', i.min_bio_treatment_dates, 'latest_bio_treatment', i.max_bio_treatment_dates, 'earliest_bio_monitoring', i.min_bio_treatment_monitoring_dates, 'latest_bio_monitoring', i.max_bio_treatment_monitoring_dates, 'earliest_mechanical_treatment', i.min_mechanical_treatment_dates, 'latest_mechanical_treatment', i.max_mechanical_treatment_dates, 'earliest_mechanical_monitoring', i.min_mechanical_treatment_monitoring_dates, 'latest_mechanical_monitoring', i.max_mechanical_treatment_monitoring_dates, 'reported_area', i.reported_area, 'jurisdictions', i.jurisdictions), 'geometry', st_asgeojson(s.geog)::jsonb) AS geojson
+      FROM invasivesbc.iapp_site_summary i
+        JOIN invasivesbc.iapp_spatial s ON i.site_id = s.site_id
+      WHERE 1 = 1
+    WITH DATA;
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`
+    set search_path=invasivesbc,public;
+    drop materialized view invasivesbc.iapp_site_summary_and_geojson;
+    drop materialized view invasivesbc.iapp_site_summary;
+    `);
+}

--- a/database/src/migrations/0014_iapp_extra_fuzzy_columns.ts
+++ b/database/src/migrations/0014_iapp_extra_fuzzy_columns.ts
@@ -100,7 +100,13 @@ export async function up(knex: Knex): Promise<void> {
           i.reported_area,
           i.all_species_on_site_as_array,
           i.site_paper_file_id,
-          i.agencies, 
+          i.agencies,
+          CASE WHEN (i.has_biological_treatment_monitorings OR 
+              i.has_chemical_treatment_monitorings OR
+              i.has_mechanical_treatment_monitorings) 
+            THEN 'Yes' 
+            ELSE 'No' 
+          END AS monitored,
           json_build_object('type', 'Feature', 'properties', json_build_object('site_id', i.site_id, 'species', i.all_species_on_site, 'has_surveys', i.has_surveys, 'has_biological_treatments', i.has_biological_treatments, 'has_biological_monitorings', i.has_biological_treatment_monitorings, 'has_biological_dispersals', i.has_biological_dispersals, 'has_chemical_treatments', i.has_chemical_treatments, 'has_chemical_monitorings', i.has_chemical_treatment_monitorings, 'has_mechanical_treatments', i.has_mechanical_treatments, 'has_mechanical_monitorings', i.has_mechanical_treatment_monitorings, 'earliest_survey', i.min_survey, 'latest_survey', i.max_survey, 'earliest_chemical_treatment', i.min_chemical_treatment_dates, 'latest_chemical_treatment', i.max_chemical_treatment_dates, 'earliest_chemical_monitoring', i.min_chemical_treatment_monitoring_dates, 'latest_chemical_monitoring', i.max_chemical_treatment_monitoring_dates, 'earliest_bio_dispersal', i.min_bio_dispersal_dates, 'latest_bio_dispersal', i.max_bio_dispersal_dates, 'earliest_bio_treatment', i.min_bio_treatment_dates, 'latest_bio_treatment', i.max_bio_treatment_dates, 'earliest_bio_monitoring', i.min_bio_treatment_monitoring_dates, 'latest_bio_monitoring', i.max_bio_treatment_monitoring_dates, 'earliest_mechanical_treatment', i.min_mechanical_treatment_dates, 'latest_mechanical_treatment', i.max_mechanical_treatment_dates, 'earliest_mechanical_monitoring', i.min_mechanical_treatment_monitoring_dates, 'latest_mechanical_monitoring', i.max_mechanical_treatment_monitoring_dates, 'reported_area', i.reported_area, 'jurisdictions', i.jurisdictions), 'geometry', st_asgeojson(s.geog)::jsonb) AS geojson
         FROM invasivesbc.iapp_site_summary i
           JOIN invasivesbc.iapp_spatial s ON i.site_id = s.site_id

--- a/database/src/migrations/0014_iapp_extra_fuzzy_columns.ts
+++ b/database/src/migrations/0014_iapp_extra_fuzzy_columns.ts
@@ -12,97 +12,100 @@ export async function up(knex: Knex): Promise<void> {
       TABLESPACE pg_default
       AS WITH jurisdiction_data AS (
               SELECT DISTINCT regexp_split_to_array(survey_extract.jurisdictions::text, '($1<=)(, )'::text) AS jurisdictions,
-                  survey_extract.estimated_area_hectares,
                   survey_extract.site_id
                 FROM invasivesbc.survey_extract
               ),
       paper_file_list AS (SELECT DISTINCT(se.site_paper_file_id), se.site_id 
-              FROM survey_extract se 
-              GROUP BY se.site_id, se.site_paper_file_id),
-	    agencies AS (SELECT sea.site_id, string_agg(DISTINCT(sea.survey_agency), ', ') AS agency_agg
-              FROM survey_extract sea 
-              GROUP BY sea.site_id)
+	  	FROM survey_extract se 
+	  	GROUP BY se.site_id, se.site_paper_file_id),
+	  agencies AS (SELECT sea.site_id, string_agg(DISTINCT(sea.survey_agency), ', ') AS agency_agg
+	  	FROM survey_extract sea 
+	  	GROUP BY sea.site_id),
+	  areas AS (SELECT DISTINCT ON(z.site_id) z.site_id, z.estimated_area_hectares, z.survey_date 
+	    FROM invasivesbc.survey_extract z
+	    ORDER BY z.site_id, z.survey_date DESC)
       SELECT i.site_id,
-        i.all_species_on_site,
-        i.decimal_longitude,
-        i.decimal_latitude,
-        i.min_survey,
-        i.max_survey,
-        i.min_chemical_treatment_dates,
-        i.max_chemical_treatment_dates,
-        i.min_chemical_treatment_monitoring_dates,
-        i.max_chemical_treatment_monitoring_dates,
-        i.min_bio_dispersal_dates,
-        i.max_bio_dispersal_dates,
-        i.min_bio_treatment_dates,
-        i.max_bio_treatment_dates,
-        i.min_bio_treatment_monitoring_dates,
-        i.max_bio_treatment_monitoring_dates,
-        i.min_mechanical_treatment_dates,
-        i.max_mechanical_treatment_dates,
-        i.min_mechanical_treatment_monitoring_dates,
-        i.max_mechanical_treatment_monitoring_dates,
-        i.has_surveys,
-        i.has_biological_treatment_monitorings,
-        i.has_biological_treatments,
-        i.has_biological_dispersals,
-        i.has_chemical_treatment_monitorings,
-        i.has_chemical_treatments,
-        i.has_mechanical_treatments,
-        i.has_mechanical_treatment_monitorings,
-        jd.jurisdictions,
-        jd.estimated_area_hectares AS reported_area,
-        string_to_array(i.all_species_on_site::text, ', '::text) AS all_species_on_site_as_array,
-        p.site_paper_file_id,
-        a.agency_agg AS agencies
-      FROM invasivesbc.iapp_site_summary_slow i
-        JOIN jurisdiction_data jd ON i.site_id = jd.site_id
-        JOIN paper_file_list p ON jd.site_id = p.site_id
-        JOIN agencies a ON p.site_id = a.site_id
-      WHERE 1 = 1
-    WITH DATA;
-    
-    
-    CREATE MATERIALIZED VIEW invasivesbc.iapp_site_summary_and_geojson
-    TABLESPACE pg_default
-    AS SELECT i.site_id,
-        i.all_species_on_site,
-        i.decimal_longitude,
-        i.decimal_latitude,
-        i.min_survey,
-        i.max_survey,
-        i.min_chemical_treatment_dates,
-        i.max_chemical_treatment_dates,
-        i.min_chemical_treatment_monitoring_dates,
-        i.max_chemical_treatment_monitoring_dates,
-        i.min_bio_dispersal_dates,
-        i.max_bio_dispersal_dates,
-        i.min_bio_treatment_dates,
-        i.max_bio_treatment_dates,
-        i.min_bio_treatment_monitoring_dates,
-        i.max_bio_treatment_monitoring_dates,
-        i.min_mechanical_treatment_dates,
-        i.max_mechanical_treatment_dates,
-        i.min_mechanical_treatment_monitoring_dates,
-        i.max_mechanical_treatment_monitoring_dates,
-        i.has_surveys,
-        i.has_biological_treatment_monitorings,
-        i.has_biological_treatments,
-        i.has_biological_dispersals,
-        i.has_chemical_treatment_monitorings,
-        i.has_chemical_treatments,
-        i.has_mechanical_treatments,
-        i.has_mechanical_treatment_monitorings,
-        i.jurisdictions,
-        i.reported_area,
-        i.all_species_on_site_as_array,
-        i.site_paper_file_id,
-        i.agencies, 
-        json_build_object('type', 'Feature', 'properties', json_build_object('site_id', i.site_id, 'species', i.all_species_on_site, 'has_surveys', i.has_surveys, 'has_biological_treatments', i.has_biological_treatments, 'has_biological_monitorings', i.has_biological_treatment_monitorings, 'has_biological_dispersals', i.has_biological_dispersals, 'has_chemical_treatments', i.has_chemical_treatments, 'has_chemical_monitorings', i.has_chemical_treatment_monitorings, 'has_mechanical_treatments', i.has_mechanical_treatments, 'has_mechanical_monitorings', i.has_mechanical_treatment_monitorings, 'earliest_survey', i.min_survey, 'latest_survey', i.max_survey, 'earliest_chemical_treatment', i.min_chemical_treatment_dates, 'latest_chemical_treatment', i.max_chemical_treatment_dates, 'earliest_chemical_monitoring', i.min_chemical_treatment_monitoring_dates, 'latest_chemical_monitoring', i.max_chemical_treatment_monitoring_dates, 'earliest_bio_dispersal', i.min_bio_dispersal_dates, 'latest_bio_dispersal', i.max_bio_dispersal_dates, 'earliest_bio_treatment', i.min_bio_treatment_dates, 'latest_bio_treatment', i.max_bio_treatment_dates, 'earliest_bio_monitoring', i.min_bio_treatment_monitoring_dates, 'latest_bio_monitoring', i.max_bio_treatment_monitoring_dates, 'earliest_mechanical_treatment', i.min_mechanical_treatment_dates, 'latest_mechanical_treatment', i.max_mechanical_treatment_dates, 'earliest_mechanical_monitoring', i.min_mechanical_treatment_monitoring_dates, 'latest_mechanical_monitoring', i.max_mechanical_treatment_monitoring_dates, 'reported_area', i.reported_area, 'jurisdictions', i.jurisdictions), 'geometry', st_asgeojson(s.geog)::jsonb) AS geojson
-      FROM invasivesbc.iapp_site_summary i
-        JOIN invasivesbc.iapp_spatial s ON i.site_id = s.site_id
-      WHERE 1 = 1
-    WITH DATA;
+          i.all_species_on_site,
+          i.decimal_longitude,
+          i.decimal_latitude,
+          i.min_survey,
+          i.max_survey,
+          i.min_chemical_treatment_dates,
+          i.max_chemical_treatment_dates,
+          i.min_chemical_treatment_monitoring_dates,
+          i.max_chemical_treatment_monitoring_dates,
+          i.min_bio_dispersal_dates,
+          i.max_bio_dispersal_dates,
+          i.min_bio_treatment_dates,
+          i.max_bio_treatment_dates,
+          i.min_bio_treatment_monitoring_dates,
+          i.max_bio_treatment_monitoring_dates,
+          i.min_mechanical_treatment_dates,
+          i.max_mechanical_treatment_dates,
+          i.min_mechanical_treatment_monitoring_dates,
+          i.max_mechanical_treatment_monitoring_dates,
+          i.has_surveys,
+          i.has_biological_treatment_monitorings,
+          i.has_biological_treatments,
+          i.has_biological_dispersals,
+          i.has_chemical_treatment_monitorings,
+          i.has_chemical_treatments,
+          i.has_mechanical_treatments,
+          i.has_mechanical_treatment_monitorings,
+          jd.jurisdictions,
+          z.estimated_area_hectares AS reported_area,
+          string_to_array(i.all_species_on_site::text, ', '::text) AS all_species_on_site_as_array,
+          p.site_paper_file_id,
+          a.agency_agg AS agencies
+        FROM invasivesbc.iapp_site_summary_slow i
+          JOIN jurisdiction_data jd ON i.site_id = jd.site_id
+          JOIN paper_file_list p ON jd.site_id = p.site_id
+          JOIN agencies a ON p.site_id = a.site_id
+          JOIN areas z ON a.site_id = z.site_id
+        WHERE 1 = 1
+      WITH DATA;
+      
+      
+      CREATE MATERIALIZED VIEW invasivesbc.iapp_site_summary_and_geojson
+      TABLESPACE pg_default
+      AS SELECT i.site_id,
+          i.all_species_on_site,
+          i.decimal_longitude,
+          i.decimal_latitude,
+          i.min_survey,
+          i.max_survey,
+          i.min_chemical_treatment_dates,
+          i.max_chemical_treatment_dates,
+          i.min_chemical_treatment_monitoring_dates,
+          i.max_chemical_treatment_monitoring_dates,
+          i.min_bio_dispersal_dates,
+          i.max_bio_dispersal_dates,
+          i.min_bio_treatment_dates,
+          i.max_bio_treatment_dates,
+          i.min_bio_treatment_monitoring_dates,
+          i.max_bio_treatment_monitoring_dates,
+          i.min_mechanical_treatment_dates,
+          i.max_mechanical_treatment_dates,
+          i.min_mechanical_treatment_monitoring_dates,
+          i.max_mechanical_treatment_monitoring_dates,
+          i.has_surveys,
+          i.has_biological_treatment_monitorings,
+          i.has_biological_treatments,
+          i.has_biological_dispersals,
+          i.has_chemical_treatment_monitorings,
+          i.has_chemical_treatments,
+          i.has_mechanical_treatments,
+          i.has_mechanical_treatment_monitorings,
+          i.jurisdictions,
+          i.reported_area,
+          i.all_species_on_site_as_array,
+          i.site_paper_file_id,
+          i.agencies, 
+          json_build_object('type', 'Feature', 'properties', json_build_object('site_id', i.site_id, 'species', i.all_species_on_site, 'has_surveys', i.has_surveys, 'has_biological_treatments', i.has_biological_treatments, 'has_biological_monitorings', i.has_biological_treatment_monitorings, 'has_biological_dispersals', i.has_biological_dispersals, 'has_chemical_treatments', i.has_chemical_treatments, 'has_chemical_monitorings', i.has_chemical_treatment_monitorings, 'has_mechanical_treatments', i.has_mechanical_treatments, 'has_mechanical_monitorings', i.has_mechanical_treatment_monitorings, 'earliest_survey', i.min_survey, 'latest_survey', i.max_survey, 'earliest_chemical_treatment', i.min_chemical_treatment_dates, 'latest_chemical_treatment', i.max_chemical_treatment_dates, 'earliest_chemical_monitoring', i.min_chemical_treatment_monitoring_dates, 'latest_chemical_monitoring', i.max_chemical_treatment_monitoring_dates, 'earliest_bio_dispersal', i.min_bio_dispersal_dates, 'latest_bio_dispersal', i.max_bio_dispersal_dates, 'earliest_bio_treatment', i.min_bio_treatment_dates, 'latest_bio_treatment', i.max_bio_treatment_dates, 'earliest_bio_monitoring', i.min_bio_treatment_monitoring_dates, 'latest_bio_monitoring', i.max_bio_treatment_monitoring_dates, 'earliest_mechanical_treatment', i.min_mechanical_treatment_dates, 'latest_mechanical_treatment', i.max_mechanical_treatment_dates, 'earliest_mechanical_monitoring', i.min_mechanical_treatment_monitoring_dates, 'latest_mechanical_monitoring', i.max_mechanical_treatment_monitoring_dates, 'reported_area', i.reported_area, 'jurisdictions', i.jurisdictions), 'geometry', st_asgeojson(s.geog)::jsonb) AS geojson
+        FROM invasivesbc.iapp_site_summary i
+          JOIN invasivesbc.iapp_spatial s ON i.site_id = s.site_id
+        WHERE 1 = 1
+      WITH DATA;
   `);
 }
 


### PR DESCRIPTION
- Set up iapp fuzzy matching and easy columns
- Allow fuzzy matching with jurisdictions array
- Refactor min/max survey date to reflect proper iapp columns and set up fuzzy matching
- Set up fuzzy matching with agencies and paperfileid and fix jurisdiction bug
- Set up fuzzy matching for dispersals and treatments fields
- set up monitoring fuzzy matching
- Fix multiple iapp record per site_id bug and clean up

# Overview

This PR includes the following proposed change(s):

- {List all the changes, if possible add the linked issue/ticket #}
- #2166
- adjusts iapp database table and migration to support fuzzy filtering
- sets up fuzzy filtering for all columns
- fixes multiple iapp record bug

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- Manually ran all extract seeds and migrations
- Filtered and double checked each matching records for correctly returned by filter criteria

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
