### PR TITLE
Reduce extra redux calls

### DIFF
--- a/app/src/features/home/activities/activityRecordset/RecordSet.tsx
+++ b/app/src/features/home/activities/activityRecordset/RecordSet.tsx
@@ -35,6 +35,7 @@ export const RecordSet = (props) => {
   const [recordSetName, setRecordSetName] = useState(null);
   const [isSelected, setIsSelected] = useState(false);
   const [advancedFilters, setAdvancedFilters] = useState([]);
+  const [isInitialized, setIsInitialized] = useState(false);
   const colours = [blue[500], green[500], red[500], brown[500], purple[500]];
   const userSettings = useSelector(selectUserSettings);
   const dispatch = useDispatch();
@@ -79,6 +80,7 @@ export const RecordSet = (props) => {
           break;
       }
     }
+    setIsInitialized(true);
   };
 
   const updatePropertyStates = (propertyNames: string[]) => {
@@ -116,16 +118,26 @@ export const RecordSet = (props) => {
         }
       });
 
-      dispatch({
-        type: USER_SETTINGS_SET_RECORD_SET_REQUEST,
-        payload: {
-          updatedSet: {
-              ...initialState,
-              ...newState
-          },
-          setName: props.setName
-        }
-      });
+      if (
+        (newState['expanded'] !== initialState['expanded']) ||
+        (newState['drawOrder'] !== initialState['drawOrder']) ||
+        (newState['mapToggle'] !== initialState['mapToggle']) ||
+        (newState['color'] !== initialState['color']) ||
+        (newState['recordSetName'] !== initialState['recordSetName']) ||
+        (newState['isSelected'] !== initialState['isSelected']) ||
+        (newState['advancedFilters'] !== initialState['advancedFilters'])
+      ) {
+        dispatch({
+          type: USER_SETTINGS_SET_RECORD_SET_REQUEST,
+          payload: {
+            updatedSet: {
+                ...initialState,
+                ...newState
+            },
+            setName: props.setName
+          }
+        });
+      }
     }
   };
 
@@ -141,15 +153,17 @@ export const RecordSet = (props) => {
   }, []);
 
   useEffect(() => {
-    updatePropertyStates([
-      'expanded',
-      'mapToggle',
-      'color',
-      'recordSetName',
-      'advancedFilters',
-      'drawOrder',
-      'isSelected'
-    ]);
+    if (isInitialized) {
+      updatePropertyStates([
+        'expanded',
+        'mapToggle',
+        'color',
+        'recordSetName',
+        'advancedFilters',
+        'drawOrder',
+        'isSelected'
+      ]);
+    }
   }, [expanded, mapToggle, color, recordSetName, advancedFilters, drawOrder, isSelected]);
 
   return useMemo(


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- {List all the changes, if possible add the linked issue/ticket #}
- no ticket, new bug from previous redux refactor of record page
- USER_SETTINGS_SET_RECORD_SET is no longer dispatched 8+ times on activities page load

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?
- after rebasing, I went to the activities page and checked console log on load
- afterwards I went through every property that would trigger the dispatch manually

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
