### PR TITLE
[INV-3580] - Block scenarios in which an offline sync run could not succeed

### DIFF
--- a/app/src/UI/OfflineDataSync/OfflineDataSync.css
+++ b/app/src/UI/OfflineDataSync/OfflineDataSync.css
@@ -11,3 +11,8 @@
   margin-top: 10px;
   margin-bottom: 10px;
 }
+
+.syncDisabledMessage {
+  padding: 0 1rem;
+  color: var(--deep-red);
+}

--- a/app/src/UI/OfflineDataSync/OfflineDataSyncTable.tsx
+++ b/app/src/UI/OfflineDataSync/OfflineDataSyncTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button, LinearProgress } from '@mui/material';
 import { OfflineActivityRecord, selectOfflineActivity } from 'state/reducers/offlineActivity';
 import { useSelector } from 'utils/use_selector';
@@ -9,10 +9,30 @@ import './OfflineDataSync.css';
 import moment from 'moment';
 import { FileOpen } from '@mui/icons-material';
 import { ActivitySubtypeShortLabels } from 'sharedAPI';
+import { useHistory } from 'react-router-dom';
 
 export const OfflineDataSyncTable = () => {
   const { working, serializedActivities } = useSelector(selectOfflineActivity);
+  const { authenticated, workingOffline } = useSelector((state) => state.Auth);
+  const connected = useSelector((state) => state.Network.connected);
+
+  const [syncDisabled, setSyncDisabled] = useState(false);
+
+  const history = useHistory();
+
   const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (working) {
+      setSyncDisabled(true);
+    } else if (workingOffline || !authenticated) {
+      setSyncDisabled(true);
+    } else if (!connected) {
+      setSyncDisabled(true);
+    } else {
+      setSyncDisabled(false);
+    }
+  }, [working, workingOffline, authenticated, connected]);
 
   if (Object.values(serializedActivities).length === 0) {
     return <p>There are no locally-stored activities to synchronize.</p>;
@@ -38,8 +58,10 @@ export const OfflineDataSyncTable = () => {
                 <tr>
                   <td>
                     <Button
+                      disabled={!(workingOffline || authenticated)}
                       onClick={() => {
                         dispatch({ type: ACTIVITY_GET_LOCAL_REQUEST, payload: { activityID: key } });
+                        history.push(`/Records/Activity:${key}/form`);
                       }}
                     >
                       <FileOpen></FileOpen>
@@ -78,7 +100,7 @@ export const OfflineDataSyncTable = () => {
         </tbody>
       </table>
       <Button
-        disabled={working}
+        disabled={syncDisabled}
         variant={'contained'}
         onClick={() => {
           dispatch({ type: ACTIVITY_RUN_OFFLINE_SYNC });
@@ -86,6 +108,9 @@ export const OfflineDataSyncTable = () => {
       >
         Run Sync
       </Button>
+      {syncDisabled && (
+        <span className="syncDisabledMessage">Synchronization requires that you be online and authenticated.</span>
+      )}
       {working && <LinearProgress className={'progressBar'} />}
     </>
   );


### PR DESCRIPTION
Disable the 'Run Sync' button in scenarios where offline sync would not succeed (such as when offline or unauthenticated)

Also fixes 3581 and 3582

Closes #3580
Closes #3581 
Closes #3582
# Overview

This PR includes the following proposed change(s):

- {List all the changes, if possible add the linked issue/ticket #}

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
