### PR TITLE
Refactor tile set size shared functionality into a hook

### DIFF
--- a/app/src/UI/Overlay/TileCache/CacheFileSize.tsx
+++ b/app/src/UI/Overlay/TileCache/CacheFileSize.tsx
@@ -1,6 +1,6 @@
 import { convertBytesToReadableString } from 'utils/tile-cache/helpers';
 import { useEffect, useState } from 'react';
-import { thresholds, useTileSizeThresholds } from 'UI/Overlay/TileCache/tileSizeHook';
+import { thresholds, useTileSizeThresholds } from './tileSizeHook';
 
 type PropTypes = {
   downloadSizeInBytes: number;

--- a/app/src/UI/Overlay/TileCache/CacheFileSize.tsx
+++ b/app/src/UI/Overlay/TileCache/CacheFileSize.tsx
@@ -1,5 +1,6 @@
 import { convertBytesToReadableString } from 'utils/tile-cache/helpers';
 import { useEffect, useState } from 'react';
+import { thresholds, useTileSizeThresholds } from 'UI/Overlay/TileCache/tileSizeHook';
 
 type PropTypes = {
   downloadSizeInBytes: number;
@@ -11,29 +12,26 @@ const CacheFileSize = ({ downloadSizeInBytes }: PropTypes) => {
   const readable = convertBytesToReadableString(downloadSizeInBytes);
 
   const [className, setClassName] = useState('green');
-  const [tooLargeWarning, setTooLargeWarning] = useState(false);
 
-  enum thresholds {
-    GREEN = 400 * 1024 * 1024, // 400 MiB
-    ORANGE = 1536 * 1024 * 1024, // 1.5 GiB
-    RED = 5120 * 1024 * 1024 // 5 GiB
-  }
+  const { thresholdRange, tooLargeWarning } = useTileSizeThresholds(downloadSizeInBytes);
 
   useEffect(() => {
-    if (downloadSizeInBytes < thresholds.GREEN) {
-      setClassName('green');
-      setTooLargeWarning(false);
-    } else if (downloadSizeInBytes < thresholds.ORANGE) {
-      setClassName('orange');
-      setTooLargeWarning(false);
-    } else if (downloadSizeInBytes < thresholds.RED) {
-      setClassName('red');
-      setTooLargeWarning(false);
-    } else {
-      setClassName('deep-red');
-      setTooLargeWarning(true);
+    switch (thresholdRange) {
+      case null:
+      case thresholds.GREEN:
+        setClassName('green');
+        break;
+      case thresholds.ORANGE:
+        setClassName('orange');
+        break;
+      case thresholds.RED:
+        setClassName('red');
+        break;
+      case thresholds.DEEP_RED:
+        setClassName('deep-red');
+        break;
     }
-  }, [downloadSizeInBytes]);
+  }, [thresholdRange]);
 
   return (
     <>

--- a/app/src/UI/Overlay/TileCache/TileCacheCreationPanel.tsx
+++ b/app/src/UI/Overlay/TileCache/TileCacheCreationPanel.tsx
@@ -5,37 +5,8 @@ import { Button, Slider } from '@mui/material';
 import TileCache from 'state/actions/cache/TileCache';
 import TooltipWithIcon from 'UI/TooltipWithIcon/TooltipWithIcon';
 import CacheFileSize from './CacheFileSize';
-
-// seems to be about right for this dataset
-const APPROX_SIZE_PER_TILE = 15 * 1024;
-const DOWNLOAD_LIMIT = 5 * 1024 * 1024 * 1024; // 5 GiB
-const AVAILABLE_ZOOMS = [
-  {
-    value: 12,
-    label: 'Zoom 12',
-    scale: '1:150,000'
-  },
-  {
-    value: 14,
-    label: 'Zoom 14',
-    scale: '1:35,000'
-  },
-  {
-    value: 16,
-    label: 'Zoom 16',
-    scale: '1:8,000'
-  },
-  {
-    value: 18,
-    label: 'Zoom 18',
-    scale: '1:2,000'
-  },
-  {
-    value: 20,
-    label: 'Zoom 20',
-    scale: '1:500'
-  }
-];
+import { useTileSizeThresholds } from 'UI/Overlay/TileCache/tileSizeHook';
+import { APPROX_SIZE_PER_TILE, AVAILABLE_ZOOMS } from './constants';
 
 const TileCacheCreationPanel = () => {
   const boundingBoxToolTipText =
@@ -51,14 +22,16 @@ const TileCacheCreationPanel = () => {
 
   const [downloadDisabled, setDownloadDisabled] = useState<boolean>(false);
 
+  const { overDownloadLimit } = useTileSizeThresholds(approximateDownloadSize);
+
   useEffect(() => {
     if (!drawnShape || approximateDownloadSize == null) {
       setDownloadDisabled(true);
       return;
     }
 
-    setDownloadDisabled(approximateDownloadSize > DOWNLOAD_LIMIT);
-  }, [drawnShape, approximateDownloadSize]);
+    setDownloadDisabled(overDownloadLimit);
+  }, [drawnShape, approximateDownloadSize, overDownloadLimit]);
 
   useEffect(() => {
     if (!drawnShape) {

--- a/app/src/UI/Overlay/TileCache/TileCacheCreationPanel.tsx
+++ b/app/src/UI/Overlay/TileCache/TileCacheCreationPanel.tsx
@@ -5,7 +5,7 @@ import { Button, Slider } from '@mui/material';
 import TileCache from 'state/actions/cache/TileCache';
 import TooltipWithIcon from 'UI/TooltipWithIcon/TooltipWithIcon';
 import CacheFileSize from './CacheFileSize';
-import { useTileSizeThresholds } from 'UI/Overlay/TileCache/tileSizeHook';
+import { useTileSizeThresholds } from './tileSizeHook';
 import { APPROX_SIZE_PER_TILE, AVAILABLE_ZOOMS } from './constants';
 
 const TileCacheCreationPanel = () => {

--- a/app/src/UI/Overlay/TileCache/constants.ts
+++ b/app/src/UI/Overlay/TileCache/constants.ts
@@ -1,0 +1,32 @@
+export const DOWNLOAD_LIMIT = 5 * 1024 * 1024 * 1024; // 5 GiB
+
+// seems to be about right for this dataset
+export const APPROX_SIZE_PER_TILE = 15 * 1024;
+
+export const AVAILABLE_ZOOMS = [
+  {
+    value: 12,
+    label: 'Zoom 12',
+    scale: '1:150,000'
+  },
+  {
+    value: 14,
+    label: 'Zoom 14',
+    scale: '1:35,000'
+  },
+  {
+    value: 16,
+    label: 'Zoom 16',
+    scale: '1:8,000'
+  },
+  {
+    value: 18,
+    label: 'Zoom 18',
+    scale: '1:2,000'
+  },
+  {
+    value: 20,
+    label: 'Zoom 20',
+    scale: '1:500'
+  }
+];

--- a/app/src/UI/Overlay/TileCache/tileSizeHook.ts
+++ b/app/src/UI/Overlay/TileCache/tileSizeHook.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { DOWNLOAD_LIMIT } from './constants';
+
+export enum thresholds {
+  GREEN = 400 * 1024 * 1024, // 400 MiB
+  ORANGE = 1536 * 1024 * 1024, // 1.5 GiB
+  RED = 5120 * 1024 * 1024, // 5 GiB
+  DEEP_RED = RED + 1
+}
+
+export const useTileSizeThresholds = (size: number | null) => {
+  const [tooLargeWarning, setTooLargeWarning] = useState(false);
+  const [thresholdRange, setThresholdRange] = useState<thresholds | null>(null);
+  const [overDownloadLimit, setOverDownloadLimit] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (size == null) {
+      setThresholdRange(null);
+      setTooLargeWarning(false);
+    } else if (size < thresholds.GREEN) {
+      setThresholdRange(thresholds.GREEN);
+      setTooLargeWarning(false);
+    } else if (size < thresholds.ORANGE) {
+      setThresholdRange(thresholds.ORANGE);
+      setTooLargeWarning(false);
+    } else if (size < thresholds.RED) {
+      setThresholdRange(thresholds.RED);
+      setTooLargeWarning(false);
+    } else {
+      setThresholdRange(thresholds.DEEP_RED);
+      setTooLargeWarning(true);
+    }
+
+    if (size !== null) {
+      setOverDownloadLimit(size > DOWNLOAD_LIMIT);
+    }
+  }, [size]);
+
+  return {
+    thresholdRange,
+    tooLargeWarning,
+    overDownloadLimit
+  };
+};


### PR DESCRIPTION
`useTileSizeThresholds(size: number)` computes both color-based thresholds and whether size exceeds download limit. moves duplicated functionality into a single reusable hook. Move associated constants into a separate file for findability.

# Overview

This PR includes the following proposed change(s):

- {List all the changes, if possible add the linked issue/ticket #}

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
