### PR TITLE
Fix for new record dialog cache issue

### DIFF
--- a/app/src/components/activities-list/Tables/NewRecordDialog.tsx
+++ b/app/src/components/activities-list/Tables/NewRecordDialog.tsx
@@ -255,7 +255,7 @@ const NewRecordDialog = (props: INewRecordDialog) => {
   };
 
   const handleRecordTypeChange = (event: any) => {
-    setNewRecordDialogState({ ...newRecordDialogState, recordType: event.target.value });
+    setNewRecordDialogState({ ...newRecordDialogState, recordType: event.target.value, recordSubtype: '' });
   };
 
   const handleRecordSubtypeChange = (event: any) => {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- {List all the changes, if possible add the linked issue/ticket #}
- # didn't find a ticket for this
- quick fix for new record button being clickable after changing type and subtype being blank

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- Refreshed the page, verified that the cache still works
- Refreshed the page, changed type and refreshed the page again then verified that the button is disabled
- refreshed the page, changed type, set subtype, changed type again and refreshed the page to verify disabled button

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
