### PR TITLE
[INV-3452] Tighten Number inputs for Prompt Modals

### DIFF
--- a/app/src/UI/UserInputModals/ManualUtmModal.tsx
+++ b/app/src/UI/UserInputModals/ManualUtmModal.tsx
@@ -27,9 +27,9 @@ const ManualUtmModal = ({
   confirmText,
   cancelText
 }: ManualUtmModalInterface) => {
-  const [zone, setUserZone] = useState<number>();
-  const [easting, setUserEasting] = useState<number>();
-  const [northing, setUserNorthing] = useState<number>();
+  const [zone, setUserZone] = useState<string>();
+  const [easting, setUserEasting] = useState<string>();
+  const [northing, setUserNorthing] = useState<string>();
   const [results, setResults] = useState<number[]>([]);
 
   const dispatch = useDispatch();
@@ -43,27 +43,36 @@ const ManualUtmModal = ({
     handleClose();
   };
   const buildResponse = (): UtmInputObj => ({
-    zone: zone!,
-    easting: easting!,
-    northing: northing!,
+    zone: parseFloat(zone!),
+    easting: parseFloat(easting!),
+    northing: parseFloat(northing!),
     results: results
   });
   /**
    * Calculate lat long from UTM.
    */
   useEffect(() => {
-    if (zone !== undefined && easting !== undefined && northing !== undefined) {
-      setResults(calc_lat_long_from_utm(zone, easting, northing) ?? []);
+    try {
+      if (zone !== undefined && easting !== undefined && northing !== undefined) {
+        setResults(calc_lat_long_from_utm(parseFloat(zone), parseFloat(easting), parseFloat(northing)) ?? []);
+      } else {
+        setResults([]);
+      }
+    } catch (ex) {
+      console.error(ex);
+      setResults([]);
     }
   }, [zone, easting, northing]);
 
   /**
    * @desc change handler for all inputs
    */
-  const handleChange = (value: string, setter: (input: number) => void) => {
-    const result = parseFloat(value);
-    if (!isNaN(result)) {
-      setter(result);
+  const handleChange = (value: string, setter: (input: string | undefined) => void) => {
+    const regex = /^[+-]?\d*(?:[.,]\d*)?$/;
+    if (!value) {
+      setter(undefined);
+    } else if (regex.test(value)) {
+      setter(value);
     }
   };
 
@@ -86,7 +95,6 @@ const ManualUtmModal = ({
         <FormControl className="inputCont">
           <TextField
             aria-label="Zone"
-            inputProps={{ type: 'number' }}
             label="Zone"
             onChange={(evt) => handleChange(evt.currentTarget.value, setUserZone)}
             value={zone ?? ''}
@@ -94,14 +102,12 @@ const ManualUtmModal = ({
           <TextField
             sx={{ margin: '10pt 0' }}
             aria-label="Easting"
-            inputProps={{ type: 'number' }}
             label="Easting"
             onChange={(evt) => handleChange(evt.currentTarget.value, setUserEasting)}
             value={easting ?? ''}
           />
           <TextField
             aria-label="Northing"
-            inputProps={{ type: 'number' }}
             label="Northing"
             onChange={(evt) => handleChange(evt.currentTarget.value, setUserNorthing)}
             value={northing ?? ''}

--- a/app/src/UI/UserInputModals/NumberModal.tsx
+++ b/app/src/UI/UserInputModals/NumberModal.tsx
@@ -53,7 +53,7 @@ const NumberModal = ({
    */
   const handleChange = (value: string) => {
     const floatReg = /^[+-]?\d*(?:[.,]\d*)?$/;
-    const intReg = /^-?[0-9]+$/;
+    const intReg = /^[+-]?\d*$/;
     const regex = acceptFloats ? floatReg : intReg;
     if (!value) {
       setUserNumber(undefined);

--- a/app/src/UI/UserInputModals/NumberModal.tsx
+++ b/app/src/UI/UserInputModals/NumberModal.tsx
@@ -55,10 +55,10 @@ const NumberModal = ({
     const floatReg = /^[+-]?\d*(?:[.,]\d*)?$/;
     const intReg = /^-?[0-9]+$/;
     const regex = acceptFloats ? floatReg : intReg;
-    if (regex.test(value)) {
-      setUserNumber(value);
-    } else if (!value) {
+    if (!value) {
       setUserNumber(undefined);
+    } else if (regex.test(value)) {
+      setUserNumber(value);
     }
     validateUserInput(parseFloat(value));
   };


### PR DESCRIPTION
# Overview

> No change to Look / Feel / Use cases

- Number and UTM Modals internally treat all inputs as strings instead of numbers
    - The return value in callbacks are still parsed and treated as numbers 
- removed `parseInt` calls, since parseFloat will return an int if applicable, and regex is now validating correctness of Int v Float
- removed MUIs validation ` inputProps={{ type: 'number' }}` from all input fields
    - handling change values from these becomes wonky when trying to clear an input or add/remove decimals. a typo in a long number can be read as an empty string, reducing control of resetting an input field to empty, or prematurely resetting a value 
- Swapped validation to use Regex instead, so give finer control over user input, allow null fields, and handling mistypes
- Add try/catch block to manual UTM to help prevent broken inputs maintaining an old state and not an up to date value
- Closes #3452 