### PR TITLE
Closes #3091

### DIFF
--- a/appv2/src/UI/Map/Buttons/ButtonContainer.tsx
+++ b/appv2/src/UI/Map/Buttons/ButtonContainer.tsx
@@ -5,7 +5,7 @@ import { FindMeToggle, LocationMarker, PanToMe } from './FindMe';
 import { HDToggle } from './HDToggle';
 import { LegendsButton } from "./LegendsButton";
 import { WhatsHereButton, WhatsHereDrawComponent } from './WhatsHereButton';
-import { WhatsHereCurrentRecordHighlighted, WhatsHereMarker } from './WhatsHereMarker';
+import { WhatsHereCurrentRecordHighlighted } from './WhatsHereMarker';
 import './ButtonContainer.css';
 import { useSelector } from 'util/use_selector';
 import { NewRecord } from './NewRecord';

--- a/appv2/src/state/reducers/map.ts
+++ b/appv2/src/state/reducers/map.ts
@@ -400,7 +400,6 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           draftState.layers[index].IDList = action.payload.IDList;
           draftState.layers[index].loading = false;
 
-
           if (draftState.IAPPGeoJSONDict !== undefined) {
             GeoJSONFilterSetForLayer(draftState, state, 'IAPP', action.payload.recordSetID, action.payload.IDList);
           }

--- a/appv2/src/state/reducers/map.ts
+++ b/appv2/src/state/reducers/map.ts
@@ -230,7 +230,9 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
             draftState.recordTables[action.payload.recordSetID] = {};
           }
           draftState.recordTables[action.payload.recordSetID].loading = true;
-          draftState.recordTables[action.payload.recordSetID].reqCount = draftState.recordTables[action.payload.recordSetID].reqCount ? draftState.recordTables[action.payload.recordSetID].reqCount + 1 : 1;
+          draftState.recordTables[action.payload.recordSetID].page = action.payload.page;
+          draftState.recordTables[action.payload.recordSetID].limit = action.payload.limit;
+          draftState.recordTables[action.payload.recordSetID].tableFiltersHash = action.payload.tableFiltersHash;
           break;
         }
         case ACTIVITIES_GEOJSON_GET_SUCCESS: {
@@ -312,16 +314,26 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
         }
         case IAPP_TABLE_ROWS_GET_SUCCESS:
         case ACTIVITIES_TABLE_ROWS_GET_SUCCESS: {
+          // the hash, page, and limit all need to line up
+          if(draftState.recordTables?.[action.payload.recordSetID]?.tableFiltersHash !== action.payload.tableFiltersHash){
+            console.log('hash mismatch', draftState.recordTables?.[action.payload.recordSetID]?.tableFiltersHash, action.payload.tableFiltersHash);
+            break;
+          }
+          if((Number(draftState.recordTables?.[action.payload.recordSetID]?.limit) !== Number(action.payload.limit))){
+            console.log('limit mismatch', draftState.recordTables?.[action.payload.recordSetID]?.limit, action.payload.limit);
+            console.log('typeof', typeof draftState.recordTables?.[action.payload.recordSetID]?.limit, typeof action.payload.limit);
+            break;
+          }
+          if((Number(draftState.recordTables?.[action.payload.recordSetID]?.page) !== Number(action.payload.page))){
+            console.log('page mismatch', draftState.recordTables?.[action.payload.recordSetID]?.page, action.payload.page);
+            break;
+          }
           if (draftState.recordTables?.[action.payload.recordSetID]) {
             draftState.recordTables[action.payload.recordSetID].rows = action.payload.rows;
           } else {
             draftState.recordTables[action.payload.recordSetID] = {};
             draftState.recordTables[action.payload.recordSetID].rows = action.payload.rows;
           } // set defaults
-          if (!draftState.recordTables?.[action.payload.recordSetID]?.page)
-            draftState.recordTables[action.payload.recordSetID].page = 0;
-          if (!draftState.recordTables?.[action.payload.recordSetID]?.limit)
-            draftState.recordTables[action.payload.recordSetID].limit = 20;
           draftState.recordTables[action.payload.recordSetID].loading = false;
           break;
         }

--- a/appv2/src/state/reducers/map.ts
+++ b/appv2/src/state/reducers/map.ts
@@ -256,8 +256,8 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
             draftState.layers.push({ recordSetID: action.payload.recordSetID, type: 'Activity' });
             index = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.recordSetID);
           }
+          draftState.layers[index].tableFiltersHash = action.payload.tableFiltersHash;
           draftState.layers[index].loading = true;
-          draftState.layers[index].reqCount = draftState.layers[index].reqCount ? draftState.layers[index].reqCount + 1 : 1;
           if (!draftState.layers[index].layerState) {
             draftState.layers[index].layerState = {
               color: 'blue',
@@ -273,8 +273,8 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
             draftState.layers.push({ recordSetID: action.payload.recordSetID, type: 'IAPP' });
             index = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.recordSetID);
           }
+          draftState.layers[index].tableFiltersHash = action.payload.tableFiltersHash;
           draftState.layers[index].loading = true;
-          draftState.layers[index].reqCount = draftState.layers[index].reqCount ? draftState.layers[index].reqCount + 1 : 1;
           if (!draftState.layers[index].layerState) {
             draftState.layers[index].layerState = {
               color: 'blue',
@@ -291,10 +291,15 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           break;
         }
         case ACTIVITIES_GET_IDS_FOR_RECORDSET_SUCCESS: {
+
           let index = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.recordSetID);
           if (!draftState.layers[index])
             draftState.layers.push({ recordSetID: action.payload.recordSetID, type: 'Activity' });
           index = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.recordSetID);
+
+          if(action.payload.tableFiltersHash !== draftState.layers[index]?.tableFiltersHash){
+            break;
+          }
           draftState.layers[index].IDList = action.payload.IDList;
           draftState.layers[index].loading = false;
 
@@ -377,6 +382,9 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           let index = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.recordSetID);
           if (!draftState.layers[index]) draftState.layers.push({ recordSetID: action.payload.recordSetID });
           index = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.recordSetID);
+          if(action.payload.tableFiltersHash !== draftState.layers[index]?.tableFiltersHash){
+            break;
+          }
           draftState.layers[index].IDList = action.payload.IDList;
           draftState.layers[index].loading = false;
 

--- a/appv2/src/state/sagas/map.ts
+++ b/appv2/src/state/sagas/map.ts
@@ -631,12 +631,12 @@ function* handle_UserFilterChange(action) {
   )
     if (recordSetType === 'Activity') {
       if (currentSet === action.payload.setID)
-        yield put({ type: ACTIVITIES_TABLE_ROWS_GET_REQUEST, payload: { recordSetID: action.payload.setID } });
-      yield put({ type: ACTIVITIES_GET_IDS_FOR_RECORDSET_REQUEST, payload: { recordSetID: action.payload.setID } });
+        yield put({ type: ACTIVITIES_TABLE_ROWS_GET_REQUEST, payload: { recordSetID: action.payload.setID, tableFiltersHash: recordSetsState.recordSets?.[action.payload.setID]?.tableFiltersHash } });
+      yield put({ type: ACTIVITIES_GET_IDS_FOR_RECORDSET_REQUEST, payload: { recordSetID: action.payload.setID, tableFiltersHash: recordSetsState.recordSets?.[action.payload.setID]?.tableFiltersHash } });
     } else {
       if (currentSet === action.payload.setID)
-        yield put({ type: IAPP_TABLE_ROWS_GET_REQUEST, payload: { recordSetID: action.payload.setID } });
-      yield put({ type: IAPP_GET_IDS_FOR_RECORDSET_REQUEST, payload: { recordSetID: action.payload.setID } });
+        yield put({ type: IAPP_TABLE_ROWS_GET_REQUEST, payload: { recordSetID: action.payload.setID, tableFiltersHash: recordSetsState.recordSets?.[action.payload.setID]?.tableFiltersHash } });
+      yield put({ type: IAPP_GET_IDS_FOR_RECORDSET_REQUEST, payload: { recordSetID: action.payload.setID, tableFiltersHash: recordSetsState.recordSets?.[action.payload.setID]?.tableFiltersHash } });
     }
 }
 
@@ -644,9 +644,9 @@ function* handle_PAGE_OR_LIMIT_UPDATE(action) {
   const recordSetsState = yield select(selectUserSettings);
   const recordSetType = recordSetsState.recordSets?.[action.payload.setID]?.recordSetType;
   if (recordSetType === 'Activity') {
-    yield put({ type: ACTIVITIES_TABLE_ROWS_GET_REQUEST, payload: { recordSetID: action.payload.setID } });
+    yield put({ type: ACTIVITIES_TABLE_ROWS_GET_REQUEST, payload: { recordSetID: action.payload.setID, tableFiltersHash: recordSetsState.recordSets?.[action.payload.setID]?.tableFiltersHash } });
   } else {
-    yield put({ type: IAPP_TABLE_ROWS_GET_REQUEST, payload: { recordSetID: action.payload.setID } });
+    yield put({ type: IAPP_TABLE_ROWS_GET_REQUEST, payload: { recordSetID: action.payload.setID, tableFiltersHash: recordSetsState.recordSets?.[action.payload.setID]?.tableFiltersHash } });
   }
 }
 
@@ -672,9 +672,9 @@ function* handle_MAP_INIT_FOR_RECORDSETS(action) {
   let actionsToPut = [];
   allUninitializedLayers.map((layer) => {
     if (layer.recordSetType === 'Activity') {
-      actionsToPut.push({ type: ACTIVITIES_GET_IDS_FOR_RECORDSET_REQUEST, payload: { recordSetID: layer.recordSetID } });
+      actionsToPut.push({ type: ACTIVITIES_GET_IDS_FOR_RECORDSET_REQUEST, payload: { recordSetID: layer.recordSetID, tableFiltersHash: 'init' } });
     } else {
-      actionsToPut.push({ type: IAPP_GET_IDS_FOR_RECORDSET_REQUEST, payload: { recordSetID: layer.recordSetID } });
+      actionsToPut.push({ type: IAPP_GET_IDS_FOR_RECORDSET_REQUEST, payload: { recordSetID: layer.recordSetID, tableFiltersHash: 'init' } });
     }
 
   });

--- a/appv2/src/state/sagas/map.ts
+++ b/appv2/src/state/sagas/map.ts
@@ -150,18 +150,18 @@ function* handle_MAP_INIT_REQUEST(action) {
   const defaultRecordSet = {
     ['1']: {
       recordSetType: 'Activity',
-      recordSetName: 'My Drafts',
+      recordSetName: 'My Drafts'
     },
     ['2']: {
       recordSetType: 'Activity',
       recordSetName: 'All InvasivesBC Activities',
-      drawOrder: 1,
+      drawOrder: 1
     },
     ['3']: {
       recordSetType: 'IAPP',
       recordSetName: 'All IAPP Records',
       color: '#21f34f',
-      drawOrder: 2,
+      drawOrder: 2
     }
   };
   const recordSets = oldAppState?.recordSets ? oldAppState.recordSets : defaultRecordSet;
@@ -259,7 +259,7 @@ function* handle_WHATS_HERE_FEATURE(action) {
     });
 
     var activityLayersLoading = toggledOnActivityLayers.filter((layer) => {
-      return layer.loading
+      return layer.loading;
     });
 
     var toggledOnIAPPLayers = mapState.layers.filter((layer) => {
@@ -584,39 +584,39 @@ function* handle_URL_CHANGE(action) {
     });
 
     let recordSetsState = yield select(selectUserSettings);
-    let mapState = yield select(selectMap);
-    if (!recordSetsState.recordSets) {
-      yield take(USER_SETTINGS_GET_INITIAL_STATE_SUCCESS);
+    let recordSetType = recordSetsState.recordSets?.[id]?.recordSetType;
+    if(recordSetType === undefined){
+      yield take(USER_SETTINGS_GET_INITIAL_STATE_SUCCESS)
       recordSetsState = yield select(selectUserSettings);
-      mapState = yield select(selectMap);
+      recordSetType = recordSetsState.recordSets?.[id]?.recordSetType;
     }
-    const recordSet = JSON.parse(JSON.stringify(recordSetsState.recordSets?.[id]));
+    console.log('%crecordSetType:, ' + recordSetType, 'color: #00ff00')
+    const mapState = yield select(selectMap);
+    const page = mapState.recordTables?.[id]?.page || 0;
+    const limit = mapState.recordTables?.[id]?.limit || 20;
 
-    const type = recordSet.recordSetType;
-    if (type === 'Activity') {
+    if (recordSetType === 'Activity') {
       yield put({
         type: ACTIVITIES_TABLE_ROWS_GET_REQUEST,
         payload: {
-          recordSetID: id
+          recordSetID: id,
+          tableFiltersHash: recordSetsState.recordSets?.[id]?.tableFiltersHash,
+          page: page,
+          limit: limit
         }
       });
     } else {
       yield put({
         type: IAPP_TABLE_ROWS_GET_REQUEST,
         payload: {
-          recordSetID: id
+          recordSetID: id,
+          tableFiltersHash: recordSetsState.recordSets?.[id]?.tableFiltersHash,
+          page: page,
+          limit: limit
         }
       });
     }
   }
-
-  /*let mapState = yield select(selectMap);
-  if (!url.includes('WhatsHere') && mapState.whatsHere.toggle) {
-    yield put({
-      type: MAP_TOGGLE_WHATS_HERE
-    });
-  }
-  */
 }
 
 function* handle_UserFilterChange(action) {
@@ -631,22 +631,73 @@ function* handle_UserFilterChange(action) {
   )
     if (recordSetType === 'Activity') {
       if (currentSet === action.payload.setID)
-        yield put({ type: ACTIVITIES_TABLE_ROWS_GET_REQUEST, payload: { recordSetID: action.payload.setID, tableFiltersHash: recordSetsState.recordSets?.[action.payload.setID]?.tableFiltersHash } });
-      yield put({ type: ACTIVITIES_GET_IDS_FOR_RECORDSET_REQUEST, payload: { recordSetID: action.payload.setID, tableFiltersHash: recordSetsState.recordSets?.[action.payload.setID]?.tableFiltersHash } });
+        yield put({
+          type: ACTIVITIES_TABLE_ROWS_GET_REQUEST,
+          payload: {
+            recordSetID: action.payload.setID,
+            tableFiltersHash: recordSetsState.recordSets?.[action.payload.setID]?.tableFiltersHash,
+            page: 0,
+            limit: 20
+          }
+        });
+      yield put({
+        type: ACTIVITIES_GET_IDS_FOR_RECORDSET_REQUEST,
+        payload: {
+          recordSetID: action.payload.setID,
+          tableFiltersHash: recordSetsState.recordSets?.[action.payload.setID]?.tableFiltersHash
+        }
+      });
     } else {
       if (currentSet === action.payload.setID)
-        yield put({ type: IAPP_TABLE_ROWS_GET_REQUEST, payload: { recordSetID: action.payload.setID, tableFiltersHash: recordSetsState.recordSets?.[action.payload.setID]?.tableFiltersHash } });
-      yield put({ type: IAPP_GET_IDS_FOR_RECORDSET_REQUEST, payload: { recordSetID: action.payload.setID, tableFiltersHash: recordSetsState.recordSets?.[action.payload.setID]?.tableFiltersHash } });
+        yield put({
+          type: IAPP_TABLE_ROWS_GET_REQUEST,
+          payload: {
+            recordSetID: action.payload.setID,
+            tableFiltersHash: recordSetsState.recordSets?.[action.payload.setID]?.tableFiltersHash,
+            page: 0,
+            limit: 20
+          }
+        });
+      yield put({
+        type: IAPP_GET_IDS_FOR_RECORDSET_REQUEST,
+        payload: {
+          recordSetID: action.payload.setID,
+          tableFiltersHash: recordSetsState.recordSets?.[action.payload.setID]?.tableFiltersHash
+        }
+      });
     }
 }
 
 function* handle_PAGE_OR_LIMIT_UPDATE(action) {
   const recordSetsState = yield select(selectUserSettings);
   const recordSetType = recordSetsState.recordSets?.[action.payload.setID]?.recordSetType;
+  const mapState = yield select(selectMap);
+
+  const page = action.payload.page ? action.payload.page : mapState.recordTables?.[action.payload.recordSetID]?.page;
+  const limit = action.payload.limit
+    ? action.payload.limit
+    : mapState.recordTables?.[action.payload.recordSetID]?.limit;
+
   if (recordSetType === 'Activity') {
-    yield put({ type: ACTIVITIES_TABLE_ROWS_GET_REQUEST, payload: { recordSetID: action.payload.setID, tableFiltersHash: recordSetsState.recordSets?.[action.payload.setID]?.tableFiltersHash } });
+    yield put({
+      type: ACTIVITIES_TABLE_ROWS_GET_REQUEST,
+      payload: {
+        recordSetID: action.payload.setID,
+        tableFiltersHash: recordSetsState.recordSets?.[action.payload.setID]?.tableFiltersHash,
+        page: page,
+        limit: limit
+      }
+    });
   } else {
-    yield put({ type: IAPP_TABLE_ROWS_GET_REQUEST, payload: { recordSetID: action.payload.setID, tableFiltersHash: recordSetsState.recordSets?.[action.payload.setID]?.tableFiltersHash } });
+    yield put({
+      type: IAPP_TABLE_ROWS_GET_REQUEST,
+      payload: {
+        recordSetID: action.payload.setID,
+        tableFiltersHash: recordSetsState.recordSets?.[action.payload.setID]?.tableFiltersHash,
+        page: page,
+        limit: limit
+      }
+    });
   }
 }
 
@@ -655,30 +706,40 @@ function* handle_MAP_INIT_FOR_RECORDSETS(action) {
   const recordSets = Object.keys(userSettingsState.recordSets);
 
   // current layers
-  const layers = yield select((state) => state.Map.layers)
+  const layers = yield select((state) => state.Map.layers);
   const layerIDs = layers.map((layer) => layer.recordSetID);
 
   // current but unintialized:
-  const currentUninitializedLayers = layers.filter((layer) => !layer?.IDList).map((layer) => {return { recordSetID: layer.recordSetID, recordSetType: layer.type }});
+  const currentUninitializedLayers = layers
+    .filter((layer) => !layer?.IDList)
+    .map((layer) => {
+      return { recordSetID: layer.recordSetID, recordSetType: layer.type };
+    });
 
   // in record set but not in layers
   const newLayerIDs = recordSets.filter((recordSet) => !layerIDs.includes(recordSet));
-  const newUninitializedLayers = newLayerIDs.map((layer) => {return { recordSetID: layer, recordSetType: userSettingsState.recordSets[layer].recordSetType }});
+  const newUninitializedLayers = newLayerIDs.map((layer) => {
+    return { recordSetID: layer, recordSetType: userSettingsState.recordSets[layer].recordSetType };
+  });
 
   // combined:
-  const allUninitializedLayers = [...currentUninitializedLayers, ...newUninitializedLayers];  
-
+  const allUninitializedLayers = [...currentUninitializedLayers, ...newUninitializedLayers];
 
   let actionsToPut = [];
   allUninitializedLayers.map((layer) => {
     if (layer.recordSetType === 'Activity') {
-      actionsToPut.push({ type: ACTIVITIES_GET_IDS_FOR_RECORDSET_REQUEST, payload: { recordSetID: layer.recordSetID, tableFiltersHash: 'init' } });
+      actionsToPut.push({
+        type: ACTIVITIES_GET_IDS_FOR_RECORDSET_REQUEST,
+        payload: { recordSetID: layer.recordSetID, tableFiltersHash: 'init' }
+      });
     } else {
-      actionsToPut.push({ type: IAPP_GET_IDS_FOR_RECORDSET_REQUEST, payload: { recordSetID: layer.recordSetID, tableFiltersHash: 'init' } });
+      actionsToPut.push({
+        type: IAPP_GET_IDS_FOR_RECORDSET_REQUEST,
+        payload: { recordSetID: layer.recordSetID, tableFiltersHash: 'init' }
+      });
     }
-
   });
-  yield all(actionsToPut.map((action) => put(action)))
+  yield all(actionsToPut.map((action) => put(action)));
 }
 
 function* handle_REMOVE_CLIENT_BOUNDARY(action) {
@@ -771,7 +832,7 @@ function* activitiesPageSaga() {
 
     takeEvery(REFETCH_SERVER_BOUNDARIES, refetchServerBoundaries),
 
-    takeEvery(USER_SETTINGS_ADD_RECORD_SET,handle_MAP_INIT_FOR_RECORDSETS),
+    takeEvery(USER_SETTINGS_ADD_RECORD_SET, handle_MAP_INIT_FOR_RECORDSETS),
     takeEvery(REMOVE_SERVER_BOUNDARY, handle_REMOVE_SERVER_BOUNDARY),
     takeEvery(PAGE_OR_LIMIT_UPDATE, handle_PAGE_OR_LIMIT_UPDATE),
     takeEvery(USER_SETTINGS_GET_INITIAL_STATE_SUCCESS, handle_USER_SETTINGS_GET_INITIAL_STATE_SUCCESS),
@@ -800,7 +861,7 @@ function* activitiesPageSaga() {
     takeEvery(MAP_LABEL_EXTENT_FILTER_REQUEST, handle_MAP_LABEL_EXTENT_FILTER_REQUEST),
     takeEvery(IAPP_EXTENT_FILTER_REQUEST, handle_IAPP_EXTENT_FILTER_REQUEST),
     takeEvery(URL_CHANGE, handle_URL_CHANGE),
-    takeEvery(CUSTOM_LAYER_DRAWN, persistClientBoundaries),
+    takeEvery(CUSTOM_LAYER_DRAWN, persistClientBoundaries)
   ]);
 }
 

--- a/appv2/src/state/sagas/map/dataAccess.ts
+++ b/appv2/src/state/sagas/map/dataAccess.ts
@@ -113,9 +113,6 @@ export function* handle_IAPP_GET_IDS_FOR_RECORDSET_REQUEST(action) {
     filterObject.limit = 200000;
     filterObject.selectColumns = ['site_id'];
 
-    const layerReqCount = mapState?.layers?.filter((layer) => {
-      return layer?.recordSetID === action.payload.recordSetID;
-    })?.[0]?.reqCount;
 
     // if mobile or web
     if (true) {
@@ -124,7 +121,7 @@ export function* handle_IAPP_GET_IDS_FOR_RECORDSET_REQUEST(action) {
         payload: {
           filterObj: filterObject,
           recordSetID: action.payload.recordSetID,
-          reqCount: layerReqCount
+          tableFiltersHash: action.payload.tableFiltersHash
         }
       });
     }
@@ -220,21 +217,29 @@ export function* handle_IAPP_TABLE_ROWS_GET_REQUEST(action) {
       currentState,
       mapState?.clientBoundaries
     );
-    filterObject.page = action.payload.page
-      ? action.payload.page
-      : mapState.recordTables?.[action.payload.recordSetID]?.page;
-    filterObject.limit = action.payload.limit
-      ? action.payload.limit
-      : mapState.recordTables?.[action.payload.recordSetID]?.limit;
-    // if mobile or web
-    const reqCount = mapState?.recordTables?.[action.payload.recordSetID]?.reqCount;
+    filterObject.page = action.payload.page;
+    filterObject.limit = action.payload.limit;
+
+    if (mapState?.recordTables?.[action.payload.recordSetID]?.tableFiltersHash !== action.payload.tableFiltersHash) {
+      console.log('Stale tableRow request (tableFiltersHash mismatch), aborting')
+      return;
+    }
+    if (
+      mapState?.recordTables?.[action.payload.recordSetID]?.page !== action.payload.page ||
+      mapState?.recordTables?.[action.payload.recordSetID]?.limit !== action.payload.limit
+    ) {
+      console.log('Stale tableRow request (page or limit mismatch), aborting')
+      return;
+    }
     if (true) {
       yield put({
         type: IAPP_TABLE_ROWS_GET_ONLINE,
         payload: {
           filterObj: filterObject,
           recordSetID: action.payload.recordSetID,
-          reqCount: reqCount
+          tableFiltersHash: action.payload.tableFiltersHash,
+          page: action.payload.page,
+          limit: action.payload.limit
         }
       });
     }

--- a/appv2/src/state/sagas/map/dataAccess.ts
+++ b/appv2/src/state/sagas/map/dataAccess.ts
@@ -174,14 +174,20 @@ export function* handle_ACTIVITIES_TABLE_ROWS_GET_REQUEST(action) {
       currentState,
       mapState?.clientBoundaries
     );
-    filterObject.page = action.payload.page
-      ? action.payload.page
-      : mapState.recordTables?.[action.payload.recordSetID]?.page;
-    filterObject.limit = action.payload.limit
-      ? action.payload.limit
-      : mapState.recordTables?.[action.payload.recordSetID]?.limit;
+    filterObject.page = action.payload.page;
+    filterObject.limit = action.payload.limit;
 
-    const reqCount = mapState?.recordTables?.[action.payload.recordSetID]?.reqCount;
+    if (mapState?.recordTables?.[action.payload.recordSetID]?.tableFiltersHash !== action.payload.tableFiltersHash) {
+      console.log('Stale tableRow request (tableFiltersHash mismatch), aborting')
+      return;
+    }
+    if (
+      mapState?.recordTables?.[action.payload.recordSetID]?.page !== action.payload.page ||
+      mapState?.recordTables?.[action.payload.recordSetID]?.limit !== action.payload.limit
+    ) {
+      console.log('Stale tableRow request (page or limit mismatch), aborting')
+      return;
+    }
 
     if (true) {
       yield put({
@@ -189,7 +195,10 @@ export function* handle_ACTIVITIES_TABLE_ROWS_GET_REQUEST(action) {
         payload: {
           filterObj: filterObject,
           recordSetID: action.payload.recordSetID,
-          reqCount: reqCount
+          tableFiltersHash: action.payload.tableFiltersHash,
+          page: action.payload.page,
+          limit: action.payload.limit
+
         }
       });
     }

--- a/appv2/src/state/sagas/map/dataAccess.ts
+++ b/appv2/src/state/sagas/map/dataAccess.ts
@@ -79,10 +79,6 @@ export function* handle_ACTIVITIES_GET_IDS_FOR_RECORDSET_REQUEST(action) {
   filterObject.limit = 200000;
   filterObject.selectColumns = ['activity_id'];
 
-  const layerReqCount = mapState?.layers?.filter((layer) => {
-    return layer?.recordSetID === action.payload.recordSetID;
-  })?.[0]?.reqCount;
-
   try {
     // if mobile or web
     if (true) {
@@ -91,7 +87,7 @@ export function* handle_ACTIVITIES_GET_IDS_FOR_RECORDSET_REQUEST(action) {
         payload: {
           filterObj: filterObject,
           recordSetID: action.payload.recordSetID,
-          reqCount: layerReqCount
+          tableFiltersHash: action.payload.tableFiltersHash
         }
       });
     }

--- a/appv2/src/state/sagas/map/online.ts
+++ b/appv2/src/state/sagas/map/online.ts
@@ -138,20 +138,18 @@ export function* handle_IAPP_GEOJSON_GET_ONLINE(action) {
 
 export function* handle_ACTIVITIES_TABLE_ROWS_GET_ONLINE(action) {
   let mapState = yield select((state) => state.Map);
-  let reqCount = mapState?.recordTables[action.payload.recordSetID]?.reqCount;
-  if (reqCount !== action.payload.reqCount) {
-    return;
-  }
+  let tableFiltersHash = mapState?.recordTables[action.payload.recordSetID]?.tableFiltersHash;
 
   const networkReturn = yield InvasivesAPI_Call('POST', `/api/v2/activities/`, {
     filterObjects: [action.payload.filterObj]
   });
 
   mapState = yield select((state) => state.Map);
-  reqCount = mapState?.recordTables[action.payload.recordSetID]?.reqCount;
-  if (reqCount !== action.payload.reqCount) {
+  tableFiltersHash = mapState?.recordTables[action.payload.recordSetID]?.tableFiltersHash;
+  if (tableFiltersHash !== action.payload.tableFiltersHash) {
     return;
   }
+
 
   if (networkReturn.data.result) {
     yield put({
@@ -159,7 +157,9 @@ export function* handle_ACTIVITIES_TABLE_ROWS_GET_ONLINE(action) {
       payload: {
         recordSetID: action.payload.recordSetID,
         rows: networkReturn.data.result,
-        reqCount: action.payload.reqCount
+        tableFiltersHash: action.payload.tableFiltersHash,
+        page: action.payload.page,
+        limit: action.payload.limit
       }
     });
   } else {
@@ -168,6 +168,8 @@ export function* handle_ACTIVITIES_TABLE_ROWS_GET_ONLINE(action) {
       payload: {
         recordSetID: action.payload.recordSetID,
         rows: networkReturn.data.result,
+        page: action.payload.page,
+        limit: action.payload.limit,
         error: networkReturn.data
       }
     });

--- a/appv2/src/state/sagas/map/online.ts
+++ b/appv2/src/state/sagas/map/online.ts
@@ -158,7 +158,8 @@ export function* handle_ACTIVITIES_TABLE_ROWS_GET_ONLINE(action) {
       type: ACTIVITIES_TABLE_ROWS_GET_SUCCESS,
       payload: {
         recordSetID: action.payload.recordSetID,
-        rows: networkReturn.data.result
+        rows: networkReturn.data.result,
+        reqCount: action.payload.reqCount
       }
     });
   } else {
@@ -166,6 +167,7 @@ export function* handle_ACTIVITIES_TABLE_ROWS_GET_ONLINE(action) {
       type: ACTIVITIES_TABLE_ROWS_GET_FAILURE,
       payload: {
         recordSetID: action.payload.recordSetID,
+        rows: networkReturn.data.result,
         error: networkReturn.data
       }
     });
@@ -190,7 +192,8 @@ export function* handle_IAPP_TABLE_ROWS_GET_ONLINE(action) {
       type: IAPP_TABLE_ROWS_GET_SUCCESS,
       payload: {
         recordSetID: action.payload.recordSetID,
-        rows: networkReturn.data.result
+        rows: networkReturn.data.result,
+        reqCount: action.payload.reqCount
       }
     });
   } else {
@@ -198,7 +201,8 @@ export function* handle_IAPP_TABLE_ROWS_GET_ONLINE(action) {
       type: IAPP_TABLE_ROWS_GET_FAILURE,
       payload: {
         recordSetID: action.payload.recordSetID,
-        error: networkReturn.data
+        error: networkReturn.data,
+        reqCount: action.payload.reqCount
       }
     });
   }
@@ -211,11 +215,11 @@ export function* handle_ACTIVITIES_GET_IDS_FOR_RECORDSET_ONLINE(action) {
   //const networkReturn = yield InvasivesAPI_Call('GET', `/api/activities/`, action.payload.ActivityFilterCriteria);
 
   const mapState = yield select((state) => state.Map);
-  const layerReqCount = mapState?.layers?.filter((layer) => {
+  const tableFiltersHash = mapState?.layers?.filter((layer) => {
     return layer?.recordSetID === action.payload.recordSetID;
-  })?.[0]?.reqCount;
+  })?.[0]?.tableFiltersHash;
 
-  if (!layerReqCount === action.payload.layerReqCount) {
+  if (!tableFiltersHash === action.payload.tableFiltersHash) {
     return;
   }
 
@@ -225,20 +229,24 @@ export function* handle_ACTIVITIES_GET_IDS_FOR_RECORDSET_ONLINE(action) {
       return row.activity_id;
     });
 
+    // check again after the network call
     const mapState = yield select((state) => state.Map);
-    const layerReqCount = mapState?.layers?.filter((layer) => {
+    const tableFiltersHash = mapState?.layers?.filter((layer) => {
       return layer?.recordSetID === action.payload.recordSetID;
-    })?.[0]?.reqCount;
-
-    if (!layerReqCount === action.payload.layerReqCount) {
+    })?.[0]?.tableFiltersHash;
+  
+    if (!tableFiltersHash === action.payload.tableFiltersHash) {
       return;
     }
+
 
     yield put({
       type: ACTIVITIES_GET_IDS_FOR_RECORDSET_SUCCESS,
       payload: {
         recordSetID: action.payload.recordSetID,
-        IDList: IDList
+        IDList: IDList,
+        tableFiltersHash: action.payload.tableFiltersHash
+
       }
     });
   } else {
@@ -282,7 +290,8 @@ export function* handle_IAPP_GET_IDS_FOR_RECORDSET_ONLINE(action) {
       type: IAPP_GET_IDS_FOR_RECORDSET_SUCCESS,
       payload: {
         recordSetID: action.payload.recordSetID,
-        IDList: IDList
+        IDList: IDList,
+        layerReqCount: action.payload.layerReqCount
       }
     });
   } else {
@@ -297,29 +306,4 @@ export function* handle_IAPP_GET_IDS_FOR_RECORDSET_ONLINE(action) {
   }
 }
 
-export function* handle_MAP_WHATS_HERE_GET_POI_ONLINE(action) {
-  const networkReturn = yield InvasivesAPI_Call('GET', `/api/points-of-interest/`, action.payload.IAPPFilterCriteria);
 
-  if (networkReturn.data.result.rows) {
-    const IDList = networkReturn.data.result.rows.map((row) => {
-      return row.site_id;
-    });
-
-    yield put({
-      type: IAPP_GET_IDS_FOR_RECORDSET_SUCCESS,
-      payload: {
-        recordSetID: action.payload.recordSetID,
-        IDList: IDList
-      }
-    });
-  } else {
-    /*  put({
-      type: IAPP_GET_IDS_FOR_RECORDSET_ONLINE,
-      payload: {
-        recordSetID: action.payload.recordSetID,
-        error: networkReturn.data
-      }
-    });
-    */
-  }
-}

--- a/appv2/src/state/sagas/map/online.ts
+++ b/appv2/src/state/sagas/map/online.ts
@@ -178,14 +178,14 @@ export function* handle_ACTIVITIES_TABLE_ROWS_GET_ONLINE(action) {
 
 export function* handle_IAPP_TABLE_ROWS_GET_ONLINE(action) {
   let mapState = yield select((state) => state.Map);
-  let reqCount = mapState?.recordTables[action.payload.recordSetID]?.reqCount;
-  if (reqCount !== action.payload.reqCount) {
-    return;
-  }
+  let tableFiltersHash = mapState?.recordTables[action.payload.recordSetID]?.tableFiltersHash;
+
   const networkReturn = yield InvasivesAPI_Call('POST', `/api/v2/IAPP/`, { filterObjects: [action.payload.filterObj] });
   mapState = yield select((state) => state.Map);
-  reqCount = mapState?.recordTables[action.payload.recordSetID]?.reqCount;
-  if (reqCount !== action.payload.reqCount) {
+
+  mapState = yield select((state) => state.Map);
+  tableFiltersHash = mapState?.recordTables[action.payload.recordSetID]?.tableFiltersHash;
+  if (tableFiltersHash !== action.payload.tableFiltersHash) {
     return;
   }
 
@@ -195,7 +195,9 @@ export function* handle_IAPP_TABLE_ROWS_GET_ONLINE(action) {
       payload: {
         recordSetID: action.payload.recordSetID,
         rows: networkReturn.data.result,
-        reqCount: action.payload.reqCount
+        tableFiltersHash: action.payload.tableFiltersHash,
+        page: action.payload.page,
+        limit: action.payload.limit
       }
     });
   } else {
@@ -204,7 +206,9 @@ export function* handle_IAPP_TABLE_ROWS_GET_ONLINE(action) {
       payload: {
         recordSetID: action.payload.recordSetID,
         error: networkReturn.data,
-        reqCount: action.payload.reqCount
+        tableFiltersHash: action.payload.tableFiltersHash,
+        page: action.payload.page,
+        limit: action.payload.limit
       }
     });
   }
@@ -266,11 +270,11 @@ export function* handle_ACTIVITIES_GET_IDS_FOR_RECORDSET_ONLINE(action) {
 export function* handle_IAPP_GET_IDS_FOR_RECORDSET_ONLINE(action) {
   const networkReturn = yield InvasivesAPI_Call('POST', `/api/v2/IAPP/`, { filterObjects: [action.payload.filterObj] });
   const mapState = yield select((state) => state.Map);
-  const layerReqCount = mapState?.layers?.filter((layer) => {
+  const tableFiltersHash = mapState?.layers?.filter((layer) => {
     return layer?.recordSetID === action.payload.recordSetID;
-  })?.[0]?.reqCount;
+  })?.[0]?.tableFiltersHash;
 
-  if (!layerReqCount === action.payload.layerReqCount) {
+  if (!tableFiltersHash === action.payload.tableFiltersHash) {
     return;
   }
 
@@ -279,21 +283,23 @@ export function* handle_IAPP_GET_IDS_FOR_RECORDSET_ONLINE(action) {
     const IDList = list?.map((row) => {
       return row.site_id;
     });
+    // check again after the network call
     const mapState = yield select((state) => state.Map);
-    const layerReqCount = mapState?.layers?.filter((layer) => {
+    const tableFiltersHash = mapState?.layers?.filter((layer) => {
       return layer?.recordSetID === action.payload.recordSetID;
-    })?.[0]?.reqCount;
-
-    if (!layerReqCount === action.payload.layerReqCount) {
+    })?.[0]?.tableFiltersHash;
+  
+    if (!tableFiltersHash === action.payload.tableFiltersHash) {
       return;
     }
+
 
     yield put({
       type: IAPP_GET_IDS_FOR_RECORDSET_SUCCESS,
       payload: {
         recordSetID: action.payload.recordSetID,
         IDList: IDList,
-        layerReqCount: action.payload.layerReqCount
+        tableFiltersHash: action.payload.tableFiltersHash
       }
     });
   } else {


### PR DESCRIPTION
Use a hash of table filters for each recordset (and page params for table) to ignore out of order responses, and in a few spots short circuit some actions found to be stale.  Long term would be nice to see E2E action + network call + db query canceling.