### PR TITLE
[INV-3497] Get bounding box given a filter parameter

### DIFF
--- a/api/src/paths/recordset-bbox.ts
+++ b/api/src/paths/recordset-bbox.ts
@@ -29,7 +29,13 @@ POST.apiDoc = {
       content: {
         'application/json': {
           schema: {
-            properties: {}
+            type: 'object',
+            properties: {
+              bbox: {
+                type: 'string',
+                description: 'Bounding box for the given filters'
+              }
+            }
           }
         }
       }
@@ -67,7 +73,7 @@ const bboxSql = (cte: SQLStatement): SQLStatement => {
  * @desc Create Bounding box based on the filter properties for a given recordset
  */
 function postHandler(): RequestHandler {
-  return async (req, res, next) => {
+  return async (req, res) => {
     const connection = await getDBConnection();
     if (!connection) {
       return res.status(503).json({

--- a/api/src/paths/recordset-bbox.ts
+++ b/api/src/paths/recordset-bbox.ts
@@ -1,0 +1,96 @@
+import { ALL_ROLES, SECURITY_ON } from 'constants/misc';
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { getLogger } from 'utils/logger';
+import { getActivitiesSQLv2, sanitizeActivityFilterObject } from './v2/activities';
+import SQL, { SQLStatement } from 'sql-template-strings';
+import { getDBConnection } from 'database/db';
+
+const defaultLog = getLogger('recordset-bbox');
+export const POST: Operation = [postHandler()];
+
+POST.apiDoc = {
+  description: 'Fetch bounding box based on search criteria',
+  tags: ['recordset-bbox'],
+  security: SECURITY_ON ? [{ Bearer: ALL_ROLES }] : [],
+  requestBody: {
+    description: 'Recordset search filter criteria',
+    content: {
+      'application/json': {
+        schema: {
+          properties: {}
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Bounding box response object',
+      content: {
+        'application/json': {
+          schema: {
+            properties: {}
+          }
+        }
+      }
+    },
+    401: {
+      $ref: '#/components/responses/401'
+    },
+    503: {
+      $ref: '#/components/responses/503'
+    },
+    default: {
+      $ref: '#/components/responses/default'
+    }
+  }
+};
+
+function postHandler(): RequestHandler {
+  return async (req, res, next) => {
+    const connection = await getDBConnection();
+    if (!connection) {
+      return res.status(503).json({
+        message: 'Database connection unavailable',
+        namespace: 'recordset-bbox',
+        code: 503
+      });
+    }
+    try {
+      if (req.body?.filterObjects?.[0]) {
+        const activitiesSql: SQLStatement = getActivitiesSQLv2(
+          sanitizeActivityFilterObject(req.body.filterObjects[0], req)
+        );
+        let newSQL: SQLStatement = SQL` WITH userQuery AS ( `;
+
+        newSQL.append(activitiesSql.text.replaceAll(/;/g, '').replace('activity_id', 'geog'));
+        newSQL.append(` )
+          SELECT ST_AsText(ST_Extent(geometry(geog))) as bbox
+          FROM userQuery
+          WHERE geog IS not null;
+        `);
+        const response = await connection.query(newSQL.text, newSQL.values);
+        // const response = await connection.query(activitiesSql.text, activitiesSql.values);
+        res.status(200).json(response);
+      } else {
+        return res.status(400).json({
+          message: 'Missing filter Objects from request',
+          request: req.body,
+          namespace: 'recordset-bbox',
+          code: 400
+        });
+      }
+    } catch (e) {
+      console.error(e);
+      return res.status(500).json({
+        message: 'Server Error occured',
+        request: req.body,
+        namespace: 'recordset-bbox',
+        code: 500,
+        error: e
+      });
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/api/src/paths/recordset-bbox.ts
+++ b/api/src/paths/recordset-bbox.ts
@@ -59,7 +59,7 @@ POST.apiDoc = {
  */
 const bboxSql = (cte: SQLStatement): SQLStatement => {
   const bboxQuery: SQLStatement = SQL` WITH userQuery AS ( `;
-  // Remove semicolons from original query, swap activity_id column to geog
+  // Remove semicolons from original query
   bboxQuery.append(cte.text.replaceAll(/;/g, ''));
   bboxQuery.append(` )
           SELECT ST_AsText(ST_Extent(geometry(geog))) as bbox

--- a/api/src/paths/recordset-bbox.ts
+++ b/api/src/paths/recordset-bbox.ts
@@ -60,11 +60,15 @@ POST.apiDoc = {
 const bboxSql = (cte: SQLStatement): SQLStatement => {
   const bboxQuery: SQLStatement = SQL` WITH userQuery AS ( `;
   // Remove semicolons from original query, swap activity_id column to geog
-  bboxQuery.append(cte.text.replaceAll(/;/g, '').replace('activity_id', 'geog'));
+  bboxQuery.append(cte.text.replaceAll(/;/g, ''));
   bboxQuery.append(` )
           SELECT ST_AsText(ST_Extent(geometry(geog))) as bbox
-          FROM userQuery
-          WHERE geog IS not null;
+          FROM invasivesbc.activity_incoming_data
+          WHERE geog IS not null
+          AND activity_id in (
+            SELECT activity_id
+            FROM userQuery
+          )
         `);
   return bboxQuery;
 };

--- a/api/src/paths/v2/activities/bbox.ts
+++ b/api/src/paths/v2/activities/bbox.ts
@@ -6,12 +6,14 @@ import { getLogger } from 'utils/logger';
 import { getActivitiesSQLv2, sanitizeActivityFilterObject } from 'queries/activities-v2-queries';
 import { getDBConnection } from 'database/db';
 
-const defaultLog = getLogger('recordset-bbox');
+const NAMESPACE = 'bbox';
+
+const defaultLog = getLogger(NAMESPACE);
 export const POST: Operation = [postHandler()];
 
 POST.apiDoc = {
   description: 'Fetch bounding box based on search criteria',
-  tags: ['bbox'],
+  tags: [NAMESPACE],
   security: SECURITY_ON ? [{ Bearer: ALL_ROLES }] : [],
   requestBody: {
     description: 'Recordset search filter criteria',
@@ -61,12 +63,12 @@ function postHandler(): RequestHandler {
     if (!connection) {
       return res.status(503).json({
         message: 'Database connection unavailable',
-        namespace: 'recordset-bbox',
+        namespace: NAMESPACE,
         code: 503
       });
     }
     try {
-      defaultLog.debug({ label: 'recordset-bbox', message: 'postHandler', body: req.body });
+      defaultLog.debug({ label: NAMESPACE, message: 'postHandler', body: req.body });
       if (req.body?.filterObjects?.[0]) {
         const filterObject = sanitizeActivityFilterObject(req.body.filterObjects[0], req);
         filterObject.boundingBoxOnly = true;
@@ -79,7 +81,7 @@ function postHandler(): RequestHandler {
           return res.status(404).json({
             message: 'No Results',
             request: req.body,
-            namespace: 'recordset-bbox',
+            namespace: NAMESPACE,
             code: 404
           });
         }
@@ -87,20 +89,20 @@ function postHandler(): RequestHandler {
         return res.status(400).json({
           message: 'Missing filter Objects from request',
           request: req.body,
-          namespace: 'recordset-bbox',
+          namespace: NAMESPACE,
           code: 400
         });
       }
     } catch (error) {
       defaultLog.debug({
-        lavel: 'recordset-bbox',
+        label: NAMESPACE,
         message: 'error',
         error
       });
       return res.status(500).json({
         message: 'Server Error occured',
         request: req.body,
-        namespace: 'recordset-bbox',
+        namespace: NAMESPACE,
         code: 500,
         error
       });

--- a/api/src/paths/v2/activities/bbox.ts
+++ b/api/src/paths/v2/activities/bbox.ts
@@ -1,9 +1,9 @@
-import { ALL_ROLES, SECURITY_ON } from 'constants/misc';
 import { RequestHandler } from 'express';
 import { Operation } from 'express-openapi';
-import { getLogger } from 'utils/logger';
-import { getActivitiesSQLv2, sanitizeActivityFilterObject } from './v2/activities';
 import SQL, { SQLStatement } from 'sql-template-strings';
+import { ALL_ROLES, SECURITY_ON } from 'constants/misc';
+import { getLogger } from 'utils/logger';
+import { getActivitiesSQLv2, sanitizeActivityFilterObject } from 'queries/activities-v2-queries';
 import { getDBConnection } from 'database/db';
 
 const defaultLog = getLogger('recordset-bbox');
@@ -11,7 +11,7 @@ export const POST: Operation = [postHandler()];
 
 POST.apiDoc = {
   description: 'Fetch bounding box based on search criteria',
-  tags: ['recordset-bbox'],
+  tags: ['bbox'],
   security: SECURITY_ON ? [{ Bearer: ALL_ROLES }] : [],
   requestBody: {
     description: 'Recordset search filter criteria',

--- a/api/src/paths/v2/activities/index.ts
+++ b/api/src/paths/v2/activities/index.ts
@@ -1,0 +1,138 @@
+import { getuid } from 'process';
+import { Operation } from 'express-openapi';
+import { RequestHandler } from 'express';
+import { getLogger } from 'utils/logger';
+import { streamActivitiesResult } from 'utils/iapp-json-utils';
+import { getDBConnection } from 'database/db';
+import { ALL_ROLES, SECURITY_ON } from 'constants/misc';
+import { InvasivesRequest } from 'utils/auth-utils';
+import { getActivitiesSQLv2, sanitizeActivityFilterObject } from 'queries/activities-v2-queries';
+
+const defaultLog = getLogger('activity');
+
+export const POST: Operation = [getActivitiesBySearchFilterCriteria()];
+
+POST.apiDoc = {
+  description: 'Fetches all activities based on search criteria.',
+  tags: ['activity'],
+  security: SECURITY_ON
+    ? [
+        {
+          Bearer: ALL_ROLES
+        }
+      ]
+    : [],
+  requestBody: {
+    description: 'Activities Request Object',
+    content: {
+      'application/json': {
+        schema: {
+          properties: {}
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Activity get response object array.',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                rows: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      // Don't specify exact object properties, as it will vary, and is not currently enforced anyways
+                      // Eventually this could be updated to be a oneOf list, similar to the Post request below.
+                    }
+                  }
+                },
+                count: {
+                  type: 'number'
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    304: {
+      $ref: '#/components/responses/304'
+    },
+    401: {
+      $ref: '#/components/responses/401'
+    },
+    503: {
+      $ref: '#/components/responses/503'
+    },
+    default: {
+      $ref: '#/components/responses/default'
+    }
+  }
+};
+
+/**
+ * Fetches all activity records based on request search filter criteria.
+ *
+ * @return {RequestHandler}
+ */
+function getActivitiesBySearchFilterCriteria(): RequestHandler {
+  const reqID = getuid();
+  return async (req: InvasivesRequest, res) => {
+    if (req.authContext.roles.length === 0) {
+      res.status(401).json({ message: 'No Role for user' });
+    }
+
+    const rawBodyCriteria = req.body['filterObjects'];
+    const filterObject = sanitizeActivityFilterObject(rawBodyCriteria?.[0], req);
+    defaultLog.debug({ label: 'v2/activity', message: 'getActivitiesBySearchFilterCriteria v2', body: '' });
+
+    let connection;
+    let sql;
+
+    try {
+      connection = await getDBConnection();
+      if (!connection) {
+        defaultLog.error({
+          label: 'v2/activity',
+          message: 'getActivitiesBySearchFilterCriteria',
+          body: 'reqID:' + reqID + ' - ' + 'Database connection unavailable'
+        });
+        return res.status(503).json({ message: 'Database connection unavailable', namespace: 'activities', code: 503 });
+      }
+
+      sql = getActivitiesSQLv2(filterObject);
+
+      if (filterObject.isCSV && filterObject.CSVType) {
+        res.status(200);
+        await streamActivitiesResult(filterObject, res, sql);
+      } else {
+        const response = await connection.query(sql.text, sql.values);
+
+        return res.status(200).json({
+          message: 'fetched activities by criteria',
+          request: req.body,
+          result: response.rows,
+          count: response.rowCount,
+          namespace: 'activities',
+          code: 200
+        });
+      }
+    } catch (error) {
+      defaultLog.debug({ label: 'getActivitiesBySearchFilterCriteria', message: 'error', error });
+      return res.status(500).json({
+        message: 'Error getting activities by search filter criteria',
+        error,
+        namespace: 'v2/activities',
+        code: 500
+      });
+    } finally {
+      connection?.release();
+    }
+  };
+}

--- a/api/src/paths/vectors/{source}/{z}/{x}/{y}.ts
+++ b/api/src/paths/vectors/{source}/{z}/{x}/{y}.ts
@@ -3,7 +3,7 @@ import { Operation } from 'express-openapi';
 import { InvasivesRequest } from 'utils/auth-utils';
 import { PostgresTileService } from 'utils/vectors/tile-service';
 import { ALL_ROLES, SECURITY_ON } from 'constants/misc';
-import { sanitizeActivityFilterObject } from 'paths/v2/activities';
+import { sanitizeActivityFilterObject } from 'queries/activities-v2-queries';
 import { sanitizeIAPPFilterObject } from 'paths/v2/iapp';
 
 export const GET: Operation = [tile()];

--- a/api/src/queries/activities-v2-queries.ts
+++ b/api/src/queries/activities-v2-queries.ts
@@ -1,84 +1,11 @@
-import { getuid } from 'process';
-import { Operation } from 'express-openapi';
-import { RequestHandler } from 'express';
 import SQL, { SQLStatement } from 'sql-template-strings';
 import { escapeLiteral } from 'pg';
 import { validActivitySortColumns } from 'sharedAPI/src/misc/sortColumns';
 import { getLogger } from 'utils/logger';
-import { streamActivitiesResult } from 'utils/iapp-json-utils';
-import { getDBConnection } from 'database/db';
-import { ALL_ROLES, SECURITY_ON } from 'constants/misc';
-import { InvasivesRequest } from 'utils/auth-utils';
 
-const defaultLog = getLogger('activity');
+const defaultLog = getLogger('activities-v2-queries');
 
-export const POST: Operation = [getActivitiesBySearchFilterCriteria()];
-
-POST.apiDoc = {
-  description: 'Fetches all activities based on search criteria.',
-  tags: ['activity'],
-  security: SECURITY_ON
-    ? [
-        {
-          Bearer: ALL_ROLES
-        }
-      ]
-    : [],
-  requestBody: {
-    description: 'Activities Request Object',
-    content: {
-      'application/json': {
-        schema: {
-          properties: {}
-        }
-      }
-    }
-  },
-  responses: {
-    200: {
-      description: 'Activity get response object array.',
-      content: {
-        'application/json': {
-          schema: {
-            type: 'array',
-            items: {
-              type: 'object',
-              properties: {
-                rows: {
-                  type: 'array',
-                  items: {
-                    type: 'object',
-                    properties: {
-                      // Don't specify exact object properties, as it will vary, and is not currently enforced anyways
-                      // Eventually this could be updated to be a oneOf list, similar to the Post request below.
-                    }
-                  }
-                },
-                count: {
-                  type: 'number'
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    304: {
-      $ref: '#/components/responses/304'
-    },
-    401: {
-      $ref: '#/components/responses/401'
-    },
-    503: {
-      $ref: '#/components/responses/503'
-    },
-    default: {
-      $ref: '#/components/responses/default'
-    }
-  }
-};
-
-export function sanitizeActivityFilterObject(filterObject: any, req: any) {
+function sanitizeActivityFilterObject(filterObject: any, req: any) {
   const sanitizedSearchCriteria = {
     serverSideNamedFilters: {},
     selectColumns: [],
@@ -312,6 +239,10 @@ export function sanitizeActivityFilterObject(filterObject: any, req: any) {
   //todo actually validate:
   sanitizedSearchCriteria.isCSV = filterObject?.isCSV;
   sanitizedSearchCriteria.CSVType = filterObject?.CSVType;
+
+  // may be explicitly set to true by calling function
+  sanitizedSearchCriteria.boundingBoxOnly = false;
+
   defaultLog.debug({
     label: 'getActivitiesBySearchFilterCriteria',
     message: 'sanitizedObject',
@@ -321,68 +252,7 @@ export function sanitizeActivityFilterObject(filterObject: any, req: any) {
   return sanitizedSearchCriteria;
 }
 
-/**
- * Fetches all activity records based on request search filter criteria.
- *
- * @return {RequestHandler}
- */
-function getActivitiesBySearchFilterCriteria(): RequestHandler {
-  const reqID = getuid();
-  return async (req: InvasivesRequest, res) => {
-    if (req.authContext.roles.length === 0) {
-      res.status(401).json({ message: 'No Role for user' });
-    }
-
-    const rawBodyCriteria = req.body['filterObjects'];
-    const filterObject = sanitizeActivityFilterObject(rawBodyCriteria?.[0], req);
-    defaultLog.debug({ label: 'v2/activity', message: 'getActivitiesBySearchFilterCriteria v2', body: '' });
-
-    let connection;
-    let sql;
-
-    try {
-      connection = await getDBConnection();
-      if (!connection) {
-        defaultLog.error({
-          label: 'v2/activity',
-          message: 'getActivitiesBySearchFilterCriteria',
-          body: 'reqID:' + reqID + ' - ' + 'Database connection unavailable'
-        });
-        return res.status(503).json({ message: 'Database connection unavailable', namespace: 'activities', code: 503 });
-      }
-
-      sql = getActivitiesSQLv2(filterObject);
-
-      if (filterObject.isCSV && filterObject.CSVType) {
-        res.status(200);
-        await streamActivitiesResult(filterObject, res, sql);
-      } else {
-        const response = await connection.query(sql.text, sql.values);
-
-        return res.status(200).json({
-          message: 'fetched activities by criteria',
-          request: req.body,
-          result: response.rows,
-          count: response.rowCount,
-          namespace: 'activities',
-          code: 200
-        });
-      }
-    } catch (error) {
-      defaultLog.debug({ label: 'getActivitiesBySearchFilterCriteria', message: 'error', error });
-      return res.status(500).json({
-        message: 'Error getting activities by search filter criteria',
-        error,
-        namespace: 'v2/activities',
-        code: 500
-      });
-    } finally {
-      connection?.release();
-    }
-  };
-}
-
-export function getActivitiesSQLv2(filterObject: any) {
+function getActivitiesSQLv2(filterObject: any) {
   defaultLog.debug({
     label: 'getActivitiesBySearchFilterCriteria',
     message: 'sql',
@@ -396,12 +266,14 @@ export function getActivitiesSQLv2(filterObject: any) {
     sqlStatement = fromStatement(sqlStatement, filterObject);
     sqlStatement = whereStatement(sqlStatement, filterObject);
     sqlStatement = groupByStatement(sqlStatement, filterObject);
-    if (!filterObject.vt_request) {
+    if (filterObject.vt_request) {
+      sqlStatement.append(` ) SELECT ST_AsMVT(mvtgeom.*, 'data', 4096, 'geom', 'feature_id') as data from mvtgeom;`);
+    } else if (filterObject.boundingBoxOnly) {
+      sqlStatement.append(`) SELECT ST_AsText(ST_Extent(geometry(geog))) as bbox;`);
+    } else {
       sqlStatement = orderByStatement(sqlStatement, filterObject);
       sqlStatement = limitStatement(sqlStatement, filterObject);
       sqlStatement = offSetStatement(sqlStatement, filterObject);
-    } else {
-      sqlStatement.append(` ) SELECT ST_AsMVT(mvtgeom.*, 'data', 4096, 'geom', 'feature_id') as data from mvtgeom;`);
     }
 
     defaultLog.debug({ label: 'getActivitiesBySearchFilterCriteria', message: 'sql', body: sqlStatement });
@@ -912,7 +784,7 @@ function whereStatement(sqlStatement: SQLStatement, filterObject: any) {
     where.append(
       ` AND (
           ${tableAlias}.species_biocontrol_full is null
-          OR 
+          OR
           ${tableAlias}.species_biocontrol_full not in (
             SELECT agent_code_description
             FROM invasivesbc.private_biocontrol_agents
@@ -949,3 +821,5 @@ function offSetStatement(sqlStatement: SQLStatement, filterObject: any) {
   const offset = sqlStatement.append(` offset ${filterObject.offset};`);
   return offset;
 }
+
+export { sanitizeActivityFilterObject, getActivitiesSQLv2 };

--- a/api/src/utils/vectors/tile-service.ts
+++ b/api/src/utils/vectors/tile-service.ts
@@ -1,5 +1,5 @@
+import { getActivitiesSQLv2 } from 'queries/activities-v2-queries';
 import { getDBConnection } from 'database/db';
-import { getActivitiesSQLv2 } from 'paths/v2/activities';
 import { getIAPPSQLv2 } from 'paths/v2/iapp';
 
 export interface TileService {


### PR DESCRIPTION
# Overview

> One step towards offline map caching

This PR includes the following proposed change(s):

New API endpoint `/v2/activities/bbox`:
- Using the same filter rules applied to a recordset, this endpoint can be targetted to make a bounding box for all the records contained within it.
- Uses the existing `sanitizeActivityFilterObject()` and `getActivitiesSQLv2()` functionality, reducing maintenance and providing same level of security.

## Testing

Copied Filter payloads from recordset network requests and used them against this new endpoint, Rendered the response objects in an external tool. Results came out as expected, given how bounding boxes function

> [!NOTE]
> This Endpoint is not wired up to anything, I tested manually using the ThunderClient extension in VSC

## Example Details

### Payload example *(Every record made by me)*:

```json
{
	"filterObjects": [
		{
			"limit": 200000,
			"recordSetType": "Activity",
			"selectColumns": [
				"activity_id"
			],
			"tableFilters": [
				{
					"field": "created_by",
					"filter": "EXAMPLE_ID",
					"filterType": "tableFilter",
					"id": "FILTER_ID_EXAMPLE",
					"operator": "CONTAINS",
					"operator2": "AND"
				}
			]
		}
	]
}
```

### API Response:

```json
{
  "bbox": "POLYGON((-127.03320312500054 48.42276700740098,-127.03320312500054 55.69957876911636,-118.78194475016757 55.69957876911636,-118.78194475016757 48.42276700740098,-127.03320312500054 48.42276700740098))"
}
```

### Response displayed using a [MapViewer](https://9revolution9.com/tools/geo/wkt_geojson/):

![image](https://github.com/user-attachments/assets/391e68d9-d2b2-49ad-b18a-585c85bb28f0)


