### PR TITLE
Hide untested recordsets

### DIFF
--- a/app/src/state/reducers/batch.ts
+++ b/app/src/state/reducers/batch.ts
@@ -193,7 +193,11 @@ function createBatchReducer() {
           ...state,
           working: false,
           error: false,
-          templates: action.payload
+          templates: action.payload.filter(template => [
+            'observation_terrestrial_plant',
+            'treatment_mechanical_terrestrial_plant',
+            'treatment_chemical_terrestrial_plant'
+          ].includes(template.key))
         };
       case BATCH_TEMPLATE_LIST_ERROR:
         return {


### PR DESCRIPTION
Only show terrestrial observation, terrestrial mechanical treatment, and terrestrial chemical treatment.

# Overview

This PR includes the following proposed change(s):

- Added filter to only show terrestrial observation, terrestrial mechanical treatment, and terrestrial chemical treatment.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

- Verified list of record sets on the templates page
- Verified list of record sets displayed in the dropdown on create batch page

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
