### PR TITLE
[INV-3366] Users can delete records

### DIFF
--- a/api/src/paths/activities.ts
+++ b/api/src/paths/activities.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { RequestHandler, Response } from 'express';
+import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
 import { SQLStatement } from 'sql-template-strings';
 import { ALL_ROLES, SECURITY_ON } from 'constants/misc';

--- a/api/src/queries/activity-queries.ts
+++ b/api/src/queries/activity-queries.ts
@@ -875,6 +875,21 @@ export const deleteActivitiesSQL = (activityIds: Array<string>, req?: any): SQLS
 };
 
 /**
+ * @desc SQL Query to get all monitoring records matching a Treatment record
+ * @param treatmentRecordID 
+ * @returns { SQLStatement }
+ */
+export const getLinkedMonitoringRecordsFromTreatmentSQL = (treatmentRecordID: string): SQLStatement => (
+  SQL`
+    SELECT activity_id
+    FROM activity_incoming_data
+    WHERE activity_type = 'Monitoring'
+    AND iscurrent = True
+    AND activity_payload->'form_data'->'activity_type_data'->>'linked_id' = ${treatmentRecordID};
+  `
+);
+
+/**
  * SQL query to un-delete activity records.
  *
  * @param {string} activityIds


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Refactored `deleteActivitiesByIds` function
- Master Admins can delete activity records as they could before
- Creators can delete their own records.
- `Treatment` records cannot be deleted if a `Monitoring` record is linked
- Deletion is available to all record types, previously scoped to only be
- Closes #3366