### PR TITLE
Remove default RJSF Submit button (again)

### DIFF
--- a/app/src/UI/Overlay/Records/Activity/form/FormContainer.tsx
+++ b/app/src/UI/Overlay/Records/Activity/form/FormContainer.tsx
@@ -203,6 +203,7 @@ const FormContainer: React.FC<any> = (props) => {
               });
             }}
           >
+            <React.Fragment />
           </Form>
           {isActivityChemTreatment() && (
             <ChemicalTreatmentDetailsForm


### PR DESCRIPTION
# Overview

React.Fragment was previously removed in a previous refactor of hooks to state.
Removal led to the appearance of the RJSF Default `Submit` button.

This was flagged in Issue #3395