### PR TITLE
[INV-3412] Enhancement: Create Linestrings in Track me tool

### DIFF
--- a/app/src/UI/Map2/Controls/FindMe.tsx
+++ b/app/src/UI/Map2/Controls/FindMe.tsx
@@ -64,7 +64,7 @@ export const TrackMeToggle = (props) => {
 
   const promptHandler = (input: string | number) => {
     console.log(input);
-    dispatch({ type: MAP_TOGGLE_TRACK_ME_DRAW_GEO_START, payload: input });
+    dispatch({ type: MAP_TOGGLE_TRACK_ME_DRAW_GEO_START, payload: { type: input } });
   };
   const clickHandler = () => {
     setShow(false);

--- a/app/src/UI/Map2/Controls/FindMe.tsx
+++ b/app/src/UI/Map2/Controls/FindMe.tsx
@@ -11,7 +11,8 @@ import MyLocationIcon from '@mui/icons-material/MyLocation';
 import PolylineIcon from '@mui/icons-material/Polyline';
 import DirectionsWalkIcon from '@mui/icons-material/DirectionsWalk';
 import { useSelector } from 'utils/use_selector';
-import { promptConfirmationInput } from 'utils/userPrompts';
+import { promptRadioInput } from 'utils/userPrompts';
+import GeoShapes from 'constants/geoShapes';
 
 export const FindMeToggle = (props) => {
   const positionTracking = useSelector((state) => state.Map?.positionTracking);
@@ -61,21 +62,21 @@ export const TrackMeToggle = (props) => {
   const [show, setShow] = React.useState(false);
   const divRef = useRef();
 
-  const promptHandler = (res: boolean) => {
-    if (!drawGeometryTracking && res) {
-      dispatch({ type: MAP_TOGGLE_TRACK_ME_DRAW_GEO_START });
-    }
+  const promptHandler = (input: string | number) => {
+    console.log(input);
+    dispatch({ type: MAP_TOGGLE_TRACK_ME_DRAW_GEO_START, payload: input });
   };
   const clickHandler = () => {
     setShow(false);
-    if (drawGeometryTracking) {
+    if (drawGeometryTracking.isTracking) {
       dispatch({ type: MAP_TOGGLE_TRACK_ME_DRAW_GEO_STOP });
     } else {
       dispatch(
-        promptConfirmationInput({
+        promptRadioInput({
           callback: promptHandler,
+          options: [GeoShapes.LineString, GeoShapes.Polygon],
           prompt:
-            'On the Activity Page this will edit your geometry for the record, and create a polygon once complete.',
+            "Select the type of shape you wish to create. If you choose a LineString you'll be able to add a buffer at the end",
           title: 'Are you sure you want to track your path?',
           confirmText: 'Start Tracking'
         })
@@ -86,7 +87,7 @@ export const TrackMeToggle = (props) => {
   return (
     <>
       {positionTracking ? (
-        <div ref={divRef} className={drawGeometryTracking ? 'map-btn-selected' : 'map-btn'}>
+        <div ref={divRef} className={drawGeometryTracking.isTracking ? 'map-btn-selected' : 'map-btn'}>
           <Tooltip
             open={show}
             classes={{ tooltip: 'toolTip' }}

--- a/app/src/UI/Overlay/Records/Activity/Form.tsx
+++ b/app/src/UI/Overlay/Records/Activity/Form.tsx
@@ -100,7 +100,7 @@ export const ActivityForm = (props) => {
     } else {
       const callback = (input: string | number) => {
         dispatch({ type: MAP_TOGGLE_TRACKING_ON });
-        dispatch({ type: MAP_TOGGLE_TRACK_ME_DRAW_GEO_START, payload: input });
+        dispatch({ type: MAP_TOGGLE_TRACK_ME_DRAW_GEO_START, payload: { type: input } });
       };
       dispatch(
         promptRadioInput({

--- a/app/src/UI/Overlay/Records/Activity/Form.tsx
+++ b/app/src/UI/Overlay/Records/Activity/Form.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import FormContainer from './form/FormContainer';
 import { useDispatch, useSelector } from 'react-redux';
 import './Form.css';
@@ -7,12 +7,13 @@ import { ActivitySubtypeShortLabels } from 'sharedAPI';
 import { RENDER_DEBUG } from 'UI/App';
 import { Button } from '@mui/material';
 import { calc_lat_long_from_utm } from 'utils/utm';
-import { lengthToRadians } from '@turf/helpers';
 import {
   MAP_TOGGLE_TRACK_ME_DRAW_GEO_START,
   MAP_TOGGLE_TRACK_ME_DRAW_GEO_STOP,
   MAP_TOGGLE_TRACKING_ON
 } from 'state/actions';
+import GeoShapes from 'constants/geoShapes';
+import { promptRadioInput } from 'utils/userPrompts';
 
 export const ActivityForm = (props) => {
   const ref = useRef(0);
@@ -94,13 +95,23 @@ export const ActivityForm = (props) => {
     };
   };
   const clickHandler = () => {
-    const startTrackingConfirmation =
-      'Are you sure you want to track your path? On the Activity Page this will edit your geometry for the record, and create a polygon once complete.';
-    if (drawGeometryTracking) {
+    if (drawGeometryTracking.isTracking) {
       dispatch({ type: MAP_TOGGLE_TRACK_ME_DRAW_GEO_STOP });
-    } else if (!drawGeometryTracking && confirm(startTrackingConfirmation)) {
-      dispatch({ type: MAP_TOGGLE_TRACKING_ON });
-      dispatch({ type: MAP_TOGGLE_TRACK_ME_DRAW_GEO_START });
+    } else {
+      const callback = (input: string | number) => {
+        dispatch({ type: MAP_TOGGLE_TRACKING_ON });
+        dispatch({ type: MAP_TOGGLE_TRACK_ME_DRAW_GEO_START, payload: input });
+      };
+      dispatch(
+        promptRadioInput({
+          callback,
+          options: [GeoShapes.LineString, GeoShapes.Polygon],
+          prompt:
+            "Select the type of shape you wish to create. If you choose a LineString you'll be able to add a buffer at the end",
+          title: 'Are you sure you want to track your path?',
+          confirmText: 'Start Tracking'
+        })
+      );
     }
   };
 

--- a/app/src/UI/UserInputModals/ConfirmationModal.tsx
+++ b/app/src/UI/UserInputModals/ConfirmationModal.tsx
@@ -8,7 +8,15 @@ import { UnknownAction } from 'redux';
 /**
  * @desc Customizable Input Modal for collecting boolean responses from a user.
  */
-const ConfirmationModal = ({ callback, id, prompt, title, confirmText, cancelText }: ConfirmationModalInterface) => {
+const ConfirmationModal = ({
+  callback,
+  disableCancel,
+  id,
+  prompt,
+  title,
+  confirmText,
+  cancelText
+}: ConfirmationModalInterface) => {
   const dispatch = useDispatch();
   const handleRedux = (redux: ReduxPayload[]) => {
     for (const action of redux) {
@@ -37,7 +45,7 @@ const ConfirmationModal = ({ callback, id, prompt, title, confirmText, cancelTex
         </DialogContent>
         <Divider />
         <DialogActions>
-          <Button onClick={handleClose}>{cancelText ?? 'Cancel'}</Button>
+          {!disableCancel && <Button onClick={handleClose}>{cancelText ?? 'Cancel'}</Button>}
           <Button onClick={handleConfirmation}>{confirmText ?? 'Confirm'}</Button>
         </DialogActions>
       </Box>

--- a/app/src/UI/UserInputModals/DateModal.tsx
+++ b/app/src/UI/UserInputModals/DateModal.tsx
@@ -21,7 +21,18 @@ import { closeModal } from 'utils/userPrompts';
 import { useDispatch } from 'react-redux';
 import { UnknownAction } from 'redux';
 
-const DateModal = ({ callback, prompt, id, title, confirmText, cancelText, min, max, label }: DateModalInterface) => {
+const DateModal = ({
+  callback,
+  disableCancel,
+  prompt,
+  id,
+  title,
+  confirmText,
+  cancelText,
+  min,
+  max,
+  label
+}: DateModalInterface) => {
   const [userDate, setUserDate] = useState<Dayjs>(dayjs());
   const [validationError, setValidationError] = useState<string>('');
   const dispatch = useDispatch();
@@ -88,7 +99,7 @@ const DateModal = ({ callback, prompt, id, title, confirmText, cancelText, min, 
         </FormControl>
         <Divider />
         <DialogActions>
-          <Button onClick={handleClose}>{cancelText ?? 'Cancel'}</Button>
+          {!disableCancel && <Button onClick={handleClose}>{cancelText ?? 'Cancel'}</Button>}
           <Button onClick={handleConfirmation}>{confirmText ?? 'Confirm'}</Button>
         </DialogActions>
       </Box>

--- a/app/src/UI/UserInputModals/NumberModal.tsx
+++ b/app/src/UI/UserInputModals/NumberModal.tsx
@@ -21,6 +21,7 @@ import { UnknownAction } from 'redux';
 const NumberModal = ({
   callback,
   prompt,
+  disableCancel,
   title,
   id,
   confirmText,
@@ -133,7 +134,7 @@ const NumberModal = ({
         </FormControl>
         <Divider />
         <DialogActions>
-          <Button onClick={handleClose}>{cancelText ?? 'Cancel'}</Button>
+          {!disableCancel && <Button onClick={handleClose}>{cancelText ?? 'Cancel'}</Button>}
           <Button onClick={handleConfirmation}>{confirmText ?? 'Confirm'}</Button>
         </DialogActions>
       </Box>

--- a/app/src/UI/UserInputModals/RadioModal.tsx
+++ b/app/src/UI/UserInputModals/RadioModal.tsx
@@ -23,7 +23,17 @@ import { ChangeEvent, useState } from 'react';
 /**
  * @desc Customizable Input Modal for collecting boolean responses from a user.
  */
-const RadioModal = ({ callback, id, prompt, title, confirmText, cancelText, options, label }: RadioModalInterface) => {
+const RadioModal = ({
+  callback,
+  disableCancel,
+  id,
+  prompt,
+  title,
+  confirmText,
+  cancelText,
+  options,
+  label
+}: RadioModalInterface) => {
   const [userInput, setUserInput] = useState<number | string>('');
   const dispatch = useDispatch();
   const handleRedux = (redux: ReduxPayload[]) => {
@@ -72,7 +82,7 @@ const RadioModal = ({ callback, id, prompt, title, confirmText, cancelText, opti
         </DialogContent>
         <Divider />
         <DialogActions>
-          <Button onClick={handleClose}>{cancelText ?? 'Cancel'}</Button>
+          {!disableCancel && <Button onClick={handleClose}>{cancelText ?? 'Cancel'}</Button>}
           <Button onClick={handleConfirmation} disabled={!(options as any[]).includes(userInput)}>
             {confirmText ?? 'Confirm'}
           </Button>

--- a/app/src/UI/UserInputModals/TextModal.tsx
+++ b/app/src/UI/UserInputModals/TextModal.tsx
@@ -20,6 +20,7 @@ import { UnknownAction } from 'redux';
 
 const TextModal = ({
   callback,
+  disableCancel,
   prompt,
   regex,
   regexErrorText,
@@ -111,7 +112,7 @@ const TextModal = ({
         </FormControl>
         <Divider />
         <DialogActions>
-          <Button onClick={handleClose}>{cancelText ?? 'Cancel'}</Button>
+          {!disableCancel && <Button onClick={handleClose}>{cancelText ?? 'Cancel'}</Button>}
           <Button onClick={handleConfirmation}>{confirmText ?? 'Confirm'}</Button>
         </DialogActions>
       </Box>

--- a/app/src/UI/UserInputModals/UserInputModalController.tsx
+++ b/app/src/UI/UserInputModals/UserInputModalController.tsx
@@ -29,6 +29,7 @@ const UserInputModalController = () => {
       return (
         <ConfirmationModal
           callback={prompt.callback}
+          disableCancel={prompt?.disableCancel}
           id={prompt.id}
           title={prompt.title}
           prompt={prompt.prompt}
@@ -43,6 +44,7 @@ const UserInputModalController = () => {
           callback={prompt.callback}
           cancelText={prompt?.cancelText}
           confirmText={prompt?.confirmText}
+          disableCancel={prompt?.disableCancel}
           id={prompt.id}
           label={prompt?.label}
           max={prompt?.max}
@@ -55,9 +57,11 @@ const UserInputModalController = () => {
       prompt = prompts[0] as NumberModalInterface;
       return (
         <NumberModal
+          acceptFloats={prompt?.acceptFloats}
           callback={prompt?.callback}
           cancelText={prompt.cancelText}
           confirmText={prompt.confirmText}
+          disableCancel={prompt?.disableCancel}
           id={prompt.id}
           label={prompt.label}
           max={prompt.max}
@@ -65,7 +69,6 @@ const UserInputModalController = () => {
           prompt={prompt.prompt}
           selectOptions={prompt.selectOptions}
           title={prompt.title}
-          acceptFloats={prompt?.acceptFloats}
         />
       );
     case PromptTypes.Radio:
@@ -75,6 +78,7 @@ const UserInputModalController = () => {
           callback={prompt.callback}
           cancelText={prompt?.cancelText}
           confirmText={prompt?.confirmText}
+          disableCancel={prompt?.disableCancel}
           id={prompt.id}
           label={prompt?.label}
           options={prompt.options}
@@ -88,6 +92,7 @@ const UserInputModalController = () => {
         <TextModal
           callback={prompt?.callback}
           cancelText={prompt?.cancelText}
+          disableCancel={prompt?.disableCancel}
           confirmText={prompt?.confirmText}
           label={prompt?.label}
           id={prompt.id}

--- a/app/src/interfaces/prompt-interfaces.ts
+++ b/app/src/interfaces/prompt-interfaces.ts
@@ -12,6 +12,7 @@ export interface ReduxPayload {
  * @interface BasePromptInterface Confirmation Modal Prompts
  * @property {string} cancelText Text override for 'Cancel' button text
  * @property {string} confirmText Text override for 'Confirm' button text
+ * @property {boolean} disableCancel Hides the cancel button from the modal.
  * @property {string} id Id for a given Prompt (Used for deleting)
  * @property {string[] | string} prompt Main text body, Can use array to handle multiple paragraphs
  * @property {string} title Title for modal
@@ -20,6 +21,7 @@ export interface ReduxPayload {
 interface BasePromptInterface {
   cancelText?: string;
   confirmText?: string;
+  disableCancel?: boolean;
   id?: string;
   prompt: string[] | string;
   title: string;

--- a/app/src/state/reducers/activity.ts
+++ b/app/src/state/reducers/activity.ts
@@ -27,6 +27,7 @@ import {
 
 import { AppConfig } from '../config';
 import { getCustomErrorTransformer } from 'rjsf/business-rules/customErrorTransformer';
+import GeoShapes from 'constants/geoShapes';
 
 interface ActivityState {
   activity: any;
@@ -40,7 +41,10 @@ interface ActivityState {
   suggestedJurisdictions: [];
   suggestedPersons: [];
   suggestedTreatmentIDs: [];
-  track_me_draw_geo: boolean;
+  track_me_draw_geo: {
+    isTracking: boolean;
+    type: GeoShapes | null;
+  };
   activity_copy_buffer: object | null;
 }
 
@@ -52,7 +56,10 @@ const initialState: ActivityState = {
   failCode: null,
   initialized: false,
   loading: false,
-  track_me_draw_geo: false,
+  track_me_draw_geo: {
+    isTracking: false,
+    type: null
+  },
   saved_activity_hash: null,
   suggestedJurisdictions: [],
   suggestedPersons: [],
@@ -161,8 +168,9 @@ function createActivityReducer(configuration: AppConfig): (ActivityState, AnyAct
         }
         case ACTIVITY_GET_SUGGESTED_TREATMENT_IDS_SUCCESS: {
           draftState.suggestedTreatmentIDs = [...action.payload.suggestedTreatmentIDs];
-          if(draftState?.schema?.properties?.activity_type_data?.properties?.linked_id)
-          draftState.schema.properties.activity_type_data.properties.linked_id.options = action.payload.suggestedTreatmentIDs
+          if (draftState?.schema?.properties?.activity_type_data?.properties?.linked_id)
+            draftState.schema.properties.activity_type_data.properties.linked_id.options =
+              action.payload.suggestedTreatmentIDs;
           break;
         }
         case ACTIVITY_CREATE_SUCCESS: {
@@ -195,11 +203,17 @@ function createActivityReducer(configuration: AppConfig): (ActivityState, AnyAct
           break;
         }
         case MAP_TOGGLE_TRACK_ME_DRAW_GEO_START: {
-          draftState.track_me_draw_geo = true;
+          draftState.track_me_draw_geo = {
+            isTracking: true,
+            type: action.payload.type ?? null
+          };
           break;
         }
         case MAP_TOGGLE_TRACK_ME_DRAW_GEO_CLOSE: {
-          draftState.track_me_draw_geo = false;
+          draftState.track_me_draw_geo = {
+            isTracking: false,
+            type: null
+          };
           break;
         }
         case ACTIVITY_EDIT_PHOTO_SUCCESS: {

--- a/app/src/state/reducers/map.ts
+++ b/app/src/state/reducers/map.ts
@@ -82,6 +82,7 @@ import {
 import { AppConfig } from '../config';
 import { getUuid } from './userSettings';
 import { CURRENT_MIGRATION_VERSION, MIGRATION_VERSION_KEY } from 'constants/offline_state_version';
+import GeoShapes from 'constants/geoShapes';
 
 export enum LeafletWhosEditingEnum {
   ACTIVITY = 'ACTIVITY',
@@ -238,7 +239,10 @@ export interface MapState {
   map_zoom: number;
   panned: boolean;
   positionTracking: boolean;
-  track_me_draw_geo: boolean;
+  track_me_draw_geo: {
+    isTracking: boolean;
+    type: GeoShapes | null;
+  };
   quickPanToRecord: boolean;
   recordSetForCSV: number;
   recordTables: object;
@@ -405,7 +409,10 @@ const initialState: MapState = {
   MapMode: 'VECTOR_ENDPOINT',
   panned: false,
   positionTracking: false,
-  track_me_draw_geo: false,
+  track_me_draw_geo: {
+    isTracking: false,
+    type: null
+  },
   quickPanToRecord: false,
 
   recordSetForCSV: 0,
@@ -928,11 +935,17 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           break;
         }
         case MAP_TOGGLE_TRACK_ME_DRAW_GEO_START: {
-          draftState.track_me_draw_geo = true;
+          draftState.track_me_draw_geo = {
+            isTracking: true,
+            type: action.payload.type ?? null
+          };
           break;
         }
         case MAP_TOGGLE_TRACK_ME_DRAW_GEO_CLOSE: {
-          draftState.track_me_draw_geo = false;
+          draftState.track_me_draw_geo = {
+            isTracking: false,
+            type: null
+          };
           break;
         }
         case MAP_TOGGLE_WHATS_HERE: {

--- a/app/src/state/sagas/activity.ts
+++ b/app/src/state/sagas/activity.ts
@@ -330,7 +330,7 @@ function* handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_STOP(action) {
 function* handle_MAP_SET_COORDS(action) {
   const MINIMUM_DISTANCE_BETWEEN_POINTS_IN_METERS = 1;
   const activityState = yield select(selectActivity);
-  if (activityState.track_me_draw_geo) {
+  if (activityState.track_me_draw_geo.isTracking) {
     let currentGeo = activityState?.activity?.geometry?.[0];
     if (!currentGeo) {
       currentGeo = {

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -471,9 +471,14 @@ export function* handle_ACTIVITY_UPDATE_GEO_SUCCESS(action) {
   try {
     const currentState = yield select(selectActivity);
     const currentActivity = currentState.activity;
-    const hasSelfIntersections =
-      currentActivity?.geometry?.[0]?.geometry && kinks(currentActivity?.geometry?.[0]?.geometry).features.length > 0;
-    const wipLinestring = currentActivity?.geometry?.[0]?.geometry?.type === 'LineString';
+    let hasSelfIntersections = false;
+    if (
+      currentActivity?.geometry?.[0]?.geometry &&
+      currentActivity?.geometry?.[0]?.geometry?.type !== GeoShapes.Point
+    ) {
+      hasSelfIntersections = kinks(currentActivity?.geometry?.[0]?.geometry).features.length > 0;
+    }
+    const wipLinestring = currentActivity?.geometry?.[0]?.geometry?.type === GeoShapes.LineString;
     const reportedAreaLessThanMaxArea =
       currentActivity?.geometry && currentActivity?.form_data?.activity_data?.reported_area < MAX_AREA;
     if (reportedAreaLessThanMaxArea && !wipLinestring && !hasSelfIntersections) {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):
- Modals accept new optional prop to hide cancel button from user *(e.g.: ensuring users don't back out when having to apply buffer)*
- Refactor LineString prompt to use Prompt System over browser method
- Refactor In-Form track button to use Prompt System over browser method
- Correct `handle_ACTIVITY_UPDATE_GEO_SUCCESS` to not error out when user enters `Point` shape, preventing jurisdiction checks/updates
- Users can now 'Track me draw' `LineStrings` in addition to `Polygons`
  - Added Switch statement to include specific validation rules per shape, improving scalability in future enhancements.

> [!NOTE]
> I also wrote [documentation](https://github.com/bcgov/invasivesbc/wiki/GPS-Draw-Tool)

Closes #3412
## Screenshots

Track me starting (LineString mode)

![image](https://github.com/user-attachments/assets/c011c130-35a0-4c0b-9dc3-eb92cc2a61a8)

User Walks their Walk

![image](https://github.com/user-attachments/assets/34723f0e-4aa7-4406-805e-b32fd4dd780f)

When User ends walk they are prompted to add a buffer
![image](https://github.com/user-attachments/assets/45cab2fc-f901-464f-a78a-38377b2a3bd0)

Buffer added to shape
![image](https://github.com/user-attachments/assets/20737cea-ee22-4b50-b3df-2dd4ab3af039)
