### PR TITLE
[INV-3575] BUG** Handle errors outside of geomWithinBC Function

### DIFF
--- a/app/src/constants/alertMessages.ts
+++ b/app/src/constants/alertMessages.ts
@@ -23,6 +23,12 @@ const mappingAlertMessages: Record<string, AlertMessage> = {
     subject: AlertSubjects.Map,
     content: 'Activity geometry intersects itself'
   },
+  cannotValidateRegion: {
+    severity: AlertSeverity.Error,
+    subject: AlertSubjects.Map,
+    content: 'An error occured while validating the GeoTracking shape, please try again.',
+    autoClose: 10
+  },
   trackMyPathStoppedEarly: {
     content: '"Track my path" stopped.',
     severity: AlertSeverity.Info,

--- a/app/src/state/sagas/activity.ts
+++ b/app/src/state/sagas/activity.ts
@@ -292,13 +292,18 @@ function* handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_STOP(action) {
 
   // Validation Checks
 
-  const geometryIsWithinBC = yield call(geomWithinBC, newGeo);
   const geographyWillContainIntersections = kinks(newGeo.geometry).features?.length > 0;
   const geometryHasPositiveArea = Math.floor(calculateGeometryArea(newGeo.geometry)) >= 0;
 
   // Error Alerts
-  if (!geometryIsWithinBC) {
-    validationErrors.push(mappingAlertMessages.notWithinBC);
+  try {
+    const geometryIsWithinBC = yield call(geomWithinBC, newGeo);
+    if (!geometryIsWithinBC) {
+      validationErrors.push(mappingAlertMessages.notWithinBC);
+    }
+  } catch (err) {
+    validationErrors.push(mappingAlertMessages.cannotValidateRegion);
+    console.error(err);
   }
   if (geographyWillContainIntersections) {
     validationErrors.push(mappingAlertMessages.willContainIntersections);

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -221,8 +221,6 @@ export function* handle_ACTIVITY_UPDATE_GEO_REQUEST(action: Record<string, any>)
       }
     }
 
-    const geoToTest =
-      sanitizedGeo.geometry.type === GeoShapes.MultiPolygon ? centroid(sanitizedGeo.geometry) : sanitizedGeo;
     let isWithinBC = false;
 
     if (sanitizedGeo) {

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -226,7 +226,12 @@ export function* handle_ACTIVITY_UPDATE_GEO_REQUEST(action: Record<string, any>)
     let isWithinBC = false;
 
     if (sanitizedGeo) {
-      isWithinBC = yield call(geomWithinBC, sanitizedGeo);
+      try {
+        isWithinBC = yield call(geomWithinBC, sanitizedGeo);
+      } catch (err) {
+        yield put(Alerts.create(mappingAlertMessages.cannotValidateRegion));
+        console.error(err);
+      }
     }
 
     if (areWellsInside && activityState.activity.activity_subtype === 'Activity_Treatment_ChemicalPlantTerrestrial') {

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -229,6 +229,7 @@ export function* handle_ACTIVITY_UPDATE_GEO_REQUEST(action: Record<string, any>)
       } catch (err) {
         yield put(Alerts.create(mappingAlertMessages.cannotValidateRegion));
         console.error(err);
+        return;
       }
     }
 

--- a/app/src/utils/geomWithinBC.ts
+++ b/app/src/utils/geomWithinBC.ts
@@ -7,11 +7,7 @@ import booleanContains from '@turf/boolean-contains';
  */
 function* geomWithinBC(geometry) {
   let BC_AREA: Record<string, any> | null = null;
-  try {
-    BC_AREA = (yield import('../state/sagas/activity/_bcArea')).default;
-  } catch (e) {
-    console.error('Could not load BC geometry file, unable to validate bounds');
-  }
+  BC_AREA = (yield import('../state/sagas/activity/_bcArea')).default;
   if (BC_AREA !== null) {
     return booleanContains(BC_AREA.features[0] as any, geometry as any);
   }


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

User errors report bug where location claims to not be in BC. Likely culprit is an error being eaten and returning an arbitrary false when the BC_AREA fails to be bounced in

- Remove try-catch from function
- Handle error where function is called, Alert user to try again
- Create new Alert for when this occurs.