### PR TITLE
Minor Fix - Private flag in static class

### DIFF
--- a/app/src/state/actions/prompts/Prompt.ts
+++ b/app/src/state/actions/prompts/Prompt.ts
@@ -17,7 +17,7 @@ class Prompt {
   /**
    * @desc Action type for creating new prompts.
    */
-  private static readonly NEW_PROMPT = 'Prompt/NewPrompt';
+  static readonly NEW_PROMPT = 'Prompt/NewPrompt';
   /**
    * @desc Helper function for creating modals to gather a 'boolean' input
    * @param {ConfirmationModalInterface} prompt component props


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):
- Correct minor error where a static class value was marked private
    - Value was referenced in reducer case as a catch all 