### PR TITLE
[INV-3679][INV-3681] Change Cache Text, Remove Cache Delete Button, Add Communication layers

### DIFF
--- a/app/src/UI/AlertsContainer/AlertsContainer.tsx
+++ b/app/src/UI/AlertsContainer/AlertsContainer.tsx
@@ -3,7 +3,7 @@
  * @external {@link https://github.com/bcgov/invasivesbc/wiki/User-Alert-System }
  */
 import { Alert, AlertTitle, Button, Icon } from '@mui/material';
-import { MapOutlined, Assignment, InsertPhoto, Wifi } from '@mui/icons-material';
+import { MapOutlined, Assignment, InsertPhoto, Wifi, Save } from '@mui/icons-material';
 import { useDispatch } from 'react-redux';
 import './AlertsContainer.css';
 import AlertMessage from 'interfaces/AlertMessage';
@@ -30,6 +30,8 @@ const AlertsContainer = () => {
         return <InsertPhoto />;
       case AlertSubjects.Network:
         return <Wifi />;
+      case AlertSubjects.Cache:
+        return <Save />;
       default:
         break;
     }

--- a/app/src/UI/Overlay/Records/RecordSetCacheButtons.tsx
+++ b/app/src/UI/Overlay/Records/RecordSetCacheButtons.tsx
@@ -1,10 +1,10 @@
 import { RecordSetType, UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
-import { Button, IconButton, Tooltip } from '@mui/material';
-import EjectIcon from '@mui/icons-material/Eject';
+import { Button, Tooltip } from '@mui/material';
 import SaveIcon from '@mui/icons-material/Save';
 import { MouseEvent, useEffect, useState } from 'react';
 import RecordCache from 'state/actions/cache/RecordCache';
 import { useDispatch, useSelector } from 'utils/use_selector';
+import Prompt from 'state/actions/prompts/Prompt';
 
 interface PropTypes {
   recordSet: UserRecordSet;
@@ -14,61 +14,87 @@ interface PropTypes {
 const RecordSetCacheButtons = ({ recordSet, setId }: PropTypes) => {
   const dispatch = useDispatch();
   const connected = useSelector((state) => state.Network.connected);
+  const [cacheActionEnabled, setCacheActionEnabled] = useState<boolean>(false);
 
-  const [deleteEnabled, setDeleteEnabled] = useState<boolean>(false);
-  const [saveEnabled, setSaveEnabled] = useState<boolean>(false);
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    switch (recordSet.cacheMetadata.status) {
+      case UserRecordCacheStatus.NOT_CACHED:
+        downloadCache();
+        break;
+      case UserRecordCacheStatus.ERROR:
+      case UserRecordCacheStatus.CACHED:
+        deleteCache();
+        break;
+    }
+  };
+  const downloadCache = () => {
+    const callback = (confirmation: boolean) => {
+      if (confirmation) {
+        dispatch(RecordCache.requestCaching({ setId }));
+      }
+    };
+    dispatch(
+      Prompt.confirmation({
+        title: 'Download Records',
+        prompt: 'Would you like to download this cache? The record sets will be available for offline use.',
+        callback
+      })
+    );
+  };
+
+  const deleteCache = () => {
+    const callback = (confirmation: boolean) => {
+      if (confirmation) dispatch(RecordCache.deleteCache({ setId }));
+    };
+    dispatch(
+      Prompt.confirmation({
+        title: 'Delete Records',
+        prompt: [
+          'Do you want to remove these records from your device? They will no longer be accessible offline.',
+          'This action will not delete the records from the database.'
+        ],
+        callback
+      })
+    );
+  };
+
+  /** Modify the existing status key to be more user readable */
+  const formatStatusKey = (cacheStatus: UserRecordCacheStatus): string => {
+    if (!cacheStatus) {
+      return 'Unknown';
+    } else if (cacheStatus === UserRecordCacheStatus.NOT_CACHED) {
+      return 'Save';
+    }
+    return cacheStatus.replaceAll('_', ' ');
+  };
 
   useEffect(() => {
-    setDeleteEnabled(
-      [UserRecordCacheStatus.CACHED, UserRecordCacheStatus.ERROR].includes(recordSet.cacheMetadata?.status)
-    );
-    setSaveEnabled(
-      (!recordSet.cacheMetadata || [UserRecordCacheStatus.NOT_CACHED].includes(recordSet.cacheMetadata?.status)) &&
-        recordSet.recordSetType == RecordSetType.Activity &&
-        connected
+    setCacheActionEnabled(
+      connected &&
+        [UserRecordCacheStatus.CACHED, UserRecordCacheStatus.NOT_CACHED, UserRecordCacheStatus.ERROR].includes(
+          recordSet.cacheMetadata?.status
+        )
     );
   }, [recordSet.cacheMetadata?.status, connected]);
 
-  const onClickInitCache = (e: MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation();
-    dispatch(RecordCache.requestCaching({ setId }));
-  };
-
-  const onClickInitClearCache = (e: MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation();
-    dispatch(RecordCache.deleteCache({ setId }));
-  };
-
+  if (recordSet.recordSetType !== RecordSetType.Activity) {
+    return;
+  }
   return (
-    <>
-      <Tooltip classes={{ tooltip: 'toolTip' }} title="Click to save this layer and it's records">
-        <span>
-          <Button
-            disabled={!saveEnabled}
-            className="records__set__layer_cache"
-            onClick={(e) => onClickInitCache(e)}
-            variant="outlined"
-          >
-            {recordSet.cacheMetadata?.status ?? 'UNKNOWN'}
-            <SaveIcon />
-          </Button>
-        </span>
-      </Tooltip>
-
-      <Tooltip classes={{ tooltip: 'toolTip' }} title="Click to clear cached data for this layer of records">
-        <>
-          {recordSet.cacheMetadata?.status == UserRecordCacheStatus.DELETING && 'Deleting Cache'}
-          <IconButton
-            className="records__set__layer_cache"
-            disabled={!deleteEnabled}
-            onClick={(e) => onClickInitClearCache(e)}
-            color="primary"
-          >
-            <EjectIcon />
-          </IconButton>
-        </>
-      </Tooltip>
-    </>
+    <Tooltip classes={{ tooltip: 'toolTip' }} title="Click to save this layer and it's records">
+      <span>
+        <Button
+          disabled={!cacheActionEnabled}
+          className="records__set__layer_cache"
+          onClick={handleClick}
+          variant="outlined"
+        >
+          {formatStatusKey(recordSet.cacheMetadata?.status)}
+          <SaveIcon />
+        </Button>
+      </span>
+    </Tooltip>
   );
 };
 

--- a/app/src/UI/Overlay/Records/RecordSetCacheButtons.tsx
+++ b/app/src/UI/Overlay/Records/RecordSetCacheButtons.tsx
@@ -38,6 +38,7 @@ const RecordSetCacheButtons = ({ recordSet, setId }: PropTypes) => {
       Prompt.confirmation({
         title: 'Download Records',
         prompt: 'Would you like to download this cache? The record sets will be available for offline use.',
+        confirmText: 'Download Records',
         callback
       })
     );
@@ -54,6 +55,7 @@ const RecordSetCacheButtons = ({ recordSet, setId }: PropTypes) => {
           'Do you want to remove these records from your device? They will no longer be accessible offline.',
           'This action will not delete the records from the database.'
         ],
+        confirmText: 'Delete Records',
         callback
       })
     );

--- a/app/src/constants/alertEnums.ts
+++ b/app/src/constants/alertEnums.ts
@@ -2,7 +2,8 @@ export enum AlertSubjects {
   Map = 'map',
   Form = 'form',
   Photo = 'photo',
-  Network = 'network'
+  Network = 'network',
+  Cache = 'cache'
 }
 
 export enum AlertSeverity {

--- a/app/src/constants/alerts/cacheAlerts.ts
+++ b/app/src/constants/alerts/cacheAlerts.ts
@@ -1,0 +1,31 @@
+import { AlertSeverity, AlertSubjects } from 'constants/alertEnums';
+import AlertMessage from 'interfaces/AlertMessage';
+
+const cacheAlertMessages: Record<string, AlertMessage> = {
+  recordsetCacheFailed: {
+    content: 'Recordset failed to download.',
+    severity: AlertSeverity.Error,
+    subject: AlertSubjects.Cache,
+    autoClose: 4
+  },
+  recordsetCacheSuccess: {
+    content: 'Recordset downloaded successfully.',
+    severity: AlertSeverity.Success,
+    subject: AlertSubjects.Cache,
+    autoClose: 4
+  },
+  recordsetDeleteCacheFailed: {
+    content: 'Failed to delete Recordset.',
+    severity: AlertSeverity.Error,
+    subject: AlertSubjects.Cache,
+    autoClose: 4
+  },
+  recordsetDeleteCacheSuccess: {
+    content: 'Recordset has been deleted.',
+    severity: AlertSeverity.Success,
+    subject: AlertSubjects.Cache,
+    autoClose: 4
+  }
+};
+
+export default cacheAlertMessages;

--- a/app/src/state/reducers/alertsAndPrompts.ts
+++ b/app/src/state/reducers/alertsAndPrompts.ts
@@ -4,6 +4,8 @@ import AlertMessage from 'interfaces/AlertMessage';
 import Alerts from 'state/actions/alerts/Alerts';
 import Prompt from 'state/actions/prompts/Prompt';
 import { PromptAction } from 'interfaces/prompt-interfaces';
+import RecordCache from 'state/actions/cache/RecordCache';
+import cacheAlertMessages from 'constants/alerts/cacheAlerts';
 
 interface AlertsAndPromptsState {
   alerts: AlertMessage[];
@@ -15,31 +17,41 @@ const initialState: AlertsAndPromptsState = {
   prompts: []
 };
 
+const filterDuplicates = (key: keyof AlertMessage, matchValue: any, state: AlertMessage[]): any[] =>
+  state.filter((entry) => entry[key] !== matchValue);
+
 export function createAlertsAndPromptsReducer(
   configuration: AppConfig
 ): (AlertsAndPromptsState, AnyAction) => AlertsAndPromptsState {
   return (state: AlertsAndPromptsState = initialState, action) => {
     return createNextState(state, (draftState) => {
       if (Alerts.create.match(action)) {
-        const newID = nanoid();
         const newAlertIsDuplicate = state.alerts.some(
           (item) => action.payload.content === item.content && action.payload.severity === item.severity
         );
         if (!newAlertIsDuplicate) {
-          draftState.alerts = [...state.alerts, { ...action.payload, id: newID }];
+          draftState.alerts = [...state.alerts, { ...action.payload, id: nanoid() }];
         }
       } else if (Alerts.deleteOne.match(action)) {
-        draftState.alerts = state.alerts.filter((alert) => alert.id !== action.payload.id);
+        draftState.alerts = filterDuplicates('id', action.payload.id, state.alerts);
       } else if (Alerts.deleteAll.match(action)) {
         draftState.alerts = [];
       } else if (Prompt.closeOne.match(action)) {
+        draftState.prompts = filterDuplicates('id', action.payload.id, state.prompts);
         draftState.prompts = state.prompts.filter((prompt) => prompt.id !== action.payload.id);
       } else if (Prompt.closeAll.match(action)) {
         draftState.prompts = [];
       } else if (RegExp(Prompt.NEW_PROMPT).exec(action.type)) {
         const newPrompt: PromptAction = action.payload;
-        const newID = nanoid();
-        draftState.prompts = [...state.prompts, { ...newPrompt, id: newID }];
+        draftState.prompts = [...state.prompts, { ...newPrompt, id: nanoid() }];
+      } else if (RecordCache.requestCaching.fulfilled.match(action)) {
+        draftState.alerts = [...state.alerts, { ...cacheAlertMessages.recordsetCacheSuccess, id: nanoid() }];
+      } else if (RecordCache.requestCaching.rejected.match(action)) {
+        draftState.alerts = [...state.alerts, { ...cacheAlertMessages.recordsetCacheFailed, id: nanoid() }];
+      } else if (RecordCache.deleteCache.rejected.match(action)) {
+        draftState.alerts = [...state.alerts, { ...cacheAlertMessages.recordsetDeleteCacheFailed, id: nanoid() }];
+      } else if (RecordCache.deleteCache.fulfilled.match(action)) {
+        draftState.alerts = [...state.alerts, { ...cacheAlertMessages.recordsetDeleteCacheSuccess, id: nanoid() }];
       }
     });
   };


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Combined functionality of the Delete/Download buttons for Recordset caching
    - Uses context of cache status to determine download / delete, reducing bloat and confusion in iconography
        - Closes #3679 
    - Prompts user confirmation before performing action
    - Don't render the option when Recordset is IAPP
    - Format the enum values for Recordset status' to be more user friendly without compromising existing cache statuses. 
        - Closes #3681 

- Communications
    - Add Alerts for cache related subjects
    - Hook into Success/Fail cache actions to give alerts to user when actions finish/fail 

## Screenshots

Download Record Prompt (Delete one nearly identical)
![image](https://github.com/user-attachments/assets/eead23fa-ae96-4eb0-a1d1-b2efcc902770)

Cached Buttons no longer have Underscores, NOT_CACHED prompt now 'SAVE'
![image](https://github.com/user-attachments/assets/86d3ce1f-f53a-44c6-be71-892184eda0b9)

Example Alert
![image](https://github.com/user-attachments/assets/0147a968-d74c-4128-a33e-20b0d00d3a29)
