### PR TITLE
Set api location_description maxLength to 2000

### DIFF
--- a/api/src/openapi/api-doc.json
+++ b/api/src/openapi/api-doc.json
@@ -500,7 +500,7 @@
           "location_description": {
             "type": "string",
             "title": "Location Description",
-            "maxLength": 300,
+            "maxLength": 2000,
             "minLength": 5,
             "default": "",
             "x-tooltip-text": "Text entry to provide location directions. Locations should start general and get more specific"
@@ -625,7 +625,7 @@
           "location_description": {
             "type": "string",
             "title": "Location Description",
-            "maxLength": 300,
+            "maxLength": 2000,
             "minLength": 5,
             "default": "",
             "x-tooltip-text": "Text entry to provide location directions. Locations should start general and get more specific"

--- a/api/src/openapi/api-doc/Activity_Data_Components.ts
+++ b/api/src/openapi/api-doc/Activity_Data_Components.ts
@@ -82,7 +82,7 @@ export const Activity = {
     location_description: {
       type: 'string',
       title: 'Location Description',
-      maxLength: 300,
+      maxLength: 2000,
       minLength: 5,
       default: '',
       'x-tooltip-text':


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- issue/#2307

## Type of change

- [x] Increased OpenAPI Location Description maxLength from 300 characters to 2000 characters.
- [x] All locations of location_description and maxLength have been increased.

## How Has This Been Tested?

No testing on this yet.  Testing on submission of form with 2000 character would be best.  How to reproduce form with location_description field?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
