### PR TITLE
2521 api role check on activity query

### DIFF
--- a/api/src/models/activity.ts
+++ b/api/src/models/activity.ts
@@ -67,7 +67,7 @@ export class ActivityPostRequestBody {
             return item;
           })) ||
         [],
-      user_role: obj?.user_role?.role_id || null
+      user_role: [obj?.user_role?.role_id] || []
     };
 
     this.activity_id = (obj && obj.activity_id) || null;
@@ -128,7 +128,7 @@ export class ActivitySearchCriteria {
   search_feature: GeoJSON.FeatureCollection;
   search_feature_server_id: number;
 
-  user_role?: string[];
+  user_roles?: any[];
 
   column_names: string[];
 
@@ -178,7 +178,7 @@ export class ActivitySearchCriteria {
     this.search_feature = (obj && obj.search_feature) || null;
     this.search_feature_server_id = (obj && obj.search_feature_server_id) || null;
 
-    this.user_role = (obj && obj?.user_role) || [];
+    this.user_roles = (obj && obj?.user_roles) || [];
 
     this.column_names = (obj && obj.column_names) || [];
 

--- a/api/src/models/activity.ts
+++ b/api/src/models/activity.ts
@@ -45,8 +45,6 @@ export class ActivityPostRequestBody {
 
   jurisdiction: string[];
 
-  roles: string[];
-
   /**
    * Creates an instance of ActivityPostRequestBody.
    *
@@ -68,7 +66,8 @@ export class ActivityPostRequestBody {
             delete item.encoded_file;
             return item;
           })) ||
-        []
+        [],
+      user_role: obj?.user_role?.role_id || null
     };
 
     this.activity_id = (obj && obj.activity_id) || null;
@@ -100,8 +99,6 @@ export class ActivityPostRequestBody {
     this.species_treated = obj?.species_treated || [];
 
     this.jurisdiction = obj?.jurisdiction || [];
-
-    this.roles = obj?.roles || [];
   }
 }
 
@@ -131,7 +128,7 @@ export class ActivitySearchCriteria {
   search_feature: GeoJSON.FeatureCollection;
   search_feature_server_id: number;
 
-  user_roles: string[];
+  user_role?: string[];
 
   column_names: string[];
 
@@ -180,8 +177,8 @@ export class ActivitySearchCriteria {
 
     this.search_feature = (obj && obj.search_feature) || null;
     this.search_feature_server_id = (obj && obj.search_feature_server_id) || null;
-    
-    this.user_roles = (obj && obj.user_roles) || [];
+
+    this.user_role = (obj && obj?.user_role) || [];
 
     this.column_names = (obj && obj.column_names) || [];
 

--- a/api/src/models/activity.ts
+++ b/api/src/models/activity.ts
@@ -45,6 +45,8 @@ export class ActivityPostRequestBody {
 
   jurisdiction: string[];
 
+  roles: string[];
+
   /**
    * Creates an instance of ActivityPostRequestBody.
    *
@@ -98,6 +100,8 @@ export class ActivityPostRequestBody {
     this.species_treated = obj?.species_treated || [];
 
     this.jurisdiction = obj?.jurisdiction || [];
+
+    this.roles = obj?.roles || [];
   }
 }
 

--- a/api/src/paths/activities.ts
+++ b/api/src/paths/activities.ts
@@ -149,10 +149,12 @@ function getActivitiesBySearchFilterCriteria(): RequestHandler {
     const roleName = (req as any).authContext.roles[0]?.role_name;
     const sanitizedSearchCriteria = new ActivitySearchCriteria(criteria);
     // sanitizedSearchCriteria.created_by = [req.authContext.user['preferred_username']];
-    const isAuth = req.authContext?.user !== null ? true:  false;
-
-
-
+    const isAuth = req.authContext?.user !== null ? true : false;
+    const user_role = (req as any).authContext?.roles?.[0]?.role_id;
+    if (user_role) {
+      const user_roles = Array.from({ length: user_role }, (_, i) => i + 1);
+      sanitizedSearchCriteria.user_roles = user_roles;
+    }
 
     if (!isAuth || !roleName || roleName.includes('animal')) {
       sanitizedSearchCriteria.hideTreatmentsAndMonitoring = true;

--- a/api/src/paths/activity.ts
+++ b/api/src/paths/activity.ts
@@ -379,7 +379,7 @@ function updateActivity(): RequestHandler {
   return async (req: InvasivesRequest, res) => {
     defaultLog.debug({ label: 'activity', message: 'updateActivity', body: req.params });
 
-    const data = { ...req.body, media_keys: req['media_keys'] };
+    const data = { ...req.body, media_keys: req['media_keys'], user_role: req.authContext?.roles[0] };
 
     const isAdmin = (req as any).authContext.roles[0].role_id === 18 ? true : false;
     const sanitizedActivityData = new ActivityPostRequestBody(data);

--- a/api/src/paths/activity.ts
+++ b/api/src/paths/activity.ts
@@ -271,14 +271,13 @@ function createActivity(): RequestHandler {
   return async (req: InvasivesRequest, res) => {
     defaultLog.debug({ label: 'activity', message: 'createActivity', body: req.params });
 
-    const data = { ...req.body, media_keys: req['media_keys'] };
+    const data = { ...req.body, media_keys: req['media_keys'], user_role: req.authContext?.roles[0] };
 
     const sanitizedActivityData = new ActivityPostRequestBody(data);
     sanitizedActivityData.created_by = req.authContext?.friendlyUsername;
     sanitizedActivityData.created_by_with_guid = req.authContext?.preferredUsername;
     sanitizedActivityData.updated_by = req.authContext?.friendlyUsername;
     sanitizedActivityData.updated_by_with_guid = req.authContext?.preferredUsername;
-    sanitizedActivityData.roles = req.authContext.roles;
 
     const connection = await getDBConnection();
 

--- a/api/src/paths/activity.ts
+++ b/api/src/paths/activity.ts
@@ -278,6 +278,7 @@ function createActivity(): RequestHandler {
     sanitizedActivityData.created_by_with_guid = req.authContext?.preferredUsername;
     sanitizedActivityData.updated_by = req.authContext?.friendlyUsername;
     sanitizedActivityData.updated_by_with_guid = req.authContext?.preferredUsername;
+    sanitizedActivityData.roles = req.authContext.roles;
 
     const connection = await getDBConnection();
 

--- a/api/src/queries/activity-queries.ts
+++ b/api/src/queries/activity-queries.ts
@@ -370,15 +370,27 @@ export const getActivitiesSQL = (
     sqlStatement.append(SQL`)`);
   }
 
-
-  /*
   if (searchCriteria.user_roles && searchCriteria.user_roles.length > 0) {
-    const roles = searchCriteria.user_roles.map((role: any) => parseInt(role.role_id));
+    // const roles = searchCriteria.user_roles.map((role: any) => parseInt(role.role_id));
+    // sqlStatement.append(
+    //   SQL` AND ${searchCriteria.user_roles} && ARRAY(select jsonb_array_elements_text(activity_payload->'user_role'))::int[]`
+    // );
     sqlStatement.append(
-      SQL` AND ${roles} && ARRAY(select jsonb_array_elements_text(activity_payload->'user_role'))::int[]`
+      SQL` AND
+      (
+        SELECT max(x) AS max_role_id FROM (
+          SELECT UNNEST (
+            ARRAY (
+              SELECT jsonb_array_elements_text(activity_payload->'user_role'))::int[]) AS x, 
+                activity_incoming_data_id 
+              FROM activity_incoming_data
+          ) AS max_role 
+          WHERE a.activity_incoming_data_id = max_role.activity_incoming_data_id 
+          GROUP BY activity_incoming_data_id
+        ) = ANY( ${searchCriteria.user_roles} )
+      `
     );
   }
-  */
 
   // subtype and subtype full are a bit mismatched in places, this will search both:
   if (searchCriteria.activity_subtype && searchCriteria.activity_subtype.length) {

--- a/api/src/utils/batch/execution.ts
+++ b/api/src/utils/batch/execution.ts
@@ -25,20 +25,11 @@ export function _mapToDBObject(row, status, type, subtype, userInfo): _MappedFor
 
   const shortId = shortYear + ActivityLetter[subtype] + uuidToCreate.substr(0, 4).toUpperCase();
 
+  let mapped = activity_create_function(type, subtype, userInfo?.preferred_username, 'Brennan', userInfo?.pac_number);
 
-  let mapped = activity_create_function(
-    type,
-    subtype,
-    userInfo?.preferred_username,
-    [],
-    'Brennan',
-    userInfo?.pac_number
-  );
+  mapped = mapDefaultFields(mapped, row);
 
- mapped = mapDefaultFields(mapped, row)
-
-  mapped['form_data']['form_status'] = 'Submitted'
-
+  mapped['form_data']['form_status'] = 'Submitted';
 
   return {
     id: uuidToCreate,

--- a/app/src/components/activities-list/Tables/Plant/ActivityGrid.tsx
+++ b/app/src/components/activities-list/Tables/Plant/ActivityGrid.tsx
@@ -98,7 +98,6 @@ const filterContainerClassname = `
 
 export const getSearchCriteriaFromFilters = (
   advancedFilterRows: any,
-  rolesUserHasAccessTo: any,
   recordSets: any,
   setName: string,
   isIAPP: boolean,
@@ -111,9 +110,7 @@ export const getSearchCriteriaFromFilters = (
   const form_status_filter = advancedFilterRows?.filter((x) => x.filterField === 'record_status');
   const created_by = created_by_filter?.length === 1 ? created_by_filter[0].filterValue : null;
   const form_status = form_status_filter?.length === 1 ? form_status_filter[0].filterValue : ActivityStatus.SUBMITTED;
-  let filter: any = {
-    user_roles: rolesUserHasAccessTo
-  };
+  let filter: any = {};
   if (created_by) {
     filter.created_by = [created_by];
   }

--- a/app/src/features/home/activities/ActivitiesPage.tsx
+++ b/app/src/features/home/activities/ActivitiesPage.tsx
@@ -301,7 +301,6 @@ const PageContainer = (props) => {
             for (const selectedSet of selectedRecordSets) {
               const filter = await getSearchCriteriaFromFilters(
                 selectedSet.advancedFilters,
-                accessRoles,
                 userSettings.recordSets,
                 selectedSet.recordSetName,
                 false,

--- a/app/src/features/home/activities/activityRecordset/RecordSetAccordionSummary.tsx
+++ b/app/src/features/home/activities/activityRecordset/RecordSetAccordionSummary.tsx
@@ -98,7 +98,6 @@ const RecordSetAccordionSummary = (props) => {
     const recordSets = [];
     const filter = await getSearchCriteriaFromFilters(
       userSettings.recordSets[props.setName].advancedFilters,
-      accessRoles,
       userSettings.recordSets,
       props.recordSetName,
       false,

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -168,7 +168,6 @@ export function* handle_ACTIVITY_CREATE_REQUEST(action) {
       action.payload.type,
       action.payload.subType,
       authState.username,
-      authState.accessRoles,
       authState.displayName,
       authState.extendedInfo.pac_number
     );

--- a/app/src/state/sagas/map.ts
+++ b/app/src/state/sagas/map.ts
@@ -83,7 +83,6 @@ function* handle_USER_SETTINGS_SET_RECORD_SET_SUCCESS(action) {
   sets[action.payload.updatedSetName] = { ...action.payload.updatedSet };
   const filterCriteria = yield getSearchCriteriaFromFilters(
     action.payload.updatedSet.advancedFilterRows,
-    authState.accessRoles,
     sets,
     action.payload.updatedSetName,
     action.payload.updatedSet.recordSetType === 'POI' ? true : false,
@@ -229,7 +228,6 @@ function* handle_MAP_INIT_REQUEST(action) {
   const filterCriteria = yield getSearchCriteriaFromFilters(
     [],
     //    action.payload.recordSets[2].advancedFilterRows,
-    authState.accessRoles,
     sets,
     '2',
     false,
@@ -242,7 +240,6 @@ function* handle_MAP_INIT_REQUEST(action) {
   const IAPP_filter = yield getSearchCriteriaFromFilters(
     [],
     //action.payload.recordSets[3].advancedFilterRows,
-    authState.accessRoles,
     sets,
     '3',
     true,
@@ -374,7 +371,6 @@ function* handle_FILTER_STATE_UPDATE(action) {
     if (action.payload[x].type === 'POI') {
       const IAPP_filter = getSearchCriteriaFromFilters(
         action.payload?.[x]?.filters?.advancedFilters,
-        authState.accessRoles,
         recordSets,
         x,
         true,
@@ -392,7 +388,6 @@ function* handle_FILTER_STATE_UPDATE(action) {
     } else {
       const activityFilter = getSearchCriteriaFromFilters(
         action.payload?.[x]?.filters?.advancedFilters,
-        authState.accessRoles,
         recordSets,
         x,
         false,
@@ -425,7 +420,6 @@ function* handle_ACTIVITIES_GET_IDS_FOR_RECORDSET_SUCCESS(action) {
 
   const filters = getSearchCriteriaFromFilters(
     recordSet.advancedFilters,
-    authState.accessRoles,
     recordSetsState.recordSets,
     recordSetID,
     false,
@@ -456,7 +450,6 @@ function* handle_IAPP_GET_IDS_FOR_RECORDSET_SUCCESS(action) {
 
   const filters = getSearchCriteriaFromFilters(
     recordSet.advancedFilters,
-    authState.accessRoles,
     recordSetsState.recordSets,
     recordSetID,
     true,
@@ -480,7 +473,6 @@ function* handle_PAGE_OR_LIMIT_UPDATE(action) {
 
   const filters = getSearchCriteriaFromFilters(
     recordSet.advancedFilters,
-    authState.accessRoles,
     recordSetsState.recordSets,
     recordSetID,
     type === 'POI' ? true : false,
@@ -788,7 +780,6 @@ function* handle_RECORD_SET_TO_EXCEL_REQUEST(action) {
     if (set.recordSetType === 'POI') {
       let filters = getSearchCriteriaFromFilters(
         set?.advancedFilters ? set?.advancedFilters : null,
-        authState?.accessRoles,
         userSettings?.recordSets ? userSettings?.recordSets : null,
         action.payload.id,
         true,
@@ -817,7 +808,6 @@ function* handle_RECORD_SET_TO_EXCEL_REQUEST(action) {
     } else {
       const filters = getSearchCriteriaFromFilters(
         set.advancedFilters,
-        authState.accessRoles,
         userSettings?.recordSets,
         action.payload.id,
         false,

--- a/sharedAPI/src/index.ts
+++ b/sharedAPI/src/index.ts
@@ -1,23 +1,20 @@
-import { Feature } from "geojson";
-import moment from "moment";
+import { Feature } from 'geojson';
+import moment from 'moment';
 import { v4 as uuidv4 } from 'uuid';
 export * from './herbicideCalculator'
 export * from './chemTreatmentValidation'
 export * from './herbicideApplicationRates'
 
-
 export const activity_create_function = (
   type: string,
   subType: string,
   username: string,
-  accessRoles: Array<any>,
   displayName: string,
   pac_number?: string
 ) => {
   let activityV1 = generateDBActivityPayload({}, null, type, subType);
   let activityV2 = populateSpeciesArrays(activityV1);
   activityV2.created_by = username;
-  activityV2.user_role = accessRoles.map((role) => role.role_id);
 
   //    if ([ActivityType.Observation, ActivityType.Treatment].includes(activityV2.activity_type))
   {
@@ -67,7 +64,6 @@ export function generateDBActivityPayload(
     },
     media: undefined,
     created_by: undefined,
-    user_role: undefined,
     sync_status: ActivitySyncStatus.NOT_SAVED,
     form_status: ActivityStatus.DRAFT,
     review_status: 'Not Reviewed',


### PR DESCRIPTION
- [rebase] Prevent client to API role check for security on activity create
- Fix user role stamp in activity creation and remove access role from search criteria
- Fix query and set up to get activities of roles of a lower value

# Overview

This PR includes the following proposed change(s):

- {List all the changes, if possible add the linked issue/ticket #}
- #2521
- removed the passing of roles through client to api
- stamped single role of user in activity within api 
- fixed query to activities filtering roles of higher level out

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
- created  roles at levels 1, 4, 8, 10 etc
- tested to see if only roles of activities created under current were displayed

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
