### PR TITLE
Public auth activities API

### DIFF
--- a/api/src/paths/activities-lean.ts
+++ b/api/src/paths/activities-lean.ts
@@ -28,7 +28,7 @@ POST.apiDoc = {
       ]
     : [],
   requestBody: {
-    description: 'Activities search filter criteria object.',
+    description: 'Activities lean search filter criteria object.',
     content: {
       'application/json': {
         schema: {
@@ -108,7 +108,7 @@ POST.apiDoc = {
   },
   responses: {
     200: {
-      description: 'Activity get response object array.',
+      description: 'Activities lean get response object array.',
       content: {
         'application/json': {
           schema: {
@@ -212,16 +212,19 @@ DELETE.apiDoc = {
  */
 function getActivitiesBySearchFilterCriteria(): RequestHandler {
   return async (req: InvasivesRequest, res) => {
+    const authContext = (req as any)?.authContext;
+    const isAuth = authContext?.isAuth ?? false;
+
     defaultLog.debug({
       label: 'activity',
       message: 'getActivitiesBySearchFilterCriteria',
       body: req.body
     });
 
-    const roleName = (req as any).authContext.roles[0]?.role_name;
+    const roleName = authContext.roles[0]?.role_name;
     const sanitizedSearchCriteria = new ActivitySearchCriteria(req.body);
 
-    if (!roleName || roleName.includes('animal')) {
+    if (!isAuth || !roleName || roleName.includes('animal')) {
       sanitizedSearchCriteria.hideTreatmentsAndMonitoring = true;
     } else {
       sanitizedSearchCriteria.hideTreatmentsAndMonitoring = false;
@@ -239,7 +242,7 @@ function getActivitiesBySearchFilterCriteria(): RequestHandler {
     }
 
     try {
-      const sqlStatement: SQLStatement = getActivitiesSQL(sanitizedSearchCriteria, true);
+      const sqlStatement: SQLStatement = getActivitiesSQL(sanitizedSearchCriteria, true, isAuth);
 
       // Check for sql and role:
       // console.log('========================= activities-lean.ts 232', sqlStatement.text);

--- a/api/src/paths/activities.ts
+++ b/api/src/paths/activities.ts
@@ -225,7 +225,7 @@ function getActivitiesBySearchFilterCriteria(): RequestHandler {
 
       // needs to be mutable
       let response = await connection.query(sqlStatement.text, sqlStatement.values);
-      if (!isAuth) {
+      if (!sanitizedSearchCriteria.activity_id_only && !isAuth) {
         if (response.rows.length > 0) {
           // remove sensitive data from json obj
           for (var i in response.rows) {

--- a/api/src/paths/activities.ts
+++ b/api/src/paths/activities.ts
@@ -150,7 +150,7 @@ function getActivitiesBySearchFilterCriteria(): RequestHandler {
     // sanitizedSearchCriteria.created_by = [req.authContext.user['preferred_username']];
     const isAuth = req.authContext?.isAuth ?? false;
 
-    if (!roleName || roleName.includes('animal')) {
+    if (!isAuth || !roleName || roleName.includes('animal')) {
       sanitizedSearchCriteria.hideTreatmentsAndMonitoring = true;
     } else {
       sanitizedSearchCriteria.hideTreatmentsAndMonitoring = false;

--- a/api/src/paths/points-of-interest.ts
+++ b/api/src/paths/points-of-interest.ts
@@ -83,15 +83,12 @@ export const isIAPPrelated = (PointOfInterestSearchCriteria: any) => {
  */
 function getPointsOfInterestBySearchFilterCriteria(): RequestHandler {
   return async (req: InvasivesRequest, res) => {
-   const criteria: any = {}//JSON.parse(<string>req.query['query']);
-
-
-
     /// check if public, check if site_id only
     // boot out if includes name filters
-    const authstuff = (req as any).authContext
-    console.log('auth stuff')
-    console.log(authstuff)
+    const isAuth = (req as any).authContext?.isAuth;
+    // no criteria if public until defined allowed fields.
+    // const criteria: any = JSON.parse(<string>req.query['query']);
+    const criteria: any = isAuth ? JSON.parse(<string>req.query['query']) : {};
 
     defaultLog.debug({
       label: 'point-of-interest',
@@ -115,6 +112,7 @@ function getPointsOfInterestBySearchFilterCriteria(): RequestHandler {
     }
 
     const sanitizedSearchCriteria = new PointOfInterestSearchCriteria(criteria);
+    console.log('sanitizedSearchCriteria',sanitizedSearchCriteria);
     const connection = await getDBConnection();
 
     if (!connection) {

--- a/api/src/paths/points-of-interest.ts
+++ b/api/src/paths/points-of-interest.ts
@@ -12,6 +12,7 @@ import { getPointsOfInterestSQL, getSpeciesMapSQL } from '../queries/point-of-in
 import { getLogger } from '../utils/logger';
 import cacheService from '../utils/cache-service';
 import { createHash } from 'crypto';
+import { InvasivesRequest } from 'utils/auth-utils';
 
 const defaultLog = getLogger('point-of-interest');
 
@@ -81,8 +82,16 @@ export const isIAPPrelated = (PointOfInterestSearchCriteria: any) => {
  * @return {RequestHandler}
  */
 function getPointsOfInterestBySearchFilterCriteria(): RequestHandler {
-  return async (req, res) => {
-    const criteria = JSON.parse(<string>req.query['query']);
+  return async (req: InvasivesRequest, res) => {
+   const criteria: any = {}//JSON.parse(<string>req.query['query']);
+
+
+
+    /// check if public, check if site_id only
+    // boot out if includes name filters
+    const authstuff = (req as any).authContext
+    console.log('auth stuff')
+    console.log(authstuff)
 
     defaultLog.debug({
       label: 'point-of-interest',

--- a/api/src/utils/auth-utils.ts
+++ b/api/src/utils/auth-utils.ts
@@ -74,6 +74,7 @@ export const authenticate = async (req: InvasivesRequest) => {
       return new Promise<void>((resolve: any) => {
         req.authContext = {
           preferredUsername: null,
+          friendlyUsername: null,
           user: null,
           roles: [],
           isAuth: false
@@ -148,6 +149,7 @@ export const authenticate = async (req: InvasivesRequest) => {
         createIfNeeded.then(() => {
           req.authContext = {
             preferredUsername: null,
+            friendlyUsername: null,
             user: null,
             roles: [],
             isAuth: true,

--- a/api/src/utils/auth-utils.ts
+++ b/api/src/utils/auth-utils.ts
@@ -63,7 +63,7 @@ export const authenticate = async (req: InvasivesRequest) => {
       '/api/activities-lean/',
       '/api/points-of-interest-lean/',
       '/api/points-of-interest/',
-      // '/api/activities/',
+      '/api/activities/',
       // '/api/activity/',
       // '/api/iapp-jurisdictions/',
       // '/api/code_tables/invasive_plant_code/',

--- a/api/src/utils/auth-utils.ts
+++ b/api/src/utils/auth-utils.ts
@@ -70,21 +70,16 @@ export const authenticate = async (req: InvasivesRequest) => {
       // '/api/code_tables/jurisdiction_code/',
     ].includes(req.originalUrl.split('?')?.[0]));
 
-    // add url
-    if (isPublicURL) {
-      {
-        return new Promise<void>((resolve: any) => {
-          req.authContext = {
-            preferredUsername: null,
-            friendlyUsername: null,
+    if (isPublicURL && (req.method === 'GET' || req.method === 'POST')) {
+      return new Promise<void>((resolve: any) => {
+        req.authContext = {
+          preferredUsername: null,
           user: null,
-            roles: [],
-            isAuth: false
-          };
-
-          resolve();
-        });
-      }
+          roles: [],
+          isAuth: false
+        };
+        resolve();
+      });
     } else {
       throw {
         code: 401,


### PR DESCRIPTION
# Overview
#2304 portion for Activities public API
This PR includes the following proposed change(s):

When NOT authenticated:
- Removes sensitive data on Activities API full and lean response.
- Ignores search filters for created_by and updated_by.

## Type of change

- [x] Requests for created_by, updated_by and reviewed_by search filters are disabled at the SQL and column_names level when NOT authenticated.
- [x] Remove(null/[]) created_by, updated_by, reviewed_by, user_role, activity_persons data from API response when NOT authenticated.
- [x] Enable /api/activities API URL for public access.

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested manually by Postman requests, compared authenticated and public response data - screenshots.
Have not tested authenticated or column_names removed correctly.

## Screenshots
<img width="1114" alt="image" src="https://user-images.githubusercontent.com/117766863/217079220-ee3f2e01-29c0-4a1c-a8a3-181fc8a246c1.png">
<img width="1114" alt="image" src="https://user-images.githubusercontent.com/117766863/217079247-d103c803-edf4-4717-9635-85dddee6a2d5.png">
<img width="1114" alt="image" src="https://user-images.githubusercontent.com/117766863/217079256-090b5298-6323-401c-be0b-3a8da441a629.png">

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
