### PR TITLE
[INV-3672] Linked ID showing improperly

### DIFF
--- a/app/src/UI/Overlay/Records/Activity/form/FormContainer.tsx
+++ b/app/src/UI/Overlay/Records/Activity/form/FormContainer.tsx
@@ -24,6 +24,7 @@ import { getCustomErrorTransformer } from 'rjsf/business-rules/customErrorTransf
 import debounce from 'lodash.debounce';
 import { RENDER_DEBUG } from 'UI/App';
 import AgentSelectAutoComplete from 'rjsf/widgets/AgentSelectAutoComplete';
+import LinkedIdSelectAutoComplete from 'rjsf/widgets/LinkedIdSelectAutoComplete';
 
 const FormContainer = () => {
   const ref = useRef(0);
@@ -137,7 +138,8 @@ const FormContainer = () => {
             widgets={{
               'multi-select-autocomplete': MultiSelectAutoComplete,
               'single-select-autocomplete': SingleSelectAutoComplete,
-              'agent-select-autocomplete': AgentSelectAutoComplete
+              'agent-select-autocomplete': AgentSelectAutoComplete,
+              'linked-id-select-autocomplete': LinkedIdSelectAutoComplete
             }}
             readonly={isDisabled}
             key={activity_ID + pasteCount + reported_area}

--- a/app/src/rjsf/uiSchema/BaseUISchemaComponents.ts
+++ b/app/src/rjsf/uiSchema/BaseUISchemaComponents.ts
@@ -82,14 +82,14 @@ const Observation = {
 };
 
 const Monitoring = {
-  linked_id: { 'ui:widget': 'single-select-autocomplete' },
+  linked_id: { 'ui:widget': 'linked-id-select-autocomplete' },
   copy_geometry: { 'ui:widget': 'single-select-autocomplete' },
   activity_persons: {},
   'ui:order': ['linked_id', 'copy_geometry', 'activity_persons']
 };
 
 const Monitoring_Biocontrol_Release = {
-  linked_id: { 'ui:widget': 'single-select-autocomplete' },
+  linked_id: { 'ui:widget': 'linked-id-select-autocomplete' },
   legacy_iapp_id: {},
   activity_persons: {},
   'ui:order': ['linked_id', 'copy_geometry', 'legacy_iapp_id', 'activity_persons']

--- a/app/src/rjsf/widgets/AgentSelectAutoComplete.tsx
+++ b/app/src/rjsf/widgets/AgentSelectAutoComplete.tsx
@@ -86,6 +86,11 @@ const AgentSelectAutoComplete = (props: WidgetProps) => {
       onLoad={() => {
         props.onChange(value);
       }}
+      SelectProps={{
+        MenuProps: {
+          sx: { height: '300px' }
+        }
+      }}
     >
       {filteredOptions.map((entry) => (
         <MenuItem key={entry.value} value={entry.value}>

--- a/app/src/rjsf/widgets/LinkedIdSelectAutoComplete.tsx
+++ b/app/src/rjsf/widgets/LinkedIdSelectAutoComplete.tsx
@@ -47,11 +47,15 @@ const LinkedIdSelectAutoComplete = (props: WidgetProps) => {
         }
       }}
     >
-      {suggestedTreatmentIDs.map((entry) => (
-        <MenuItem key={entry.value} value={entry.value}>
-          {entry.label}
-        </MenuItem>
-      ))}
+      {suggestedTreatmentIDs.length > 0 ? (
+        suggestedTreatmentIDs.map((entry) => (
+          <MenuItem key={entry.value} value={entry.value}>
+            {entry.label}
+          </MenuItem>
+        ))
+      ) : (
+        <MenuItem disabled>No treatment records found in selected area.</MenuItem>
+      )}
     </TextField>
   );
 };

--- a/app/src/rjsf/widgets/LinkedIdSelectAutoComplete.tsx
+++ b/app/src/rjsf/widgets/LinkedIdSelectAutoComplete.tsx
@@ -1,0 +1,59 @@
+import { TextField, MenuItem } from '@mui/material';
+import { SelectAutoCompleteContext } from 'UI/Overlay/Records/Activity/form/SelectAutoCompleteContext';
+import { ChangeEvent, useContext, useEffect, useState } from 'react';
+import { WidgetProps } from '@rjsf/utils';
+import { useSelector } from 'utils/use_selector';
+import { nanoid } from '@reduxjs/toolkit';
+
+const LinkedIdSelectAutoComplete = (props: WidgetProps) => {
+  const selectAutoCompleteContext = useContext(SelectAutoCompleteContext);
+  if (!selectAutoCompleteContext) {
+    throw new Error('Context not provided to AgentSelectAutoComplete.tsx');
+  }
+  /**
+   * @desc Change Handler for Select Menu, fires RJSF onChangeEvent and updates local state
+   */
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setValue(event.target.value);
+    props.onChange(event.target.value);
+  };
+
+  const { setLastFieldChanged } = selectAutoCompleteContext;
+  const { suggestedTreatmentIDs } = useSelector((state) => state.ActivityPage);
+  const [value, setValue] = useState(props.value ?? null);
+  const [renderKey] = useState(props.id + nanoid());
+
+  useEffect(() => {
+    setLastFieldChanged({ id: props.id, option: value });
+  }, [value]);
+
+  return (
+    <TextField
+      select
+      required={props.required}
+      key={renderKey}
+      onFocus={(event) => props.onFocus(event.target.id, event.target.nodeValue)}
+      id={props.id}
+      disabled={props.disabled}
+      label={props.label}
+      value={value ?? ''}
+      onChange={handleChange}
+      onLoad={() => {
+        props.onChange(value);
+      }}
+      SelectProps={{
+        MenuProps: {
+          sx: { height: '300px' }
+        }
+      }}
+    >
+      {suggestedTreatmentIDs.map((entry) => (
+        <MenuItem key={entry.value} value={entry.value}>
+          {entry.label}
+        </MenuItem>
+      ))}
+    </TextField>
+  );
+};
+
+export default LinkedIdSelectAutoComplete;

--- a/app/src/state/reducers/activity.ts
+++ b/app/src/state/reducers/activity.ts
@@ -107,8 +107,6 @@ function createActivityReducer(): (ActivityState: ActivityState, AnyAction) => A
         draftState.suggestedPersons = [...action.payload];
       } else if (Activity.Suggestions.treatmentIdsSuccess.match(action)) {
         draftState.suggestedTreatmentIDs = [...action.payload];
-        if (draftState?.schema?.properties?.activity_type_data?.properties?.linked_id)
-          draftState.schema.properties.activity_type_data.properties.linked_id.options = action.payload;
       } else if (Activity.createReq.match(action)) {
         const activity_copy_buffer = JSON.parse(JSON.stringify(draftState.activity_copy_buffer));
         Object.assign(draftState, {
@@ -213,7 +211,7 @@ function createActivityReducer(): (ActivityState: ActivityState, AnyAction) => A
             break;
         }
       }
-    }) as ActivityState;
+    });
   };
 }
 

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -480,7 +480,7 @@ export function* handle_ACTIVITY_GET_SUGGESTED_TREATMENT_IDS_REQUEST(action) {
         } as FeatureCollection)
       : false;
 
-    if (linkedActivitySubtypes.length > 0) {
+    if (linkedActivitySubtypes.length > 0 && search_feature) {
       yield put(
         Activity.Suggestions.treatmentIdsRequestOnline({
           activity_subtype: linkedActivitySubtypes,

--- a/app/src/state/sagas/activity/online.ts
+++ b/app/src/state/sagas/activity/online.ts
@@ -226,7 +226,7 @@ export function* handle_ACTIVITY_GET_SUGGESTED_TREATMENT_IDS_REQUEST_ONLINE(acti
     console.error(e);
     yield put(
       Alerts.create({
-        content: 'An error occured while fetching suggested persons. Suggestions will not be displayed',
+        content: 'An error occured while fetching suggested treatment IDs. Suggestions will not be displayed',
         severity: AlertSeverity.Error,
         subject: AlertSubjects.Form,
         autoClose: 8


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Initial bug was New activities firing LinkedID calls when creating a new record and a geography had not been set
    - Blocked calls when shape doesn't exist.
- Moved component into own widget, separating from the existing catch-all `SingleSelectAutoComplete.tsx`
    - Removed object drilling that occurs with Linked_Id state in the reduce
    - Create `LinkedIdSelectAutoComplete.tsx` to handle the state of the widget
- Correct max-height attribute for `AgentSelectAutoComplete` for tidiness.
- Correct text in Alert
- Closes #3672