### PR TITLE
Fix for the Map-Exporter cron job failure

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -12,7 +12,7 @@
     "pre-commit": "lint-staged",
     "dev": "nodemon --exec 'tsx' src/server --watch ../sharedAPI --watch .",
     "start": "tsx src/server",
-    "export-map": "ts-node src/map-exporter",
+    "export-map": "tsx src/map-exporter",
     "export-geojson": "ts-node src/geojson-exporter",
     "test": "NODE_OPTIONS='--import tsx' mocha \"./src/tests/**/*.test.ts\" --timeout 10000",
     "lint": "eslint",


### PR DESCRIPTION
# Overview
Fix to run the `export-map` cron job 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change