### PR TITLE
Move Max Old Space to environment

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/bcgov/invasivesbc.git"
   },
   "scripts": {
-    "start": "NODE_OPTIONS='--max-old-space-size=18192' ts-node src/server",
+    "start": "ts-node src/server",
     "clean": "gulp clean",
     "build": "gulp build",
     "start:reload": "./node_modules/.bin/nodemon src/server.ts --exec ts-node",


### PR DESCRIPTION
It's not respected in the environment when set in the package.json, and is causing some OOM crashes in production

Be sure to set it locally as required.

# Overview

This PR includes the following proposed change(s):

- {List all the changes, if possible add the linked issue/ticket #}

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
