### PR TITLE
[INV-3430] UI Enhancement for Custom Layers

### DIFF
--- a/app/src/UI/Map2/Controls/CustomizeLayerDialog.css
+++ b/app/src/UI/Map2/Controls/CustomizeLayerDialog.css
@@ -1,0 +1,30 @@
+#customMapLayerDialog {
+}
+
+#customMapLayerDialog .dialogTitle {
+  background-color: var(--bc-blue);
+  color: white;
+  border-bottom: 2pt solid var(--bc-yellow);
+  margin-bottom: 5pt;
+}
+
+#customMapLayerDialog .dialogBody {
+  background-color: white;
+  display: flex;
+  width: 400px;
+  max-width: 100%;
+  min-height: 50pt;
+  box-sizing: border-box;
+  padding: 10pt;
+}
+
+#customMapLayerDialog .dialogBody .formCont {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 100%;
+}
+
+#customMapLayerDialog .dialogBody div .MuiFormControl-root {
+  margin: 5pt 0;
+}


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Move inline-functions out of `tsx` into named functions in component to better separate the look and logic
- Send an alert when users make a Layer using `Draw` so they know the next step is to draw the layer.
- Move String values to Enums for consistent behaviour.
- Set null defaults for states instead of magic values, set prop values to `??  null` to avoid  `trying to control previously uncontrolled value` errors
- Collapse the Layer menu when user is drawing 
- Fix any flagged TS Errors
- Changed the useSelector to the typed version of the useSelector
- Overhaul UI to fit the identity of the application, and present a clean interface.
- Closes #3430 (Ticket includes old screenshots)

![image](https://github.com/user-attachments/assets/b5163ba5-0159-4582-86ae-5096cddeadfc)

![image](https://github.com/user-attachments/assets/b19ac380-9838-4712-b9b4-541cf4483fef)

![image](https://github.com/user-attachments/assets/f1c766ed-458b-4ac4-b9a1-b22a5a4c5d6f)
