### PR TITLE
[INV-3405] Prompt Overhaul -- Pt2

### DIFF
--- a/app/src/UI/Overlay/Batch/batch-upload/ClipboardHelper.tsx
+++ b/app/src/UI/Overlay/Batch/batch-upload/ClipboardHelper.tsx
@@ -1,20 +1,39 @@
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { IconButton } from '@mui/material';
-import React from 'react';
+import { AlertSeverity, AlertSubjects } from 'constants/alertEnums';
+import { useDispatch } from 'react-redux';
+import { NEW_ALERT } from 'state/actions';
 
 export const CopyToClipboardButton = (props: { content: string }) => {
+  const dispatch = useDispatch();
+
+  const copyToClipboard = async ({ value }: any) => {
+    if (!navigator.clipboard) {
+      dispatch({
+        type: NEW_ALERT,
+        payload: {
+          content: 'No clipboard supported',
+          subject: AlertSubjects.Form,
+          severity: AlertSeverity.Error
+        }
+      });
+      return;
+    }
+    await navigator.clipboard.writeText(value);
+    dispatch({
+      type: NEW_ALERT,
+      payload: {
+        content: 'Copied to clipboard!',
+        subject: AlertSubjects.Form,
+        severity: AlertSeverity.Success,
+        autoClose: 3
+      }
+    });
+  };
+
   return (
-    <IconButton onClick={() => copyToClipboard({ value: props.content, message: 'Copied to clipboard!' })}>
-      <ContentCopyIcon></ContentCopyIcon>
+    <IconButton onClick={() => copyToClipboard({ value: props.content })}>
+      <ContentCopyIcon />
     </IconButton>
   );
-};
-
-export const copyToClipboard = async ({ message, value }: any) => {
-  if (!navigator.clipboard) {
-    console.error('No clipboard support');
-    return;
-  }
-  await navigator.clipboard.writeText(value);
-  alert(message);
 };

--- a/app/src/UI/Overlay/Records/Records.tsx
+++ b/app/src/UI/Overlay/Records/Records.tsx
@@ -27,6 +27,7 @@ import './Records.css';
 import { OverlayHeader } from '../OverlayHeader';
 import Spinner from 'UI/Spinner/Spinner';
 import { useHistory } from 'react-router-dom';
+import { promptConfirmationInput } from 'utils/userPrompts';
 
 export const Records = () => {
   const MapMode = useSelector((state: any) => state.Map?.MapMode);
@@ -123,19 +124,26 @@ export const Records = () => {
 
   const onClickDeleteRecordSet = (set: any, e) => {
     e.stopPropagation();
-    if (
-      /*eslint-disable*/
-      confirm(
-        'Are you sure you want to remove this record set?  The data will persist but you will no longer have this set of filters or the map layer.'
-      )
-    ) {
-      dispatch({
-        type: USER_SETTINGS_REMOVE_RECORD_SET,
-        payload: {
-          setID: set
-        }
-      });
-    }
+    const callback = (userConfirmation: boolean) => {
+      if (userConfirmation) {
+        dispatch({
+          type: USER_SETTINGS_REMOVE_RECORD_SET,
+          payload: {
+            setID: set
+          }
+        });
+      }
+    };
+    dispatch(
+      promptConfirmationInput({
+        title: 'Deleting Record Set',
+        prompt: [
+          'Are you sure you want to remove this record set?',
+          'The data will persist but you will no longer have this set of filters or the map layer.'
+        ],
+        callback
+      })
+    );
   };
 
   const onClickInitCache = (set: any, e) => {
@@ -250,8 +258,9 @@ export const Records = () => {
                       borderWidth: typeof highlightedSet === 'string' && highlightedSet === set ? '5px' : '1px',
                       padding: typeof highlightedSet === 'string' && highlightedSet === set ? '0px 5px' : '4px 9px',
                       boxSizing: 'border-box',
-                      height: '30pt',
-                    }}>
+                      height: '30pt'
+                    }}
+                  >
                     <div key={set + 'spinner'}>{!loadMap?.[set] ? <Spinner /> : <></>}</div>
                     <div className="records_set_left_hand_items">
                       <>
@@ -293,7 +302,11 @@ export const Records = () => {
                         )}
                       </>
                       <div className="records_set_name">
-                        {isEditingName && !['1', '2', '3'].includes(set) ? <></> : <Typography>{recordSets?.[set]?.recordSetName}</Typography>}
+                        {isEditingName && !['1', '2', '3'].includes(set) ? (
+                          <></>
+                        ) : (
+                          <Typography>{recordSets?.[set]?.recordSetName}</Typography>
+                        )}
                       </div>
                     </div>
 
@@ -382,8 +395,8 @@ export const Records = () => {
                       </Tooltip>
 
                       {recordSets?.[set]?.recordSetName === 'All InvasivesBC Activities' ||
-                        recordSets?.[set]?.recordSetName === 'All IAPP Records' ||
-                        recordSets?.[set]?.recordSetName === 'My Drafts' ? (
+                      recordSets?.[set]?.recordSetName === 'All IAPP Records' ||
+                      recordSets?.[set]?.recordSetName === 'My Drafts' ? (
                         <></>
                       ) : (
                         <div className="records_set_layer_colour">
@@ -400,8 +413,8 @@ export const Records = () => {
                       )}
 
                       {recordSets?.[set]?.recordSetName === 'All InvasivesBC Activities' ||
-                        recordSets?.[set]?.recordSetName === 'All IAPP Records' ||
-                        recordSets?.[set]?.recordSetName === 'My Drafts' ? (
+                      recordSets?.[set]?.recordSetName === 'All IAPP Records' ||
+                      recordSets?.[set]?.recordSetName === 'My Drafts' ? (
                         <></>
                       ) : (
                         <Tooltip

--- a/app/src/UI/UserInputModals/NumberModal.tsx
+++ b/app/src/UI/UserInputModals/NumberModal.tsx
@@ -32,7 +32,7 @@ const NumberModal = ({
   label,
   acceptFloats
 }: NumberModalInterface) => {
-  const [userNumber, setUserNumber] = useState<number>(0);
+  const [userNumber, setUserNumber] = useState<number>();
   const [validationError, setValidationError] = useState<string>('');
   const dispatch = useDispatch();
   const handleRedux = (redux: ReduxPayload[]) => {
@@ -43,7 +43,7 @@ const NumberModal = ({
   const handleConfirmation = () => {
     const inputIsValid = validateUserInput();
     if (inputIsValid) {
-      handleRedux(callback(userNumber) ?? []);
+      handleRedux(callback((userNumber as number) ?? 0) ?? []);
       handleClose();
     }
   };
@@ -51,18 +51,9 @@ const NumberModal = ({
    * @desc change handler for select menu
    */
   const handleChange = (value: string) => {
-    if (value === '') {
-      setUserNumber(0);
-    } else if (acceptFloats) {
-      const result = parseFloat(value);
-      if (!isNaN(result)) {
-        setUserNumber(result);
-      }
-    } else {
-      const result = parseInt(value);
-      if (!isNaN(result)) {
-        setUserNumber(result);
-      }
+    const result = acceptFloats ? parseFloat(value) : parseInt(value);
+    if (!isNaN(result)) {
+      setUserNumber(result);
     }
     validateUserInput();
   };
@@ -77,7 +68,9 @@ const NumberModal = ({
    */
   const validateUserInput = (): boolean => {
     let error: string = '';
-    if (selectOptions && !selectOptions.includes(userNumber)) {
+    if (typeof userNumber !== 'number') {
+      error = 'Value cannot be blank.';
+    } else if (selectOptions && !selectOptions.includes(userNumber)) {
       error = 'Must select a value from the select menu';
     } else if (min !== undefined && max !== undefined && (userNumber < min || max < userNumber)) {
       error = `Number must be between (${min}) and (${max})`;
@@ -128,7 +121,7 @@ const NumberModal = ({
               label={label ?? 'Enter response'}
               onBlur={validateUserInput}
               onChange={(evt) => handleChange(evt.currentTarget.value)}
-              value={userNumber}
+              value={userNumber ?? ''}
             />
           )}
         </FormControl>


### PR DESCRIPTION
> [!TIP]
> This PR is **NOT** Branched off of Pt 1

# Overview

This PR includes the following proposed change(s):
- Refactored `handle_ACTIVITY_UPDATE_GEO_REQUEST` to re-include the functionality of `getSetNumberFromUser`.
    - This now uses the Prompt system instead of browser methods.
    - Prompt refires the event, including the previously missing information (area). 
- Refactored `ClipboardHelper` to use self-clearing alerts instead of browser `alert()`'s.
- For Point Geography, Users can select a value between 1-10m inclusive,  instead of being limited to 1, 5, 10. Closes #3427
- Refactor the Number Modal to not use 0 as a default value without throwing errors. 
- Closes #3405

Other than one browser alert used exclusively for iOS Background Tracking, this should remove all browser `confirm()`, `prompt()`, and `alert()`'s 