### PR TITLE
[INV-3460] Modify use of getClosestWells

### DIFF
--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -221,7 +221,8 @@ export function* handle_ACTIVITY_UPDATE_GEO_REQUEST(action: Record<string, any>)
     let areWellsInside = false;
 
     if (reported_area < MAX_AREA && !isWIPLinestring && latitude && longitude) {
-      nearestWells = yield getClosestWells(sanitizedGeo, true);
+      const networkState = yield select(selectNetworkConnected);
+      nearestWells = yield getClosestWells(sanitizedGeo, networkState.connected);
       if (nearestWells?.well_objects.length === 0) {
         wellInformationArr = [
           {

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -221,8 +221,7 @@ export function* handle_ACTIVITY_UPDATE_GEO_REQUEST(action: Record<string, any>)
     let areWellsInside = false;
 
     if (reported_area < MAX_AREA && !isWIPLinestring && latitude && longitude) {
-      const networkState = yield select(selectNetworkConnected);
-      nearestWells = yield getClosestWells(sanitizedGeo, networkState.connected);
+      nearestWells = yield getClosestWells(sanitizedGeo);
       if (nearestWells?.well_objects.length === 0) {
         wellInformationArr = [
           {

--- a/app/src/utils/closestWellsHelpers.tsx
+++ b/app/src/utils/closestWellsHelpers.tsx
@@ -4,15 +4,18 @@ import polygonToLine from '@turf/polygon-to-line';
 import inside from '@turf/inside';
 import buffer from '@turf/buffer';
 import { getDataFromDataBCv2 } from './WFSConsumer';
+import { selectNetworkConnected } from 'state/reducers/network';
+import { select } from 'redux-saga/effects';
 
 //gets layer data based on the layer name
-export function* getClosestWells(inputGeometry, online) {
+export function* getClosestWells(inputGeometry) {
   const firstFeature = inputGeometry;
+  const networkState = yield select(selectNetworkConnected);
   //get the map extent as geoJson polygon feature
   const bufferedGeo = buffer(firstFeature, 1, { units: 'kilometers' });
   //if well layer is selected
   //if online, just get data from WFSonline consumer
-  if (online) {
+  if (networkState.connected) {
     const returnVal = yield getDataFromDataBCv2('WHSE_WATER_MANAGEMENT.GW_WATER_WELLS_WRBC_SVW', bufferedGeo, true);
 
     if (!returnVal?.features) {

--- a/app/src/utils/closestWellsHelpers.tsx
+++ b/app/src/utils/closestWellsHelpers.tsx
@@ -20,6 +20,9 @@ export function* getClosestWells(inputGeometry, online) {
     } else {
       return getWellsArray(returnVal.features, firstFeature);
     }
+  } else {
+    /* TODO */
+    return { well_objects: [], areWellsInside: undefined };
   }
   //if offline: try to get layer data from sqlite local storage
   /*  else {


### PR DESCRIPTION
# Overview

Observed when offline that creating a shape with proper area, would always call `getClosestWells` with a default of being online. This always triggers an API call that never resolves and halts the entire process. When a couple of these fire off, they then form a race condition of resolution, and that leads to multiple Draw tools being created in the constant rerendering. 

Since users access these tools in poor-connection areas, this can make things difficult. This fix is a temporary bandaid on a solution, as offline functionality is being worked on overall

- Access `connected` state from inside getClosestWells
    - Remove Param from the function call 
- Return formatted response when not offline (Stub) so function can resolve

