### PR TITLE
spatial filter display and pagination tweaks

### DIFF
--- a/appv2/src/UI/Overlay/Records/RecordSet.tsx
+++ b/appv2/src/UI/Overlay/Records/RecordSet.tsx
@@ -157,15 +157,18 @@ const RecordSetFooter = (props) => {
   const recordTable = useSelector((state: any) => state.Map.recordTables?.[props.setID]);
 
   const totalRecords = layer?.IDList?.length;
-  const loading = layer?.loadingIDList;
+  // const loaded = layer?.loaded;
   const firstRowIndex = recordTable?.page * recordTable?.limit;
   const lastRowIndex =
     totalRecords < firstRowIndex + recordTable?.limit
       ? totalRecords
       : firstRowIndex + recordTable?.limit;
-  const recordDisplayString = layer?.IDList && totalRecords < 1 ? 
-      'No records found' : 
-      `${firstRowIndex + 1} to ${lastRowIndex} of ${totalRecords} records`;
+  let recordDisplayString = 'Loading...';
+  if (totalRecords !== undefined && totalRecords > 0 && !isNaN(firstRowIndex) && !isNaN(lastRowIndex)) {
+    recordDisplayString = `${firstRowIndex + 1} to ${lastRowIndex} of ${totalRecords} records`;
+  } else if (layer?.IDList && totalRecords < 1) {
+    recordDisplayString = 'No records found';
+  }
 
   const shouldDisplayNextButton = totalRecords > lastRowIndex;
   const shouldDisplayPreviousButton = firstRowIndex > 0;
@@ -199,11 +202,7 @@ const RecordSetFooter = (props) => {
         {shouldDisplayPreviousButton ? <ArrowLeftIcon onClick={onClickPrevious} /> : <></>}
       </div>
       <div className="recordSet_pageOfAndTotal">
-      {loading ?
-      '(loading)'
-      :
-      recordDisplayString
-      }
+      {recordDisplayString}
       </div>
       <div className="recordSet_pageNext">
         {shouldDisplayNextButton ? <ArrowRightIcon onClick={onClickNext} /> : <></>}

--- a/appv2/src/UI/Overlay/Records/RecordSet.tsx
+++ b/appv2/src/UI/Overlay/Records/RecordSet.tsx
@@ -409,7 +409,7 @@ const Filter = (props) => {
                   <option key={Math.random()} value={'CONTAINED IN'} label={'CONTAINED IN'}>
                   CONTAINED IN
                   </option>
-                  <option key={Math.random()} value={'NOT CONTAINED IN'} label={'NOT CONTAINED IN'}>
+                  <option key={Math.random()} disabled={true} value={'NOT CONTAINED IN'} label={'NOT CONTAINED IN'}>
                     NOT CONTAINED IN
                   </option>
                 </>

--- a/appv2/src/UI/Overlay/Records/RecordSet.tsx
+++ b/appv2/src/UI/Overlay/Records/RecordSet.tsx
@@ -157,17 +157,19 @@ const RecordSetFooter = (props) => {
   const recordTable = useSelector((state: any) => state.Map.recordTables?.[props.setID]);
 
   const totalRecords = layer?.IDList?.length;
-  // const loaded = layer?.loaded;
+  const loaded = layer?.loaded;
   const firstRowIndex = recordTable?.page * recordTable?.limit;
   const lastRowIndex =
     totalRecords < firstRowIndex + recordTable?.limit
       ? totalRecords
       : firstRowIndex + recordTable?.limit;
   let recordDisplayString = 'Loading...';
-  if (totalRecords !== undefined && totalRecords > 0 && !isNaN(firstRowIndex) && !isNaN(lastRowIndex)) {
-    recordDisplayString = `${firstRowIndex + 1} to ${lastRowIndex} of ${totalRecords} records`;
-  } else if (layer?.IDList && totalRecords < 1) {
-    recordDisplayString = 'No records found';
+  if (loaded) {
+    if (totalRecords !== undefined && totalRecords > 0 && !isNaN(firstRowIndex) && !isNaN(lastRowIndex)) {
+      recordDisplayString = `${firstRowIndex + 1} to ${lastRowIndex} of ${totalRecords} records`;
+    } else if (layer?.IDList && totalRecords < 1) {
+      recordDisplayString = 'No records found';
+    }
   }
 
   const shouldDisplayNextButton = totalRecords > lastRowIndex;

--- a/appv2/src/UI/Overlay/Records/RecordSet.tsx
+++ b/appv2/src/UI/Overlay/Records/RecordSet.tsx
@@ -157,11 +157,15 @@ const RecordSetFooter = (props) => {
   const recordTable = useSelector((state: any) => state.Map.recordTables?.[props.setID]);
 
   const totalRecords = layer?.IDList?.length;
+  const loading = layer?.loadingIDList;
   const firstRowIndex = recordTable?.page * recordTable?.limit;
   const lastRowIndex =
     totalRecords < firstRowIndex + recordTable?.limit
       ? totalRecords
       : firstRowIndex + recordTable?.limit;
+  const recordDisplayString = layer?.IDList && totalRecords < 1 ? 
+      'No records found' : 
+      `${firstRowIndex + 1} to ${lastRowIndex} of ${totalRecords} records`;
 
   const shouldDisplayNextButton = totalRecords > lastRowIndex;
   const shouldDisplayPreviousButton = firstRowIndex > 0;
@@ -194,9 +198,13 @@ const RecordSetFooter = (props) => {
       <div className="recordSet_pagePrevious">
         {shouldDisplayPreviousButton ? <ArrowLeftIcon onClick={onClickPrevious} /> : <></>}
       </div>
-      <div className="recordSet_pageOfAndTotal">{`${firstRowIndex + 1} to ${lastRowIndex} of ${
-        totalRecords ? totalRecords : '(Loading)'
-      } records`}</div>
+      <div className="recordSet_pageOfAndTotal">
+      {loading ?
+      '(loading)'
+      :
+      recordDisplayString
+      }
+      </div>
       <div className="recordSet_pageNext">
         {shouldDisplayNextButton ? <ArrowRightIcon onClick={onClickNext} /> : <></>}
       </div>

--- a/appv2/src/state/reducers/map.ts
+++ b/appv2/src/state/reducers/map.ts
@@ -246,12 +246,13 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           break;
         }
         case ACTIVITIES_GET_IDS_FOR_RECORDSET_REQUEST: {
-          if (draftState[action.payload.recordSetID]) draftState[action.payload.recordSetID].loaded = false;
+          let index = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.recordSetID);
+          draftState.layers[index].loaded = false;
           break;
         }
         case IAPP_GET_IDS_FOR_RECORDSET_REQUEST: {
-          if (draftState.layers[action.payload.recordSetID])
-            draftState.layers[action.payload.recordSetID].loaded = false;
+          let index = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.recordSetID);
+          draftState.layers[index].loaded = false;
           break;
         }
         case ACTIVITIES_GET_IDS_FOR_RECORDSET_SUCCESS: {

--- a/appv2/src/state/reducers/map.ts
+++ b/appv2/src/state/reducers/map.ts
@@ -55,7 +55,9 @@ import {
   WHATS_HERE_IAPP_ROWS_SUCCESS,
   WHATS_HERE_PAGE_ACTIVITY,
   WHATS_HERE_PAGE_POI,
-  WHATS_HERE_SORT_FILTER_UPDATE
+  WHATS_HERE_SORT_FILTER_UPDATE,
+  ACTIVITIES_GET_IDS_FOR_RECORDSET_REQUEST,
+  IAPP_GET_IDS_FOR_RECORDSET_REQUEST
 } from '../actions';
 
 import { createNextState } from '@reduxjs/toolkit';
@@ -438,9 +440,9 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           break;
         }
         case MAP_TOGGLE_WHATS_HERE: {
-          if(draftState.whatsHere.toggle) {
-            draftState.whatsHere.loadingActivities = false
-            draftState.whatsHere.loadingIAPP = false
+          if (draftState.whatsHere.toggle) {
+            draftState.whatsHere.loadingActivities = false;
+            draftState.whatsHere.loadingIAPP = false;
           }
           draftState.whatsHere.toggle = !state.whatsHere.toggle;
           draftState.whatsHere.feature = null;

--- a/appv2/src/state/reducers/map.ts
+++ b/appv2/src/state/reducers/map.ts
@@ -245,12 +245,34 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           }
           break;
         }
+        case ACTIVITIES_GET_IDS_FOR_RECORDSET_REQUEST: {
+          // const newState = JSON.parse(JSON.stringify({ ...state.layers }));
+          // if (newState[action.payload.recordSetID]) newState[action.payload.recordSetID].loadingIDList = true;
+          // return {
+          //   ...state,
+          //   layers: JSON.parse(JSON.stringify({ ...newState }))
+          // };
+          if (draftState[action.payload.recordSetID]) draftState[action.payload.recordSetID].loadingIDList = true;
+          break;
+        }
+        case IAPP_GET_IDS_FOR_RECORDSET_REQUEST: {
+          // const newState = JSON.parse(JSON.stringify({ ...state.layers }));
+          // if (newState[action.payload.recordSetID]) newState[action.payload.recordSetID].loadingIDList = false;
+          // return {
+          //   ...state,
+          //   layers: JSON.parse(JSON.stringify({ ...newState }))
+          // };
+          if (draftState.layers[action.payload.recordSetID])
+            draftState.layers[action.payload.recordSetID].loadingIDList = false;
+          break;
+        }
         case ACTIVITIES_GET_IDS_FOR_RECORDSET_SUCCESS: {
           let index = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.recordSetID);
           if (!draftState.layers[index]) draftState.layers.push({ recordSetID: action.payload.recordSetID });
           index = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.recordSetID);
           draftState.layers[index].IDList = action.payload.IDList;
           draftState.layers[index].loaded = true;
+          draftState.layers[index].loadingIDList = false;
 
           //if (draftState.activitiesGeoJSON?.features?.length > 0) {
           if (draftState.activitiesGeoJSONDict !== undefined) {
@@ -341,6 +363,7 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           index = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.recordSetID);
           draftState.layers[index].IDList = action.payload.IDList;
           draftState.layers[index].loaded = true;
+          draftState.layers[index].loadingIDList = false;
 
           if (draftState.IAPPGeoJSON?.features?.length > 0) {
             GeoJSONFilterSetForLayer(draftState, state, 'IAPP', action.payload.recordSetID, action.payload.IDList);

--- a/appv2/src/state/reducers/map.ts
+++ b/appv2/src/state/reducers/map.ts
@@ -246,24 +246,12 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           break;
         }
         case ACTIVITIES_GET_IDS_FOR_RECORDSET_REQUEST: {
-          // const newState = JSON.parse(JSON.stringify({ ...state.layers }));
-          // if (newState[action.payload.recordSetID]) newState[action.payload.recordSetID].loadingIDList = true;
-          // return {
-          //   ...state,
-          //   layers: JSON.parse(JSON.stringify({ ...newState }))
-          // };
-          if (draftState[action.payload.recordSetID]) draftState[action.payload.recordSetID].loadingIDList = true;
+          if (draftState[action.payload.recordSetID]) draftState[action.payload.recordSetID].loaded = false;
           break;
         }
         case IAPP_GET_IDS_FOR_RECORDSET_REQUEST: {
-          // const newState = JSON.parse(JSON.stringify({ ...state.layers }));
-          // if (newState[action.payload.recordSetID]) newState[action.payload.recordSetID].loadingIDList = false;
-          // return {
-          //   ...state,
-          //   layers: JSON.parse(JSON.stringify({ ...newState }))
-          // };
           if (draftState.layers[action.payload.recordSetID])
-            draftState.layers[action.payload.recordSetID].loadingIDList = false;
+            draftState.layers[action.payload.recordSetID].loaded = false;
           break;
         }
         case ACTIVITIES_GET_IDS_FOR_RECORDSET_SUCCESS: {
@@ -272,7 +260,6 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           index = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.recordSetID);
           draftState.layers[index].IDList = action.payload.IDList;
           draftState.layers[index].loaded = true;
-          draftState.layers[index].loadingIDList = false;
 
           //if (draftState.activitiesGeoJSON?.features?.length > 0) {
           if (draftState.activitiesGeoJSONDict !== undefined) {
@@ -363,7 +350,6 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           index = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.recordSetID);
           draftState.layers[index].IDList = action.payload.IDList;
           draftState.layers[index].loaded = true;
-          draftState.layers[index].loadingIDList = false;
 
           if (draftState.IAPPGeoJSON?.features?.length > 0) {
             GeoJSONFilterSetForLayer(draftState, state, 'IAPP', action.payload.recordSetID, action.payload.IDList);


### PR DESCRIPTION
- disabled not contained in for drawn spatial filter
- Upgrade pagination on record sets for clearer UX

# Overview

This PR includes the following proposed change(s):

- {List all the changes, if possible add the linked issue/ticket #}
- Fisabled the option for not contained in for the drawn spatial filter
- Made pagination have a "no records found" option while cleaning up the undefined and loading

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
