### PR TITLE
pagination

### DIFF
--- a/app/src/components/activities-list/Tables/Plant/ActivityGrid.tsx
+++ b/app/src/components/activities-list/Tables/Plant/ActivityGrid.tsx
@@ -20,6 +20,8 @@ import { Chip, List } from '@mui/material';
 import { FilterDialog, IFilterDialog } from '../FilterDialog';
 import { DocType } from 'constants/database';
 import SaveIcon from '@mui/icons-material/Save';
+import ArrowLeftIcon from '@mui/icons-material/ArrowLeft';
+import ArrowRightIcon from '@mui/icons-material/ArrowRight';
 import { ActivityStatus } from 'constants/activities';
 import { useSelector } from '../../../../state/utilities/use_selector';
 import { selectAuth } from '../../../../state/reducers/auth';
@@ -228,6 +230,7 @@ const ActivityGrid = (props) => {
   const [save, setSave] = useState(0);
   const [cursorPos, setCursorPos] = useState(0);
   const [sortColumns, setSortColumns] = useState<readonly SortColumn[]>([]);
+  const [pageNumber, setPageNumber] = useState(1);
 
   const dispatch = useDispatch();
   const { accessRoles } = useSelector(selectAuth);
@@ -312,7 +315,7 @@ const ActivityGrid = (props) => {
         getActivities();
       }
     }
-  }, [save, JSON.stringify(userSettings?.recordSets?.[props.setName]), sortColumns]);
+  }, [save, JSON.stringify(userSettings?.recordSets?.[props.setName]), sortColumns, filters, pageNumber]);
 
   const handleAccordionExpand = () => {
     setAccordionExpanded((prev) => !prev);
@@ -326,7 +329,7 @@ const ActivityGrid = (props) => {
       props.setName,
       false,
       filters.enabled ? filters : null,
-      0,
+      pageNumber - 1, //limit indexed at 0
       20,
       sortColumns.length ? [...sortColumns] : null
     );
@@ -353,7 +356,7 @@ const ActivityGrid = (props) => {
       props.setName,
       true,
       filters.enabled ? filters : null,
-      0,
+      pageNumber - 1, //limit indexed at 0
       20,
       sortColumns.length ? [...sortColumns] : []
     );
@@ -633,6 +636,27 @@ const ActivityGrid = (props) => {
     });
   };
 
+  function Pagination() {
+    return <div>
+      {pageNumber <= 1 ? <Button disabled><ArrowLeftIcon></ArrowLeftIcon></Button> : 
+        <Button 
+        onClick={(e) => {
+          e.stopPropagation();
+          setPageNumber(pageNumber - 1);
+        }}>
+          <ArrowLeftIcon></ArrowLeftIcon>
+        </Button>
+      }
+      <span>{pageNumber}</span>
+      <Button onClick={(e) => {
+        e.stopPropagation();
+        setPageNumber(pageNumber + 1);
+      }}>
+        <ArrowRightIcon></ArrowRightIcon>
+      </Button>
+    </div>;
+  }
+
   return useMemo(
     () => (
       <Box key={'gridbox_' + props.setName} maxHeight="100%" paddingBottom="20px">
@@ -736,6 +760,7 @@ const ActivityGrid = (props) => {
                 onSortColumnsChange={setSortColumns}
                 components={{ rowRenderer: RowRenderer }}
               />
+              <Pagination></Pagination>
             </div>
           </FilterContext.Provider>
         )}

--- a/app/src/components/activities-list/Tables/Plant/ActivityGrid.tsx
+++ b/app/src/components/activities-list/Tables/Plant/ActivityGrid.tsx
@@ -22,6 +22,7 @@ import { DocType } from 'constants/database';
 import SaveIcon from '@mui/icons-material/Save';
 import ArrowLeftIcon from '@mui/icons-material/ArrowLeft';
 import ArrowRightIcon from '@mui/icons-material/ArrowRight';
+import DoubleArrowLeftIcon from '@mui/icons-material/KeyboardDoubleArrowLeft';
 import { ActivityStatus } from 'constants/activities';
 import { useSelector } from '../../../../state/utilities/use_selector';
 import { selectAuth } from '../../../../state/reducers/auth';
@@ -643,7 +644,16 @@ const ActivityGrid = (props) => {
 
   function Pagination() {
     return <div className={classes.pagination}>
-      {pageNumber <= 1 ? <Button disabled sx={{ m: 1, p: 1 }} size={'small'}><ArrowLeftIcon></ArrowLeftIcon></Button> : 
+      {pageNumber <= 1 ? <Button disabled sx={{ m: 0, p: 0 }} size={'small'}><DoubleArrowLeftIcon></DoubleArrowLeftIcon></Button> : 
+        <Button sx={{ m: 1, p: 1 }} size={'small'}
+        onClick={(e) => {
+          e.stopPropagation();
+          setPageNumber(1);
+        }}>
+          <DoubleArrowLeftIcon></DoubleArrowLeftIcon>
+        </Button>
+      }
+      {pageNumber <= 1 ? <Button disabled sx={{ m: 0, p: 0 }} size={'small'}><ArrowLeftIcon></ArrowLeftIcon></Button> : 
         <Button sx={{ m: 1, p: 1 }} size={'small'}
         onClick={(e) => {
           e.stopPropagation();

--- a/app/src/components/activities-list/Tables/Plant/ActivityGrid.tsx
+++ b/app/src/components/activities-list/Tables/Plant/ActivityGrid.tsx
@@ -70,6 +70,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     inlineSize: '100%',
     padding: '4px',
     fontSize: '14px'
+  },
+  pagination: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    alignItems: 'center'
   }
 }));
 
@@ -637,9 +642,9 @@ const ActivityGrid = (props) => {
   };
 
   function Pagination() {
-    return <div>
-      {pageNumber <= 1 ? <Button disabled><ArrowLeftIcon></ArrowLeftIcon></Button> : 
-        <Button 
+    return <div className={classes.pagination}>
+      {pageNumber <= 1 ? <Button disabled sx={{ m: 1, p: 1 }} size={'small'}><ArrowLeftIcon></ArrowLeftIcon></Button> : 
+        <Button sx={{ m: 1, p: 1 }} size={'small'}
         onClick={(e) => {
           e.stopPropagation();
           setPageNumber(pageNumber - 1);
@@ -648,7 +653,8 @@ const ActivityGrid = (props) => {
         </Button>
       }
       <span>{pageNumber}</span>
-      <Button onClick={(e) => {
+      <Button sx={{ m: 1, p: 1 }} size={'small'}
+      onClick={(e) => {
         e.stopPropagation();
         setPageNumber(pageNumber + 1);
       }}>


### PR DESCRIPTION
- Integrate Pagination functionality
- Edit pagination styling
- Add a back-to-beginning button to pagination

# Overview

This PR includes the following proposed change(s):

- {List all the changes, if possible add the linked issue/ticket #}
- #2191
- Created simple pagination for record set tables with next page, prev page and start page buttons

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- tested manually by clicking new buttons and verifying the results on datasets with more than one page available

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
