### PR TITLE
Clear active activity when active activity deleted

### DIFF
--- a/app/src/components/form/FormControlsComponent.tsx
+++ b/app/src/components/form/FormControlsComponent.tsx
@@ -5,6 +5,9 @@ import { useInvasivesApi } from '../../hooks/useInvasivesApi';
 import { useSelector } from '../../state/utilities/use_selector';
 import { selectAuth } from '../../state/reducers/auth';
 import { selectActivity } from 'state/reducers/activity';
+import { selectUserSettings } from 'state/reducers/userSettings';
+import { useDispatch } from 'react-redux';
+import { USER_SETTINGS_SET_SELECTED_RECORD_REQUEST } from 'state/actions';
 
 export interface IFormControlsComponentProps {
   classes?: any;
@@ -27,10 +30,21 @@ const FormControlsComponent: React.FC<IFormControlsComponentProps> = (props: any
   const isDisabled = props.isDisabled || false;
   const [open, setOpen] = React.useState(false);
   const { accessRoles, displayName } = useSelector(selectAuth);
+  const userSettings = useSelector(selectUserSettings);
+  const dispatch = useDispatch();
 
   const activityInState = useSelector(selectActivity);
 
   const deleteRecord = () => {
+    // On record deletion, clear selected record
+    if (userSettings.selectedRecord.id === activityInState.activity.activity_id) {
+      dispatch({
+        type: USER_SETTINGS_SET_SELECTED_RECORD_REQUEST,
+        payload: {
+          selectedRecord: null
+        }
+      });
+    }
     const activityIds = [activityInState.activity.activity_id];
     dataAccess.deleteActivities(activityIds);
     history.push('/home/activities');


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- When user deletes record, check if that record is the active activity in userSettings reducer. If so, clear it.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
