### PR TITLE
[INV-3370] CSS** bump size of map tools by 33%

### DIFF
--- a/app/src/UI/Map2/map.css
+++ b/app/src/UI/Map2/map.css
@@ -104,6 +104,11 @@
   z-index: 999;
 }
 
+.maplibregl-ctrl-group > button {
+  height: 30pt;
+  width: 30pt;
+}
+
 .loadedMap {
   display: none;
 }


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):
Increase map tool icons from default of `30px` -> `40px` Making more friendly for mobile users

New:
![image](https://github.com/user-attachments/assets/301fbd4d-61a1-4b60-abf4-e77966330830)
Old:
![image](https://github.com/user-attachments/assets/f4a80c87-71d7-4a3b-8073-f84597ee9c96)
