### PR TITLE
[INV-3390] Bugfix - Recordset Pane hidden behind footer

### DIFF
--- a/app/src/state/sagas/map.ts
+++ b/app/src/state/sagas/map.ts
@@ -949,11 +949,13 @@ function* handle_MAP_ON_SHAPE_CREATE(action) {
 }
 
 function* handle_MAP_ON_SHAPE_UPDATE(action) {
-  const appModeUrl = yield select((state: any) => state.AppMode.url);
+  const { appModeUrl, panelOpen } = yield select((state: any) => state.AppMode);
   const whatsHereToggle = yield select((state: any) => state.Map.whatsHere.toggle);
-
   if (appModeUrl && /Activity/.test(appModeUrl) && !whatsHereToggle) {
     yield put({ type: ACTIVITY_UPDATE_GEO_REQUEST, payload: { geometry: [action.payload] } });
+  }
+  if (!panelOpen) {
+    yield put({ type: TOGGLE_PANEL });
   }
 }
 


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):
- add check in `handle_MAP_SHAPE_UPDATE` to open the main panel if its closed.
- Since no other details were provided by reporter, Closes #3390

## About the bug
- Have not been able to reliably cause this bug to occur in anyway. 
- Observed that if you create a custom map layer, the main overlay is closed, but completing the shape does not reopen the panel. 
    - its an assumption this was the bug, as it was submitted by a user with no additional details