### PR TITLE
[INV-3687] PMP Validation

### DIFF
--- a/app/src/UI/Overlay/Records/Activity/form/FormContainer.tsx
+++ b/app/src/UI/Overlay/Records/Activity/form/FormContainer.tsx
@@ -87,7 +87,9 @@ const FormContainer = () => {
   const rjsfThemeLight = createTheme(rjsfTheme as ThemeOptions);
 
   useEffect(() => {
-    formRef.current?.validateForm();
+    if (isActivityChemTreatment()) {
+      formRef.current?.validateForm();
+    }
     const currentState = formRef.current?.state;
     dispatch({ type: ACTIVITY_ERRORS, payload: { errors: currentState?.errors } });
   }, [formRef]);

--- a/app/src/UI/Overlay/Records/Activity/form/FormContainer.tsx
+++ b/app/src/UI/Overlay/Records/Activity/form/FormContainer.tsx
@@ -87,6 +87,7 @@ const FormContainer = () => {
   const rjsfThemeLight = createTheme(rjsfTheme as ThemeOptions);
 
   useEffect(() => {
+    formRef.current?.validateForm();
     const currentState = formRef.current?.state;
     dispatch({ type: ACTIVITY_ERRORS, payload: { errors: currentState?.errors } });
   }, [formRef]);
@@ -98,7 +99,7 @@ const FormContainer = () => {
   const ErrorListTemplate = (err: { errors?: unknown[] }) => {
     return (
       <>
-        {(err.errors?.length || 0) > 0 && (
+        {(err.errors?.length ?? 0) > 0 && (
           <div>
             <Typography color="error" sx={{ mt: 8, mb: 4 }}>
               Red text indicates mandatory entry in order to go from a status of Draft to Submitted. You can however
@@ -118,7 +119,7 @@ const FormContainer = () => {
     return <CircularProgress />;
   }
   return (
-    <Box sx={{ pl: '15%', pr: '15%' }}>
+    <Box sx={{ px: '15%' }}>
       <ThemeProvider theme={darkTheme ? rjsfThemeDark : rjsfThemeLight}>
         <SelectAutoCompleteContextProvider>
           {!createdByUser && userIsAdmin && (
@@ -147,6 +148,7 @@ const FormContainer = () => {
             formData={formDataState}
             schema={activitySchema}
             uiSchema={activityUISchema}
+            onError={() => {}}
             liveValidate={true}
             customValidate={customValidators()}
             validator={validator}

--- a/app/src/rjsf/business-rules/customErrorTransformer.ts
+++ b/app/src/rjsf/business-rules/customErrorTransformer.ts
@@ -2,46 +2,29 @@
 
 /**
  * Returns a custom error transformer.
- *
- * @return {*}
  */
 export const getCustomErrorTransformer = () => {
-  return (errors: any[]) => {
-    return errors.filter((error) => {
+  const errorMessages = [
+    'should be equal to one of the allowed values',
+    'should match "then" schema',
+    'should match exactly one schema in oneOf',
+    'should match some schema in anyOf',
+    'must match exactly one schema in oneOf',
+    'must be equal to one of the allowed values'
+  ];
+  return (errors: any[]) =>
+    errors.filter((error) => {
       if (error.message.includes('must have required property')) {
         error.message = 'is a required field';
         return error;
       }
-
-      if (error.message === 'should be equal to one of the allowed values') {
+      if (errorMessages.includes(error.message)) {
         return false;
       }
-
-      if (error.message === 'should match "then" schema') {
-        return false;
-      }
-
-      if (error.message === 'should match exactly one schema in oneOf') {
-        return false;
-      }
-
-      if (error.message === 'should match some schema in anyOf') {
-        return false;
-      }
-      if (error.message === 'must match exactly one schema in oneOf') {
-        return false;
-      }
-
-      if (error.message === 'must be equal to one of the allowed values') {
-        return false;
-      }
-
       if (error.message === 'should match pattern "[A-Za-z -]+"') {
         error.message = 'Only letters are allowed';
         return error;
       }
-
       return true;
     });
-  };
 };

--- a/app/src/rjsf/widgets/SingleSelectAutoComplete.tsx
+++ b/app/src/rjsf/widgets/SingleSelectAutoComplete.tsx
@@ -131,7 +131,7 @@ const SingleSelectAutoComplete = (props: WidgetProps) => {
         if (reason === 'clear') {
           // NOTE: currently disabled.
           setValue(null);
-          props.onChange(null);
+          props.onChange(undefined);
         } else {
           setValue(option);
           props.onChange(option.value ?? option);


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

> [!IMPORTANT]
> This fix is symptomatic of a larger issue with re-rendering not working properly for `props.rawErrors`in the custom validation. 
> When the rawErrors array is updated, the FieldTemplates are not re-rendering as expected. However, since most errors are self-contained, the change events trigger a re-render of the component, which resolves the issue. This behavior doesn't apply to the `PMP not in dropdown` and `Pest Management Plans` inputs, as these are independent from each other but share a custom validation rule. So when the error is removed, a re-render is not created.

## Smaller Fixes
- Fixed issue in SingleSelectAutoComplete, where non-responses need to be `undefined` and not `null`. this triggers `must be a string` errors when user deletes an input
- Reduce `customErrorTransformer` to be more DRY and readable

## FormContainer.tsx

- Flip padding to `x` instead of explicit left/right
- manually call `validateForm()` in the useEffect when we are doing a Chemical Treatment form 
    - The useEffect is fired by the debounced function, so this won't produce `n` validation checks where `n` is keystrokes 
    - When we use `liveValidate()`, nothing gets logged because its an implicit action. Opposite of this, when we explicitly perform `validateForm()` Rjsf fires a console.error containing the validation errors
        - We can override handling of `validateForm()` by adding the `onError` prop to `<Form>`, eliminating the logs.

Closes #3687 
Ticket #3706 created to address the overarching Render concerns
