### PR TITLE
[INV-3579] Optimization** Refactor SingleSelectAutoComplete.tsx

### DIFF
--- a/app/src/UI/Overlay/Records/Activity/Form.tsx
+++ b/app/src/UI/Overlay/Records/Activity/Form.tsx
@@ -112,7 +112,7 @@ export const ActivityForm = (props) => {
               <td className={'leftHeaderCol'}>Activity Date:</td>
               <td className={'leftValueCol'}>
                 {new Date(form_data.activity_data.activity_date_time).toLocaleDateString()}
-              </td>{' '}
+              </td>
             </tr>
           </tbody>
         </table>
@@ -179,16 +179,14 @@ export const ActivityForm = (props) => {
         <ul>
           {activity_history?.map((item, index) => {
             return (
-              <>
-                <li key={index}>
-                  <ul className={'inner_audit_list'}>
-                    <li>Version : {item?.version + (item?.iscurrent ? ' (Current) ' : '')}</li>
-                    <li>Updated By: {item?.updated_by}</li>
-                    <li>Activity Status: {item?.form_status}</li>
-                    <li>Created at: {item?.created_timestamp}</li>
-                  </ul>
-                </li>
-              </>
+              <li key={index}>
+                <ul className={'inner_audit_list'}>
+                  <li>Version : {item?.version + (item?.iscurrent ? ' (Current) ' : '')}</li>
+                  <li>Updated By: {item?.updated_by}</li>
+                  <li>Activity Status: {item?.form_status}</li>
+                  <li>Created at: {item?.created_timestamp}</li>
+                </ul>
+              </li>
             );
           })}
         </ul>

--- a/app/src/rjsf/business-rules/handleSuggestedJurisdictions.ts
+++ b/app/src/rjsf/business-rules/handleSuggestedJurisdictions.ts
@@ -1,0 +1,48 @@
+import { AutoCompleteSelectOption } from 'rjsf/widgets/SingleSelectAutoComplete';
+
+/**
+ * @desc Helper used on jurisdictions keys. Iterates the SuggestedJurisdictions state and flags matching keys as suggested, sorting them to the top.
+ * @param suggestedJurisdictionsInState Jurisdictions suggested given a particular area.
+ * @param enumOptions Select Options list.
+ */
+const handleSuggestedJurisdictions = (
+  suggestedJurisdictionsInState: Record<string, any>[],
+  enumOptions: AutoCompleteSelectOption[]
+) => {
+  const suggestedJurisdictions = suggestedJurisdictionsInState ? [...suggestedJurisdictionsInState] : [];
+  const additionalEnumOptions: AutoCompleteSelectOption[] = [];
+  suggestedJurisdictions.forEach((jurisdiction) => {
+    if (jurisdiction.geojson) {
+      additionalEnumOptions.push({
+        label: jurisdiction.geojson.properties.type ?? null,
+        value: jurisdiction.geojson.properties.code_name ?? null,
+        title: jurisdiction.geojson.properties.name ?? null,
+        suggested: true
+      } as AutoCompleteSelectOption);
+    } else if (jurisdiction.properties) {
+      additionalEnumOptions.push({
+        label: jurisdiction.properties.type ?? null,
+        value: jurisdiction.properties.code_name ?? null,
+        title: jurisdiction.properties.name ?? null,
+        suggested: true
+      } as AutoCompleteSelectOption);
+    }
+  });
+  enumOptions.forEach((option, index) => {
+    additionalEnumOptions.forEach((additionalOption) => {
+      if (option.value === additionalOption.value) {
+        enumOptions[index].suggested = true;
+      }
+    });
+  });
+  enumOptions.sort((left, right) => {
+    if (left.hasOwnProperty('suggested')) {
+      return -1;
+    } else if (right.hasOwnProperty('suggested')) {
+      return 1;
+    }
+    return 0;
+  });
+};
+
+export default handleSuggestedJurisdictions;

--- a/app/src/rjsf/widgets/SingleSelectAutoComplete.tsx
+++ b/app/src/rjsf/widgets/SingleSelectAutoComplete.tsx
@@ -125,7 +125,7 @@ const SingleSelectAutoComplete = (props: WidgetProps) => {
       getOptionLabel={(option) => option.label ?? getLabelFromValue(option) ?? ''}
       id={props.id}
       inputValue={inputValue ?? ''}
-      isOptionEqualToValue={(option) => [option.value, ''].includes(value)}
+      isOptionEqualToValue={(option) => !value || option.value === value || option.value === value.value}
       key={renderKey}
       onChange={(event: any, option: AutoCompleteSelectOption, reason: string) => {
         if (reason === 'clear') {

--- a/app/src/rjsf/widgets/SingleSelectAutoComplete.tsx
+++ b/app/src/rjsf/widgets/SingleSelectAutoComplete.tsx
@@ -76,9 +76,6 @@ const SingleSelectAutoComplete = (props: WidgetProps) => {
   const [inputValue, setInputValue] = useState(getLabelFromValue(props.value ?? null));
   const [renderKey, setRenderKey] = useState(props.id + nanoid());
 
-  if (props.id.includes('jurisdiction_code')) {
-    handleSuggestedJurisdictions(suggestedJurisdictionsInState, listOptions);
-  }
   useEffect(() => {
     if (!lastFieldChanged?.id) {
       return;
@@ -109,6 +106,9 @@ const SingleSelectAutoComplete = (props: WidgetProps) => {
     }
   }, [JSON.stringify(suggestedJurisdictionsInState)]);
 
+  if (props.id.includes('jurisdiction_code')) {
+    handleSuggestedJurisdictions(suggestedJurisdictionsInState, listOptions);
+  }
   return (
     <Autocomplete
       autoHighlight

--- a/app/src/rjsf/widgets/SingleSelectAutoComplete.tsx
+++ b/app/src/rjsf/widgets/SingleSelectAutoComplete.tsx
@@ -1,13 +1,18 @@
 import { createFilterOptions } from '@mui/material/Autocomplete';
 import StarIcon from '@mui/icons-material/Star';
-import { Typography, Box, TextField, Autocomplete } from '@mui/material';
+import { TextField, Autocomplete, MenuItem } from '@mui/material';
 import { SelectAutoCompleteContext } from 'UI/Overlay/Records/Activity/form/SelectAutoCompleteContext';
 import { useContext, useEffect, useState } from 'react';
 import { WidgetProps } from '@rjsf/utils';
 import { useSelector } from 'utils/use_selector';
 import { nanoid } from '@reduxjs/toolkit';
 // Custom type to support this widget
-export type AutoCompleteSelectOption = { label: string; value: any; title: any; suggested?: boolean };
+export type AutoCompleteSelectOption = {
+  label: string;
+  value: any;
+  title: any;
+  suggested?: boolean;
+};
 
 /**
  * @desc Helper used on jurisdictions keys. Iterates the SuggestedJurisdictions state and flags matching keys as suggested, sorting them to the top.
@@ -83,35 +88,40 @@ const handleSuggestedJurisdictions = (
  */
 
 const SingleSelectAutoComplete = (props: WidgetProps) => {
-  const suggestedJurisdictionsInState = useSelector((state) => state.ActivityPage.suggestedJurisdictions);
   const selectAutoCompleteContext = useContext(SelectAutoCompleteContext);
   if (!selectAutoCompleteContext) {
     throw new Error('Context not provided to SingleSelectAutoComplete.tsx');
   }
+
+  /**
+   * @desc Gets list of select options provided
+   * @returns {AutoCompleteSelectOption[]} Select options for input field
+   */
+  const getListOptions = (): AutoCompleteSelectOption[] => {
+    const isEnums = props.options?.enumOptions && props.options.enumOptions.length > 0;
+    return isEnums
+      ? JSON.parse(JSON.stringify(props.options.enumOptions ?? []))
+      : (JSON.parse(JSON.stringify(props?.schema?.options ?? [])) ?? []);
+  };
+
+  /**
+   * @desc Converts an option value into an option label
+   * @param value Code value
+   * @returns Matching label, or value provided
+   */
+  const getLabelFromValue = (value: string): string => listOptions.find((item) => item.value === value)?.label ?? value;
+
+  const suggestedJurisdictionsInState = useSelector((state) => state.ActivityPage.suggestedJurisdictions);
   const { setLastFieldChanged, lastFieldChanged } = selectAutoCompleteContext;
 
-  const optionValueLabels: Record<string, any> = {};
-  const optionValueSuggested: Record<string, any> = {};
-
-  const isEnums = props.options?.enumOptions && props.options.enumOptions.length > 0;
-  const enumOptions: AutoCompleteSelectOption[] = isEnums
-    ? JSON.parse(JSON.stringify(props.options.enumOptions ?? []))
-    : (JSON.parse(JSON.stringify(props?.schema?.options ?? [])) ?? []);
+  const [listOptions] = useState<AutoCompleteSelectOption[]>(getListOptions());
+  const [value, setValue] = useState(props.value ?? null);
+  const [inputValue, setInputValue] = useState(getLabelFromValue(props.value ?? null));
+  const [renderKey, setRenderKey] = useState(props.id + nanoid());
 
   if (props.id.includes('jurisdiction_code')) {
-    handleSuggestedJurisdictions(suggestedJurisdictionsInState, enumOptions);
+    handleSuggestedJurisdictions(suggestedJurisdictionsInState, listOptions);
   }
-
-  const optionValues = Object.values(enumOptions).map((option) => {
-    optionValueLabels[option.value] = option.label ?? option.title ?? option.value;
-    optionValueSuggested[option.value] = option.suggested ?? false;
-    return option.value;
-  });
-
-  const startingValue = props.value ?? null;
-  const [value, setValue] = useState(startingValue);
-  const [inputValue, setInputValue] = useState(startingValue ? optionValueLabels[startingValue] : '');
-  const [renderKey, setRenderKey] = useState(props.id + nanoid());
   useEffect(() => {
     if (!lastFieldChanged?.id) {
       return;
@@ -133,7 +143,7 @@ const SingleSelectAutoComplete = (props: WidgetProps) => {
   }, [lastFieldChanged, props.id]);
 
   useEffect(() => {
-    setLastFieldChanged({ id: props.id, option: value });
+    setLastFieldChanged({ id: props.id, option: value?.value ?? value });
   }, [value]);
 
   useEffect(() => {
@@ -143,75 +153,57 @@ const SingleSelectAutoComplete = (props: WidgetProps) => {
   }, [JSON.stringify(suggestedJurisdictionsInState)]);
 
   return (
-    <div>
-      <Autocomplete
-        key={renderKey}
-        autoHighlight
-        autoSelect={props.required}
-        blurOnSelect
-        openOnFocus
-        renderOption={(props, option) => {
-          return (
-            //@ts-ignore
-            <Box {...props} key={`rjsfSingleSelect${nanoid()}`} style={{ display: 'flex', flexDirection: 'row' }}>
-              {optionValueSuggested[option] && <StarIcon style={{ fontSize: 15, marginRight: 7 }} color="warning" />}
-              <Typography>
-                {option ? optionValueLabels[option] : ''}
-                {optionValueSuggested[option] && <i> - Suggested based on location</i>}
-              </Typography>
-            </Box>
-          );
-        }}
-        selectOnFocus
-        onFocus={(event) => props.onFocus(event.target.id, event.target.nodeValue)}
-        isOptionEqualToValue={(option) => option === value || value === ''}
-        clearOnEscape={!props.required}
-        disableClearable={props.required}
-        id={props.id}
-        disabled={props.disabled}
-        clearOnBlur={false}
-        value={value}
-        onLoad={(event) => {
-          props.onChange(startingValue);
-        }}
-        onChange={(event: any, option: string, reason: string) => {
-          if (reason === 'clear') {
-            // NOTE: currently disabled.
-            // Creates validaton issues where an empty value will pass even if required
-            setValue('');
-            props.onChange('');
-          } else {
-            setValue(option);
-
-            // NOTE: passing string value to onChange, which might be expecting format
-            // object: { value, label }
-            // this will likely result in future compatibility errors with custom onChange functions
-            // but can't change this easily without creating many validation errors
-            props.onChange(option);
-          }
-        }}
-        options={optionValues}
-        filterOptions={createFilterOptions({
-          // limit: 500, // NOTE: removed for now, but might want with very long lists
-          stringify: (option) => option + ' ' + optionValueLabels[option]
-        })}
-        getOptionLabel={(option) => {
-          return optionValueLabels[option] ? optionValueLabels[option] : '';
-        }}
-        inputValue={inputValue}
-        onInputChange={(event, newInputValue) => setInputValue(newInputValue)}
-        renderInput={(params) => (
-          <TextField
-            {...params}
-            autoComplete="new-password"
-            variant="outlined"
-            required={props.required}
-            label={props.label || props.schema.title}
-            placeholder={'Begin typing to filter results...'}
-          />
-        )}
-      />
-    </div>
+    <Autocomplete
+      autoHighlight
+      autoSelect={props.required}
+      blurOnSelect
+      clearOnBlur={false}
+      clearOnEscape={!props.required}
+      disableClearable={props.required}
+      disabled={props.disabled}
+      filterOptions={createFilterOptions({
+        // limit: 500, // NOTE: removed for now, but might want with very long lists
+        stringify: (option) => `${option?.label} ${option?.value}`
+      })}
+      getOptionLabel={(option) => option.label ?? getLabelFromValue(option) ?? ''}
+      id={props.id}
+      inputValue={inputValue ?? ''}
+      isOptionEqualToValue={(option) => [option.value, ''].includes(value)}
+      key={renderKey}
+      onChange={(event: any, option: AutoCompleteSelectOption, reason: string) => {
+        if (reason === 'clear') {
+          // NOTE: currently disabled.
+          setValue(null);
+          props.onChange(null);
+        } else {
+          setValue(option);
+          props.onChange(option.value ?? option);
+        }
+      }}
+      onFocus={(event) => props.onFocus(event.target.id, event.target.nodeValue)}
+      onInputChange={(event, newInputValue) => setInputValue(newInputValue)}
+      openOnFocus
+      options={listOptions}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          autoComplete="new-password"
+          variant="outlined"
+          required={props.required}
+          label={props.label || props.schema.title}
+          placeholder={'Begin typing to filter results...'}
+        />
+      )}
+      renderOption={(props, option) => (
+        <MenuItem {...props} key={`rjsfSingleSelect${nanoid()}`}>
+          {option.suggested && <StarIcon style={{ fontSize: 15, marginRight: 7 }} color="warning" />}
+          {option.label ?? ''}
+          {option.suggested && <i> - Suggested based on location</i>}
+        </MenuItem>
+      )}
+      selectOnFocus
+      value={value ?? ''}
+    />
   );
 };
 

--- a/app/src/rjsf/widgets/SingleSelectAutoComplete.tsx
+++ b/app/src/rjsf/widgets/SingleSelectAutoComplete.tsx
@@ -6,57 +6,14 @@ import { useContext, useEffect, useState } from 'react';
 import { WidgetProps } from '@rjsf/utils';
 import { useSelector } from 'utils/use_selector';
 import { nanoid } from '@reduxjs/toolkit';
+import handleSuggestedJurisdictions from 'rjsf/business-rules/handleSuggestedJurisdictions';
+
 // Custom type to support this widget
 export type AutoCompleteSelectOption = {
   label: string;
   value: any;
   title: any;
   suggested?: boolean;
-};
-
-/**
- * @desc Helper used on jurisdictions keys. Iterates the SuggestedJurisdictions state and flags matching keys as suggested, sorting them to the top.
- * @param suggestedJurisdictionsInState Jurisdictions suggested given a particular area.
- * @param enumOptions Select Options list.
- */
-const handleSuggestedJurisdictions = (
-  suggestedJurisdictionsInState: Record<string, any>[],
-  enumOptions: AutoCompleteSelectOption[]
-) => {
-  const suggestedJurisdictions = suggestedJurisdictionsInState ? [...suggestedJurisdictionsInState] : [];
-  const additionalEnumOptions: AutoCompleteSelectOption[] = [];
-  suggestedJurisdictions.forEach((jurisdiction) => {
-    if (jurisdiction.geojson) {
-      additionalEnumOptions.push({
-        label: jurisdiction.geojson.properties.type ?? null,
-        value: jurisdiction.geojson.properties.code_name ?? null,
-        title: jurisdiction.geojson.properties.name ?? null,
-        suggested: true
-      } as AutoCompleteSelectOption);
-    } else if (jurisdiction.properties) {
-      additionalEnumOptions.push({
-        label: jurisdiction.properties.type ?? null,
-        value: jurisdiction.properties.code_name ?? null,
-        title: jurisdiction.properties.name ?? null,
-        suggested: true
-      } as AutoCompleteSelectOption);
-    }
-  });
-  enumOptions.forEach((option, index) => {
-    additionalEnumOptions.forEach((additionalOption) => {
-      if (option.value === additionalOption.value) {
-        enumOptions[index].suggested = true;
-      }
-    });
-  });
-  enumOptions.sort((left, right) => {
-    if (left.hasOwnProperty('suggested')) {
-      return -1;
-    } else if (right.hasOwnProperty('suggested')) {
-      return 1;
-    }
-    return 0;
-  });
 };
 
 /**


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):
- Reduce tracking/generating multiple objects per SingleSelect render, in favour of a single one
- Persist list of values in useState to avoid costly rerenders
- Move suggested jurisdictions code into its own file for business rules
- Convert most explicit returns to implicit returns, shortening lines
- Simplify code heavily  
- remove `div` wrapping component, Visually it remains unchanged
- Alphabetize Keys because there is so many
- Closes #3579

## Testing
Submitted three forms and cross referenced to the db

Presently it is expected to work, so opening a draft PR to get the code in reviewers eyes sooner