### PR TITLE
[INV-3574] Bugfix** GeoTracker crash when location not enabled

### DIFF
--- a/app/src/constants/alertMessages.ts
+++ b/app/src/constants/alertMessages.ts
@@ -3,6 +3,12 @@ import { AlertSeverity, AlertSubjects } from './alertEnums';
 
 const mappingAlertMessages: Record<string, AlertMessage> = {
   // Errors
+  cannotGetUsersCoordinates: {
+    content: "We couldn't access your location. Please check your location settings and try again!",
+    severity: AlertSeverity.Error,
+    subject: AlertSubjects.Map,
+    autoClose: 15
+  },
   notWithinBC: {
     content: 'Activity is not within BC',
     severity: AlertSeverity.Error,

--- a/app/src/state/sagas/activity.ts
+++ b/app/src/state/sagas/activity.ts
@@ -231,7 +231,7 @@ function* handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_START(action) {
       message = mappingAlertMessages.trackingStarted;
   }
 
-  const initCoords = coords.hasOwnProperty('long') ? [[coords.long, coords.lat]] : [];
+  const initCoords = coords?.hasOwnProperty('long') ? [[coords.long, coords.lat]] : [];
   const initGeo = {
     type: 'Feature',
     properties: {},


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Convert Message to constant using IIFE syntax
- adding Elvis to `.hasOwnProperty()` call (this was the cause of error)
- Added Alert messages for Location settings being offline to better communicate to user
- Added termination of GeoTracking when coordinates unavailable at start.
- Closes #3574