### PR TITLE
Update rounding adjustments for values in the Herbicide calculator

### DIFF
--- a/sharedAPI/src/validation/herbicideCalculator.ts
+++ b/sharedAPI/src/validation/herbicideCalculator.ts
@@ -616,7 +616,7 @@ export const mSpecie_mLGHerb_spray_usingProdAppRate = (
  * ------------------------Helper Functions-----------------------------------
  */
 export const parseToRightFormat = (value: number) => {
-  return Number(value.toFixed(4));
+  return Number(value.toFixed(10));
 };
 export interface IGeneralFields {
   application_start_time?: Date;


### PR DESCRIPTION
# Overview

- Adjusted rounding in the herbicide calculator to 10 decimal places from the previous 4.

This PR includes the following proposed change(s):
- Closes #3525

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
