### PR TITLE
[INV-3483] Make recordset object keys use Date instead of length

### DIFF
--- a/app/src/state/reducers/userSettings.ts
+++ b/app/src/state/reducers/userSettings.ts
@@ -330,7 +330,7 @@ function createUserSettingsReducer(configuration: AppConfig): (UserSettingsState
           break;
         }
         case USER_SETTINGS_ADD_RECORD_SET: {
-          draftState.recordSets[Object.keys(draftState.recordSets).length + 1] = {
+          draftState.recordSets[Date.now()] = {
             tableFilters: [],
             color: 'blue',
             drawOrder: 0,


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):
- Deleting any old record meant that new recordset would overwrite a record on the list indefinitely.
- Now uses Date.now() as the identifier since its only stored locally.
    - This change resolves the bug, and shouldn't affect existing recordsets
- Closes #3483