### PR TITLE
[3405-INV] Part 1**   Refactor Manual UTM to Prompt

### DIFF
--- a/app/src/UI/Overlay/Records/Activity/Form.tsx
+++ b/app/src/UI/Overlay/Records/Activity/Form.tsx
@@ -13,7 +13,8 @@ import {
   MAP_TOGGLE_TRACKING_ON
 } from 'state/actions';
 import GeoShapes from 'constants/geoShapes';
-import { promptRadioInput } from 'utils/userPrompts';
+import { promptRadioInput, promptUtmInput } from 'utils/userPrompts';
+import { UtmInputObj } from 'interfaces/prompt-interfaces';
 
 export const ActivityForm = (props) => {
   const ref = useRef(0);
@@ -41,58 +42,28 @@ export const ActivityForm = (props) => {
   const invasive_plant = useSelector((state: any) => state.ActivityPage?.activity?.invasive_plant);
   const drawGeometryTracking = useSelector((state: any) => state.Map?.track_me_draw_geo);
 
+  /**
+   * @desc Handler for creating a manual UTM Entry initiated by user
+   */
   const manualUTMEntry = () => {
-    let validZone = false;
-    let zone;
-    let validNorthing = false;
-    let northing;
-    let validEasting = false;
-    let easting;
-
-    while (!validZone) {
-      zone = prompt('Enter a valid UTM Zone');
-      if (zone === null) return;
-      if (!isNaN(Number(zone))) {
-        validZone = true;
-        break;
-      }
-    }
-    if (!validZone) {
-      return; // allow for cancel
-    }
-    while (!validEasting) {
-      easting = prompt('Enter a valid UTM Easting');
-      if (easting === null) return;
-      if (!isNaN(Number(easting))) {
-        validEasting = true;
-        break;
-      }
-    }
-    if (!validEasting) {
-      //allow for cancel
-      return;
-    }
-    while (!validNorthing) {
-      northing = prompt('Enter a valid UTM Northing');
-      if (northing === null) return;
-      if (!isNaN(Number(northing))) {
-        validNorthing = true;
-        break;
-      }
-    }
-    if (!validNorthing) {
-      return; // allow for cancel
-    }
-
-    const result = JSON.parse(JSON.stringify(calc_lat_long_from_utm(Number(zone), Number(easting), Number(northing))));
-    const geo: any = {
-      type: 'Feature',
-      geometry: {
-        type: 'Point',
-        coordinates: [result[0], result[1]]
-      },
-      properties: {}
+    const utmCallback = (input: UtmInputObj) => {
+      const geo: any = {
+        type: 'Feature',
+        geometry: {
+          type: 'Point',
+          coordinates: [input.results[0], input.results[1]]
+        },
+        properties: {}
+      };
     };
+
+    dispatch(
+      promptUtmInput({
+        title: 'Enter a manual UTM',
+        prompt: 'Fill in the fields below to create your own UTM Coordinates',
+        callback: utmCallback
+      })
+    );
   };
   const clickHandler = () => {
     if (drawGeometryTracking.isTracking) {

--- a/app/src/UI/Overlay/Records/Activity/Form.tsx
+++ b/app/src/UI/Overlay/Records/Activity/Form.tsx
@@ -44,6 +44,7 @@ export const ActivityForm = (props) => {
 
   /**
    * @desc Handler for creating a manual UTM Entry initiated by user
+   * @TODO Finish flow of function
    */
   const manualUTMEntry = () => {
     const utmCallback = (input: UtmInputObj) => {

--- a/app/src/UI/UserInputModals/ManualUtmModal.tsx
+++ b/app/src/UI/UserInputModals/ManualUtmModal.tsx
@@ -1,0 +1,117 @@
+import {
+  Box,
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  FormControl,
+  Modal,
+  TextField,
+  Typography
+} from '@mui/material';
+import './UserInputModals.css';
+import { useEffect, useState } from 'react';
+import { ManualUtmModalInterface, ReduxPayload } from 'interfaces/prompt-interfaces';
+import { closeModal } from 'utils/userPrompts';
+import { useDispatch } from 'react-redux';
+import { UnknownAction } from 'redux';
+import { calc_lat_long_from_utm } from 'utils/utm';
+
+const ManualUtmModal = ({
+  callback,
+  disableCancel,
+  prompt,
+  title,
+  id,
+  confirmText,
+  cancelText
+}: ManualUtmModalInterface) => {
+  const [zone, setUserZone] = useState<number>();
+  const [easting, setUserEasting] = useState<number>();
+  const [northing, setUserNorthing] = useState<number>();
+  const [results, setResults] = useState<any[]>([]);
+
+  const dispatch = useDispatch();
+  const handleRedux = (redux: ReduxPayload[]) => {
+    for (const action of redux) {
+      dispatch(action as UnknownAction);
+    }
+  };
+  const handleConfirmation = () => {
+    handleRedux(callback(results) ?? []);
+    handleClose();
+  };
+
+  /**
+   * Calculate lat long from UTM.
+   */
+  useEffect(() => {
+    if (zone !== undefined && easting !== undefined && northing !== undefined) {
+      setResults(calc_lat_long_from_utm(zone, easting, northing) ?? []);
+    }
+  }, [zone, easting, northing]);
+
+  /**
+   * @desc change handler for all inputs
+   */
+  const handleChange = (value: string, setter: (input: number) => void) => {
+    const result = parseFloat(value);
+    if (!isNaN(result)) {
+      setter(result);
+    }
+  };
+
+  const handleClose = () => {
+    dispatch(closeModal(id!));
+  };
+
+  return (
+    <Modal open aria-labelledby="modal-modal-title" aria-describedby="modal-modal-description">
+      <Box id="confirmationModal">
+        <DialogTitle className="modalTitle">{title}</DialogTitle>
+        <Divider />
+        <DialogContent>
+          {Array.isArray(prompt) ? (
+            prompt.map((item) => <Typography key={item}>{item}</Typography>)
+          ) : (
+            <Typography>{prompt}</Typography>
+          )}
+        </DialogContent>
+        <FormControl className="inputCont">
+          <TextField
+            aria-label="Zone"
+            inputProps={{ type: 'number' }}
+            label="Zone"
+            onChange={(evt) => handleChange(evt.currentTarget.value, setUserZone)}
+            value={zone ?? ''}
+          />
+          <TextField
+            sx={{ margin: '10pt 0' }}
+            aria-label="Number Input"
+            inputProps={{ type: 'number' }}
+            label="Easting"
+            onChange={(evt) => handleChange(evt.currentTarget.value, setUserEasting)}
+            value={easting ?? ''}
+          />
+          <TextField
+            aria-label="Number Input"
+            inputProps={{ type: 'number' }}
+            label="Northing"
+            onChange={(evt) => handleChange(evt.currentTarget.value, setUserNorthing)}
+            value={northing ?? ''}
+          />
+        </FormControl>
+        <Divider />
+        <DialogActions>
+          {!disableCancel && <Button onClick={handleClose}>{cancelText ?? 'Cancel'}</Button>}
+          <Button onClick={handleConfirmation} disabled={results.length === 0}>
+            {confirmText ?? 'Confirm'}
+          </Button>
+        </DialogActions>
+      </Box>
+    </Modal>
+  );
+};
+
+export default ManualUtmModal;

--- a/app/src/UI/UserInputModals/ManualUtmModal.tsx
+++ b/app/src/UI/UserInputModals/ManualUtmModal.tsx
@@ -12,7 +12,7 @@ import {
 } from '@mui/material';
 import './UserInputModals.css';
 import { useEffect, useState } from 'react';
-import { ManualUtmModalInterface, ReduxPayload } from 'interfaces/prompt-interfaces';
+import { ManualUtmModalInterface, ReduxPayload, UtmInputObj } from 'interfaces/prompt-interfaces';
 import { closeModal } from 'utils/userPrompts';
 import { useDispatch } from 'react-redux';
 import { UnknownAction } from 'redux';
@@ -30,7 +30,7 @@ const ManualUtmModal = ({
   const [zone, setUserZone] = useState<number>();
   const [easting, setUserEasting] = useState<number>();
   const [northing, setUserNorthing] = useState<number>();
-  const [results, setResults] = useState<any[]>([]);
+  const [results, setResults] = useState<number[]>([]);
 
   const dispatch = useDispatch();
   const handleRedux = (redux: ReduxPayload[]) => {
@@ -39,10 +39,15 @@ const ManualUtmModal = ({
     }
   };
   const handleConfirmation = () => {
-    handleRedux(callback(results) ?? []);
+    handleRedux(callback(buildResponse()) ?? []);
     handleClose();
   };
-
+  const buildResponse = (): UtmInputObj => ({
+    zone: zone!,
+    easting: easting!,
+    northing: northing!,
+    results: results
+  });
   /**
    * Calculate lat long from UTM.
    */

--- a/app/src/UI/UserInputModals/UserInputModalController.tsx
+++ b/app/src/UI/UserInputModals/UserInputModalController.tsx
@@ -1,5 +1,7 @@
 import DateModal from './DateModal';
+import ManualUtmModal from './ManualUtmModal';
 import NumberModal from './NumberModal';
+import RadioModal from './RadioModal';
 import TextModal from './TextModal';
 import ConfirmationModal from './ConfirmationModal';
 import { useSelector } from 'utils/use_selector';
@@ -7,11 +9,11 @@ import { PromptTypes } from 'constants/promptEnums';
 import {
   ConfirmationModalInterface,
   DateModalInterface,
+  ManualUtmModalInterface,
   NumberModalInterface,
   RadioModalInterface,
   TextModalInterface
 } from 'interfaces/prompt-interfaces';
-import RadioModal from './RadioModal';
 
 /**
  * @desc Handler for all User Input Modals, Uses Redux store as a queue to display prompts to user when input is needed
@@ -51,6 +53,19 @@ const UserInputModalController = () => {
           min={prompt?.min}
           prompt={prompt?.prompt}
           title={prompt?.title}
+        />
+      );
+    case PromptTypes.ManualUtm:
+      prompt = prompts[0] as ManualUtmModalInterface;
+      return (
+        <ManualUtmModal
+          cancelText={prompt?.cancelText}
+          callback={prompt.callback}
+          confirmText={prompt?.confirmText}
+          disableCancel={prompt?.disableCancel}
+          id={prompt.id}
+          prompt={prompt.prompt}
+          title={prompt.title}
         />
       );
     case PromptTypes.Number:

--- a/app/src/constants/promptEnums.ts
+++ b/app/src/constants/promptEnums.ts
@@ -6,6 +6,7 @@
 export enum PromptTypes {
   Confirmation,
   Date,
+  ManualUtm,
   Number,
   Radio,
   Text

--- a/app/src/interfaces/prompt-interfaces.ts
+++ b/app/src/interfaces/prompt-interfaces.ts
@@ -52,6 +52,14 @@ export interface DateModalInterface extends BasePromptInterface {
 }
 
 /**
+ * @interface ManualUtmModalInterface
+ * @extends BasePromptInterface
+ * @property { (input: UtmObject) => void | ReduxPayload[] } callback Action result for user input. if an array is returned, fires all redux actions contained
+ */
+export interface ManualUtmModalInterface extends BasePromptInterface {
+  callback: (input: number[]) => void | ReduxPayload[];
+}
+/**
  * @interface NumberModalInterface
  * @extends BasePromptInterface
  * @property {boolean} acceptFloats Allow user to enter floats as input value

--- a/app/src/interfaces/prompt-interfaces.ts
+++ b/app/src/interfaces/prompt-interfaces.ts
@@ -52,12 +52,21 @@ export interface DateModalInterface extends BasePromptInterface {
 }
 
 /**
+ * @desc Response object interface for user created UTMs
+ */
+export interface UtmInputObj {
+  zone: number;
+  northing: number;
+  easting: number;
+  results: number[];
+}
+/**
  * @interface ManualUtmModalInterface
  * @extends BasePromptInterface
- * @property { (input: UtmObject) => void | ReduxPayload[] } callback Action result for user input. if an array is returned, fires all redux actions contained
+ * @property { (input: UtmInputObj) => void | ReduxPayload[] } callback Action result for user input. if an array is returned, fires all redux actions contained
  */
 export interface ManualUtmModalInterface extends BasePromptInterface {
-  callback: (input: number[]) => void | ReduxPayload[];
+  callback: (input: UtmInputObj) => void | ReduxPayload[];
 }
 /**
  * @interface NumberModalInterface

--- a/app/src/utils/userPrompts.ts
+++ b/app/src/utils/userPrompts.ts
@@ -7,6 +7,7 @@ import { PromptTypes } from 'constants/promptEnums';
 import {
   ConfirmationModalInterface,
   DateModalInterface,
+  ManualUtmModalInterface,
   NumberModalInterface,
   RadioModalInterface,
   TextModalInterface
@@ -76,6 +77,18 @@ export const promptRadioInput = (prompt: RadioModalInterface) => {
  */
 export const promptTextInput = (prompt: TextModalInterface) => {
   prompt.type = PromptTypes.Text;
+  return {
+    type: NEW_PROMPT,
+    payload: prompt
+  };
+};
+
+/**
+ * @desc Helper function for creating modals to gather manual UTM inputs
+ * @param {ManualUtmModalInterface} prompt component props
+ */
+export const promptUtmInput = (prompt: ManualUtmModalInterface) => {
+  prompt.type = PromptTypes.ManualUtm;
   return {
     type: NEW_PROMPT,
     payload: prompt


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):
- Part of #3405 
- Add Modal for creating manual UTM
    - Cleaner approach than chaining 3 NumberModals back to back, giving user all their info at once
- Refactor `ManualUTM` in `Form.tsx` to use Prompt controller instead of browser methods. 

> [!IMPORTANT]
> The goal in this ticket was removing all built-in browser prompt systems, but it was discovered this particular feature was incomplete at time of refactor. It was moved into the prompt system, and a new ticket was created #3428 to finish the work that was started