### PR TITLE
[INV-3408] Fix oversized Header Logo in older devices

### DIFF
--- a/app/src/UI/Header/Header.css
+++ b/app/src/UI/Header/Header.css
@@ -18,6 +18,7 @@
 .HeaderBar {
   height: var(--header-bar-height);
   cursor: pointer;
+  width: 100%;
   background-color: #036;
   position: relative;
   z-index: 2147483646;
@@ -110,13 +111,16 @@
   left: 10px;
   align-items: center;
   height: var(--header-bar-height);
-
-  img {
-    box-sizing: border-box;
-    height: calc(var(--header-bar-height) - 20px);
-  }
 }
 
+#InvBcLogo {
+  box-sizing: border-box;
+  object-fit: 'contain';
+  background-color: white;
+  border-radius: 5px;
+  padding: 5;
+  height: calc(var(--header-bar-height) - 20px);
+}
 .avatar-menu {
   display: flex;
   position: absolute;
@@ -151,5 +155,4 @@ div.network-status-display {
     line-height: 1.5;
     letter-spacing: 0.00938em;
   }
-
 }

--- a/app/src/UI/Header/Header.tsx
+++ b/app/src/UI/Header/Header.tsx
@@ -202,16 +202,7 @@ const LogoutButton = () => {
 const InvIcon = () => {
   return (
     <div className="inv-icon">
-      <img
-        src={invbclogo}
-        style={{
-          objectFit: 'contain',
-          backgroundColor: 'white',
-          borderRadius: 4,
-          padding: 5
-        }}
-        alt="B.C. Government Logo"
-      />
+      <img src={invbclogo} id="InvBcLogo" alt="B.C. Government Logo" />
       <div id="appTitle">InvasivesBC</div>
     </div>
   );
@@ -307,7 +298,7 @@ const LoginOrOutMemo = React.memo(() => {
   };
 
   const navToUpdateRequest = () => {
-    history.push({ pathname: '/AccessRequest', });
+    history.push({ pathname: '/AccessRequest' });
     dispatch({
       type: TOGGLE_PANEL,
       payload: { panelOpen: true, fullScreen: true }


### PR DESCRIPTION
# Overview
The Logo in the Header was showing as massive when displayed on older iPads (Replicable with iPad Air 5th Generation simulator). 
On remediation, it was also noticed that the Header greatly exceeded the Container object as well.
Error `Viewport argument key "interactive-widget" not recognized and ignored.` Is noted in the console when using the simulator, potentially influencing the undesired behaviour?

This PR includes the following proposed change(s):

- Added ID to Banner Logo for Specificity
    - Lifted CSS out of `.tsx` file into `.css` file.
- Set max width to Header to prevent overflowing

## Result

<img width="637" alt="image" src="https://github.com/user-attachments/assets/60160a01-c804-44ea-83bb-08092fa80992">

## Testing It
- Ran in Two simulator devices in browser, iPad 6th Generation iOS 17.0 in build, seemed normal
- Ran in browsers, all looked normal.

Closes #3408


## Original Issue
![image](https://github.com/user-attachments/assets/1d5d11ab-8d77-403d-9b51-c80c95d2d2db)
