### PR TITLE
[INV-3481] Add Cadastre Map Layer

### DIFF
--- a/app/src/UI/Overlay/Legend/LegendsPopup.tsx
+++ b/app/src/UI/Overlay/Legend/LegendsPopup.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-
 import './LegendsPopup.css';
+import mapLayers from './mapLayers';
 
 import invbclogo from '/assets/InvasivesBC_Icon.svg';
 import Button from '@mui/material/Button';
@@ -1856,7 +1855,7 @@ const LegendsPopup = () => {
               Layer Picker feature of the application with the source object name from the BC Data warehouse -
               accessible through the <a href="https://catalogue.data.gov.bc.ca/">British Columbia Data Catalogue</a>.
             </p>
-            <table className="table table-blue-header">
+            <table className="table table-striped table-blue-header">
               <thead>
                 <tr>
                   <th>Layer Picker Label</th>
@@ -1864,54 +1863,12 @@ const LegendsPopup = () => {
                 </tr>
               </thead>
               <tbody>
-                <tr>
-                  <td>Regional DistrictsM</td>
-                  <td>WHSE_LEGAL_ADMIN_BOUNDARIES.ABMS_REGIONAL_DISTRICTS_SP</td>
-                </tr>
-                <tr>
-                  <td>BC ParksM</td>
-                  <td>WHSE_TANTALIS.TA_PARK_ECORES_PA_SVW</td>
-                </tr>
-                <tr>
-                  <td>Municipality BoundariesM</td>
-                  <td>WHSE_LEGAL_ADMIN_BOUNDARIES.ABMS_MUNICIPALITIES_SP</td>
-                </tr>
-                <tr>
-                  <td>BC Major WatershedsM</td>
-                  <td>WHSE_BASEMAPPING.BC_MAJOR_WATERSHEDS</td>
-                </tr>
-                <tr>
-                  <td>Freshwater Atlas RiversM</td>
-                  <td>WHSE_BASEMAPPING.FWA_RIVERS_POLY</td>
-                </tr>
-                <tr>
-                  <td>Freshwater LakesM</td>
-                  <td>WHSE_LAND_AND_NATURAL_RESOURCE.EAUBC_LAKES_SP</td>
-                </tr>
-                <tr>
-                  <td>Freshwater Atlas Stream NetworkM</td>
-                  <td>WHSE_BASEMAPPING.FWA_STREAM_NETWORKS_SP</td>
-                </tr>
-                <tr>
-                  <td>Water Licenses Drinking WaterM</td>
-                  <td>WHSE_WATER_MANAGEMENT.WLS_BC_POD_DRINKNG_SOURCES_SP</td>
-                </tr>
-                <tr>
-                  <td>Water Rights LicensesM</td>
-                  <td>WHSE_WATER_MANAGEMENT.WLS_WATER_RIGHTS_LICENCES_SV</td>
-                </tr>
-                <tr>
-                  <td>Water WellsM</td>
-                  <td>WHSE_WATER_MANAGEMENT.GW_WATER_WELLS_WRBC_SVW</td>
-                </tr>
-                <tr>
-                  <td>Digital Road Atlas (DRA) – Master Partially-Attributed Roads</td>
-                  <td>WHSE_BASEMAPPING.DRA_DGTL_ROAD_ATLAS_MPAR_SP</td>
-                </tr>
-                <tr>
-                  <td>MOTI RFIM</td>
-                  <td>WHSE_IMAGERY_AND_BASE_MAPS.MOT_ROAD_FEATURES_INVNTRY_SP</td>
-                </tr>
+                {mapLayers.map((layer) => (
+                  <tr>
+                    <td>{layer.layerPickerLabel}</td>
+                    <td>{layer.objectName}</td>
+                  </tr>
+                ))}
               </tbody>
             </table>
           </div>

--- a/app/src/UI/Overlay/Legend/mapLayers.ts
+++ b/app/src/UI/Overlay/Legend/mapLayers.ts
@@ -1,0 +1,56 @@
+const mapLayers = [
+  {
+    layerPickerLabel: 'Regional Districts',
+    objectName: 'WHSE_LEGAL_ADMIN_BOUNDARIES.ABMS_REGIONAL_DISTRICTS_SP'
+  },
+  {
+    layerPickerLabel: 'BC Parks',
+    objectName: 'WHSE_TANTALIS.TA_PARK_ECORES_PA_SVW'
+  },
+  {
+    layerPickerLabel: 'Municipality Boundaries',
+    objectName: 'WHSE_LEGAL_ADMIN_BOUNDARIES.ABMS_MUNICIPALITIES_SP'
+  },
+  {
+    layerPickerLabel: 'BC Major Watersheds',
+    objectName: 'WHSE_BASEMAPPING.BC_MAJOR_WATERSHEDS'
+  },
+  {
+    layerPickerLabel: 'Freshwater Atlas Rivers',
+    objectName: 'WHSE_BASEMAPPING.FWA_RIVERS_POLY'
+  },
+  {
+    layerPickerLabel: 'Freshwater Lakes',
+    objectName: 'WHSE_LAND_AND_NATURAL_RESOURCE.EAUBC_LAKES_SP'
+  },
+  {
+    layerPickerLabel: 'Freshwater Atlas Stream Network',
+    objectName: 'WHSE_BASEMAPPING.FWA_STREAM_NETWORKS_SP'
+  },
+  {
+    layerPickerLabel: 'Water Licenses Drinking Water',
+    objectName: 'WHSE_WATER_MANAGEMENT.WLS_BC_POD_DRINKNG_SOURCES_SP'
+  },
+  {
+    layerPickerLabel: 'Water Rights Licenses',
+    objectName: 'WHSE_WATER_MANAGEMENT.WLS_WATER_RIGHTS_LICENCES_SV'
+  },
+  {
+    layerPickerLabel: 'Water Wells',
+    objectName: 'WHSE_WATER_MANAGEMENT.GW_WATER_WELLS_WRBC_SVW'
+  },
+  {
+    layerPickerLabel: 'Digital Road Atlas (DRA) - Master Partially-Attributed Roads',
+    objectName: 'WHSE_BASEMAPPING.DRA_DGTL_ROAD_ATLAS_MPAR_SP'
+  },
+  {
+    layerPickerLabel: 'MOTI RFI',
+    objectName: 'WHSE_IMAGERY_AND_BASE_MAPS.MOT_ROAD_FEATURES_INVNTRY_SP'
+  },
+  {
+    layerPickerLabel: 'PMBC Parcel Cadastre',
+    objectName: 'WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_SVW'
+  }
+].sort((a, b) => (a.layerPickerLabel > b.layerPickerLabel ? -1 : 1));
+
+export default mapLayers;

--- a/app/src/UI/Overlay/Legend/mapLayers.ts
+++ b/app/src/UI/Overlay/Legend/mapLayers.ts
@@ -48,7 +48,7 @@ const mapLayers = [
     objectName: 'WHSE_IMAGERY_AND_BASE_MAPS.MOT_ROAD_FEATURES_INVNTRY_SP'
   },
   {
-    layerPickerLabel: 'PMBC Parcel Cadastre',
+    layerPickerLabel: 'PMBC Parcel Cadastre - Private',
     objectName: 'WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_SVW'
   }
 ].sort((a, b) => (a.layerPickerLabel > b.layerPickerLabel ? -1 : 1));

--- a/app/src/UI/Overlay/Legend/mapLayers.ts
+++ b/app/src/UI/Overlay/Legend/mapLayers.ts
@@ -51,6 +51,6 @@ const mapLayers = [
     layerPickerLabel: 'PMBC Parcel Cadastre - Private',
     objectName: 'WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_SVW'
   }
-].sort((a, b) => (a.layerPickerLabel > b.layerPickerLabel ? -1 : 1));
+].sort((a, b) => (a.layerPickerLabel < b.layerPickerLabel ? -1 : 1));
 
 export default mapLayers;

--- a/app/src/constants/offline_state_version.ts
+++ b/app/src/constants/offline_state_version.ts
@@ -1,5 +1,5 @@
 /*
 handle purging the offline storage on app version upgrade
  */
-export const CURRENT_MIGRATION_VERSION = 20240907;
+export const CURRENT_MIGRATION_VERSION = 20240908;
 export const MIGRATION_VERSION_KEY = '_persistedMigrationVersion';

--- a/app/src/state/reducers/map.ts
+++ b/app/src/state/reducers/map.ts
@@ -208,7 +208,7 @@ const DEFAULT_LOCAL_LAYERS = [
     toggle: false
   },
   {
-    title: 'PMBC Parcel Cadastre',
+    title: 'PMBC Parcel Cadastre - Private',
     type: 'wms',
     url:
       'https://openmaps.gov.bc.ca/geo/ows?bbox={bbox-epsg-3857}&format=image/png&service=WMS&version=1.3.0&request=GetMap&srs=EPSG:3857&transparent=true&width=256&height=256&style=5899&OWNER_TYPE=Private&raster-opacity=0.5&styles=5903&layers=' +

--- a/app/src/state/reducers/map.ts
+++ b/app/src/state/reducers/map.ts
@@ -126,7 +126,6 @@ const DEFAULT_LOCAL_LAYERS = [
       'WHSE_LEGAL_ADMIN_BOUNDARIES.ABMS_MUNICIPALITIES_SP',
     toggle: false
   },
-
   {
     title: 'Cut blocks',
     type: 'wms',
@@ -207,8 +206,17 @@ const DEFAULT_LOCAL_LAYERS = [
       'https://openmaps.gov.bc.ca/geo/ows?bbox={bbox-epsg-3857}&format=image/png&service=WMS&version=1.3.0&request=GetMap&srs=EPSG:3857&transparent=true&width=256&height=256&raster-opacity=0.5&layers=' +
       'WHSE_IMAGERY_AND_BASE_MAPS.MOT_ROAD_FEATURES_INVNTRY_SP',
     toggle: false
+  },
+  {
+    title: 'PMBC Parcel Cadastre',
+    type: 'wms',
+    url:
+      'https://openmaps.gov.bc.ca/geo/ows?bbox={bbox-epsg-3857}&format=image/png&service=WMS&version=1.3.0&request=GetMap&srs=EPSG:3857&transparent=true&width=256&height=256&style=5899&OWNER_TYPE=Private&raster-opacity=0.5&styles=5903&layers=' +
+      'WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_SVW',
+    toggle: false,
+    opacity: 0.6
   }
-];
+].sort((a, b) => (a.title < b.title ? -1 : 1));
 
 export interface MapState {
   [MIGRATION_VERSION_KEY]: number;


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Add new default layer `PMBC Parcel Cadastre - Private` 
- Update `LegendsPopup` to include new entry
    - Move hardcoded table into Object array in separate file.
- Bump migration key up so existing users get the new list.
- Closes #3481