### PR TITLE
[INV-3391] Simplify API return for Activity Autofill

### DIFF
--- a/api/src/paths/application-user.ts
+++ b/api/src/paths/application-user.ts
@@ -84,6 +84,7 @@ async function getUsers(req, res, next) {
   const connection = await getDBConnection();
   const userIsAdmin = isAdminFromAuthContext(req);
   const isAppUser = req?.authContext?.roles.length > 0;
+
   if (!isAppUser) {
     return res.status(401).json({
       message: 'Unauthorized access',
@@ -92,7 +93,7 @@ async function getUsers(req, res, next) {
       code: 401
     });
   }
-  console.log("It's the User Info!", req.authContext);
+
   if (!connection) {
     return res.status(503).json({
       message: 'Failed to establish database connection',

--- a/api/src/queries/user-queries.ts
+++ b/api/src/queries/user-queries.ts
@@ -19,6 +19,21 @@ export const getUsersSQL = (): SQLStatement => {
     GROUP BY au.user_id;
   `;
 };
+/**
+ * @desc Sql for limited information regarding users.
+ */
+export const getSanitizedUsersForAutofillSQL = (): SQLStatement => {
+  return SQL`
+  SELECT
+    first_name,
+    last_name,
+    pac_number,
+    pac_service_number_1,
+    pac_service_number_2
+  FROM application_user
+  WHERE account_status = 1;
+  `;
+};
 
 export const getUserByIDIRSQL = (idir_userid: string): SQLStatement => {
   return SQL`

--- a/api/src/queries/user-queries.ts
+++ b/api/src/queries/user-queries.ts
@@ -19,6 +19,7 @@ export const getUsersSQL = (): SQLStatement => {
     GROUP BY au.user_id;
   `;
 };
+
 /**
  * @desc Sql for limited information regarding users.
  */


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

## Modify the `get` method for `/application-user`:
- Block non-app users (users with 0 roles)
- Create a sanitized set of data for non-admin users.
  - Currently only returns values needed for PAC Autofill
    - Can be easily adjusted later as needs change