### PR TITLE
Set map palette from SLD style configuration

### DIFF
--- a/app/src/components/map/Donut.tsx
+++ b/app/src/components/map/Donut.tsx
@@ -16,18 +16,13 @@ interface IDonutSVGProps {
 }
 
 export const DonutSVG: React.FC<IDonutSVGProps> = ({ data, bins = 32, thickness = 20 }) => {
-  const palette = [
-    '#67AC39',
-    '#A7E2D3',
-    '#0B0F22',
-    '#B63D73',
-    '#ACCE6C',
-    '#B289D8',
-    '#F4E4DE',
-    '#4270C0',
-    '#C2C44D',
-    '#3AADA3'
-  ];
+  const activityPalette = {
+    Biocontrol : '#845ec2',
+    FREP: '#de852c',
+    Monitoring: '#2138e0',
+    Observation: '#399c3e',
+    Treatment: '#c6c617'
+  };
 
   const segments = [];
 
@@ -83,17 +78,14 @@ export const DonutSVG: React.FC<IDonutSVGProps> = ({ data, bins = 32, thickness 
     startingBin++;
   }
 
-  let paletteColoursUsed = 0;
-
   return (
     <svg viewBox={`0 0 200 200`}>
       {sortedData.map((d, i) => {
-        let fillColour;
+        let fillColour;   
         if (!!d.fillColour) {
           fillColour = d.fillColour;
         } else {
-          fillColour = palette[paletteColoursUsed % palette.length];
-          paletteColoursUsed++;
+          fillColour = activityPalette[d.name];
         }
         const rendered = [];
         for (let s = d.startBin; s <= d.endBin; s++) {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

issue/ticket #2372

## Type of change

- [x] Removed old random palette and setter method.
- [x] Reads SLD object file to set the activity type colours at initialization.
- To update the colors from a sld object file update, refresh of page is required. It is not aware that an update has happened.
- In future, this configurable palette setting could be implemented into WebPack/Vite to read the sld and generate a included file with a palette object.  That is if hot reloading of SLD files is not required.

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes.
- [x] Manually tested all levels of zoom to validate consistency.

## Screenshots
<img width="1149" alt="image" src="https://user-images.githubusercontent.com/117766863/209870212-a03d2437-da1c-4a34-b65a-6a6618b0cb9f.png">
<img width="1149" alt="image" src="https://user-images.githubusercontent.com/117766863/209870230-9677aa7d-e206-45d1-9e27-70d62882295e.png">

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
