### PR TITLE
[INV-3364] Update Context/Save menu UI

### DIFF
--- a/app/src/UI/App.css
+++ b/app/src/UI/App.css
@@ -37,10 +37,9 @@ body {
   flex-flow: column wrap;
   position: relative;
   box-sizing: border-box;
-  padding: calc(var(--extra-top-padding) + env(safe-area-inset-top, 0)) env(safe-area-inset-right, 0) calc(var(--extra-bottom-padding) + env(safe-area-inset-bottom, 0)) env(safe-area-inset-left, 0);
+  padding: calc(var(--extra-top-padding) + env(safe-area-inset-top, 0)) env(safe-area-inset-right, 0);
   overflow: hidden;
   height: 100svh;
-
 
   /* set by compilation flag */
 
@@ -90,9 +89,8 @@ body {
 
 .overlay-content {
   width: 100%;
-}
-
-.overlay-content-fullscreen {
+  height: 100%;
+  box-sizing: border-box;
 }
 
 #app-pre-auth-init {
@@ -108,7 +106,7 @@ body {
   --footer-bar-height: 32px;
   --map-button-bar-height: 45px;
   --overlay-height: 200px;
-  --overlay-grip-height: 20px; /* grab handle */
+  --overlay-grip-height: 25px; /* grab handle */
   --extra-top-padding: 0px;
   --extra-bottom-padding: 0px;
 }
@@ -134,10 +132,6 @@ body {
 }
 
 @media only screen and (width >= 1281px) {
-  :root {
-
-  }
-
   .App {
     &.web {
       --header-bar-height: 60px;

--- a/app/src/UI/Footer/Footer.tsx
+++ b/app/src/UI/Footer/Footer.tsx
@@ -9,9 +9,7 @@ export const Footer: React.FC = () => {
       <img
         alt="bcLogo"
         src={sunriseLogo}
-        width="60px"
         style={{ objectFit: 'cover', cursor: 'pointer' }}
-        height="28px"
       />
       {INFORMATIONAL_LINKS.map((link) => {
         return (

--- a/app/src/UI/Overlay/FormMenuButtons.tsx
+++ b/app/src/UI/Overlay/FormMenuButtons.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@mui/material';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useSelector } from 'utils/use_selector';
 import {
   ACTIVITY_COPY_REQUEST,
   ACTIVITY_DELETE_REQUEST,
@@ -9,10 +10,12 @@ import {
   ACTIVITY_SUBMIT_REQUEST,
   OVERLAY_MENU_TOGGLE
 } from 'state/actions';
-import { useSelector } from 'utils/use_selector';
 
 export const FormMenuButtons = (props) => {
   const dispatch = useDispatch();
+
+  const [saveDisabled, setSaveDisabled] = useState(false);
+  const [draftDisabled, setDraftDisabled] = useState(false);
 
   const { connected } = useSelector((state) => state.Network);
   const activityCreatedBy = useSelector((state: any) => state.ActivityPage?.activity?.created_by);
@@ -21,75 +24,74 @@ export const FormMenuButtons = (props) => {
   const username = useSelector((state: any) => state.Auth?.username);
   const accessRoles = useSelector((state: any) => state.Auth?.accessRoles);
 
-  const [saveDisabled, setSaveDisabled] = useState(false);
-  const [draftDisabled, setDraftDisabled] = useState(false);
-
   useEffect(() => {
     if (!activityCreatedBy || !username || !accessRoles) return;
-
-    const notMine = username !== activityCreatedBy;
-    const notAdmin =
-      accessRoles.filter((role) => {
-        return role.role_id === 18;
-      }).length === 0;
-    if (notAdmin && notMine) {
-      setSaveDisabled(true);
-    } else {
+    const createdByUser = username === activityCreatedBy;
+    const isAdmin = accessRoles.some((role: Record<string, any>) => role.role_id === 18);
+    if (isAdmin || createdByUser) {
       setSaveDisabled(false);
+    } else {
+      setSaveDisabled(true);
     }
     if (status === 'Submitted') {
       setDraftDisabled(true);
     }
   }, [accessRoles, username, activityCreatedBy]);
 
+  const handleSaveDraft = () => {
+    dispatch({ type: ACTIVITY_SAVE_REQUEST });
+    dispatch({ type: OVERLAY_MENU_TOGGLE });
+  }
+  const handlePublish = () => {
+    dispatch({ type: ACTIVITY_SUBMIT_REQUEST });
+    dispatch({ type: OVERLAY_MENU_TOGGLE });
+  }
+  const handleCopy = () => {
+    dispatch({ type: ACTIVITY_COPY_REQUEST });
+    dispatch({ type: OVERLAY_MENU_TOGGLE });
+  }
+  const handlePaste = () => {
+    dispatch({ type: ACTIVITY_PASTE_REQUEST });
+    dispatch({ type: OVERLAY_MENU_TOGGLE });
+  }
+  const handleDelete = () => {
+    dispatch({ type: ACTIVITY_DELETE_REQUEST });
+    dispatch({ type: OVERLAY_MENU_TOGGLE });
+    setTimeout(() => history.back(), 5000);
+  }
+
   return (
     <>
       <Button
-        onClick={() => {
-          dispatch({ type: ACTIVITY_SAVE_REQUEST });
-          dispatch({ type: OVERLAY_MENU_TOGGLE });
-        }}
+        onClick={handleSaveDraft}
         disabled={saveDisabled || draftDisabled}
         variant="contained"
       >
         SAVE TO DRAFT {connected || '(LOCAL OFFLINE)'}
       </Button>
       <Button
-        onClick={() => {
-          dispatch({ type: ACTIVITY_SUBMIT_REQUEST });
-          dispatch({ type: OVERLAY_MENU_TOGGLE });
-        }}
-        disabled={saveDisabled || !connected || activityErrors?.length > 0 ? true : false}
+        onClick={handlePublish}
+        disabled={saveDisabled || !connected || activityErrors?.length > 0}
         variant="contained"
       >
         SAVE & PUBLISH TO SUBMITTED
       </Button>
       <Button
-        onClick={() => {
-          dispatch({ type: ACTIVITY_COPY_REQUEST });
-          dispatch({ type: OVERLAY_MENU_TOGGLE });
-        }}
+        onClick={handleCopy}
         variant="contained"
       >
         COPY FORM
       </Button>
       <Button
         disabled={saveDisabled}
-        onClick={() => {
-          dispatch({ type: ACTIVITY_PASTE_REQUEST });
-          dispatch({ type: OVERLAY_MENU_TOGGLE });
-        }}
+        onClick={handlePaste}
         variant="contained"
       >
         PASTE FORM
       </Button>
       <Button
         disabled={saveDisabled || !connected}
-        onClick={() => {
-          dispatch({ type: ACTIVITY_DELETE_REQUEST });
-          dispatch({ type: OVERLAY_MENU_TOGGLE });
-          setTimeout(() => history.back(), 5000);
-        }}
+        onClick={handleDelete}
         variant="contained"
       >
         DELETE

--- a/app/src/UI/Overlay/IAPP/IAPPRecords.css
+++ b/app/src/UI/Overlay/IAPP/IAPPRecords.css
@@ -50,9 +50,6 @@
   overflow: hidden hidden;
 }
 
-.records_set_layer_colour {
-}
-
 .record {
   height: 100px;
   width: 100%;
@@ -64,20 +61,20 @@
 
 .records__activity__header {
   /* same height as the apps header and footer */
-  height: 5vh;
   width: 100%;
   border-color: black;
   display: flex;
   justify-content: center;
-  overflow: scroll;
 }
 
 .records__activity_buttons {
-  height: 5vh;
   width: 100%;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  & > button {
+    height: 20pt;
+  }
 }
 
 .records__activity_buttons > * {

--- a/app/src/UI/Overlay/Overlay.css
+++ b/app/src/UI/Overlay/Overlay.css
@@ -1,7 +1,3 @@
-#overlaydiv {
-  cursor: pointer;
-}
-
 .overlayMenuResizeButtons {
   display: flex;
   flex-direction: row;
@@ -34,6 +30,4 @@
   height: 100%;
   width: 100%;
   overflow-y: auto;
-
-  /* /scroll-behavior: ; */
 }

--- a/app/src/UI/Overlay/OverlayHeader.css
+++ b/app/src/UI/Overlay/OverlayHeader.css
@@ -16,6 +16,10 @@
     border: 1px solid darkgrey;
     height: 100%;
     vertical-align: baseline;
+    box-shadow: none;
+    &:hover {
+      border: 1px solid #036;
+    }
   }
 
   .left {

--- a/app/src/UI/Overlay/OverlayMenu.css
+++ b/app/src/UI/Overlay/OverlayMenu.css
@@ -1,11 +1,31 @@
 .overlayMenu {
   display: flex;
-  background-color: #333;
   flex-direction: column;
   height: 100%;
   width: 100%;
+  box-sizing: border-box;
+  border-top: 1pt solid #16161d;
+  background-color: #036;
 }
-
 .overlayMenu > * {
   flex-grow: 1;
+}
+
+.overlayMenuSub {
+  display: flex;
+  flex-direction: column;
+  & > button {
+    border-radius: 0;
+    height: 45pt;
+  }
+  & > button:disabled {
+    background-color: #444;
+    color: #999;
+  }
+}
+@media (width <= 1024px) {
+  .overlayMenuSub > button {
+    border-bottom: 1pt solid #16161d;
+    padding: 15pt;
+  }
 }

--- a/app/src/UI/Overlay/OverlayMenu.tsx
+++ b/app/src/UI/Overlay/OverlayMenu.tsx
@@ -8,15 +8,17 @@ export const OverlayMenu = (props) => {
   const dispatch = useDispatch();
   return (
     <div className="overlayMenu">
-      {props.children}
-      <Button
-        onClick={() => {
-          dispatch({ type: OVERLAY_MENU_TOGGLE });
-        }}
-        variant="contained"
-      >
-        CLOSE
-      </Button>
+      <div className='overlayMenuSub'>
+        {props.children}
+        <Button
+          onClick={() => {
+            dispatch({ type: OVERLAY_MENU_TOGGLE });
+          }}
+          variant="contained"
+        >
+          CLOSE
+        </Button>
+      </div>
     </div>
   );
 };

--- a/app/src/UI/Overlay/Records/Activity/Form.css
+++ b/app/src/UI/Overlay/Records/Activity/Form.css
@@ -22,7 +22,6 @@
   text-align: left !important;
   align-items: left !important;
   width: 100%;
-
 }
 
 .showAuditInfoDialog {
@@ -41,6 +40,7 @@
   overflow: scroll;
   display: flex;
   max-width: 80%;
+  margin-top: 1em;
   padding-left: 15%;
   padding-right: 15%;
 }
@@ -99,9 +99,6 @@ td {
 
 .removeInvasivePlantButton {
   padding-top: 10px;
-}
-
-.invasive_plant_tooltip {
 }
 
 #herbicides_section {

--- a/app/src/UI/Overlay/Records/Records.css
+++ b/app/src/UI/Overlay/Records/Records.css
@@ -55,8 +55,6 @@
   overflow-x: hidden;
   overflow-y: hidden;
 }
-.records_set_layer_colour {
-}
 
 .record {
   height: 100px;
@@ -69,20 +67,20 @@
 
 .records__activity__header {
   /* same height as the apps header and footer */
-  height: 5vh;
   width: 100%;
   border-color: black;
   display: flex;
   justify-content: center;
-  overflow: scroll;
 }
 
 .records__activity_buttons {
-  height: 5vh;
   width: 100%;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  & > button {
+    height: 20pt;
+  }
 }
 
 .records__activity_buttons > * {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Update Buttons (Fig. 1) in Records Overlay to not have scroll values  
- Update Save/Context menu to have (Fig 2.): 
   - larger buttons
   - non-white background moved to BC Blue
   - remove border-radius from buttons due to being 100% width.
   - Made color of disabled buttons lighter and more easily readable
   - Added darker border between buttons on iPad viewports since users can't benefit from the ":hover" pseudo class  (Fig. 3)
- Adjust BC Logo in footer to look slightly less compressed

![image](https://github.com/user-attachments/assets/fe105b9b-8fa3-4898-9a95-75bd6a6ffa70)
![image](https://github.com/user-attachments/assets/432022cb-ac0a-4168-b10d-680f32174804)
![image](https://github.com/user-attachments/assets/cab45677-fecf-443b-a3ed-2060bd0622b8)

>[!TIP]
> Screenshots from the current version

![image](https://github.com/user-attachments/assets/89d8e870-3395-42e9-808c-f9d02e08e213)

[Scrolling buttons]

![image](https://github.com/user-attachments/assets/6628af7c-8eb1-455a-a570-64969e4bc581)

[Smaller buttons, darker disabled, white background, crunchier logo]
