### PR TITLE
[INV-3411] Update subsequent access requests instead of creating new

### DIFF
--- a/api/src/queries/access-request-queries.ts
+++ b/api/src/queries/access-request-queries.ts
@@ -17,7 +17,7 @@ export const getAccessRequestsSQL = (): SQLStatement => {
  */
 export const userHasPendingAccessRequestSQL = (username: string): SQLStatement => {
   return SQL`
-    SELECT *
+    SELECT access_request_id
     FROM access_request
     WHERE request_type = 'ACCESS'
     AND status = 'NOT_APPROVED'
@@ -61,23 +61,23 @@ export const updateAccessRequestSQL = (access_request_id: number, accessRequest:
   return SQL`
     UPDATE access_request
     SET
-      idir_account_name = ${accessRequest?.idir},
-      bceid_account_name = ${accessRequest?.bceid},
-      first_name = ${accessRequest?.firstName},
-      last_name = ${accessRequest?.lastName},
-      primary_email = ${accessRequest?.email},
-      work_phone_number = ${accessRequest?.phone},
+      idir_account_name = ${accessRequest.idir ? accessRequest.idir : null},
+      bceid_account_name = ${accessRequest.bceid ? accessRequest.bceid : null},
+      first_name = ${accessRequest.firstName ? accessRequest.firstName : null},
+      last_name = ${accessRequest.lastName ? accessRequest.lastName : null},
+      primary_email = ${accessRequest.email ? accessRequest.email : null},
+      work_phone_number = ${accessRequest.phone ? accessRequest.phone : null},
       funding_agencies = ${appendNRQ(accessRequest?.fundingAgencies)},
       employer = ${appendNRQ(accessRequest?.employer)},
-      pac_number = ${accessRequest?.pacNumber},
-      pac_service_number_1 = ${accessRequest?.psn1},
-      pac_service_number_2 = ${accessRequest?.psn2},
-      requested_roles = ${accessRequest?.requested_roles},
-      comments = ${accessRequest?.comments},
-      idir_userid = ${accessRequest?.idirUserId},
-      bceid_userid = ${accessRequest?.bceidUserId},
+      pac_number = ${accessRequest.pacNumber ? accessRequest.pacNumber : null},
+      pac_service_number_1 = ${accessRequest.psn1 ? accessRequest.psn1 : null},
+      pac_service_number_2 = ${accessRequest.psn2 ? accessRequest.psn2 : null},
+      requested_roles = ${accessRequest.requestedRoles ? accessRequest.requestedRoles : null},
+      comments = ${accessRequest.comments ? accessRequest.comments : null},
+      idir_userid = ${accessRequest.idirUserId ? accessRequest.idirUserId : null},
+      bceid_userid = ${accessRequest.bceidUserId ? accessRequest.bceidUserId : null},
       updated_at = CURRENT_TIMESTAMP
-    WHERE access_request_id=${access_request_id}
+    WHERE access_request_id = ${access_request_id}
     AND status = 'NOT_APPROVED'
   `;
 };

--- a/api/src/queries/update-request-queries.ts
+++ b/api/src/queries/update-request-queries.ts
@@ -58,6 +58,49 @@ export function appendNRQ(input: string) {
     else return input;
   return 'NRQ';
 }
+
+/**
+ * @param username Identity submitted for an update request
+ * @returns All pending rows associated with a user
+ */
+export const userHasPendingUpdateRequestSQL = (username: string): SQLStatement => {
+  return SQL`
+    SELECT access_request_id
+    FROM access_request
+    WHERE request_type = 'UPDATE'
+    AND status = 'NOT_APPROVED'
+    AND (
+      idir_account_name=${username}
+      OR
+      bceid_account_name=${username}
+    )
+  `;
+};
+
+export const updateUpdateRequestSQL = (
+  access_request_id: string,
+  newUpdateRequest: Record<string, any>
+): SQLStatement => {
+  console.log(access_request_id);
+  return SQL`
+    UPDATE access_request
+    SET 
+      first_name = ${newUpdateRequest.firstName ? newUpdateRequest.firstName : null},
+      last_name = ${newUpdateRequest.lastName ? newUpdateRequest.lastName : null},
+      primary_email = ${newUpdateRequest.email ? newUpdateRequest.email : null},
+      work_phone_number = ${newUpdateRequest.phone ? newUpdateRequest.phone : null},
+      funding_agencies = ${appendNRQ(newUpdateRequest.fundingAgencies ?? null)},
+      employer = ${appendNRQ(newUpdateRequest?.employer)},
+      pac_number = ${newUpdateRequest.pacNumber ? newUpdateRequest.pacNumber : null},
+      pac_service_number_1 = ${newUpdateRequest.psn1 ? newUpdateRequest.psn1 : null},
+      pac_service_number_2 = ${newUpdateRequest.psn2 ? newUpdateRequest.psn2 : null},
+      requested_roles = ${newUpdateRequest.requestedRoles ? newUpdateRequest.requestedRoles : null},
+      comments = ${newUpdateRequest.comments ? newUpdateRequest.comments : null},
+      updated_at = CURRENT_TIMESTAMP
+    WHERE access_request_id = ${access_request_id}
+    AND status = 'NOT_APPROVED'
+  `;
+};
 /**
  * SQL query to create an access request.
  *

--- a/app/src/UI/Overlay/Admin/userAccess/UserAccessPage.tsx
+++ b/app/src/UI/Overlay/Admin/userAccess/UserAccessPage.tsx
@@ -234,7 +234,7 @@ const UserAccessPage: React.FC<IAccessRequestPage> = (props) => {
         pacServiceNumber1: request.pac_service_number_1,
         pacServiceNumber2: request.pac_service_number_2,
         workPhoneNumber: request.work_phone_number,
-        dateRequested: new Date(request.created_at).toLocaleString()
+        dateRequested: new Date(request.updated_at).toLocaleString()
       });
     }
     setRequestRows(rows);
@@ -652,7 +652,7 @@ const UserAccessPage: React.FC<IAccessRequestPage> = (props) => {
                     onRowSelectionModelChange={handleAccessRequestRowSelection}
                     rows={requestRows}
                     columns={requestColumns}
-                    sortModel={[{ field: 'id', sort: 'desc' }]}
+                    sortModel={[{ field: 'dateRequested', sort: 'desc' }]}
                     checkboxSelection
                     onCellClick={handleRowClick}
                     onRowClick={handleRowClick}


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

## Frontend

> Cleaned up the flow of the Admin panel to better order by "Most recent"

- Request Date now displays the update date, not the date the request was created
- Access Request display now defaults its sort by Request Date instead of ID

## Backend

> Branched the creation path to update an existing request instead of *always* creating a new request

- Added check handler in Access Request/Update functions to see if record exists for a user before creating new one
- Added SQL to update a Users existing Access/Update request instead of creating more requests

> [!TIP]
> Have to explicitly declare nulls since optional chaining just renders fields blank **instead** of null

- Closes #3411

## Testing it
1. Sent Requests for Access/Updates, Initial requests created new entries
1. Sent duplicate requests for Access/Updates, Initial requests were updated with new timestamp
1. Declined my existing requests
1. Sent Requests for Access/Updates, New requests created new entries

> [!NOTE]
> To Preserve history, instead of updating an existing Closed/Approved requests, only requests that are currently pending will be updated
