### PR TITLE
Bypass transfer access page and fix 2 minor bugs

### DIFF
--- a/app/src/features/home/accessRequest/AccessRequestPage.tsx
+++ b/app/src/features/home/accessRequest/AccessRequestPage.tsx
@@ -45,7 +45,7 @@ const AccessRequestPage: React.FC<IAccessRequestPage> = (props) => {
   const history = useHistory();
   const api = useInvasivesApi();
   const classes = useStyles();
-  const [transferAccess, setTransferAccess] = useState('');
+  const [transferAccess, setTransferAccess] = useState('yes');
   const [accountType, setAccountType] = useState('');
 
   const authState = useSelector(selectAuth);
@@ -282,7 +282,7 @@ const AccessRequestPage: React.FC<IAccessRequestPage> = (props) => {
     },
   };
 
-  const getAgencyDescription = (name:String):String => fundingAgenciesList.find(({code_name}) => code_name === name).code_description;
+  const getAgencyDescription = (name:String):String => fundingAgenciesList.find(({code_name}) => code_name === name)?.code_description;
 
   const handleRequestedRoleChange = (event: SelectChangeEvent<typeof requestedRoles>) => {
     const {
@@ -310,7 +310,7 @@ const AccessRequestPage: React.FC<IAccessRequestPage> = (props) => {
           <Card elevation={8}>
             {!submitted && (
               <CardContent>
-                {!isUpdating && (
+                {/* {!isUpdating && (
                   <FormControl component="fieldset">
                     <FormLabel component="legend">
                       Do you wish to transfer your IAPP access to InvasivesBC when it replaces IAPP?
@@ -331,7 +331,7 @@ const AccessRequestPage: React.FC<IAccessRequestPage> = (props) => {
                     You will be removed from the InvasivesBC lists moving forward. You may, of course, rejoin us at any
                     time.
                   </Typography>
-                )}
+                )} */}
                 {(transferAccess === 'yes' || isUpdating) && (
                   <Grid container direction="column" spacing={3}>
                     {!isUpdating && (
@@ -470,6 +470,7 @@ const AccessRequestPage: React.FC<IAccessRequestPage> = (props) => {
                               id="employer"
                               variant="outlined"
                               label="Employer"
+                              InputLabelProps={{ shrink: true }}
                               error={!!employerErrorText}
                               SelectProps={{
                                 multiple: false,


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- {List all the changes, if possible add the linked issue/ticket #}
- Crystal requested the transfer access component hidden before tonight
- Removal of transfer access yes/no dialog on startup of access-request page
- Bug fix a race condition that crashed the page
- Bug fix for employer label blending into the select of the employer dropdown

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
