### PR TITLE
Remove disable max zoom resolution on topo view

### DIFF
--- a/app/src/components/map/Tools/ToolTypes/Nav/MapLocationControlGroup.tsx
+++ b/app/src/components/map/Tools/ToolTypes/Nav/MapLocationControlGroup.tsx
@@ -320,10 +320,10 @@ function ZoomControlButton() {
         width: '40px',
         height: '40px'
       }}>
-      <Tooltip title={`Max Zoom Resolution: ${isHighRes ? 'High Def' : 'Low Def'}`} placement="right-start">
+      <Tooltip title={`Max Zoom Resolution: ${isHighRes ? 'Low Def' : 'High Def'}`} placement="right-start">
         <span>
           <IconButton
-            disabled={showTopo || startTimer}
+            disabled={startTimer}
             onClick={toggleResolution}
             className={
               'leaflet-control-zoom leaflet-bar leaflet-control ' +


### PR DESCRIPTION
# Overview 
HD toggle - enable max zoom resolution button on topo view.
Switched max zoom resolution tool tip state(High Def., Low Def.) to display state when user clicks on the button.
 
This PR includes the following new proposed change(s): 
issue/#2269 
 
## Type of change 
 
- [x] Removed disabling max zoom resolution button when topographic view is enabled.
- [x] Flipped tool tip state from High to Low definition labels and vice versa. Now displays the state achieved when user clicks on the max zoom resolution button.
 
## How Has This Been Tested? 
 
Manually tested in FF and Chrome Mac browsers.
No console errors on interaction.

Side effect of the max zoom resolution being enabled now, is when user is zoomed in max in topographic view mode and clicks max zoom resolution button.  It will display imagery when zooming out and the topographical view button will still be set to topographical view.