### PR TITLE
[INV-3505] Enhance Recordset UI

### DIFF
--- a/app/src/UI/Overlay/IAPP/IAPPRecords.css
+++ b/app/src/UI/Overlay/IAPP/IAPPRecords.css
@@ -3,19 +3,6 @@
   width: 100%;
 }
 
-.records_set {
-  height: 30px;
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  border-style: dotted;
-  border-width: 1px;
-  border-color: green;
-  background-color: #fff;
-  color: black;
-  overflow: auto;
-}
-
 .record_sets_header_new_set_button {
   margin-left: auto;
 }
@@ -26,6 +13,22 @@
   display: flex;
   flex-direction: row;
   justify-content: left;
+}
+
+.records_set {
+  height: 50px;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  padding-left: 1rem;
+  border: 1pt solid black;
+  box-sizing: border-box;
+  color: black;
+  overflow: hidden;
+}
+
+.records_set:hover {
+  cursor: pointer;
 }
 
 .records_set_name {

--- a/app/src/UI/Overlay/Records/RecordSet.css
+++ b/app/src/UI/Overlay/Records/RecordSet.css
@@ -34,7 +34,6 @@
   padding-left: 2vw;
   font-size: large;
   font-weight: bold;
-  color: white;
   width: auto;
 }
 

--- a/app/src/UI/Overlay/Records/RecordSet.tsx
+++ b/app/src/UI/Overlay/Records/RecordSet.tsx
@@ -49,7 +49,7 @@ export const RecordSet = (props) => {
         <div className="recordSet_container">
           <OverlayHeader />
           <div className="stickyHeader">
-            <div className="recordSet_header" style={{ backgroundColor: recordSet?.color }}>
+            <div className="recordSet_header" style={{ backgroundColor: recordSet?.color + 50 }}>
               <div className="recordSet_back_button">
                 <Button onClick={onClickBackButton} variant="contained">
                   {'< Back'}

--- a/app/src/UI/Overlay/Records/Records.css
+++ b/app/src/UI/Overlay/Records/Records.css
@@ -9,22 +9,20 @@
 }
 
 .records_set {
-  height: 30px;
+  height: 50px;
   width: 100%;
   display: flex;
   flex-direction: row;
-  border-style: dotted;
-  border-width: 1px;
-  border-color: green;
-  background-color: #fff;
+  padding-left: 1rem;
+  border: 1pt solid black;
+  box-sizing: border-box;
   color: black;
-  overflow: auto;
+  overflow: hidden;
 }
 
-.record_sets_header_new_set_button {
-  margin-left: auto;
+.records_set:hover {
+  cursor: pointer;
 }
-
 .records_set_left_hand_items {
   height: 100%;
 

--- a/app/src/UI/Overlay/Records/Records.tsx
+++ b/app/src/UI/Overlay/Records/Records.tsx
@@ -49,8 +49,10 @@ export const Records = () => {
   const MapMode = useSelector((state) => state.Map?.MapMode);
   const recordSets = useSelector((state) => state.UserSettings?.recordSets);
 
-  const [loadMap, setLoadMap] = useState({});
+  const [highlightedSet, setHighlightedSet] = useState<string | null>();
   const [isActivitiesGeoJSONLoaded, setActivitiesGeoJSONLoaded] = useState(false);
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [loadMap, setLoadMap] = useState({});
 
   const history = useHistory();
   const dispatch = useDispatch();
@@ -206,8 +208,8 @@ export const Records = () => {
     }, 3000);
   };
 
-  const [highlightedSet, setHighlightedSet] = useState<string | null>();
-  const [isEditingName, setIsEditingName] = useState(false);
+  const highlightSet = (set: string) => setHighlightedSet(set);
+  const unHighlightSet = () => setHighlightedSet(null);
 
   if (!recordSets) {
     return;
@@ -222,8 +224,10 @@ export const Records = () => {
             onClick={() => {
               history.push('/Records/List/Local:' + set);
             }}
-            onMouseOver={setHighlightedSet.bind(this, set)}
-            onMouseOut={setHighlightedSet.bind(this, null)}
+            onMouseOver={highlightSet.bind(this, set)}
+            onFocus={highlightSet.bind(this, set)}
+            onMouseOut={unHighlightSet}
+            onBlur={unHighlightSet}
             className={'records_set'}
             // Adjust Opacity of the background-color when hovering
             style={{ backgroundColor: `${recordSets?.[set]?.color}${highlightedSet === set ? 65 : 20}` }}

--- a/app/src/UI/Overlay/Records/Records.tsx
+++ b/app/src/UI/Overlay/Records/Records.tsx
@@ -230,7 +230,7 @@ export const Records = () => {
             onBlur={unHighlightSet}
             className={'records_set'}
             // Adjust Opacity of the background-color when hovering
-            style={{ backgroundColor: `${recordSets?.[set]?.color}${highlightedSet === set ? 65 : 20}` }}
+            style={{ backgroundColor: `${recordSets[set]?.color}${highlightedSet === set ? 65 : 20}` }}
           >
             {!loadMap?.[set] && (
               <div key={set + 'spinner'}>
@@ -238,7 +238,7 @@ export const Records = () => {
               </div>
             )}
             <div className="records_set_left_hand_items">
-              {isEditingName && !DEFAULT_RECORD_TYPES.includes(recordSets?.[set]?.recordSetName) ? (
+              {isEditingName && !DEFAULT_RECORD_TYPES.includes(recordSets[set]?.recordSetName) ? (
                 <>
                   <input
                     onChange={(e) =>
@@ -251,7 +251,7 @@ export const Records = () => {
                       e.stopPropagation();
                     }}
                     type="text"
-                    value={recordSets?.[set]?.recordSetName}
+                    value={recordSets[set]?.recordSetName}
                   />
                   <Button
                     onClick={(e) => {
@@ -263,7 +263,7 @@ export const Records = () => {
                   </Button>
                 </>
               ) : (
-                !DEFAULT_RECORD_TYPES.includes(recordSets?.[set]?.recordSetName) && (
+                !DEFAULT_RECORD_TYPES.includes(recordSets[set]?.recordSetName) && (
                   <IconButton
                     onClick={(e) => {
                       e.stopPropagation();
@@ -276,26 +276,26 @@ export const Records = () => {
                 )
               )}
               <div className="records_set_name">
-                {!(isEditingName && !DEFAULT_RECORD_TYPES.includes(recordSets?.[set]?.recordSetName)) && (
-                  <Typography>{recordSets?.[set]?.recordSetName}</Typography>
+                {!(isEditingName && !DEFAULT_RECORD_TYPES.includes(recordSets[set]?.recordSetName)) && (
+                  <Typography>{recordSets[set]?.recordSetName}</Typography>
                 )}
               </div>
             </div>
 
             <div className="records_set_right_hand_items">
-              {CONFIGURATION_IS_MOBILE && recordSets?.[set]?.cached && (
+              {CONFIGURATION_IS_MOBILE && recordSets[set]?.cached && (
                 <Tooltip classes={{ tooltip: 'toolTip' }} title="Click to clear cached data for this layer of records">
                   <Button
                     className="records__set__layer_cache"
                     onClick={(e) => onClickInitClearCache(set, e)}
                     variant="outlined"
                   >
-                    {!recordSets?.[set]?.isDeletingCache ? <EjectIcon /> : 'Deleting Cache'}
+                    {!recordSets[set]?.isDeletingCache ? <EjectIcon /> : 'Deleting Cache'}
                   </Button>
                 </Tooltip>
               )}
 
-              {CONFIGURATION_IS_MOBILE && recordSets?.[set]?.cached && (
+              {CONFIGURATION_IS_MOBILE && recordSets[set]?.cached && (
                 <Tooltip
                   classes={{ tooltip: 'toolTip' }}
                   title="Click to toggle viewing cached data or online if available"
@@ -305,7 +305,7 @@ export const Records = () => {
                     onClick={(e) => onClickToggleViewCache(set, e)}
                     variant="outlined"
                   >
-                    {recordSets?.[set]?.offlineMode ? <WifiOffIcon /> : <WifiIcon />}
+                    {recordSets[set]?.offlineMode ? <WifiOffIcon /> : <WifiIcon />}
                   </Button>
                 </Tooltip>
               )}
@@ -316,11 +316,11 @@ export const Records = () => {
                     onClick={(e) => onClickInitCache(set, e)}
                     variant="outlined"
                   >
-                    {recordSets?.[set]?.cached ? (
+                    {recordSets[set]?.cached ? (
                       <>
-                        <FileDownloadDoneIcon /> {recordSets?.[set]?.cachedTime}
+                        <FileDownloadDoneIcon /> {recordSets[set]?.cachedTime}
                       </>
-                    ) : recordSets?.[set]?.isCaching ? (
+                    ) : recordSets[set]?.isCaching ? (
                       'saving'
                     ) : (
                       <>
@@ -340,7 +340,7 @@ export const Records = () => {
                   onClick={(e) => onClickToggleLabel(set, e)}
                   color="primary"
                 >
-                  {recordSets?.[set]?.labelToggle ? <LabelIcon /> : <LabelClearIcon />}
+                  {recordSets[set]?.labelToggle ? <LabelIcon /> : <LabelClearIcon />}
                 </IconButton>
               </Tooltip>
 
@@ -353,11 +353,11 @@ export const Records = () => {
                   onClick={(e) => onClickToggleLayer(set, e)}
                   color="primary"
                 >
-                  {recordSets?.[set]?.mapToggle ? <LayersIcon /> : <LayersClearIcon />}
+                  {recordSets[set]?.mapToggle ? <LayersIcon /> : <LayersClearIcon />}
                 </IconButton>
               </Tooltip>
 
-              {!DEFAULT_RECORD_TYPES.includes(recordSets?.[set]?.recordSetName) && (
+              {!DEFAULT_RECORD_TYPES.includes(recordSets[set]?.recordSetName) && (
                 <Tooltip
                   placement="bottom-start"
                   classes={{ tooltip: 'toolTip' }}
@@ -369,7 +369,7 @@ export const Records = () => {
                 </Tooltip>
               )}
 
-              {!DEFAULT_RECORD_TYPES.includes(recordSets?.[set]?.recordSetName) && (
+              {!DEFAULT_RECORD_TYPES.includes(recordSets[set]?.recordSetName) && (
                 <Tooltip
                   classes={{ tooltip: 'toolTip' }}
                   title="Delete this layer/list of records.  Does NOT delete the actual records, just the set of filters / layer configuration."


### PR DESCRIPTION
> [!CAUTION]
> ~~This PR Is branched off of #3502~~
> This PR is up to date

# Overview

This PR includes the following proposed change(s):

- Convert useSelectors to `Typed` version
- Reduce Ternary's in Jsx that resulted in React Fragments to be simple `(!)condition && Component` statements
- Remove Route wrapping component (tech debt item?)
- Increase `Touch Target` size for Recordsets `30px` -> `50px`
- Remove `type: any` from functions, convert to proper types.
- Swap most buttons for `IconButton` 
- Move most inline CSS to CSS File (Duplicated in iAPP since there is some crossover in areas of app)
    - Kept backgroundColor CSS properties, due to programmatic effect
    - removed border colouring for recordsets in favour of setting the background to lower saturation version of colors
        - Mobile users can't really benefit from `Hover` pseudo classes like desktop users can
- Closes #3505 

## Screenshots

Old Version

Border hover effect creates thick border
![image](https://github.com/user-attachments/assets/5bf1e02c-e254-4ec6-8ce2-5e2c7851bcea)

![image](https://github.com/user-attachments/assets/07e2e136-cb0e-49b5-ae77-f8d8250c67b9)

New Version 

All colors displayed

![image](https://github.com/user-attachments/assets/487cfa9a-ad99-45fc-b268-f1a65bb3220f)

Hover increases Saturation

![image](https://github.com/user-attachments/assets/d19f8cec-f3fe-4d46-9073-59789a80f98e)

![image](https://github.com/user-attachments/assets/ba3c3445-4299-4c9f-816f-6c287d4bef02)
