### PR TITLE
[INV-3590] Name map tile sets

### DIFF
--- a/app/src/UI/App.css
+++ b/app/src/UI/App.css
@@ -115,9 +115,26 @@ body {
   --success-green: #357a38;
   --warning-orange: #ffc107;
   --bc-yellow: #fcba19;
+  --blue-primary: #2196f3;
   --eigengrau: #16161d;
 }
 
+/* Color Classes */
+.deep-red {
+  color: var(--deep-red);
+}
+
+.red {
+  color: var(--error-red);
+}
+
+.green {
+  color: var(--success-green);
+}
+
+.orange {
+  color: var(--warning-orange);
+}
 @media only screen and (width <= 800px) {
   :root {
     .App {

--- a/app/src/UI/Map2/LayerPicker/LpOfflineMaps/LpOfflineMaps.tsx
+++ b/app/src/UI/Map2/LayerPicker/LpOfflineMaps/LpOfflineMaps.tsx
@@ -26,7 +26,7 @@ const LpOfflineMaps = ({ closePicker }: PropTypes) => {
       <p className="lp-subheader"></p>
       {repositories.length === 0 ? (
         <div className="lp-offline-maps-empty-collection">
-          <p>You don't have any Maptiles Cached</p>
+          <p>You don't have any map areas cached</p>
         </div>
       ) : (
         <ul>

--- a/app/src/UI/Map2/LayerPicker/LpOfflineMaps/LpOfflineMaps.tsx
+++ b/app/src/UI/Map2/LayerPicker/LpOfflineMaps/LpOfflineMaps.tsx
@@ -35,6 +35,7 @@ const LpOfflineMaps = ({ closePicker }: PropTypes) => {
             .map((item, index) => (
               <LpOfflineMapsOptions
                 id={item?.id ?? 'No Id provided'}
+                description={item.description}
                 key={item.id}
                 lastChild={index === repositories.length - 1}
                 layerVisible={visibleLayers.includes(item?.id)}

--- a/app/src/UI/Map2/LayerPicker/LpOfflineMaps/LpOfflineMapsOption.tsx
+++ b/app/src/UI/Map2/LayerPicker/LpOfflineMaps/LpOfflineMapsOption.tsx
@@ -4,15 +4,16 @@ type PropTypes = {
   id: string;
   lastChild: boolean;
   layerVisible: boolean;
+  description: string;
   onClick: (arg: string) => void;
 };
 
-const LpOfflineMapsOptions = ({ id, lastChild, layerVisible, onClick }: PropTypes) => {
+const LpOfflineMapsOptions = ({ description, id, lastChild, layerVisible, onClick }: PropTypes) => {
   return (
     <>
       <li className="lp-offline-map-option">
         <button onClick={onClick.bind(this, id)}>{layerVisible ? <Visibility /> : <VisibilityOff />}</button>
-        <p>{id}</p>
+        <p>{description || id}</p>
       </li>
       {!lastChild && (
         <li>

--- a/app/src/UI/Overlay/TileCache/TileCacheCreationPanel.tsx
+++ b/app/src/UI/Overlay/TileCache/TileCacheCreationPanel.tsx
@@ -1,7 +1,7 @@
 import { TileCacheService } from 'utils/tile-cache';
-import { useEffect, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'utils/use_selector';
-import { Button, Slider } from '@mui/material';
+import { Slider } from '@mui/material';
 import TileCache from 'state/actions/cache/TileCache';
 import TooltipWithIcon from 'UI/TooltipWithIcon/TooltipWithIcon';
 import CacheFileSize from './CacheFileSize';
@@ -11,12 +11,16 @@ import { APPROX_SIZE_PER_TILE, AVAILABLE_ZOOMS } from './constants';
 const TileCacheCreationPanel = () => {
   const boundingBoxToolTipText =
     'The latitude and longitude values for a bounding box represent the corners of a rectangular area on a map. The two pairs of coordinates show the southwest and northeast corners, defining the space that contains the object or area of interest.';
+  const handleNameChange = (evt: ChangeEvent<HTMLInputElement>) => {
+    setCacheName(evt.target.value);
+  };
   const drawnShape = useSelector((state) => state.TileCache?.drawnShapeBounds);
   const dispatch = useDispatch();
 
   const [zoom, setZoom] = useState<number>(AVAILABLE_ZOOMS[0].value);
   const [scale, setScale] = useState<string>(AVAILABLE_ZOOMS[0].scale);
 
+  const [cacheName, setCacheName] = useState<string>();
   const [tileCount, setTileCount] = useState<number | null>(null);
   const [approximateDownloadSize, setApproximateDownloadSize] = useState<number | null>(null);
 
@@ -25,13 +29,13 @@ const TileCacheCreationPanel = () => {
   const { overDownloadLimit } = useTileSizeThresholds(approximateDownloadSize);
 
   useEffect(() => {
-    if (!drawnShape || approximateDownloadSize == null) {
+    if (!drawnShape || approximateDownloadSize == null || !cacheName) {
       setDownloadDisabled(true);
       return;
     }
 
     setDownloadDisabled(overDownloadLimit);
-  }, [drawnShape, approximateDownloadSize, overDownloadLimit]);
+  }, [drawnShape, approximateDownloadSize, overDownloadLimit, cacheName]);
 
   useEffect(() => {
     if (!drawnShape) {
@@ -55,58 +59,62 @@ const TileCacheCreationPanel = () => {
 
   return (
     <section>
-      <p>
-        Choose the zoom level you want to use for saving map tiles. A higher zoom level allows you to see more detail
-        when you zoom in, but it will also take up more space on your device.
-      </p>
-      <p className="shapeDetails">
-        <b>Southwest:</b> {drawnShape.minLatitude.toFixed(5)}°, {drawnShape.minLongitude.toFixed(5)}° &nbsp;&nbsp;
-        <b>Northeast:</b> {drawnShape.maxLatitude.toFixed(5)}°, {drawnShape.maxLongitude.toFixed(5)}°{' '}
-        <TooltipWithIcon tooltipText={boundingBoxToolTipText} />
-      </p>
-
-      <Slider
-        value={zoom}
-        step={null}
-        aria-label={'Zoom Level'}
-        marks={AVAILABLE_ZOOMS}
-        sx={{ width: '80%' }}
-        min={AVAILABLE_ZOOMS[0].value}
-        max={AVAILABLE_ZOOMS[AVAILABLE_ZOOMS.length - 1].value}
-        onChange={(e, value) => {
-          if (typeof value === 'number') {
-            setZoom(value);
-            setScale(AVAILABLE_ZOOMS.find((item) => item.value === value)?.scale ?? '');
-          }
-        }}
-      />
-      <div className="shapeDetails">
+      <form>
         <p>
-          <b>Scale:</b> {scale}, <b>Map Tiles:</b> {tileCount?.toLocaleString()}{' '}
-          {approximateDownloadSize && (
-            <>
-              (approx. <CacheFileSize downloadSizeInBytes={approximateDownloadSize} />)
-            </>
-          )}
+          Choose the zoom level you want to use for saving map tiles. A higher zoom level allows you to see more detail
+          when you zoom in, but it will also take up more space on your device.
         </p>
-      </div>
-      <div className="control">
-        <Button
-          variant={'contained'}
-          disabled={downloadDisabled}
-          onClick={() => {
-            dispatch(
-              TileCache.requestCaching({
-                description: '',
-                bounds: drawnShape,
-                maxZoom: zoom
-              })
-            );
+        <p className="shapeDetails">
+          <b>Southwest:</b> {drawnShape.minLatitude.toFixed(5)}°, {drawnShape.minLongitude.toFixed(5)}° &nbsp;&nbsp;
+          <b>Northeast:</b> {drawnShape.maxLatitude.toFixed(5)}°, {drawnShape.maxLongitude.toFixed(5)}°{' '}
+          <TooltipWithIcon tooltipText={boundingBoxToolTipText} />
+        </p>
+
+        <Slider
+          value={zoom}
+          step={null}
+          aria-label={'Zoom Level'}
+          marks={AVAILABLE_ZOOMS}
+          sx={{ width: '80%' }}
+          min={AVAILABLE_ZOOMS[0].value}
+          max={AVAILABLE_ZOOMS[AVAILABLE_ZOOMS.length - 1].value}
+          onChange={(e, value) => {
+            if (typeof value === 'number') {
+              setZoom(value);
+              setScale(AVAILABLE_ZOOMS.find((item) => item.value === value)?.scale ?? '');
+            }
           }}
-        >
-          Start Download
-        </Button>
-      </div>
+        />
+        <div className="shapeDetails">
+          <p>
+            <b>Scale:</b> {scale}, <b>Map Tiles:</b> {tileCount?.toLocaleString()}{' '}
+            {approximateDownloadSize && (
+              <>
+                (approx. <CacheFileSize downloadSizeInBytes={approximateDownloadSize} />)
+              </>
+            )}
+          </p>
+        </div>
+        <div className="control">
+          <input type="text" placeholder="Cache Name" onChange={handleNameChange} value={cacheName ?? ''} />
+          <button
+            type="submit"
+            disabled={downloadDisabled}
+            onClick={(e) => {
+              e.preventDefault();
+              dispatch(
+                TileCache.requestCaching({
+                  description: cacheName ?? '',
+                  bounds: drawnShape,
+                  maxZoom: zoom
+                })
+              );
+            }}
+          >
+            Start Download
+          </button>
+        </div>
+      </form>
     </section>
   );
 };

--- a/app/src/UI/Overlay/TileCache/TileCacheList.tsx
+++ b/app/src/UI/Overlay/TileCache/TileCacheList.tsx
@@ -73,7 +73,7 @@ const TileCacheList = () => {
   if (!repositories || repositories.length === 0) {
     return (
       <section>
-        <p>You don't have any map tiles saved on your device right now.</p>
+        <p>You don't have any map areas saved on your device right now.</p>
       </section>
     );
   }

--- a/app/src/UI/Overlay/TileCache/TileCacheList.tsx
+++ b/app/src/UI/Overlay/TileCache/TileCacheList.tsx
@@ -1,4 +1,4 @@
-import { Button, IconButton } from '@mui/material';
+import { IconButton } from '@mui/material';
 import TileCache from 'state/actions/cache/TileCache';
 import { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'utils/use_selector';
@@ -53,7 +53,7 @@ const TileCacheListRow = ({ metadata, visible }) => {
           </button>
         )}
       </td>
-      <td>{metadata.id}</td>
+      <td>{metadata.description || metadata.id}</td>
       <td>{metadata.status}</td>
       <td>{stats?.tileCount}</td>
       <td>{stats && convertBytesToReadableString(stats.sizeInBytes)}</td>
@@ -82,7 +82,7 @@ const TileCacheList = () => {
       <table>
         <thead>
           <th></th>
-          <th>Cache ID</th>
+          <th>Name</th>
           <th>Status</th>
           <th>Tile Count</th>
           <th>Cache Size</th>
@@ -98,9 +98,7 @@ const TileCacheList = () => {
         You can toggle the visibility of cached map tiles here, or from the <b>Layer Picker</b>
       </p>
       <div className="control">
-        <Button variant={'contained'} onClick={() => dispatch(TileCache.repositoryList())}>
-          Refresh Table
-        </Button>
+        <button onClick={() => dispatch(TileCache.repositoryList())}>Refresh Table</button>
       </div>
     </section>
   );

--- a/app/src/UI/Overlay/TileCache/tileCache.css
+++ b/app/src/UI/Overlay/TileCache/tileCache.css
@@ -98,27 +98,46 @@ section table {
 section .control {
   display: flex;
   justify-content: flex-end;
+  align-items: center;
   margin-top: 10pt;
   width: 100%;
   box-sizing: border-box;
   padding: 1.25rem;
-}
+  flex-direction: column;
+  button,
+  input {
+    height: 30pt;
+    font-size: 12pt;
+    border-radius: 8pt;
+  }
+  button {
+    width: 110pt;
+    border: 1pt solid var(--blue-primary);
+    color: var(--blue-primary);
+    background-color: transparent;
+    transition:
+      0.7s color,
+      0.7s background-color,
+      0.7s border;
+    &:disabled {
+      border: 1pt solid lightgray;
+      color: lightgray;
+      cursor: not-allowed;
+    }
+    &:hover:not(:disabled) {
+      background-color: var(--blue-primary);
+      color: white;
+      cursor: pointer;
+    }
+  }
+  input {
+    padding: 0 0 0 10pt;
+    border: 1pt solid black;
+  }
 
-/* Color Classes */
-.deep-red {
-  color: var(--deep-red);
-}
-
-.red {
-  color: var(--error-red);
-}
-
-.green {
-  color: var(--success-green);
-}
-
-.orange {
-  color: var(--warning-orange);
+  & > *:not(:first-child) {
+    margin: 10pt 0 0 0;
+  }
 }
 
 .too-large-warning {
@@ -138,6 +157,16 @@ section .control {
     cursor: pointer;
   }
 }
+
+@media screen and (width >= 425px) {
+  section .control {
+    flex-direction: row;
+    & > *:not(:first-child) {
+      margin: 0 0 0 10pt;
+    }
+  }
+}
+
 @media screen and (width >= 768px) {
   #offline-map-overlay,
   #offline-map-overlay section,


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Add text input to `TileCacheCreationPanel.tsx` to populate `description` key
- Add `description` key as the primary for the cache names, falling back to ID in event of null/blank value 
- Removed MUI buttons in favour of homebrewed ones, lessening dependency on MUI framework
- Moved color classes to `App.css` given their primary creation case was moved to a hook, therefore eliminating the scoped values of the classes.  
- Closes #3590

## Pictures

### Input field for naming caches in the control
![image](https://github.com/user-attachments/assets/0a034f8e-9367-4f18-98de-db912abd789b)

### Mobile responsiveness

![image](https://github.com/user-attachments/assets/9cfde578-b167-49a2-be97-52e238efcf9f)

### !disabled

![image](https://github.com/user-attachments/assets/03bac442-91fe-4cee-bffb-5eb802748239)

### Displayed in Tile Cache page

![image](https://github.com/user-attachments/assets/add07640-6a12-46e5-92e5-671ef5fc1879)

### Displayed in LayerPicker

![image](https://github.com/user-attachments/assets/50d4e26b-a284-47f6-b62d-5510735162b5)
