### PR TITLE
[INV-3470] Add Long Press / Mobile Refresh Button

### DIFF
--- a/app/src/UI/Header/Header.tsx
+++ b/app/src/UI/Header/Header.tsx
@@ -45,6 +45,7 @@ import { useSelector } from 'utils/use_selector';
 import { selectAuth } from 'state/reducers/auth';
 import { selectConfiguration } from 'state/reducers/configuration';
 import { OfflineSyncHeaderButton } from 'UI/Header/OfflineSyncHeaderButton';
+import RefreshButton from './RefreshButton';
 
 type TabPredicate =
   | 'authenticated_any'
@@ -369,6 +370,7 @@ const LoginOrOutMemo = React.memo(() => {
         )}
         {!authenticated && !workingOffline && <LoginButton />}
         {workingOffline && <LoginButton labelText={'Go Online'} />}
+        {MOBILE && <RefreshButton />}
         {(authenticated || workingOffline) && <LogoutButton />}
       </Menu>
     </div>

--- a/app/src/UI/Header/RefreshButton.tsx
+++ b/app/src/UI/Header/RefreshButton.tsx
@@ -1,0 +1,18 @@
+import { Refresh } from '@mui/icons-material';
+import { ListItemIcon, MenuItem } from '@mui/material';
+import longPressEvent from 'utils/longPressEvent';
+
+const RefreshButton = () => {
+  const handleRefresh = () => location.reload();
+  const { handlers } = longPressEvent(handleRefresh);
+  return (
+    <MenuItem {...handlers}>
+      <ListItemIcon>
+        <Refresh />
+      </ListItemIcon>
+      Hold to Refresh Page
+    </MenuItem>
+  );
+};
+
+export default RefreshButton;

--- a/app/src/UI/Header/RefreshButton.tsx
+++ b/app/src/UI/Header/RefreshButton.tsx
@@ -1,10 +1,9 @@
 import { Refresh } from '@mui/icons-material';
 import { ListItemIcon, MenuItem } from '@mui/material';
-import longPressEvent from 'utils/longPressEvent';
-
+import useLongPress from 'utils/useLongPress';
 const RefreshButton = () => {
   const handleRefresh = () => location.reload();
-  const { handlers } = longPressEvent(handleRefresh);
+  const { handlers } = useLongPress(handleRefresh);
   return (
     <MenuItem {...handlers}>
       <ListItemIcon>

--- a/app/src/utils/longPressEvent.ts
+++ b/app/src/utils/longPressEvent.ts
@@ -1,0 +1,68 @@
+import { useState, useRef } from 'react';
+
+/**
+ * @desc Optional Settings for hook
+ * @property {Function} onClickCallback Event for click events, when longpresses end early
+ * @property {number} delay time of longpress in ms
+ */
+interface Options {
+  onClickCallback?: Function;
+  delay?: number;
+}
+
+/**
+ * @desc Custom Callback event hook for longpress, works for mobile and pc
+ * @external {@link https://github.com/colbyfayock/my-long-press} Source, refactored to TS and modified.
+ * @param callback Action to follow longpress.
+ * @param {Options} options additional customization
+ * @returns custom hook for longpress event.
+ */
+const longPressEvent = (callback: Function, options?: Options) => {
+  enum Actions {
+    longpress,
+    click
+  }
+  const [action, setAction] = useState<Actions>();
+
+  const timerRef = useRef<ReturnType<typeof setInterval>>({} as ReturnType<typeof setInterval>);
+  const isLongPress = useRef<boolean>(false);
+
+  const startPressTimer = () => {
+    isLongPress.current = false;
+    timerRef.current = setTimeout(() => {
+      isLongPress.current = true;
+      setAction(Actions.longpress);
+    }, 500);
+  };
+
+  const handleOnClick = (e) => {
+    if (isLongPress.current) {
+      callback();
+      return;
+    }
+    if (options?.onClickCallback) {
+      options.onClickCallback();
+    }
+    setAction(Actions.click);
+  };
+
+  const handleOnMouseDown = () => startPressTimer();
+  const handleOnMouseUp = () => clearTimeout(timerRef.current);
+  const handleOnTouchStart = () => startPressTimer();
+  const handleOnTouchEnd = () => {
+    if (action === Actions.longpress) return;
+    clearTimeout(timerRef.current);
+  };
+
+  return {
+    handlers: {
+      onClick: handleOnClick,
+      onMouseDown: handleOnMouseDown,
+      onMouseUp: handleOnMouseUp,
+      onTouchStart: handleOnTouchStart,
+      onTouchEnd: handleOnTouchEnd
+    }
+  };
+};
+
+export default longPressEvent;

--- a/app/src/utils/longPressEvent.ts
+++ b/app/src/utils/longPressEvent.ts
@@ -2,17 +2,24 @@ import { useState, useRef } from 'react';
 
 /**
  * @desc Optional Settings for hook
- * @property {Function} onClickCallback Event for click events, when longpresses end early
+ * @property {Function} onClick Event for click events, when longpresses end early
  * @property {number} delay time of longpress in ms
  */
 interface Options {
-  onClickCallback?: Function;
+  onClick?: Function;
   delay?: number;
 }
 
 /**
- * @desc Custom Callback event hook for longpress, works for mobile and pc
- * @external {@link https://github.com/colbyfayock/my-long-press} Source, refactored to TS and modified.
+ * @desc Custom event hook for longpress. can fire an event after a longpress, or optionally add a separate function for onClick
+ *       Use:
+ *        1.Import longPressEvent to component file,
+ *           - const { handlers } = longPressEvent(callbackFunction, {options});
+ *        2. use rest parameters as attributes on longpress target
+ *           - <button {...handlers}> Press Me!</button>
+ *
+ * @summary Custom Callback event hook for longpress, works for mobile and pc
+ * @external {@link https://github.com/colbyfayock/my-long-press} Source reference, refactored to TS and modified.
  * @param callback Action to follow longpress.
  * @param {Options} options additional customization
  * @returns custom hook for longpress event.

--- a/app/src/utils/useLongPress.ts
+++ b/app/src/utils/useLongPress.ts
@@ -24,7 +24,7 @@ interface Options {
  * @param {Options} options additional customization
  * @returns custom hook for longpress event.
  */
-const longPressEvent = (callback: Function, options?: Options) => {
+const useLongPress = (callback: Function, options?: Options) => {
   enum Actions {
     longpress,
     click
@@ -47,8 +47,8 @@ const longPressEvent = (callback: Function, options?: Options) => {
       callback();
       return;
     }
-    if (options?.onClickCallback) {
-      options.onClickCallback();
+    if (options?.onClick) {
+      options.onClick();
     }
     setAction(Actions.click);
   };
@@ -72,4 +72,4 @@ const longPressEvent = (callback: Function, options?: Options) => {
   };
 };
 
-export default longPressEvent;
+export default useLongPress;


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Add custom Hook for longpress/click events that can be reused wherever needed.
- Addition of Refresh button so mobile users don't have to force close / re-open app
    - Renders in Mobile from Dropdown menu
- Closes #3470