### PR TITLE
[INV-3637] PARTIAL** Mobile Friendly changes

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1464,7 +1464,8 @@
     "node_modules/@types/geojson": {
       "version": "7946.0.14",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
-      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==",
+      "dev": true
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -8033,22 +8034,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
-      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prettier-linter-helpers": {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1464,8 +1464,7 @@
     "node_modules/@types/geojson": {
       "version": "7946.0.14",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
-      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==",
-      "dev": true
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -8034,6 +8033,22 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
+      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prettier-linter-helpers": {

--- a/app/src/UI/Header/Header.css
+++ b/app/src/UI/Header/Header.css
@@ -1,115 +1,28 @@
-@media only screen and (width <= 800px) {
-  #appTitle {
-    display: none;
-  }
+#appTitle {
+  display: none;
 }
-
-@media only screen and (width >= 801px) {
-  #appTitle {
-    font-weight: bold;
-    padding-left: 5px;
-  }
-}
-
-#menu-appbar {
-  z-index: 9999999999;
-}
-
 .HeaderBar {
+  overflow: hidden;
   height: var(--header-bar-height);
-  cursor: pointer;
-  width: 100%;
-  background-color: #036;
   position: relative;
-  z-index: 2147483646;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background-color: var(--bc-blue);
+  justify-content: space-between;
+  display: flex;
+  padding: 0 5pt;
+  box-sizing: border-box;
   color: white;
   align-items: center;
 }
 
-.ButtonWrapperContainer {
-  width: 55%;
-  height: var(--header-bar-height);
-  position: absolute;
-  transform: translateX(-50%);
-  left: 50%;
-}
-
-#ButtonWrapper {
-  width: 100%;
-  height: var(--header-bar-height);
-  position: absolute;
-  display: flex;
-  justify-content: space-between;
-  flex-flow: row nowrap;
-  white-space: nowrap;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  -ms-overflow-style: -ms-autohiding-scrollbar;
-}
-
-#right-icon-container {
-  position: absolute;
-  right: 0;
-  top: 50%;
-  transform: translateY(-50%);
-  background-color: rgb(255 255 255 / 50%);
-  border-radius: 5px;
-  pointer-events: none;
-  visibility: hidden;
-}
-
-#left-icon-container {
-  position: absolute;
-  left: 0;
-  top: 50%;
-  transform: translateY(-50%);
-  background-color: rgb(255 255 255 / 50%);
-  border-radius: 5px;
-  pointer-events: none;
-  visibility: hidden;
-}
-
-.direction-icon {
-  color: black;
-}
-
-.Tab {
-  display: flex;
-
-  /* flex-direction: row;
-    flex-flow: row wrap; */
-  align-items: center;
-  padding-right: 0.5rem;
-}
-
-.Tab__Label {
-  /*    padding-top: 5px; */
-
-  /* align-self: flex-start; */
-  font-size: small;
-}
-
-.Tab__Content {
-  /* align-self: flex-start */
-}
-
-.Tab__Indicator {
-  border-bottom-style: solid;
-  border-width: 0.5vh;
-  border-color: #fcba19;
-}
-
-.network-state-control {
-  display: flex;
-  align-items: center;
-  height: 100%;
-}
-
 .inv-icon {
   display: flex;
-  position: absolute;
-  left: 10px;
   align-items: center;
+  padding: 5pt 0;
+  box-sizing: border-box;
+  margin-right: 1rem;
   height: var(--header-bar-height);
 }
 
@@ -118,41 +31,98 @@
   object-fit: 'contain';
   background-color: white;
   border-radius: 5px;
-  padding: 5;
-  height: calc(var(--header-bar-height) - 20px);
+  height: 100%;
 }
+
 .avatar-menu {
   display: flex;
-  position: absolute;
-  right: 10px;
-  align-items: center;
-  height: var(--header-bar-height);
-}
-
-div.network-status-display {
+  padding: 5pt 0;
   height: 100%;
-  padding: 0;
-  margin: 0 2px;
+  margin-left: 1rem;
+  box-sizing: border-box;
+  button {
+    padding: 0;
+  }
+}
+/* Button Container */
+.ButtonWrapperContainer {
+  height: 100%;
+  width: 100%;
+  max-width: 700pt;
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  justify-content: end;
-
-  svg {
-    flex-grow: 1;
-    vertical-align: center;
-    margin-left: 16px;
-    margin-right: 16px;
+  flex-direction: row;
+  overflow-x: auto;
+  margin-inline: auto;
+  /* Button Section */
+  #ButtonWrapper {
+    height: 100%;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    white-space: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    -ms-overflow-style: -ms-autohiding-scrollbar;
+    scrollbar-width: thin;
+    & > * {
+      margin-right: 5pt;
+      padding: 0;
+    }
   }
 
-  span.network-status-label {
+  #right-icon-container,
+  #left-icon-container {
+    background-color: rgb(255 255 255 / 50%);
+    border-radius: 5px;
+    pointer-events: none;
+    visibility: hidden;
+    display: flex;
+    align-items: center;
+  }
+}
+.direction-icon {
+  color: black;
+}
+
+.Tab {
+  display: flex;
+  align-items: center;
+  background-color: transparent;
+  border: none;
+  color: white;
+  &:hover {
+    cursor: pointer;
+  }
+}
+
+.Tab__Label {
+  font-size: small;
+}
+
+.Tab__Indicator {
+  border-bottom: 3pt solid var(--bc-yellow);
+}
+.network-state-control {
+  display: flex;
+  flex-direction: row;
+}
+
+.network-status-display {
+  display: flex;
+  box-sizing: border-box;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  font-size: small;
+  span {
+    font-size: small;
+  }
+}
+
+@media only screen and (width >= 801px) {
+  #appTitle {
     display: block;
-    margin: 0;
-    font-family: Roboto, Helvetica, Arial, sans-serif;
-    font-weight: 400;
-    font-size: 1rem;
-    line-height: 1.5;
-    letter-spacing: 0.00938em;
+    font-weight: bold;
+    padding-left: 5px;
   }
 }

--- a/app/src/UI/Header/Header.tsx
+++ b/app/src/UI/Header/Header.tsx
@@ -6,7 +6,6 @@ import {
   Avatar,
   FormControl,
   FormControlLabel,
-  FormGroup,
   Grow,
   IconButton,
   ListItemIcon,

--- a/app/src/UI/Header/Header.tsx
+++ b/app/src/UI/Header/Header.tsx
@@ -116,12 +116,15 @@ const Tab: React.FC<TabProps> = ({ predicate, platform, children, path, label, p
       }, 100);
 
       scrollContainer.addEventListener('scroll', () => {
-        if (scrollContainer.scrollLeft + scrollContainer.clientWidth >= scrollContainer.scrollWidth - 5) {
-          rightIconContainer.style.visibility = 'hidden';
-          leftIconContainer.style.visibility = 'visible';
-        } else if (scrollContainer.scrollLeft <= 5) {
+        const enableVisibleLeft = scrollContainer.scrollLeft <= 5;
+        const enableVisibleRight =
+          scrollContainer.scrollLeft + scrollContainer.clientWidth >= scrollContainer.scrollWidth - 5;
+        if (enableVisibleRight) {
           rightIconContainer.style.visibility = 'visible';
           leftIconContainer.style.visibility = 'hidden';
+        } else if (enableVisibleLeft) {
+          rightIconContainer.style.visibility = 'hidden';
+          leftIconContainer.style.visibility = 'visible';
         } else {
           rightIconContainer.style.visibility = 'visible';
           leftIconContainer.style.visibility = 'visible';
@@ -132,8 +135,8 @@ const Tab: React.FC<TabProps> = ({ predicate, platform, children, path, label, p
 
   return (
     <>
-      {canDisplayCallBack() ? (
-        <div
+      {canDisplayCallBack() && (
+        <button
           className={'Tab' + (urlFromAppModeState === path ? ' Tab__Indicator' : '')}
           onClick={() => {
             history.push(path);
@@ -145,9 +148,7 @@ const Tab: React.FC<TabProps> = ({ predicate, platform, children, path, label, p
         >
           <div className="Tab__Content">{children}</div>
           <div className="Tab__Label">{label}</div>
-        </div>
-      ) : (
-        <></>
+        </button>
       )}
     </>
   );
@@ -319,7 +320,7 @@ const LoginOrOutMemo = React.memo(() => {
   return (
     <div className={'avatar-menu'}>
       <IconButton onClick={handleClick}>
-        <Avatar></Avatar>
+        <Avatar />
       </IconButton>
       <Menu
         id="menu-appbar"
@@ -383,32 +384,29 @@ const NetworkStateControl: React.FC = () => {
   const dispatch = useDispatch();
   return (
     <div className={'network-state-control'}>
-      <FormControl>
-        <FormGroup>
-          <FormControlLabel
-            control={
-              <Switch
-                checked={connected}
-                color={'primary'}
-                size={'medium'}
-                onChange={handleNetworkStateChange}
-                inputProps={{ 'aria-label': 'controlled' }}
-              />
-            }
-            label={'Network'}
-            labelPlacement="bottom"
-          />
-        </FormGroup>
+      <FormControl className="network-status-display">
+        <FormControlLabel
+          control={
+            <Switch
+              checked={connected}
+              color={'primary'}
+              size={'medium'}
+              onChange={handleNetworkStateChange}
+              inputProps={{ 'aria-label': 'controlled' }}
+            />
+          }
+          label={'Network'}
+          labelPlacement="end"
+        />
       </FormControl>
+      <div className="network-status-display"></div>
       {connected && (
-        <>
-          <div className={'network-status-display'}>
-            <Grow in={true} appear={true}>
-              <SignalWifi4Bar fontSize={'medium'} aria-label={'Online'} />
-            </Grow>
-            <span className={'network-status-label'}>Online</span>
-          </div>
-        </>
+        <div className={'network-status-display'}>
+          <Grow in={true} appear={true}>
+            <SignalWifi4Bar fontSize={'medium'} aria-label={'Online'} />
+          </Grow>
+          <span className={'network-status-label'}>&nbsp;Online</span>
+        </div>
       )}
       {connected || (
         <div className={'network-status-display'}>
@@ -430,7 +428,7 @@ export const Header: React.FC = () => {
   }
 
   return (
-    <div className="HeaderBar">
+    <header className="HeaderBar">
       <InvIcon />
 
       <ButtonWrapper>
@@ -540,8 +538,7 @@ export const Header: React.FC = () => {
 
         {MOBILE && <NetworkStateControl />}
       </ButtonWrapper>
-
       <LoginOrOutMemo />
-    </div>
+    </header>
   );
 };

--- a/app/src/UI/Header/OfflineSyncHeaderButton.tsx
+++ b/app/src/UI/Header/OfflineSyncHeaderButton.tsx
@@ -57,14 +57,12 @@ export const OfflineSyncHeaderButton = () => {
   }, [working, serial]);
 
   return (
-    <>
-      <Button
-        onClick={() => {
-          dispatch({ type: ACTIVITY_OFFLINE_SYNC_DIALOG_SET_STATE, payload: { open: true } });
-        }}
-      >
-        {iconComponent}
-      </Button>
-    </>
+    <Button
+      onClick={() => {
+        dispatch({ type: ACTIVITY_OFFLINE_SYNC_DIALOG_SET_STATE, payload: { open: true } });
+      }}
+    >
+      {iconComponent}
+    </Button>
   );
 };

--- a/app/src/UI/Map2/Controls/ButtonContainer.css
+++ b/app/src/UI/Map2/Controls/ButtonContainer.css
@@ -15,25 +15,33 @@
 }
 
 #map-btn-container {
+  z-index: 999;
+  max-width: 100%;
   display: flex;
-  flex-flow: row nowrap;
-  place-content: space-evenly center;
-  gap: 16px;
   overflow-x: auto;
+  background: none;
+  gap: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  box-sizing: border-box;
   -webkit-overflow-scrolling: touch;
   -ms-overflow-style: -ms-autohiding-scrollbar;
   position: absolute;
-  left: 0;
-  right: 0;
   height: var(--map-button-bar-height);
   transition: bottom 0.1s ease 0.3s;
+
+  /* Enable clickthrough on div, but keep children clickable */
+  pointer-events: none;
+  & > * {
+    pointer-events: auto;
+  }
 
   .button {
     height: 100%;
     aspect-ratio: 1;
     font-weight: bold;
     border-radius: 50%;
-    color: #036;
+    color: var(--bc-blue);
 
     &:hover {
       background-color: white;
@@ -41,35 +49,23 @@
   }
 
   .basemap-btn-group {
-    padding: 0;
-    margin: 0;
     display: flex;
-    flex-flow: row nowrap;
-    gap: 0;
-
     div {
-      padding: 0;
-      margin: 0;
       border-right: 1px solid darkgrey;
-      aspect-ratio: 1;
-      flex-shrink: 0;
 
       &.selected {
         .basemap-btn {
-          background-color: #036;
-          color: #fcba19;
+          background-color: var(--bc-blue);
+          color: var(--bc-yellow);
         }
       }
 
       .basemap-btn {
         height: 100%;
         width: var(--map-button-bar-height);
-        font-weight: bold;
         border-radius: 0;
-        font-size: 14px;
         background-color: white;
-        color: #036;
-        flex-shrink: 0;
+        color: var(--bc-blue);
       }
 
       &:first-child:not(:only-child) {
@@ -82,41 +78,30 @@
         .basemap-btn {
           border-radius: 0 20% 20% 0;
         }
-
         border-right: none;
       }
 
       &:only-child {
         /* the special case when there's only one button */
-
         .basemap-btn {
           border-radius: 20%;
-
         }
-
         border: none;
-
       }
-
     }
-
   }
 
   .map-btn {
     .button {
       background-color: white;
-      color: #036;
+      color: var(--bc-blue);
     }
   }
 
   .map-btn-selected {
     .button {
-      background-color: #036;
-      color: #fcba19;
+      background-color: var(--bc-blue);
+      color: var(--bc-yellow);
     }
   }
-
-  /* background: rgb(255 255 255); */
-
-  /* background: linear-gradient(90deg, rgb(255 255 255 / 0%) 0%, rgb(255 255 255 / 50%) 50%, rgb(255 255 255 / 0%) 100%); */
 }

--- a/app/src/UI/Map2/Controls/ButtonContainer.css
+++ b/app/src/UI/Map2/Controls/ButtonContainer.css
@@ -15,7 +15,7 @@
 }
 
 #map-btn-container {
-  z-index: 999;
+  z-index: 2;
   max-width: 100%;
   display: flex;
   overflow-x: auto;

--- a/app/src/UI/Overlay/Records/Record.css
+++ b/app/src/UI/Overlay/Records/Record.css
@@ -1,0 +1,36 @@
+.selectedFormTab {
+  border-bottom-style: solid !important;
+  border-width: 0.5vh !important;
+  border-color: var(--bc-yellow) !important;
+}
+
+.records__activity__photos_button {
+  height: 5vh;
+  border-color: black;
+  border-radius: 0px !important;
+  background-color: var(--bc-blue) !important;
+}
+
+.records__activity__form_button {
+  height: 5vh;
+  border-color: black;
+  border-radius: 0px !important;
+  background-color: var(--bc-blue) !important;
+}
+
+.records__activity__map_button {
+  height: 5vh;
+  border-color: black;
+  border-radius: 0px !important;
+  background-color: var(--bc-blue) !important;
+}
+
+.records__activity_buttons {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  & > button {
+    height: 20pt;
+  }
+}

--- a/app/src/UI/Overlay/Records/Record.tsx
+++ b/app/src/UI/Overlay/Records/Record.tsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 
-import './Records.css';
+import './Record.css';
 import { Route, useHistory } from 'react-router';
 import { useSelector } from 'react-redux';
 import { ActivityForm } from './Activity/Form';

--- a/app/src/UI/Overlay/Records/RecordSetCacheButtons.tsx
+++ b/app/src/UI/Overlay/Records/RecordSetCacheButtons.tsx
@@ -1,5 +1,5 @@
-import { UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
-import { Button, Tooltip } from '@mui/material';
+import { RecordSetType, UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
+import { Button, IconButton, Tooltip } from '@mui/material';
 import EjectIcon from '@mui/icons-material/Eject';
 import SaveIcon from '@mui/icons-material/Save';
 import { MouseEvent, useEffect, useState } from 'react';
@@ -24,7 +24,7 @@ const RecordSetCacheButtons = ({ recordSet, setId }: PropTypes) => {
     );
     setSaveEnabled(
       (!recordSet.cacheMetadata || [UserRecordCacheStatus.NOT_CACHED].includes(recordSet.cacheMetadata?.status)) &&
-        recordSet.recordSetType == 'Activity' &&
+        recordSet.recordSetType == RecordSetType.Activity &&
         connected
     );
   }, [recordSet.cacheMetadata?.status, connected]);
@@ -50,25 +50,23 @@ const RecordSetCacheButtons = ({ recordSet, setId }: PropTypes) => {
             variant="outlined"
           >
             {recordSet.cacheMetadata?.status ?? 'UNKNOWN'}
-            <>
-              <SaveIcon />
-            </>
+            <SaveIcon />
           </Button>
         </span>
       </Tooltip>
 
       <Tooltip classes={{ tooltip: 'toolTip' }} title="Click to clear cached data for this layer of records">
-        <span>
+        <>
           {recordSet.cacheMetadata?.status == UserRecordCacheStatus.DELETING && 'Deleting Cache'}
-          <Button
+          <IconButton
             className="records__set__layer_cache"
             disabled={!deleteEnabled}
             onClick={(e) => onClickInitClearCache(e)}
-            variant="outlined"
+            color="primary"
           >
             <EjectIcon />
-          </Button>
-        </span>
+          </IconButton>
+        </>
       </Tooltip>
     </>
   );

--- a/app/src/UI/Overlay/Records/RecordSetControl.tsx
+++ b/app/src/UI/Overlay/Records/RecordSetControl.tsx
@@ -1,0 +1,69 @@
+import { MobileOnly } from 'UI/Predicates/MobileOnly';
+import { RecordSetCacheButtons } from './RecordSetCacheButtons';
+import { IconButton, Tooltip } from '@mui/material';
+import { UserRecordSet } from 'interfaces/UserRecordSet';
+import { ColorLens, Delete, Label, LabelOff, Layers, LayersClear } from '@mui/icons-material';
+import { MouseEvent } from 'react';
+
+type PropTypes = {
+  isDefaultRecordset: boolean;
+  recordset: UserRecordSet;
+  recordsetKey: string;
+  onClickToggleLabel: (set: string, e: MouseEvent<HTMLButtonElement>) => void;
+  onClickToggleLayer: (set: string, e: MouseEvent<HTMLButtonElement>) => void;
+  onClickCycleColour: (set: string, e: MouseEvent<HTMLButtonElement>) => void;
+  onClickDeleteRecordSet: (set: string, e: MouseEvent<HTMLButtonElement>) => void;
+};
+const RecordSetControl = ({
+  isDefaultRecordset,
+  recordset,
+  recordsetKey,
+  onClickToggleLabel,
+  onClickToggleLayer,
+  onClickCycleColour,
+  onClickDeleteRecordSet
+}: PropTypes) => {
+  const LABEL_TOGGLE_TIP =
+    'Toggle viewing the labels on the map for this layer.  If more than 200 are in the extent, you may need to zoom in to see what you are looking for.  For people on slow computers - it recalculates on drag and zoom so fewer small drags will decrease loading time.';
+  const LAYER_TOGGLE_TIP =
+    'Toggle viewing the layer on the map, and including these records in the Whats Here search results.';
+  const COLOUR_CYCLE_TIP = 'Change the colour of this layer.';
+  const DELETE_TIP =
+    'Delete this layer/list of records.  Does NOT delete the actual records, just the set of filters / layer configuration.';
+
+  return (
+    <div className="record-set-control">
+      <MobileOnly>
+        <RecordSetCacheButtons recordSet={recordset} setId={recordsetKey} />
+      </MobileOnly>
+
+      <Tooltip classes={{ tooltip: 'toolTip' }} title={LABEL_TOGGLE_TIP}>
+        <IconButton onClick={(e) => onClickToggleLabel(recordsetKey, e)} color="primary">
+          {recordset?.labelToggle ? <Label /> : <LabelOff />}
+        </IconButton>
+      </Tooltip>
+
+      <Tooltip classes={{ tooltip: 'toolTip' }} title={LAYER_TOGGLE_TIP}>
+        <IconButton onClick={(e) => onClickToggleLayer(recordsetKey, e)} color="primary">
+          {recordset?.mapToggle ? <Layers /> : <LayersClear />}
+        </IconButton>
+      </Tooltip>
+
+      {!isDefaultRecordset && (
+        <>
+          <Tooltip placement="bottom-start" classes={{ tooltip: 'toolTip' }} title={COLOUR_CYCLE_TIP}>
+            <IconButton onClick={(e) => onClickCycleColour(recordsetKey, e)} color="primary">
+              <ColorLens />
+            </IconButton>
+          </Tooltip>
+          <Tooltip classes={{ tooltip: 'toolTip' }} title={DELETE_TIP}>
+            <IconButton onClick={(e) => onClickDeleteRecordSet(recordsetKey, e)} color="primary">
+              <Delete />
+            </IconButton>
+          </Tooltip>
+        </>
+      )}
+    </div>
+  );
+};
+export default RecordSetControl;

--- a/app/src/UI/Overlay/Records/RecordSetDetails.tsx
+++ b/app/src/UI/Overlay/Records/RecordSetDetails.tsx
@@ -1,0 +1,44 @@
+import { Check, Edit } from '@mui/icons-material';
+import { IconButton } from '@mui/material';
+import { MouseEvent, ReactNode, useState } from 'react';
+
+type PropTypes = {
+  name: string;
+  recordsetKey: string;
+  isDefaultRecordset: boolean;
+  handleNameChange: (val: string, recordsetKey: string) => void;
+  children?: ReactNode;
+};
+const RecordSetDetails = ({ name, isDefaultRecordset, handleNameChange, recordsetKey, children }: PropTypes) => {
+  const [isEditing, setIsEditing] = useState<boolean>(false);
+  const toggleEdit = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    setIsEditing((prev) => !prev);
+  };
+  if (isDefaultRecordset) {
+    return (
+      <div className="record-set-details">
+        {children}
+        <p>{name}</p>
+      </div>
+    );
+  }
+  return (
+    <div className="record-set-details">
+      {children}
+      {isEditing ? (
+        <input
+          type="text"
+          value={name}
+          onChange={(evt) => handleNameChange(evt.target.value, recordsetKey)}
+          onClick={(e) => e.stopPropagation()}
+        />
+      ) : (
+        <p>{name}</p>
+      )}
+      <IconButton onClick={toggleEdit}>{isEditing ? <Check /> : <Edit />}</IconButton>
+    </div>
+  );
+};
+
+export default RecordSetDetails;

--- a/app/src/UI/Overlay/Records/RecordSetDetails.tsx
+++ b/app/src/UI/Overlay/Records/RecordSetDetails.tsx
@@ -36,7 +36,9 @@ const RecordSetDetails = ({ name, isDefaultRecordset, handleNameChange, recordse
       ) : (
         <p>{name}</p>
       )}
-      <IconButton onClick={toggleEdit}>{isEditing ? <Check /> : <Edit />}</IconButton>
+      <IconButton color="primary" onClick={toggleEdit}>
+        {isEditing ? <Check /> : <Edit />}
+      </IconButton>
     </div>
   );
 };

--- a/app/src/UI/Overlay/Records/Records.css
+++ b/app/src/UI/Overlay/Records/Records.css
@@ -5,6 +5,9 @@
     padding: 0;
     margin: 0;
     list-style-type: none;
+    li:hover {
+      cursor: pointer;
+    }
   }
 }
 

--- a/app/src/UI/Overlay/Records/Records.css
+++ b/app/src/UI/Overlay/Records/Records.css
@@ -31,7 +31,6 @@
 .record-set-control {
   width: 100%;
   display: flex;
-  /* height: 30pt; */
   align-items: center;
 }
 .record-set-details {

--- a/app/src/UI/Overlay/Records/Records.css
+++ b/app/src/UI/Overlay/Records/Records.css
@@ -1,116 +1,66 @@
-.records__container {
+#records-container {
   height: 100%;
   width: 100%;
+  ul {
+    padding: 0;
+    margin: 0;
+    list-style-type: none;
+  }
 }
 
-.addRecordSet {
+.new-recordset-button {
   height: 100px;
   width: 100px;
 }
 
-.records_set {
-  height: 50px;
-  width: 100%;
+.record-set-option {
   display: flex;
-  flex-direction: row;
-  padding-left: 1rem;
-  border: 1pt solid black;
+  flex-direction: column;
+  width: 100%;
+  min-height: 40pt;
+  padding: 5pt 1rem;
   box-sizing: border-box;
-  color: black;
-  overflow: hidden;
-}
-
-.records_set:hover {
-  cursor: pointer;
-}
-.records_set_left_hand_items {
-  height: 100%;
-
-  width: 25%;
-  display: flex;
-  flex-direction: row;
-  justify-content: left;
-}
-.records_set_name {
-  height: 100%;
-  font-size: small;
-  display: flex;
-  align-items: center;
-  overflow-y: hidden;
-  /*  text-shadow: 1px 0 0 #000, 0 -1px 0 #000, 0 1px 0 #000, -1px 0 0 #000;*/
-}
-
-.records_set_name_edit {
-  padding-left: 5px;
-
-  height: 50px;
-}
-
-.records_set_right_hand_items {
-  height: 100%;
-  display: flex;
-  width: 75%;
-  flex-direction: row;
-  justify-content: right;
-  overflow-x: hidden;
-  overflow-y: hidden;
-}
-
-.record {
-  height: 100px;
-  width: 100%;
-}
-
-.records_activity {
-  color: white;
-}
-
-.records__activity__header {
-  /* same height as the apps header and footer */
-  width: 100%;
-  border-color: black;
-  display: flex;
-  justify-content: center;
-}
-
-.records__activity_buttons {
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  & > button {
-    height: 20pt;
+  border-bottom: 1pt solid black;
+  p {
+    margin: 0;
+    padding: 0;
   }
 }
 
-.records__activity_buttons > * {
-  flex-grow: 1;
+.record-set-details,
+.record-set-control {
+  width: 100%;
+  display: flex;
+  /* height: 30pt; */
+  align-items: center;
+}
+.record-set-details {
+  flex-direction: flex-start;
+  margin-bottom: 5pt;
+  input {
+    height: 30pt;
+    border: 1pt solid lightgray;
+    font-size: 12pt;
+    border-radius: 8pt;
+    padding-left: 1rem;
+  }
+}
+.record-set-control {
+  justify-content: flex-start;
 }
 
-.selectedFormTab {
-  border-bottom-style: solid !important;
-  /*border-radius: 2vh;*/
-  border-width: 0.5vh !important;
-  border-color: #fcba19 !important;
-}
-
-.records__activity__photos_button {
-  height: 5vh;
-  border-color: black;
-  border-radius: 0px !important;
-  background-color: #003366 !important;
-}
-
-.records__activity__form_button {
-  height: 5vh;
-  border-color: black;
-  border-radius: 0px !important;
-  background-color: #003366 !important;
-}
-
-.records__activity__map_button {
-  height: 5vh;
-  border-color: black;
-  border-radius: 0px !important;
-  background-color: #003366 !important;
+@media screen and (width > 500px) {
+  .record-set-option {
+    flex-direction: row;
+  }
+  .record-set-details,
+  .record-set-control {
+    width: 50%;
+  }
+  .record-set-details {
+    margin-bottom: 0;
+  }
+  .record-set-control {
+    justify-content: flex-end;
+  }
 }

--- a/app/src/UI/Overlay/Records/Records.tsx
+++ b/app/src/UI/Overlay/Records/Records.tsx
@@ -1,14 +1,6 @@
 import { MouseEvent, useEffect, useState } from 'react';
-import ColorLensIcon from '@mui/icons-material/ColorLens';
-import Delete from '@mui/icons-material/Delete';
-import LabelIcon from '@mui/icons-material/Label';
-import LabelClearIcon from '@mui/icons-material/LabelOff';
-import LayersIcon from '@mui/icons-material/Layers';
-import LayersClearIcon from '@mui/icons-material/LayersClear';
-import EditIcon from '@mui/icons-material/Edit';
-import CheckIcon from '@mui/icons-material/Check';
 
-import { Button, IconButton, Tooltip, Typography } from '@mui/material';
+import { Button } from '@mui/material';
 import './Records.css';
 import { OverlayHeader } from '../OverlayHeader';
 import Spinner from 'UI/Spinner/Spinner';
@@ -17,8 +9,8 @@ import { useDispatch, useSelector } from 'utils/use_selector';
 import UserSettings from 'state/actions/userSettings/UserSettings';
 import { RecordSetType } from 'interfaces/UserRecordSet';
 import Prompt from 'state/actions/prompts/Prompt';
-import { MobileOnly } from 'UI/Predicates/MobileOnly';
-import { RecordSetCacheButtons } from './RecordSetCacheButtons';
+import RecordSetDetails from './RecordSetDetails';
+import RecordSetControl from './RecordSetControl';
 
 export const Records = () => {
   const DEFAULT_RECORD_TYPES = ['All InvasivesBC Activities', 'All IAPP Records', 'My Drafts'];
@@ -30,11 +22,13 @@ export const Records = () => {
 
   const [highlightedSet, setHighlightedSet] = useState<string | null>();
   const [isActivitiesGeoJSONLoaded, setIsActivitiesGeoJSONLoaded] = useState(false);
-  const [isEditingName, setIsEditingName] = useState(false);
   const [loadMap, setLoadMap] = useState({});
 
   const history = useHistory();
   const dispatch = useDispatch();
+
+  const handleNameChange = (val: string, setKey: string) =>
+    dispatch(UserSettings.RecordSet.set({ recordSetName: val }, setKey));
 
   useEffect(() => {
     // make sure the displayed status accurately reflects the contents of the cache
@@ -58,23 +52,23 @@ export const Records = () => {
     setLoadMap(rv);
   }, [JSON.stringify(mapLayers), isActivitiesGeoJSONLoaded, isIAPPGeoJSONLoaded, MapMode]);
 
-  //Record set on click handlers:
-  const onClickToggleLabel = (set: string, e: MouseEvent<HTMLButtonElement>) => {
+  //Record set handlers:
+  const handleToggleLabel = (set: string, e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     dispatch(UserSettings.RecordSet.toggleLabelVisibility(set));
   };
 
-  const onClickToggleLayer = (set: string, e: MouseEvent<HTMLButtonElement>) => {
+  const handleToggleLayer = (set: string, e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     dispatch(UserSettings.RecordSet.toggleVisibility(set));
   };
 
-  const onClickCycleColour = (set: string, e: MouseEvent<HTMLButtonElement>) => {
+  const handleCycleColour = (set: string, e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     dispatch(UserSettings.RecordSet.cycleColourById(set));
   };
 
-  const onClickDeleteRecordSet = (set: string, e: MouseEvent<HTMLButtonElement>) => {
+  const handleDeleteRecordSet = (set: string, e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     const callback = (userConfirmation: boolean) => {
       if (userConfirmation) {
@@ -100,134 +94,61 @@ export const Records = () => {
     return;
   }
   return (
-    <div className="records__container">
+    <>
       <OverlayHeader />
-      {Object.keys(recordSets)?.map((set) => {
-        return (
-          <div
-            key={set}
-            onClick={() => {
-              history.push('/Records/List/Local:' + set);
-            }}
-            onMouseOver={highlightSet.bind(this, set)}
-            onFocus={highlightSet.bind(this, set)}
-            onMouseOut={unHighlightSet}
-            onBlur={unHighlightSet}
-            className={'records_set'}
-            // Adjust Opacity of the background-color when hovering
-            style={{ backgroundColor: `${recordSets[set]?.color}${highlightedSet === set ? 65 : 20}` }}
-          >
-            {!loadMap?.[set] && (
-              <div key={set + 'spinner'}>
-                <Spinner />
-              </div>
-            )}
-            <div className="records_set_left_hand_items">
-              {isEditingName && !DEFAULT_RECORD_TYPES.includes(recordSets[set]?.recordSetName) ? (
-                <>
-                  <input
-                    type="text"
-                    value={recordSets[set]?.recordSetName}
-                    onChange={(e) => dispatch(UserSettings.RecordSet.set({ recordSetName: e.target.value }, set))}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                    }}
-                  />
-                  <Button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setIsEditingName(false);
-                    }}
-                  >
-                    <CheckIcon />
-                  </Button>
-                </>
-              ) : (
-                !DEFAULT_RECORD_TYPES.includes(recordSets[set]?.recordSetName) && (
-                  <IconButton
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setIsEditingName(true);
-                    }}
-                    color="primary"
-                  >
-                    <EditIcon />
-                  </IconButton>
-                )
-              )}
-              <div className="records_set_name">
-                {!(isEditingName && !DEFAULT_RECORD_TYPES.includes(recordSets[set]?.recordSetName)) && (
-                  <Typography>{recordSets[set]?.recordSetName}</Typography>
+      <div id="records-container">
+        <ul>
+          {Object.keys(recordSets)?.map((set) => (
+            <li
+              key={set}
+              onClick={() => history.push('/Records/List/Local:' + set)}
+              onMouseOver={highlightSet.bind(this, set)}
+              onFocus={highlightSet.bind(this, set)}
+              onMouseOut={unHighlightSet}
+              onBlur={unHighlightSet}
+              className="record-set-option"
+              style={{ backgroundColor: `${recordSets[set]?.color}${highlightedSet === set ? 65 : 20}` }}
+            >
+              <RecordSetDetails
+                name={recordSets[set]?.recordSetName}
+                isDefaultRecordset={DEFAULT_RECORD_TYPES.includes(recordSets[set]?.recordSetName)}
+                handleNameChange={handleNameChange}
+                recordsetKey={set}
+              >
+                {!loadMap?.[set] && (
+                  <div>
+                    <Spinner />
+                  </div>
                 )}
-              </div>
-            </div>
+              </RecordSetDetails>
 
-            <div className="records_set_right_hand_items">
-              <MobileOnly>
-                <RecordSetCacheButtons recordSet={recordSets[set]} setId={set} />
-              </MobileOnly>
-
-              <Tooltip
-                classes={{ tooltip: 'toolTip' }}
-                title="Toggle viewing the labels on the map for this layer.  If more than 200 are in the extent, you may need to zoom in to see what you are looking for.  For people on slow computers - it recalculates on drag and zoom so fewer small drags will decrease loading time."
-              >
-                <IconButton
-                  className="records__set__layer_toggle"
-                  onClick={(e) => onClickToggleLabel(set, e)}
-                  color="primary"
-                >
-                  {recordSets[set]?.labelToggle ? <LabelIcon /> : <LabelClearIcon />}
-                </IconButton>
-              </Tooltip>
-
-              <Tooltip
-                classes={{ tooltip: 'toolTip' }}
-                title="Toggle viewing the layer on the map, and including these records in the Whats Here search results."
-              >
-                <IconButton
-                  className="records__set__layer_toggle"
-                  onClick={(e) => onClickToggleLayer(set, e)}
-                  color="primary"
-                >
-                  {recordSets[set]?.mapToggle ? <LayersIcon /> : <LayersClearIcon />}
-                </IconButton>
-              </Tooltip>
-
-              {!DEFAULT_RECORD_TYPES.includes(recordSets[set]?.recordSetName) && (
-                <Tooltip
-                  placement="bottom-start"
-                  classes={{ tooltip: 'toolTip' }}
-                  title="Change the colour of this layer."
-                >
-                  <IconButton onClick={(e) => onClickCycleColour(set, e)} color="primary">
-                    <ColorLensIcon />
-                  </IconButton>
-                </Tooltip>
-              )}
-
-              {!DEFAULT_RECORD_TYPES.includes(recordSets[set]?.recordSetName) && (
-                <Tooltip
-                  classes={{ tooltip: 'toolTip' }}
-                  title="Delete this layer/list of records.  Does NOT delete the actual records, just the set of filters / layer configuration."
-                >
-                  <IconButton onClick={(e) => onClickDeleteRecordSet(set, e)} color="primary">
-                    <Delete />
-                  </IconButton>
-                </Tooltip>
-              )}
-            </div>
-          </div>
-        );
-      })}
-      <Button
-        onClick={dispatch.bind(this, UserSettings.RecordSet.add(RecordSetType.Activity))}
-        className={'addRecordSet'}
-      >
-        Add Layer of Records
-      </Button>
-      <Button onClick={dispatch.bind(this, UserSettings.RecordSet.add(RecordSetType.IAPP))} className={'addRecordSet'}>
-        Add IAPP Layer of Records
-      </Button>
-    </div>
+              <RecordSetControl
+                isDefaultRecordset={DEFAULT_RECORD_TYPES.includes(recordSets[set]?.recordSetName)}
+                recordset={recordSets[set]}
+                recordsetKey={set}
+                onClickToggleLabel={handleToggleLabel}
+                onClickToggleLayer={handleToggleLayer}
+                onClickCycleColour={handleCycleColour}
+                onClickDeleteRecordSet={handleDeleteRecordSet}
+              />
+            </li>
+          ))}
+        </ul>
+        <div className="records-control">
+          <Button
+            onClick={dispatch.bind(this, UserSettings.RecordSet.add(RecordSetType.Activity))}
+            className={'new-recordset-button'}
+          >
+            Add Layer of Records
+          </Button>
+          <Button
+            onClick={dispatch.bind(this, UserSettings.RecordSet.add(RecordSetType.IAPP))}
+            className={'new-recordset-button'}
+          >
+            Add IAPP Layer of Records
+          </Button>
+        </div>
+      </div>
+    </>
   );
 };

--- a/app/src/UI/Overlay/Records/Records.tsx
+++ b/app/src/UI/Overlay/Records/Records.tsx
@@ -29,7 +29,7 @@ export const Records = () => {
   const recordSets = useSelector((state) => state.UserSettings?.recordSets);
 
   const [highlightedSet, setHighlightedSet] = useState<string | null>();
-  const [isActivitiesGeoJSONLoaded, setActivitiesGeoJSONLoaded] = useState(false);
+  const [isActivitiesGeoJSONLoaded, setIsActivitiesGeoJSONLoaded] = useState(false);
   const [isEditingName, setIsEditingName] = useState(false);
   const [loadMap, setLoadMap] = useState({});
 
@@ -42,7 +42,7 @@ export const Records = () => {
   }, []);
 
   useEffect(() => {
-    setActivitiesGeoJSONLoaded(activitiesGeoJSONState.hasOwnProperty('s3'));
+    setIsActivitiesGeoJSONLoaded(activitiesGeoJSONState.hasOwnProperty('s3'));
   }, [activitiesGeoJSONState]);
 
   useEffect(() => {


### PR DESCRIPTION
# Overview

> This is partial work towards the completion of #3637

This PR includes the following proposed change(s):

> Viewport was set to Galaxy S20

1. Widen the header to better use screen space
    - Flip Network icons horizontal instead of stacked. They're too large to fit in pre-existing header size. 
    - switch outer `div` to `header` given its a header
    - CSS cleanup
2. Refactor Map Buttons to not overflow out and disappear
    - CSS Adjustments only
3. Recordset lists
    - Break /Records into sub components
    - Split into two main subcomponents
    - In Mobile widths, stack them to avoid compression
    - Editing a recordset name doesn't toggle them all into edit mode
    - Reduce logic complexity in what is supposed to render and when


## Pictures
1. Widening Header

New

![image](https://github.com/user-attachments/assets/49ffdef9-7e33-4668-b367-a7849a57120c)

Old

![image](https://github.com/user-attachments/assets/624523ec-10d0-4fe5-9924-b09327aea438)

2. Map Buttons

New

![image](https://github.com/user-attachments/assets/5c40c2c5-1176-4deb-8b65-889dca6ab5c7)

Old

> This as far left as you can scroll, given context, buttons become unusable, rightmost button is eclipsed by map details

![image](https://github.com/user-attachments/assets/d93c0b79-d56d-4d1e-9cd8-0fab9aed040c)

3. Recordsets

Old

![image](https://github.com/user-attachments/assets/34b2425e-dd39-45f6-b92d-18c1236a0f92)
![image](https://github.com/user-attachments/assets/2241235e-f9f1-433c-9bfa-046835622fba)

New 

![image](https://github.com/user-attachments/assets/c8e4444e-f54c-45e1-b13e-d3ffa7f019b7)
