### PR TITLE
[INV-3389] Hide Draw tools when not needed

### DIFF
--- a/app/src/UI/Map2/Controls/WhatsHereButton.tsx
+++ b/app/src/UI/Map2/Controls/WhatsHereButton.tsx
@@ -2,12 +2,13 @@ import React, { useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { IconButton, Tooltip } from '@mui/material';
 import { useSelector } from 'utils/use_selector';
-import { MAP_TOGGLE_WHATS_HERE } from 'state/actions';
+import { MAP_TOGGLE_WHATS_HERE, NEW_ALERT } from 'state/actions';
 import HourglassTopIcon from '@mui/icons-material/HourglassTop';
 
 import DocumentScannerIcon from '@mui/icons-material/DocumentScanner';
 import { useHistory } from 'react-router-dom';
 import 'UI/Global.css';
+import { AlertSeverity, AlertSubjects } from 'constants/alertEnums';
 
 export const WhatsHereButton = (props) => {
   const dispatch = useDispatch();
@@ -34,6 +35,15 @@ export const WhatsHereButton = (props) => {
               onClick={() => {
                 if ((whatsHere as any)?.toggle == false) {
                   dispatch({ type: MAP_TOGGLE_WHATS_HERE });
+                  dispatch({
+                    type: NEW_ALERT,
+                    payload: {
+                      content: "Draw a rectangle on the map to show what's there",
+                      autoClose: 5,
+                      severity: AlertSeverity.Info,
+                      subject: AlertSubjects.Map
+                    }
+                  });
                 } else {
                   history.goBack();
                 }
@@ -56,8 +66,6 @@ export const WhatsHereButton = (props) => {
 
 export const WhatsHereDrawComponent = (props) => {
   const ref = useRef();
-  const dispatch = useDispatch();
-  const history = useHistory();
   const whatsHere = useSelector((state: any) => state.Map?.whatsHere);
 
   useEffect(() => {

--- a/app/src/UI/Map2/Controls/WhatsHereButton.tsx
+++ b/app/src/UI/Map2/Controls/WhatsHereButton.tsx
@@ -38,7 +38,7 @@ export const WhatsHereButton = (props) => {
                   dispatch({
                     type: NEW_ALERT,
                     payload: {
-                      content: "Draw a rectangle on the map to show what's there",
+                      content: 'Outline a region on the map to view records in the area.',
                       autoClose: 5,
                       severity: AlertSeverity.Info,
                       subject: AlertSubjects.Map

--- a/app/src/UI/Map2/Helpers.tsx
+++ b/app/src/UI/Map2/Helpers.tsx
@@ -159,7 +159,7 @@ export const mapInit = (
         public_layer: {
           type: 'vector',
           url: `pmtiles://${PMTILES_URL}`,
-          attribution: 'Powered by ESRI',
+          attribution: 'Powered by ESRI'
         }
       },
       layers: [
@@ -569,39 +569,34 @@ export const rebuildLayersOnTableHashUpdate = (storeLayers, map, mode, API_BASE)
 
   */
   const storeLayersIds = storeLayers.map((layer) => {
-    return 'recordset-layer-' + layer.recordSetID + '-'
-  })
+    return 'recordset-layer-' + layer.recordSetID + '-';
+  });
 
   const allLayersOnMap = map.getLayersOrder();
   const allSourcesOnMap = Object.keys(map.style.sourceCaches);
-  const allThatAreRecordSetLayers = allLayersOnMap.filter(layer => 
-    layer.includes('recordset-layer')
-  )
-  const allThatAreRecordSetSources = allSourcesOnMap.filter(source => 
-    source.includes('recordset-layer-')
-  )
-  const recordSetLayersThatAreNotInStore = allThatAreRecordSetLayers.filter(layer => 
-       storeLayersIds.filter(storeLayerId => layer.includes(storeLayerId)).length === 0
-  )
-  const recordSetSourcesThatAreNotInStore = allThatAreRecordSetSources.filter(source => 
-       storeLayersIds.filter(storeLayerId => source.includes(storeLayerId)).length === 0
-  )
+  const allThatAreRecordSetLayers = allLayersOnMap.filter((layer) => layer.includes('recordset-layer'));
+  const allThatAreRecordSetSources = allSourcesOnMap.filter((source) => source.includes('recordset-layer-'));
+  const recordSetLayersThatAreNotInStore = allThatAreRecordSetLayers.filter(
+    (layer) => storeLayersIds.filter((storeLayerId) => layer.includes(storeLayerId)).length === 0
+  );
+  const recordSetSourcesThatAreNotInStore = allThatAreRecordSetSources.filter(
+    (source) => storeLayersIds.filter((storeLayerId) => source.includes(storeLayerId)).length === 0
+  );
 
-  recordSetLayersThatAreNotInStore.map(layer => {
+  recordSetLayersThatAreNotInStore.map((layer) => {
     try {
-      map.removeLayer(layer)
-    } catch(e) {
-      console.log('error removing layer', e)
+      map.removeLayer(layer);
+    } catch (e) {
+      console.log('error removing layer', e);
     }
-  })
-  recordSetSourcesThatAreNotInStore.map(source => {
+  });
+  recordSetSourcesThatAreNotInStore.map((source) => {
     try {
-      map.removeSource(source)
-    } catch(e) {
-      console.log('error removing source', e)
+      map.removeSource(source);
+    } catch (e) {
+      console.log('error removing source', e);
     }
-  })
-
+  });
 
   // now update the layers that are in the store
   storeLayers.map((layer: any) => {
@@ -1018,9 +1013,9 @@ export const refreshDrawControls = (
   drawingCustomLayer
 ) => {
   /*
-          We fully tear down map box draw and readd depending on app state / route, to have conditionally rendered controls:
-          Because mapbox draw doesn't clean up its old sources properly we need to do it manually
-       */
+    We fully tear down map box draw and readd depending on app state / route, to have conditionally rendered controls:
+    Because mapbox draw doesn't clean up its old sources properly we need to do it manually
+   */
   map.getLayersOrder().map((layer) => {
     if (/gl-draw/.test(layer)) {
       map.removeLayer(layer);
@@ -1041,34 +1036,21 @@ export const refreshDrawControls = (
   }
 
   if (!map.draw) {
-    if (/Report|Batch|Landing|WhatsHere/.test(appModeUrl)) {
-      initDrawModes(map, drawSetter, dispatch, uHistory, true, null, whatsHereToggle, null, draw);
-    } else if (/Records/.test(appModeUrl)) {
-      if (/Activity/.test(appModeUrl)) {
-        initDrawModes(
-          map,
-          drawSetter,
-          dispatch,
-          uHistory,
-          false,
-          activityGeo,
-          whatsHereToggle,
-          drawingCustomLayer,
-          draw
-        );
-      } else {
-        initDrawModes(map, drawSetter, dispatch, uHistory, false, null, whatsHereToggle, drawingCustomLayer, draw);
-      }
-    }
+    const noMapVisible = /Report|Batch|Landing|WhatsHere/.test(appModeUrl);
+    const userInActivity = /Activity/.test(appModeUrl);
+    const hideControls = (noMapVisible || !userInActivity) && !drawingCustomLayer;
+    initDrawModes(
+      map,
+      drawSetter,
+      dispatch,
+      uHistory,
+      hideControls,
+      userInActivity ? activityGeo : null,
+      whatsHereToggle,
+      drawingCustomLayer ?? null,
+      draw
+    );
   }
-
-  /*
-    if (whatsHereToggle && draw) {
-      draw.changeMode('whats_here_box_mode');
-    } else {
-      draw.changeMode('do_nothing');
-    }
-    */
 };
 
 export const refreshWhatsHereFeature = (map, options: any) => {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):
- Condensed logic in RefreshDrawControls to reduce complexity. 
- Added `Alert` when turning on the `What's Here?` Feature
    - The Feature already doesn't use the draw tools, users can just draw directly on the app, so notify them of this.
 - Removed some commented out code that looks like it was reintegrated elsewhere in the app

![image](https://github.com/user-attachments/assets/d6f0c780-1655-4a51-a4df-98e86adf5a2d)

**When can you expect to see draw tools**
- When an Activity is open
- When you are drawing a custom layer
- Closes #3389

> [!WARNING]
> Bug still exists that causes Draw tools to sometimes duplicate (Part of me feels this is just caused in dev environments from rerenders of the map)