### PR TITLE
[INV-3613] Toggle visibility from map caching page

### DIFF
--- a/app/src/UI/Accordion/Accordion.css
+++ b/app/src/UI/Accordion/Accordion.css
@@ -1,0 +1,28 @@
+.accordion-control {
+  height: 48px;
+  width: 100%;
+  font-size: 16pt;
+  display: flex;
+  align-items: center;
+  justify-content: left;
+  box-sizing: border-box;
+  border: none;
+  border-bottom: 1pt solid lightgray;
+  background-color: white;
+  padding: 10pt;
+
+  span {
+    margin-right: 1rem;
+  }
+
+  &:hover {
+    cursor: pointer;
+  }
+  svg:last-child {
+    margin-left: auto;
+  }
+}
+
+.accordion-panel {
+  margin-top: 10pt;
+}

--- a/app/src/UI/Accordion/Accordion.tsx
+++ b/app/src/UI/Accordion/Accordion.tsx
@@ -3,11 +3,18 @@ import './Accordion.css';
 import { Icon } from '@mui/material';
 import { ExpandLess, ExpandMore } from '@mui/icons-material';
 
-type PropTypes = {
+/**
+ * @desc Common Accordion Component
+ * @property {string} title MUI font icon name
+ * @external {@link https://mui.com/material-ui/icons/#icon-font-icons}
+ * @property {ReactNode} children Accordion Contents
+ * @property {string} title Title text for Accordion
+ */
+interface PropTypes {
   title: string;
   children: ReactNode;
   icon?: string;
-};
+}
 const Accordion = ({ title, children, icon }: PropTypes) => {
   const [open, setOpen] = useState<boolean>(false);
 

--- a/app/src/UI/Accordion/Accordion.tsx
+++ b/app/src/UI/Accordion/Accordion.tsx
@@ -1,0 +1,26 @@
+import { ReactNode, useState } from 'react';
+import './Accordion.css';
+import { Icon } from '@mui/material';
+import { ExpandLess, ExpandMore } from '@mui/icons-material';
+
+type PropTypes = {
+  title: string;
+  children: ReactNode;
+  icon?: string;
+};
+const Accordion = ({ title, children, icon }: PropTypes) => {
+  const [open, setOpen] = useState<boolean>(false);
+
+  return (
+    <>
+      <button className={`accordion-control ${open && 'active'}`} onClick={() => setOpen((prev) => !prev)}>
+        {icon && <Icon>{icon}</Icon>}
+        {title}
+        {open ? <ExpandLess color="disabled" /> : <ExpandMore color="disabled" />}
+      </button>
+
+      {open && <div className="accordion-panel">{children}</div>}
+    </>
+  );
+};
+export default Accordion;

--- a/app/src/UI/Map2/LayerPicker/LayerPicker.css
+++ b/app/src/UI/Map2/LayerPicker/LayerPicker.css
@@ -60,7 +60,7 @@ li > hr {
 #layer-picker-container .path-ul {
   list-style-type: none;
   padding: 0;
-  margin: 0 1rem;
+  margin: 0 5pt;
   box-sizing: border-box;
   background-color: var(--list-option);
   border-radius: 18pt;

--- a/app/src/UI/Map2/LayerPicker/LayerPicker.css
+++ b/app/src/UI/Map2/LayerPicker/LayerPicker.css
@@ -40,16 +40,21 @@ li > hr {
   position: absolute;
   display: flex;
   flex-direction: column;
+  justify-content: flex-start;
+  margin-bottom: auto;
   background-color: var(--bg);
   top: 0;
   right: 0;
   width: 100%;
   max-width: 400px;
   height: 100%;
-  overflow-y: auto;
   z-index: 400;
   box-sizing: border-box;
   border-left: 1pt solid var(--eigengrau);
+  .lp-content {
+    height: 100%;
+    overflow-y: auto;
+  }
 }
 
 #layer-picker-container .path-ul {

--- a/app/src/UI/Map2/LayerPicker/LayerPicker.tsx
+++ b/app/src/UI/Map2/LayerPicker/LayerPicker.tsx
@@ -2,15 +2,16 @@ import { useSelector } from 'react-redux';
 import { MOBILE } from 'state/build-time-config';
 import LayersIcon from '@mui/icons-material/Layers';
 import CloseIcon from '@mui/icons-material/Close';
-import { IconButton } from '@mui/material';
+import { IconButton, Switch } from '@mui/material';
 import './LayerPicker.css';
 import { useState } from 'react';
 import LpModules from 'constants/LpModules';
 import LayerPickerPathOption from './LayerPickerPathRow';
-import { ArrowBackIos } from '@mui/icons-material';
+import { ArrowBackIos, Expand, Menu } from '@mui/icons-material';
 import LpLayers from './LpLayers/LpLayers';
 import LpRecordSet from './LpRecordSet/LpRecordSet';
 import LpOfflineMaps from './LpOfflineMaps/LpOfflineMaps';
+import Accordion from 'UI/Accordion/Accordion';
 
 export const LayerPicker = () => {
   const closeLayerPicker = () => {
@@ -18,7 +19,7 @@ export const LayerPicker = () => {
     setPickerPath(LpModules.Init);
   };
   const [pickerPath, setPickerPath] = useState<LpModules>(LpModules.Init);
-  const [showAsAccordion] = useState<boolean>(false);
+  const [showAsAccordion, setShowAsAccordion] = useState<boolean>(false);
   const [showLayerPicker, setShowLayerPicker] = useState<boolean>(false);
   const isAuth = useSelector((state: any) => state.Auth?.authenticated);
 
@@ -35,48 +36,70 @@ export const LayerPicker = () => {
   return (
     <div id="layer-picker-container" className="layer-picker-pos">
       <div>
-        {pickerPath !== LpModules.Init && (
-          <div className="layer-context">
-            <IconButton onClick={() => setPickerPath(LpModules.Init)}>
-              <ArrowBackIos />
-            </IconButton>
-            {pickerPath}
-          </div>
-        )}
+        <div className="layer-context">
+          {pickerPath !== LpModules.Init ? (
+            <>
+              <IconButton onClick={() => setPickerPath(LpModules.Init)}>
+                <ArrowBackIos />
+              </IconButton>
+              {pickerPath}
+            </>
+          ) : (
+            <>
+              <Menu />
+              <Switch checked={showAsAccordion} onChange={() => setShowAsAccordion((prev) => !prev)} />
+              <Expand />
+            </>
+          )}
+        </div>
         <IconButton onClick={closeLayerPicker}>
           <CloseIcon />
         </IconButton>
       </div>
-      {
+      <div className="lp-content">
         {
-          [LpModules.Init]: (
-            <>
-              {showAsAccordion ? (
-                <></>
-              ) : (
-                <ul className="path-ul">
-                  <LayerPickerPathOption clickHandler={setPickerPath} pathVal={LpModules.DataBcLayers} />
-                  <li>
-                    <hr />
-                  </li>
-                  {MOBILE && (
-                    <>
-                      <LayerPickerPathOption clickHandler={setPickerPath} pathVal={LpModules.MapTiles} />
-                      <li>
-                        <hr />
-                      </li>
-                    </>
-                  )}
-                  <LayerPickerPathOption clickHandler={setPickerPath} pathVal={LpModules.Recordsets} />
-                </ul>
-              )}
-            </>
-          ),
-          [LpModules.DataBcLayers]: <LpLayers />,
-          [LpModules.Recordsets]: <LpRecordSet closePicker={closeLayerPicker} />,
-          [LpModules.MapTiles]: <LpOfflineMaps closePicker={closeLayerPicker} />
-        }[pickerPath]
-      }
+          {
+            [LpModules.Init]: (
+              <>
+                {showAsAccordion ? (
+                  <>
+                    <Accordion icon={'map'} title={LpModules.DataBcLayers}>
+                      <LpLayers />
+                    </Accordion>
+                    <Accordion icon={'save'} title={LpModules.Recordsets}>
+                      <LpRecordSet closePicker={closeLayerPicker} />
+                    </Accordion>
+                    {MOBILE && (
+                      <Accordion icon="manage_search" title={LpModules.MapTiles}>
+                        <LpOfflineMaps closePicker={closeLayerPicker} />
+                      </Accordion>
+                    )}
+                  </>
+                ) : (
+                  <ul className="path-ul">
+                    <LayerPickerPathOption clickHandler={setPickerPath} pathVal={LpModules.DataBcLayers} />
+                    <li>
+                      <hr />
+                    </li>
+                    {MOBILE && (
+                      <>
+                        <LayerPickerPathOption clickHandler={setPickerPath} pathVal={LpModules.MapTiles} />
+                        <li>
+                          <hr />
+                        </li>
+                      </>
+                    )}
+                    <LayerPickerPathOption clickHandler={setPickerPath} pathVal={LpModules.Recordsets} />
+                  </ul>
+                )}
+              </>
+            ),
+            [LpModules.DataBcLayers]: <LpLayers />,
+            [LpModules.Recordsets]: <LpRecordSet closePicker={closeLayerPicker} />,
+            [LpModules.MapTiles]: <LpOfflineMaps closePicker={closeLayerPicker} />
+          }[pickerPath]
+        }
+      </div>
     </div>
   );
 };

--- a/app/src/UI/Map2/LayerPicker/LayerPicker.tsx
+++ b/app/src/UI/Map2/LayerPicker/LayerPicker.tsx
@@ -1,4 +1,3 @@
-import { useSelector } from 'react-redux';
 import { MOBILE } from 'state/build-time-config';
 import LayersIcon from '@mui/icons-material/Layers';
 import CloseIcon from '@mui/icons-material/Close';
@@ -12,16 +11,20 @@ import LpLayers from './LpLayers/LpLayers';
 import LpRecordSet from './LpRecordSet/LpRecordSet';
 import LpOfflineMaps from './LpOfflineMaps/LpOfflineMaps';
 import Accordion from 'UI/Accordion/Accordion';
+import { useDispatch, useSelector } from 'utils/use_selector';
+import UserSettings from 'state/actions/userSettings/UserSettings';
 
 export const LayerPicker = () => {
   const closeLayerPicker = () => {
     setShowLayerPicker(false);
     setPickerPath(LpModules.Init);
   };
+  const toggleLayerPickerAccordion = () => dispatch(UserSettings.toggleLayerPickerAccordion());
   const [pickerPath, setPickerPath] = useState<LpModules>(LpModules.Init);
-  const [showAsAccordion, setShowAsAccordion] = useState<boolean>(false);
   const [showLayerPicker, setShowLayerPicker] = useState<boolean>(false);
-  const isAuth = useSelector((state: any) => state.Auth?.authenticated);
+  const isAuth = useSelector((state) => state.Auth.authenticated);
+  const accordionMode = useSelector((state) => state.UserSettings.layerPickerIsAccordion);
+  const dispatch = useDispatch();
 
   if (!isAuth) {
     return;
@@ -47,7 +50,7 @@ export const LayerPicker = () => {
           ) : (
             <>
               <Menu />
-              <Switch checked={showAsAccordion} onChange={() => setShowAsAccordion((prev) => !prev)} />
+              <Switch checked={accordionMode} onChange={toggleLayerPickerAccordion} />
               <Expand />
             </>
           )}
@@ -61,7 +64,7 @@ export const LayerPicker = () => {
           {
             [LpModules.Init]: (
               <>
-                {showAsAccordion ? (
+                {accordionMode ? (
                   <>
                     <Accordion icon={'map'} title={LpModules.DataBcLayers}>
                       <LpLayers />

--- a/app/src/UI/Map2/LayerPicker/LayerPicker.tsx
+++ b/app/src/UI/Map2/LayerPicker/LayerPicker.tsx
@@ -69,11 +69,11 @@ export const LayerPicker = () => {
                     <Accordion icon={'map'} title={LpModules.DataBcLayers}>
                       <LpLayers />
                     </Accordion>
-                    <Accordion icon={'save'} title={LpModules.Recordsets}>
+                    <Accordion icon={'manage_search'} title={LpModules.Recordsets}>
                       <LpRecordSet closePicker={closeLayerPicker} />
                     </Accordion>
                     {MOBILE && (
-                      <Accordion icon="manage_search" title={LpModules.MapTiles}>
+                      <Accordion icon="save" title={LpModules.MapTiles}>
                         <LpOfflineMaps closePicker={closeLayerPicker} />
                       </Accordion>
                     )}

--- a/app/src/UI/Overlay/TileCache/TileCacheList.tsx
+++ b/app/src/UI/Overlay/TileCache/TileCacheList.tsx
@@ -4,11 +4,13 @@ import { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'utils/use_selector';
 import { RepositoryStatistics, TileCacheService } from 'utils/tile-cache';
 import { TileCacheServiceFactory } from 'utils/tile-cache/context';
-import { Delete } from '@mui/icons-material';
+import { Delete, Visibility, VisibilityOff } from '@mui/icons-material';
 import Prompt from 'state/actions/prompts/Prompt';
 import { convertBytesToReadableString } from 'utils/tile-cache/helpers';
+import UserSettings from 'state/actions/userSettings/UserSettings';
 
-const TileCacheListRow = ({ metadata }) => {
+const TileCacheListRow = ({ metadata, visible }) => {
+  const handleToggleVisibility = (id: string) => dispatch(UserSettings.Map.toggleOverlay(id));
   const handleDelete = (id: string) => {
     const callback = (confirmation: boolean) => {
       if (confirmation) {
@@ -44,6 +46,13 @@ const TileCacheListRow = ({ metadata }) => {
 
   return (
     <tr>
+      <td>
+        {metadata.status === 'READY' && (
+          <button className="visibility-button" onClick={handleToggleVisibility.bind(this, metadata.id)}>
+            {visible ? <Visibility /> : <VisibilityOff />}
+          </button>
+        )}
+      </td>
       <td>{metadata.id}</td>
       <td>{metadata.status}</td>
       <td>{stats?.tileCount}</td>
@@ -59,8 +68,8 @@ const TileCacheListRow = ({ metadata }) => {
 
 const TileCacheList = () => {
   const repositories = useSelector((state) => state.TileCache?.repositories);
+  const visibleLayers = useSelector((state) => state.Map.enabledOverlayLayers) ?? [];
   const dispatch = useDispatch();
-  console.log(repositories);
   if (!repositories || repositories.length === 0) {
     return (
       <section>
@@ -72,6 +81,7 @@ const TileCacheList = () => {
     <section>
       <table>
         <thead>
+          <th></th>
           <th>Cache ID</th>
           <th>Status</th>
           <th>Tile Count</th>
@@ -80,10 +90,13 @@ const TileCacheList = () => {
         </thead>
         <tbody>
           {repositories.map((r) => (
-            <TileCacheListRow key={r.id} metadata={r} />
+            <TileCacheListRow key={r.id} metadata={r} visible={visibleLayers.includes(r?.id)} />
           ))}
         </tbody>
       </table>
+      <p>
+        You can toggle the visibility of cached map tiles here, or from the <b>Layer Picker</b>
+      </p>
       <div className="control">
         <Button variant={'contained'} onClick={() => dispatch(TileCache.repositoryList())}>
           Refresh Table

--- a/app/src/UI/Overlay/TileCache/TileCacheList.tsx
+++ b/app/src/UI/Overlay/TileCache/TileCacheList.tsx
@@ -7,10 +7,10 @@ import { TileCacheServiceFactory } from 'utils/tile-cache/context';
 import { Delete, Visibility, VisibilityOff } from '@mui/icons-material';
 import Prompt from 'state/actions/prompts/Prompt';
 import { convertBytesToReadableString } from 'utils/tile-cache/helpers';
-import UserSettings from 'state/actions/userSettings/UserSettings';
+import MapActions from 'state/actions/map';
 
 const TileCacheListRow = ({ metadata, visible }) => {
-  const handleToggleVisibility = (id: string) => dispatch(UserSettings.Map.toggleOverlay(id));
+  const handleToggleVisibility = (id: string) => dispatch(MapActions.toggleOverlay(id));
   const handleDelete = (id: string) => {
     const callback = (confirmation: boolean) => {
       if (confirmation) {

--- a/app/src/UI/Overlay/TileCache/tileCache.css
+++ b/app/src/UI/Overlay/TileCache/tileCache.css
@@ -69,6 +69,7 @@ section table {
   td:first-child,
   th:first-child {
     padding-left: 1rem;
+    width: 40pt;
   }
 
   td:last-child,
@@ -130,6 +131,13 @@ section .control {
   padding: 0;
 }
 
+#offline-map-overlay .visibility-button {
+  border: none;
+  background-color: transparent;
+  &:hover {
+    cursor: pointer;
+  }
+}
 @media screen and (width >= 768px) {
   #offline-map-overlay,
   #offline-map-overlay section,

--- a/app/src/state/actions/userSettings/UserSettings.ts
+++ b/app/src/state/actions/userSettings/UserSettings.ts
@@ -151,6 +151,7 @@ class UserSettings {
   static readonly setNewRecordDialogueStateSuccess = createAction<INewRecordDialogState>(
     USER_SETTINGS_SET_NEW_RECORD_DIALOG_STATE_SUCCESS
   );
+  static readonly toggleLayerPickerAccordion = createAction('UserSettings/toggleLayerPickerAccordion');
 }
 
 export default UserSettings;

--- a/app/src/state/reducers/rootReducer.ts
+++ b/app/src/state/reducers/rootReducer.ts
@@ -93,6 +93,7 @@ function createRootReducer(config: AppConfig) {
           'newRecordDialogState',
           'darkTheme',
           'boundaries',
+          'layerPickerIsAccordion',
           'mapCenter'
         ]
       },

--- a/app/src/state/reducers/userSettings.ts
+++ b/app/src/state/reducers/userSettings.ts
@@ -49,7 +49,7 @@ export interface UserSettingsState {
   recordsExpanded: boolean;
 
   boundaries: Boundary[];
-
+  layerPickerIsAccordion: boolean;
   darkTheme: boolean;
 }
 
@@ -62,7 +62,7 @@ const initialState: UserSettingsState = {
 
   apiDocsWithSelectOptions: null,
   apiDocsWithViewOptions: null,
-
+  layerPickerIsAccordion: false,
   boundaries: [],
   error: false,
   recordSets: {},
@@ -113,6 +113,8 @@ function createUserSettingsReducer(configuration: AppConfig): (UserSettingsState
         Object.keys(action.payload.updatedSet).forEach((key) => {
           draftState.recordSets[action.payload.setName][key] = action.payload.updatedSet[key];
         });
+      } else if (UserSettings.toggleLayerPickerAccordion.match(action)) {
+        draftState.layerPickerIsAccordion = !draftState.layerPickerIsAccordion;
       } else if (WhatsHere.toggle.match(action)) {
         draftState.recordsExpanded = action.payload ? false : draftState.recordsExpanded;
       } else {


### PR DESCRIPTION
# Overview

> [!IMPORTANT]
> This is branched off of PR #3612, diffs will look large until other branch is merged. Alternatively, this one branch could be merged. and the other closed.

This PR includes the following proposed change(s):

- Add Visibility toggle to `TileCacheList.ts` 
    - Since users download maps here, they may come searching here to enable them
        - Follows same logic pattern of enabling recordsets from the recordsets page. 
- Add disclaimer that Maps can be enabled here and in LayerPicker 
- Closes #3613