### PR TITLE
toggles enable

### DIFF
--- a/app/src/components/map/LayerLoaderHelpers/RecordSetLayersRenderer.tsx
+++ b/app/src/components/map/LayerLoaderHelpers/RecordSetLayersRenderer.tsx
@@ -20,7 +20,7 @@ export const RecordSetLayersRenderer = (props: any) => {
     <>
       {activitiesState?.activitiesGeoJSON?.map((l) => {
         //if (l && l.layerState.color) {
-        if (true) {
+        if (l.layerState.enabled) {
           return (
             <ActivitiesLayerV2
               key={'activitiesv2filter' + l.recordSetID}
@@ -35,7 +35,7 @@ export const RecordSetLayersRenderer = (props: any) => {
       {true && activitiesState?.IAPPGeoJSON?.length > 0 ? (
         activitiesState?.IAPPGeoJSON?.map((l) => {
           //if (l && l.layerState.color) {
-          if (l?.featureCollection?.features?.length > 0) {
+          if (l?.featureCollection?.features?.length > 0 && l.layerState.enabled) {
             return (
               <ActivitiesLayerV2
                 key={'activitiesv2filter' + l.recordSetID}

--- a/app/src/state/sagas/activities.ts
+++ b/app/src/state/sagas/activities.ts
@@ -34,6 +34,7 @@ function* handle_USER_SETTINGS_SET_RECORD_SET_SUCCESS(action) {
     limit: number,
     sortColumns: readonly SortColumn[]
   ) => {*/
+
   const authState = yield select(selectAuth);
   const sets = {};
   sets[action.payload.updatedSetName] = action.payload.updatedSet;
@@ -42,26 +43,37 @@ function* handle_USER_SETTINGS_SET_RECORD_SET_SUCCESS(action) {
     authState.accessRoles,
     sets,
     action.payload.updatedSetName,
-    false,
+    action.payload.updatedSet.recordSetType === 'POI' ? true : false,
     action.payload.updatedSet.gridFilters,
     0,
-    999
+    200000
   );
 
   const layerState = {
     color: action.payload.updatedSet.color,
     drawOrder: action.payload.updatedSet.drawOrder,
-    enabled: true
+    enabled: action.payload.updatedSet.mapToggle
   };
 
-  yield put({
-    type: ACTIVITIES_GEOJSON_GET_REQUEST,
-    payload: {
-      recordSetID: action.payload.updatedSetName,
-      activitiesFilterCriteria: filterCriteria,
-      layerState: layerState
-    }
-  });
+  if (action.payload.updatedSet.recordSetType === 'POI') {
+    yield put({
+      type: IAPP_GEOJSON_GET_REQUEST,
+      payload: {
+        recordSetID: action.payload.updatedSetName,
+        IAPPFilterCriteria: filterCriteria,
+        layerState: layerState
+      }
+    });
+  } else {
+    yield put({
+      type: ACTIVITIES_GEOJSON_GET_REQUEST,
+      payload: {
+        recordSetID: action.payload.updatedSetName,
+        activitiesFilterCriteria: filterCriteria,
+        layerState: layerState
+      }
+    });
+  }
   //uyield put({ type: ACTIVITIES_TABLE_ROW_GET_REQUEST, payload: {} });
 }
 


### PR DESCRIPTION
- wire up iapp geojson actions, handlers, and reducer case
- iapp geojson makes it into state and pins on map (display WIP, and api still limiting to 1000
- ALL IAPP sites rendering on map
- activities and POI draw on first visit
- enable togges - slow for now need to check for filter differences and split out layer state from filters

# Overview

This PR includes the following proposed change(s):

- {List all the changes, if possible add the linked issue/ticket #}

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
