### PR TITLE
[INV-3625] Rename cache set

### DIFF
--- a/app/src/UI/Overlay/TileCache/TileCacheList.tsx
+++ b/app/src/UI/Overlay/TileCache/TileCacheList.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'utils/use_selector';
 import { RepositoryStatistics, TileCacheService } from 'utils/tile-cache';
 import { TileCacheServiceFactory } from 'utils/tile-cache/context';
-import { Delete, Visibility, VisibilityOff } from '@mui/icons-material';
+import { Delete, EditAttributes, Visibility, VisibilityOff } from '@mui/icons-material';
 import Prompt from 'state/actions/prompts/Prompt';
 import { convertBytesToReadableString } from 'utils/tile-cache/helpers';
 import MapActions from 'state/actions/map';
@@ -25,6 +25,11 @@ const TileCacheListRow = ({ metadata, visible }) => {
       })
     );
   };
+
+  const handleRename = (id: string) => {
+    dispatch(TileCache.updateDescription({ repository: id, newDescription: `renamed at ${new Date().toISOString()}` }));
+  };
+
   const dispatch = useDispatch();
   const serviceRef = useRef<TileCacheService | null>(null);
   const [stats, setStats] = useState<RepositoryStatistics | null>(null);
@@ -58,6 +63,9 @@ const TileCacheListRow = ({ metadata, visible }) => {
       <td>{stats?.tileCount}</td>
       <td>{stats && convertBytesToReadableString(stats.sizeInBytes)}</td>
       <td>
+        <IconButton color={'primary'} onClick={() => handleRename(metadata.id)}>
+          <EditAttributes />
+        </IconButton>
         <IconButton color={'error'} onClick={() => handleDelete(metadata.id)}>
           <Delete />
         </IconButton>
@@ -81,12 +89,14 @@ const TileCacheList = () => {
     <section>
       <table>
         <thead>
-          <th></th>
-          <th>Name</th>
-          <th>Status</th>
-          <th>Tile Count</th>
-          <th>Cache Size</th>
-          <th>Delete</th>
+          <tr>
+            <th></th>
+            <th>Name</th>
+            <th>Status</th>
+            <th>Tile Count</th>
+            <th>Cache Size</th>
+            <th>Actions</th>
+          </tr>
         </thead>
         <tbody>
           {repositories.map((r) => (

--- a/app/src/UI/Overlay/TileCache/TileCacheList.tsx
+++ b/app/src/UI/Overlay/TileCache/TileCacheList.tsx
@@ -1,78 +1,6 @@
-import { IconButton } from '@mui/material';
 import TileCache from 'state/actions/cache/TileCache';
-import { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'utils/use_selector';
-import { RepositoryStatistics, TileCacheService } from 'utils/tile-cache';
-import { TileCacheServiceFactory } from 'utils/tile-cache/context';
-import { Delete, EditAttributes, Visibility, VisibilityOff } from '@mui/icons-material';
-import Prompt from 'state/actions/prompts/Prompt';
-import { convertBytesToReadableString } from 'utils/tile-cache/helpers';
-import MapActions from 'state/actions/map';
-
-const TileCacheListRow = ({ metadata, visible }) => {
-  const handleToggleVisibility = (id: string) => dispatch(MapActions.toggleOverlay(id));
-  const handleDelete = (id: string) => {
-    const callback = (confirmation: boolean) => {
-      if (confirmation) {
-        dispatch(TileCache.deleteRepository(id));
-      }
-    };
-    dispatch(
-      Prompt.confirmation({
-        title: 'Delete Cached Map tiles?',
-        prompt: ['Do you want to delete this set of map tiles?', 'They will no longer be available for offline use.'],
-        callback
-      })
-    );
-  };
-
-  const handleRename = (id: string) => {
-    dispatch(TileCache.updateDescription({ repository: id, newDescription: `renamed at ${new Date().toISOString()}` }));
-  };
-
-  const dispatch = useDispatch();
-  const serviceRef = useRef<TileCacheService | null>(null);
-  const [stats, setStats] = useState<RepositoryStatistics | null>(null);
-
-  useEffect(() => {
-    if (!serviceRef.current) {
-      return;
-    }
-    serviceRef.current.getRepositoryStatistics(metadata.id).then((value) => {
-      setStats(value);
-    });
-  }, [metadata.id, serviceRef.current]);
-
-  useEffect(() => {
-    TileCacheServiceFactory.getPlatformInstance().then((value) => {
-      serviceRef.current = value;
-    });
-  }, []);
-
-  return (
-    <tr>
-      <td>
-        {metadata.status === 'READY' && (
-          <button className="visibility-button" onClick={handleToggleVisibility.bind(this, metadata.id)}>
-            {visible ? <Visibility /> : <VisibilityOff />}
-          </button>
-        )}
-      </td>
-      <td>{metadata.description || metadata.id}</td>
-      <td>{metadata.status}</td>
-      <td>{stats?.tileCount}</td>
-      <td>{stats && convertBytesToReadableString(stats.sizeInBytes)}</td>
-      <td>
-        <IconButton color={'primary'} onClick={() => handleRename(metadata.id)}>
-          <EditAttributes />
-        </IconButton>
-        <IconButton color={'error'} onClick={() => handleDelete(metadata.id)}>
-          <Delete />
-        </IconButton>
-      </td>
-    </tr>
-  );
-};
+import TileCacheListRow from './TileCacheListRow';
 
 const TileCacheList = () => {
   const repositories = useSelector((state) => state.TileCache?.repositories);
@@ -90,7 +18,7 @@ const TileCacheList = () => {
       <table>
         <thead>
           <tr>
-            <th></th>
+            <th>Show</th>
             <th>Name</th>
             <th>Status</th>
             <th>Tile Count</th>

--- a/app/src/UI/Overlay/TileCache/TileCacheListRow.tsx
+++ b/app/src/UI/Overlay/TileCache/TileCacheListRow.tsx
@@ -35,8 +35,12 @@ const TileCacheListRow = ({ metadata, visible }) => {
     };
     dispatch(
       Prompt.confirmation({
-        title: 'Delete Cached Map tiles?',
-        prompt: ['Do you want to delete this set of map tiles?', 'They will no longer be available for offline use.'],
+        title: 'Delete Cached Map Area?',
+        prompt: [
+          'Do you want to delete this set of map area?',
+          'They will no longer be available for offline use.',
+          `Cache "${metadata.description || metadata.id}"`
+        ],
         callback
       })
     );

--- a/app/src/UI/Overlay/TileCache/TileCacheListRow.tsx
+++ b/app/src/UI/Overlay/TileCache/TileCacheListRow.tsx
@@ -1,0 +1,89 @@
+import { IconButton } from '@mui/material';
+import TileCache from 'state/actions/cache/TileCache';
+import { useEffect, useRef, useState } from 'react';
+import { useDispatch } from 'utils/use_selector';
+import { RepositoryStatistics, TileCacheService } from 'utils/tile-cache';
+import { TileCacheServiceFactory } from 'utils/tile-cache/context';
+import { Delete, Edit, Visibility, VisibilityOff } from '@mui/icons-material';
+import Prompt from 'state/actions/prompts/Prompt';
+import { convertBytesToReadableString } from 'utils/tile-cache/helpers';
+import MapActions from 'state/actions/map';
+
+const TileCacheListRow = ({ metadata, visible }) => {
+  const handleToggleVisibility = (id: string) => dispatch(MapActions.toggleOverlay(id));
+  const handleEditCacheDescription = () => {
+    const callback = (newName: string) => {
+      dispatch(TileCache.updateDescription({ repository: metadata.id, newDescription: newName }));
+    };
+    dispatch(
+      Prompt.text({
+        title: 'Edit Cache Name',
+        prompt: `Enter the new name to assign "${metadata.description || metadata.id}".`,
+        min: 1,
+        max: 50,
+        regex: /^(?!\s*$).+/,
+        regexErrorText: 'New name cannot be only whitespace',
+        callback
+      })
+    );
+  };
+  const handleDelete = () => {
+    const callback = (confirmation: boolean) => {
+      if (confirmation) {
+        dispatch(TileCache.deleteRepository(metadata.id));
+      }
+    };
+    dispatch(
+      Prompt.confirmation({
+        title: 'Delete Cached Map tiles?',
+        prompt: ['Do you want to delete this set of map tiles?', 'They will no longer be available for offline use.'],
+        callback
+      })
+    );
+  };
+
+  const dispatch = useDispatch();
+  const serviceRef = useRef<TileCacheService | null>(null);
+  const [stats, setStats] = useState<RepositoryStatistics | null>(null);
+
+  useEffect(() => {
+    if (!serviceRef.current) {
+      return;
+    }
+    serviceRef.current.getRepositoryStatistics(metadata.id).then((value) => {
+      setStats(value);
+    });
+  }, [metadata.id, serviceRef.current]);
+
+  useEffect(() => {
+    TileCacheServiceFactory.getPlatformInstance().then((value) => {
+      serviceRef.current = value;
+    });
+  }, []);
+
+  return (
+    <tr>
+      <td>
+        {metadata.status === 'READY' && (
+          <button className="visibility-button" onClick={handleToggleVisibility.bind(this, metadata.id)}>
+            {visible ? <Visibility /> : <VisibilityOff />}
+          </button>
+        )}
+      </td>
+      <td>{metadata.description || metadata.id}</td>
+      <td>{metadata.status}</td>
+      <td>{stats?.tileCount}</td>
+      <td>{stats && convertBytesToReadableString(stats.sizeInBytes)}</td>
+      <td>
+        <IconButton color={'primary'} onClick={handleEditCacheDescription}>
+          <Edit />
+        </IconButton>
+        <IconButton color={'error'} onClick={handleDelete}>
+          <Delete />
+        </IconButton>
+      </td>
+    </tr>
+  );
+};
+
+export default TileCacheListRow;

--- a/app/src/state/actions/cache/TileCache.ts
+++ b/app/src/state/actions/cache/TileCache.ts
@@ -4,26 +4,36 @@ import { TileCacheServiceFactory } from 'utils/tile-cache/context';
 import { ProgressCallbackParameters, RepositoryBoundingBoxSpec } from 'utils/tile-cache';
 
 class TileCache {
-  // used to tell the map we are on a page where we might want to draw a rectangle
-  static readonly setMapTileCacheMode = createAction<boolean>('SET_MAP_TILE_CACHE_MODE');
+  static readonly PREFIX = 'TileCache';
 
-  static readonly setTileCacheShape = createAction<{ geometry: GeoJSON }>('SET_TILE_CACHE_SHAPE');
-  static readonly clearTileCacheShape = createAction('CLEAR_TILE_CACHE_SHAPE');
+  // used to tell the map we are on a page where we might want to draw a rectangle
+  static readonly setMapTileCacheMode = createAction<boolean>(`${this.PREFIX}/setDrawMode`);
+
+  static readonly setTileCacheShape = createAction<{ geometry: GeoJSON }>(`${this.PREFIX}/setShape`);
+  static readonly clearTileCacheShape = createAction(`${this.PREFIX}/clearShape`);
 
   static readonly downloadProgressEvent = createAction<ProgressCallbackParameters>(
     'TILE_CACHE_DOWNLOAD_PROGRESS_EVENT'
   );
 
-  static readonly repositoryList = createAsyncThunk('TILE_CACHE_REPOSITORY_LIST', async () => {
+  static readonly repositoryList = createAsyncThunk(`${this.PREFIX}/repoList`, async () => {
     return await (await TileCacheServiceFactory.getPlatformInstance()).listRepositories();
   });
-  static readonly deleteRepository = createAsyncThunk('TILE_CACHE_REPOSITORY_DELETE', async (repository: string) => {
+  static readonly deleteRepository = createAsyncThunk(`${this.PREFIX}/repoDelete`, async (repository: string) => {
     const service = await TileCacheServiceFactory.getPlatformInstance();
     await service.deleteRepository(repository);
     return await service.listRepositories();
   });
+  static readonly updateDescription = createAsyncThunk(
+    `${this.PREFIX}/repoUpdateDescription`,
+    async (spec: { repository: string; newDescription: string }) => {
+      const service = await TileCacheServiceFactory.getPlatformInstance();
+      await service.updateDescription(spec.repository, spec.newDescription);
+      return await service.listRepositories();
+    }
+  );
   static readonly requestCaching = createAsyncThunk(
-    'TILE_CACHE_NEW_REQUEST',
+    `${this.PREFIX}/requestCaching`,
     async (
       spec: {
         description: string;

--- a/app/src/state/reducers/tile_cache.ts
+++ b/app/src/state/reducers/tile_cache.ts
@@ -166,6 +166,21 @@ function createTileCacheReducer() {
         draft.loading = false;
       }
 
+      if (TileCache.updateDescription.pending.match(action)) {
+        draft.loading = true;
+      } else if (TileCache.updateDescription.fulfilled.match(action)) {
+        draft.loading = false;
+        draft.repositories = action.payload;
+        // @ts-ignore
+        draft.mapSpecifications = action.payload
+          .filter((m) => m.status == RepositoryStatus.READY)
+          .flatMap((m) => {
+            return buildMapSpecificationFromRepositoryMetadata(m);
+          });
+      } else if (TileCache.updateDescription.rejected.match(action)) {
+        draft.loading = false;
+      }
+
       if (TileCache.setTileCacheShape.match(action)) {
         try {
           const [minX, minY, maxX, maxY] = bbox(action.payload.geometry);

--- a/app/src/utils/tile-cache/index.ts
+++ b/app/src/utils/tile-cache/index.ts
@@ -193,6 +193,8 @@ abstract class TileCacheService {
 
   public abstract getRepositoryStatistics(id: string): Promise<RepositoryStatistics>;
 
+  public abstract updateDescription(repository: string, newDescription: string): Promise<void>;
+
   protected abstract cleanupOrphanTiles(): Promise<void>;
 
   protected abstract addRepository(spec: RepositoryMetadata): Promise<void>;

--- a/app/src/utils/tile-cache/localforage-cache.ts
+++ b/app/src/utils/tile-cache/localforage-cache.ts
@@ -174,6 +174,22 @@ class LocalForageCacheService extends TileCacheService {
     };
   }
 
+  public async updateDescription(repository: string, newDescription: string) {
+    if (this.store == null) {
+      throw new Error('cache not available');
+    }
+
+    const repositories = await this.listRepositories();
+    const foundIndex = repositories.findIndex((p) => p.id == repository);
+    if (foundIndex == -1) {
+      throw new Error('repository does not exist');
+    }
+
+    repositories[foundIndex].description = newDescription;
+
+    await this.store.setItem(LocalForageCacheService.REPOSITORY_METADATA_KEY, repositories);
+  }
+
   protected async cleanupOrphanTiles(): Promise<void> {
     if (this.store == null) {
       return;

--- a/app/src/utils/tile-cache/sqlite-cache.ts
+++ b/app/src/utils/tile-cache/sqlite-cache.ts
@@ -174,6 +174,21 @@ class SQLiteTileCacheService extends TileCacheService {
     throw new Error('unimplemented');
   }
 
+  public async updateDescription(repository: string, newDescription: string) {
+    if (this.cacheDB == null) {
+      throw new Error('cache not available');
+    }
+
+    await this.cacheDB.query(
+      //language=SQLite
+
+      `UPDATE CACHE_METADATA
+       SET DESCRIPTION = ?
+       WHERE TILESET = ?;`,
+      [newDescription, repository]
+    );
+  }
+
   protected async addRepository(spec: RepositoryMetadata): Promise<void> {
     if (this.cacheDB == null) {
       throw new Error('cache not available');


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Renaming functionality added to Caches
- Split TileCacheList / Row into separate components
- Display name of Cache in delete prompt
- Closes #3625 

![image](https://github.com/user-attachments/assets/3dd4bfd8-e5fe-4fb7-818a-d4395a0934fe)

Switched to Pencil `Edit` icon, to match what was used in `/Records`
