### PR TITLE
[INV-3715] Implement Heartbeat monitoring for network connectivity

### DIFF
--- a/app/src/UI/Header/Header.tsx
+++ b/app/src/UI/Header/Header.tsx
@@ -377,7 +377,7 @@ const LoginOrOutMemo = React.memo(() => {
 
 const NetworkStateControl: React.FC = () => {
   const handleNetworkStateChange = () => {
-    dispatch(connected ? NetworkActions.offline() : NetworkActions.checkMobileNetworkStatus());
+    dispatch(connected ? NetworkActions.offline() : NetworkActions.manualReconnect());
   };
   const { connected } = useSelector((state) => state.Network);
   const dispatch = useDispatch();

--- a/app/src/UI/Header/Header.tsx
+++ b/app/src/UI/Header/Header.tsx
@@ -377,7 +377,7 @@ const LoginOrOutMemo = React.memo(() => {
 
 const NetworkStateControl: React.FC = () => {
   const handleNetworkStateChange = () => {
-    dispatch(connected ? NetworkActions.offline() : NetworkActions.online());
+    dispatch(connected ? NetworkActions.offline() : NetworkActions.checkMobileNetworkStatus());
   };
   const { connected } = useSelector((state) => state.Network);
   const dispatch = useDispatch();

--- a/app/src/UI/Header/Header.tsx
+++ b/app/src/UI/Header/Header.tsx
@@ -377,9 +377,9 @@ const LoginOrOutMemo = React.memo(() => {
 
 const NetworkStateControl: React.FC = () => {
   const handleNetworkStateChange = () => {
-    dispatch(connected ? NetworkActions.offline() : NetworkActions.manualReconnect());
+    dispatch(connected ? NetworkActions.setAdministrativeStatus(false) : NetworkActions.manualReconnect());
   };
-  const { connected } = useSelector((state) => state.Network);
+  const connected = useSelector((state) => state.Network.connected);
   const dispatch = useDispatch();
   return (
     <div className={'network-state-control'}>

--- a/app/src/constants/alerts/networkAlerts.ts
+++ b/app/src/constants/alerts/networkAlerts.ts
@@ -30,6 +30,12 @@ const networkAlertMessages: Record<string, AlertMessage> = {
     severity: AlertSeverity.Error,
     subject: AlertSubjects.Network,
     autoClose: 10
+  },
+  automaticReconnectFailed: {
+    content: 'We were unable to bring you back online. Please try again later.',
+    severity: AlertSeverity.Error,
+    subject: AlertSubjects.Network,
+    autoClose: 10
   }
 };
 

--- a/app/src/constants/misc.ts
+++ b/app/src/constants/misc.ts
@@ -11,3 +11,5 @@ export const MediumDateTimeFormat = 'MMMM D, YYYY, H:mm a'; //January 5, 2020, 3
 export const LongDateFormat = 'dddd, MMMM D, YYYY, H:mm a'; //Monday, January 5, 2020, 3:30 pm
 
 export const LongDateTimeFormat = 'dddd, MMMM D, YYYY, H:mm a'; //Monday, January 5, 2020, 3:30 pm
+
+export const HEALTH_ENDPOINT = '/api/misc/version';

--- a/app/src/state/actions/network/NetworkActions.ts
+++ b/app/src/state/actions/network/NetworkActions.ts
@@ -9,7 +9,7 @@ class NetworkActions {
     (cancel: boolean = false) => ({ payload: cancel })
   );
   static readonly userLostConnection = createAction(`${this.PREFIX}/userLostConnection`);
-  static readonly attemptToReconnectFailed = createAction(`${this.PREFIX}/attemptToReconnectFailed`);
+  static readonly manualReconnect = createAction(`${this.PREFIX}/manualReconnect`);
   static readonly automaticReconnectFailed = createAction(`${this.PREFIX}/automaticReconnectFailed`);
   static readonly checkInitConnection = createAction(`${this.PREFIX}/checkInitConnection`);
 }

--- a/app/src/state/actions/network/NetworkActions.ts
+++ b/app/src/state/actions/network/NetworkActions.ts
@@ -2,8 +2,9 @@ import { createAction } from '@reduxjs/toolkit';
 
 class NetworkActions {
   private static readonly PREFIX = 'NetworkActions';
-
   static readonly online = createAction(`${this.PREFIX}/online`);
   static readonly offline = createAction(`${this.PREFIX}/offline`);
+  static readonly checkMobileNetworkStatus = createAction(`${this.PREFIX}/checkMobileNetworkStatus`);
+  static readonly userLostConnection = createAction(`${this.PREFIX}/userLostConnection`);
 }
 export default NetworkActions;

--- a/app/src/state/actions/network/NetworkActions.ts
+++ b/app/src/state/actions/network/NetworkActions.ts
@@ -4,7 +4,13 @@ class NetworkActions {
   private static readonly PREFIX = 'NetworkActions';
   static readonly online = createAction(`${this.PREFIX}/online`);
   static readonly offline = createAction(`${this.PREFIX}/offline`);
-  static readonly checkMobileNetworkStatus = createAction(`${this.PREFIX}/checkMobileNetworkStatus`);
+  static readonly checkMobileNetworkStatus = createAction(
+    `${this.PREFIX}/checkMobileNetworkStatus`,
+    (cancel: boolean = false) => ({ payload: cancel })
+  );
   static readonly userLostConnection = createAction(`${this.PREFIX}/userLostConnection`);
+  static readonly attemptToReconnectFailed = createAction(`${this.PREFIX}/attemptToReconnectFailed`);
+  static readonly automaticReconnectFailed = createAction(`${this.PREFIX}/automaticReconnectFailed`);
+  static readonly checkInitConnection = createAction(`${this.PREFIX}/checkInitConnection`);
 }
 export default NetworkActions;

--- a/app/src/state/actions/network/NetworkActions.ts
+++ b/app/src/state/actions/network/NetworkActions.ts
@@ -4,13 +4,15 @@ class NetworkActions {
   private static readonly PREFIX = 'NetworkActions';
   static readonly online = createAction(`${this.PREFIX}/online`);
   static readonly offline = createAction(`${this.PREFIX}/offline`);
-  static readonly checkMobileNetworkStatus = createAction(
-    `${this.PREFIX}/checkMobileNetworkStatus`,
-    (cancel: boolean = false) => ({ payload: cancel })
-  );
+  static readonly monitorHeartbeat = createAction(`${this.PREFIX}/monitorHeartbeat`, (cancel: boolean = false) => ({
+    payload: cancel
+  }));
   static readonly userLostConnection = createAction(`${this.PREFIX}/userLostConnection`);
   static readonly manualReconnect = createAction(`${this.PREFIX}/manualReconnect`);
   static readonly automaticReconnectFailed = createAction(`${this.PREFIX}/automaticReconnectFailed`);
   static readonly checkInitConnection = createAction(`${this.PREFIX}/checkInitConnection`);
+  static readonly setAdministrativeStatus = createAction<boolean>(`${this.PREFIX}/toggleAdministrativeStatus`);
+  static readonly setOperationalStatus = createAction<boolean>(`${this.PREFIX}/setOperationalStatus`);
+  static readonly updateConnectionStatus = createAction<boolean>(`${this.PREFIX}/updateConnectionStatus`);
 }
 export default NetworkActions;

--- a/app/src/state/reducers/alertsAndPrompts.ts
+++ b/app/src/state/reducers/alertsAndPrompts.ts
@@ -6,8 +6,6 @@ import Prompt from 'state/actions/prompts/Prompt';
 import { PromptAction } from 'interfaces/prompt-interfaces';
 import RecordCache from 'state/actions/cache/RecordCache';
 import cacheAlertMessages from 'constants/alerts/cacheAlerts';
-import NetworkActions from 'state/actions/network/NetworkActions';
-import networkAlertMessages from 'constants/alerts/networkAlerts';
 
 interface AlertsAndPromptsState {
   alerts: AlertMessage[];

--- a/app/src/state/reducers/alertsAndPrompts.ts
+++ b/app/src/state/reducers/alertsAndPrompts.ts
@@ -6,6 +6,8 @@ import Prompt from 'state/actions/prompts/Prompt';
 import { PromptAction } from 'interfaces/prompt-interfaces';
 import RecordCache from 'state/actions/cache/RecordCache';
 import cacheAlertMessages from 'constants/alerts/cacheAlerts';
+import NetworkActions from 'state/actions/network/NetworkActions';
+import networkAlertMessages from 'constants/alerts/networkAlerts';
 
 interface AlertsAndPromptsState {
   alerts: AlertMessage[];
@@ -19,6 +21,12 @@ const initialState: AlertsAndPromptsState = {
 
 const filterDuplicates = (key: keyof AlertMessage, matchValue: any, state: AlertMessage[]): any[] =>
   state.filter((entry) => entry[key] !== matchValue);
+
+const addAlert = (state: AlertMessage[], alert: AlertMessage): AlertMessage[] => [...state, { ...alert, id: nanoid() }];
+const addPrompt = (state: PromptAction[], prompt: PromptAction): PromptAction[] => [
+  ...state,
+  { ...prompt, id: nanoid() }
+];
 
 export function createAlertsAndPromptsReducer(
   configuration: AppConfig
@@ -43,15 +51,15 @@ export function createAlertsAndPromptsReducer(
         draftState.prompts = [];
       } else if (RegExp(Prompt.NEW_PROMPT).exec(action.type)) {
         const newPrompt: PromptAction = action.payload;
-        draftState.prompts = [...state.prompts, { ...newPrompt, id: nanoid() }];
+        draftState.prompts = addPrompt(state.prompts, newPrompt);
       } else if (RecordCache.requestCaching.fulfilled.match(action)) {
-        draftState.alerts = [...state.alerts, { ...cacheAlertMessages.recordsetCacheSuccess, id: nanoid() }];
+        draftState.alerts = addAlert(state.alerts, cacheAlertMessages.recordsetCacheSuccess);
       } else if (RecordCache.requestCaching.rejected.match(action)) {
-        draftState.alerts = [...state.alerts, { ...cacheAlertMessages.recordsetCacheFailed, id: nanoid() }];
+        draftState.alerts = addAlert(state.alerts, cacheAlertMessages.recordsetCacheFailed);
       } else if (RecordCache.deleteCache.rejected.match(action)) {
-        draftState.alerts = [...state.alerts, { ...cacheAlertMessages.recordsetDeleteCacheFailed, id: nanoid() }];
+        draftState.alerts = addAlert(state.alerts, cacheAlertMessages.recordsetDeleteCacheFailed);
       } else if (RecordCache.deleteCache.fulfilled.match(action)) {
-        draftState.alerts = [...state.alerts, { ...cacheAlertMessages.recordsetDeleteCacheSuccess, id: nanoid() }];
+        draftState.alerts = addAlert(state.alerts, cacheAlertMessages.recordsetDeleteCacheSuccess);
       }
     });
   };

--- a/app/src/state/reducers/network.ts
+++ b/app/src/state/reducers/network.ts
@@ -15,7 +15,7 @@ function createNetworkReducer(initialStatus: Network) {
     return createNextState(state, (draftState: Draft<Network>) => {
       if (NetworkActions.online.match(action)) {
         draftState.connected = true;
-      } else if (NetworkActions.offline.match(action)) {
+      } else if (NetworkActions.offline.match(action) || NetworkActions.userLostConnection.match(action)) {
         draftState.connected = false;
       }
     });

--- a/app/src/state/reducers/network.ts
+++ b/app/src/state/reducers/network.ts
@@ -2,20 +2,45 @@ import { createNextState } from '@reduxjs/toolkit';
 import { Draft } from 'immer';
 import NetworkActions from 'state/actions/network/NetworkActions';
 
-interface Network {
+const HEARTBEATS_TO_FAILURE = 4;
+
+/**
+ * @desc Network State properties
+ * @property { boolean } administrativeStatus user opt-in status for connecting to network
+ * @property { boolean } connected Combination variable for User wanting network connection, and connection being available
+ * @property { number }  consecutiveHeartbeatFailures current number of concurrent failed health checks
+ * @property { boolean } operationalStatus status of connection to the API
+ */
+export interface NetworkState {
+  administrativeStatus: boolean;
   connected: boolean;
+  consecutiveHeartbeatFailures: number;
+  operationalStatus: boolean;
 }
 
-function createNetworkReducer(initialStatus: Network) {
-  const initialState: Network = {
-    ...initialStatus
-  };
+const initialState: NetworkState = {
+  administrativeStatus: true,
+  connected: true,
+  consecutiveHeartbeatFailures: 0,
+  operationalStatus: true
+};
 
+function createNetworkReducer() {
   return (state = initialState, action) => {
-    return createNextState(state, (draftState: Draft<Network>) => {
-      if (NetworkActions.online.match(action)) {
+    return createNextState(state, (draftState: Draft<NetworkState>) => {
+      if (NetworkActions.setAdministrativeStatus.match(action)) {
+        draftState.administrativeStatus = action.payload;
+        draftState.consecutiveHeartbeatFailures = HEARTBEATS_TO_FAILURE;
+      } else if (NetworkActions.updateConnectionStatus.match(action)) {
+        if (action.payload) {
+          draftState.consecutiveHeartbeatFailures = 0;
+        } else {
+          draftState.consecutiveHeartbeatFailures++;
+        }
+        draftState.operationalStatus = draftState.consecutiveHeartbeatFailures < HEARTBEATS_TO_FAILURE;
+      } else if (NetworkActions.online.match(action)) {
         draftState.connected = true;
-      } else if (NetworkActions.offline.match(action) || NetworkActions.userLostConnection.match(action)) {
+      } else if (NetworkActions.offline.match(action)) {
         draftState.connected = false;
       }
     });
@@ -23,5 +48,5 @@ function createNetworkReducer(initialStatus: Network) {
 }
 
 const selectNetworkConnected: (state) => boolean = (state) => state.Network.connected;
-
-export { selectNetworkConnected, createNetworkReducer };
+const selectNetworkState: (state) => NetworkState = (state) => state.Network;
+export { createNetworkReducer, selectNetworkConnected, selectNetworkState };

--- a/app/src/state/reducers/rootReducer.ts
+++ b/app/src/state/reducers/rootReducer.ts
@@ -14,7 +14,7 @@ import { createTrainingVideosReducer } from './training_videos';
 import { createUserSettingsReducer, UserSettingsState } from './userSettings';
 import { createIAPPSiteReducer } from './iappsite';
 import { createConfigurationReducerWithDefaultState } from './configuration';
-import { createNetworkReducer } from './network';
+import { createNetworkReducer, NetworkState } from './network';
 import { createUserInfoReducer } from './userInfo';
 import { errorHandlerReducer } from './error_handler';
 import { createOfflineActivityReducer, OfflineActivityState } from './offlineActivity';
@@ -65,7 +65,15 @@ function createRootReducer(config: AppConfig) {
       createAuthReducer(config)
     ),
     UserInfo: createUserInfoReducer({ loaded: false, accessRequested: false, activated: false }),
-    Network: createNetworkReducer({ connected: true }),
+    Network: persistReducer<NetworkState>(
+      {
+        key: 'network',
+        storage: platformStorage,
+        stateReconciler: autoMergeLevel1,
+        whitelist: ['connected', 'administrativeStatus', 'operationalStatus']
+      },
+      createNetworkReducer()
+    ),
     ActivityPage: persistReducer<ActivityState>(
       {
         key: 'activity',

--- a/app/src/state/sagas/network.ts
+++ b/app/src/state/sagas/network.ts
@@ -1,7 +1,11 @@
 import networkAlertMessages from 'constants/alerts/networkAlerts';
+import { HEALTH_ENDPOINT } from 'constants/misc';
 import { all, put, select, takeEvery } from 'redux-saga/effects';
 import Alerts from 'state/actions/alerts/Alerts';
 import NetworkActions from 'state/actions/network/NetworkActions';
+import { MOBILE } from 'state/build-time-config';
+import { selectConfiguration } from 'state/reducers/configuration';
+import { selectNetworkConnected } from 'state/reducers/network';
 import { OfflineActivitySyncState, selectOfflineActivity } from 'state/reducers/offlineActivity';
 
 function* handle_NETWORK_GO_OFFLINE() {
@@ -20,10 +24,33 @@ function* handle_NETWORK_GO_ONLINE() {
   }
 }
 
+function* handle_CHECK_MOBILE_NETWORK_STATUS() {
+  if (!MOBILE) {
+    return;
+  }
+  const currentOnlineStatus = yield select(selectNetworkConnected);
+  const configuration = yield select(selectConfiguration);
+
+  const networkCheckPassed = yield fetch(configuration.API_BASE + HEALTH_ENDPOINT)
+    .then((res) => res.status === 200)
+    .catch(() => false);
+
+  if (!networkCheckPassed && !currentOnlineStatus) {
+    yield put(Alerts.create(networkAlertMessages.attemptToReconnectFailed));
+  } else if (!networkCheckPassed) {
+    yield put(NetworkActions.userLostConnection());
+    yield put(Alerts.create(networkAlertMessages.userLostConnection));
+  } else if (networkCheckPassed && !currentOnlineStatus) {
+    // Only fire online event if we are not already online
+    yield put(NetworkActions.online());
+  }
+}
+
 function* networkSaga() {
   yield all([
     takeEvery(NetworkActions.offline, handle_NETWORK_GO_OFFLINE),
-    takeEvery(NetworkActions.online, handle_NETWORK_GO_ONLINE)
+    takeEvery(NetworkActions.online, handle_NETWORK_GO_ONLINE),
+    takeEvery(NetworkActions.checkMobileNetworkStatus, handle_CHECK_MOBILE_NETWORK_STATUS)
   ]);
 }
 

--- a/app/src/state/sagas/network.ts
+++ b/app/src/state/sagas/network.ts
@@ -6,13 +6,19 @@ import Alerts from 'state/actions/alerts/Alerts';
 import NetworkActions from 'state/actions/network/NetworkActions';
 import { MOBILE } from 'state/build-time-config';
 import { selectConfiguration } from 'state/reducers/configuration';
-import { selectNetworkConnected } from 'state/reducers/network';
 import { OfflineActivitySyncState, selectOfflineActivity } from 'state/reducers/offlineActivity';
 
-function* handle_ATTEMPT_TO_RECONNECT_FAILED() {
-  yield put(Alerts.create(networkAlertMessages.attemptToReconnectFailed));
+/**
+ * @desc Handler for a Manual Reconnect attempt by user
+ */
+function* handle_MANUAL_RECONNECT() {
+  const configuration = yield select(selectConfiguration);
+  if (yield canConnectToNetwork(configuration.API_BASE + HEALTH_ENDPOINT)) {
+    yield put(NetworkActions.online());
+  } else {
+    yield put(Alerts.create(networkAlertMessages.attemptToReconnectFailed));
+  }
 }
-
 function* handle_AUTOMATIC_RECONNECT_FAILED() {
   yield put(Alerts.create(networkAlertMessages.automaticReconnectFailed));
 }
@@ -31,14 +37,13 @@ function* handle_CHECK_MOBILE_NETWORK_STATUS(cancel: PayloadAction<boolean>) {
   const SECONDS_BETWEEN_ATTEMPTS = 5;
 
   while (true) {
-    const currentOnlineStatus = yield select(selectNetworkConnected);
     const configuration = yield select(selectConfiguration);
     let attempts: number = 0;
-    let networkCheckPassed: boolean = false;
+    let canConnect: boolean = false;
 
     do {
-      networkCheckPassed = yield canConnectToNetwork(configuration.API_BASE + HEALTH_ENDPOINT);
-      if (!networkCheckPassed) {
+      canConnect = yield canConnectToNetwork(configuration.API_BASE + HEALTH_ENDPOINT);
+      if (!canConnect) {
         attempts++;
         yield delay(SECONDS_BETWEEN_ATTEMPTS * 1000);
       }
@@ -46,16 +51,11 @@ function* handle_CHECK_MOBILE_NETWORK_STATUS(cancel: PayloadAction<boolean>) {
       if (yield cancelled()) {
         return;
       }
-    } while (!networkCheckPassed && attempts < MAX_ATTEMPTS);
+    } while (!canConnect && attempts < MAX_ATTEMPTS);
 
-    if (!networkCheckPassed && !currentOnlineStatus) {
-      yield put(NetworkActions.attemptToReconnectFailed());
-    } else if (!networkCheckPassed) {
+    if (!canConnect) {
       yield put(NetworkActions.userLostConnection());
       return;
-    } else if (networkCheckPassed && !currentOnlineStatus) {
-      // Only fire online event if we are not already online
-      yield put(NetworkActions.online());
     }
     yield delay(SECONDS_BETWEEN_CHECKS * 1000);
   }
@@ -68,7 +68,7 @@ function* handle_CHECK_MOBILE_NETWORK_STATUS(cancel: PayloadAction<boolean>) {
  */
 const canConnectToNetwork = async (url: string): Promise<boolean> => {
   return await fetch(url)
-    .then((res) => res.status === 200)
+    .then((res) => res.ok)
     .catch(() => false);
 };
 
@@ -115,25 +115,25 @@ function* handle_NETWORK_GO_ONLINE() {
  * @desc Attempt to establish connection with the API. Abandons after ~3 minutes of disconnection.
  *       When this event fires, it cancels the rolling API checks
  */
-function* handle_USER_LOST_CONNECTION() {
+function* handle_ATTEMPT_AUTOMATIC_RECONNECT() {
   const MAX_RECONNECT_ATTEMPTS = 18;
   const SECONDS_BETWEEN_ATTEMPTS = 10;
 
   const configuration = yield select(selectConfiguration);
-  let attempts: number = 0;
-  let networkCheckPassed: boolean = false;
+  let attempts = 0;
+  let canReconnect: boolean;
 
   yield put(Alerts.create(networkAlertMessages.userLostConnection));
 
   do {
-    networkCheckPassed = yield canConnectToNetwork(configuration.API_BASE + HEALTH_ENDPOINT);
-    if (!networkCheckPassed) {
+    canReconnect = yield canConnectToNetwork(configuration.API_BASE + HEALTH_ENDPOINT);
+    if (!canReconnect) {
       attempts++;
       yield delay(SECONDS_BETWEEN_ATTEMPTS * 1000);
     }
-  } while (!networkCheckPassed && attempts < MAX_RECONNECT_ATTEMPTS);
+  } while (!canReconnect && attempts < MAX_RECONNECT_ATTEMPTS);
 
-  if (networkCheckPassed) {
+  if (canReconnect) {
     yield put(NetworkActions.online());
   } else {
     yield put(NetworkActions.automaticReconnectFailed());
@@ -142,13 +142,13 @@ function* handle_USER_LOST_CONNECTION() {
 
 function* networkSaga() {
   yield all([
-    takeEvery(NetworkActions.attemptToReconnectFailed, handle_ATTEMPT_TO_RECONNECT_FAILED),
+    takeEvery(NetworkActions.manualReconnect, handle_MANUAL_RECONNECT),
     takeEvery(NetworkActions.automaticReconnectFailed, handle_AUTOMATIC_RECONNECT_FAILED),
     takeEvery(NetworkActions.checkInitConnection, handle_CHECK_INIT_CONNECTION),
     takeLatest(NetworkActions.checkMobileNetworkStatus, handle_CHECK_MOBILE_NETWORK_STATUS),
     takeEvery(NetworkActions.offline, handle_NETWORK_GO_OFFLINE),
     takeEvery(NetworkActions.online, handle_NETWORK_GO_ONLINE),
-    takeLatest(NetworkActions.userLostConnection, handle_USER_LOST_CONNECTION)
+    takeLatest(NetworkActions.userLostConnection, handle_ATTEMPT_AUTOMATIC_RECONNECT)
   ]);
 }
 

--- a/app/src/state/sagas/network.ts
+++ b/app/src/state/sagas/network.ts
@@ -1,6 +1,7 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+import { all, cancelled, delay, put, select, takeEvery, takeLatest } from 'redux-saga/effects';
 import networkAlertMessages from 'constants/alerts/networkAlerts';
 import { HEALTH_ENDPOINT } from 'constants/misc';
-import { all, put, select, takeEvery } from 'redux-saga/effects';
 import Alerts from 'state/actions/alerts/Alerts';
 import NetworkActions from 'state/actions/network/NetworkActions';
 import { MOBILE } from 'state/build-time-config';
@@ -8,10 +9,95 @@ import { selectConfiguration } from 'state/reducers/configuration';
 import { selectNetworkConnected } from 'state/reducers/network';
 import { OfflineActivitySyncState, selectOfflineActivity } from 'state/reducers/offlineActivity';
 
-function* handle_NETWORK_GO_OFFLINE() {
-  yield put(Alerts.create(networkAlertMessages.userWentOffline));
+function* handle_ATTEMPT_TO_RECONNECT_FAILED() {
+  yield put(Alerts.create(networkAlertMessages.attemptToReconnectFailed));
 }
 
+function* handle_AUTOMATIC_RECONNECT_FAILED() {
+  yield put(Alerts.create(networkAlertMessages.automaticReconnectFailed));
+}
+
+/**
+ * @desc Rolling function that targets the API to determine our online status.
+ *       On failure to reach the API, attempts up to 5 times before determining we cannot proceed
+ *       In event of this, disconnect the user and alert them of the incident.
+ */
+function* handle_CHECK_MOBILE_NETWORK_STATUS(cancel: PayloadAction<boolean>) {
+  if (!MOBILE || cancel.payload) {
+    return;
+  }
+  const MAX_ATTEMPTS = 5;
+  const SECONDS_BETWEEN_CHECKS = 20;
+  const SECONDS_BETWEEN_ATTEMPTS = 5;
+
+  while (true) {
+    const currentOnlineStatus = yield select(selectNetworkConnected);
+    const configuration = yield select(selectConfiguration);
+    let attempts: number = 0;
+    let networkCheckPassed: boolean = false;
+
+    do {
+      networkCheckPassed = yield canConnectToNetwork(configuration.API_BASE + HEALTH_ENDPOINT);
+      if (!networkCheckPassed) {
+        attempts++;
+        yield delay(SECONDS_BETWEEN_ATTEMPTS * 1000);
+      }
+
+      if (yield cancelled()) {
+        return;
+      }
+    } while (!networkCheckPassed && attempts < MAX_ATTEMPTS);
+
+    if (!networkCheckPassed && !currentOnlineStatus) {
+      yield put(NetworkActions.attemptToReconnectFailed());
+    } else if (!networkCheckPassed) {
+      yield put(NetworkActions.userLostConnection());
+      return;
+    } else if (networkCheckPassed && !currentOnlineStatus) {
+      // Only fire online event if we are not already online
+      yield put(NetworkActions.online());
+    }
+    yield delay(SECONDS_BETWEEN_CHECKS * 1000);
+  }
+}
+
+/**
+ * @desc Targets the API and checks for successful response.
+ * @param url Path to API Health check
+ * @returns Connection to API Succeeded
+ */
+const canConnectToNetwork = async (url: string): Promise<boolean> => {
+  return await fetch(url)
+    .then((res) => res.status === 200)
+    .catch(() => false);
+};
+
+/**
+ * Initial Network Connectivity Check, determines to begin application online or offline
+ */
+function* handle_CHECK_INIT_CONNECTION() {
+  if (!MOBILE) {
+    return;
+  }
+  const configuration = yield select(selectConfiguration);
+  if (yield canConnectToNetwork(configuration.API_BASE + HEALTH_ENDPOINT)) {
+    yield put(NetworkActions.online());
+  } else {
+    yield put(NetworkActions.offline());
+  }
+}
+/**
+ * @desc Handler for User manually going offline. Fires a cancellation event to stop rolling api checks.
+ */
+function* handle_NETWORK_GO_OFFLINE() {
+  yield put(Alerts.create(networkAlertMessages.userWentOffline));
+  yield put(NetworkActions.checkMobileNetworkStatus(true));
+}
+
+/**
+ * @desc When user comes online, check for any existing unsychronized Activities.
+ *       Restart the rolling Network status checks.
+ */
 function* handle_NETWORK_GO_ONLINE() {
   const { serializedActivities } = yield select(selectOfflineActivity);
   const userHasUnsynchronizedActivities = Object.keys(serializedActivities).some(
@@ -22,35 +108,47 @@ function* handle_NETWORK_GO_ONLINE() {
   } else {
     yield put(Alerts.create(networkAlertMessages.userWentOnline));
   }
+  yield put(NetworkActions.checkMobileNetworkStatus());
 }
 
-function* handle_CHECK_MOBILE_NETWORK_STATUS() {
-  if (!MOBILE) {
-    return;
-  }
-  const currentOnlineStatus = yield select(selectNetworkConnected);
+/**
+ * @desc Attempt to establish connection with the API. Abandons after ~3 minutes of disconnection.
+ *       When this event fires, it cancels the rolling API checks
+ */
+function* handle_USER_LOST_CONNECTION() {
+  const MAX_RECONNECT_ATTEMPTS = 18;
+  const SECONDS_BETWEEN_ATTEMPTS = 10;
+
   const configuration = yield select(selectConfiguration);
+  let attempts: number = 0;
+  let networkCheckPassed: boolean = false;
 
-  const networkCheckPassed = yield fetch(configuration.API_BASE + HEALTH_ENDPOINT)
-    .then((res) => res.status === 200)
-    .catch(() => false);
+  yield put(Alerts.create(networkAlertMessages.userLostConnection));
 
-  if (!networkCheckPassed && !currentOnlineStatus) {
-    yield put(Alerts.create(networkAlertMessages.attemptToReconnectFailed));
-  } else if (!networkCheckPassed) {
-    yield put(NetworkActions.userLostConnection());
-    yield put(Alerts.create(networkAlertMessages.userLostConnection));
-  } else if (networkCheckPassed && !currentOnlineStatus) {
-    // Only fire online event if we are not already online
+  do {
+    networkCheckPassed = yield canConnectToNetwork(configuration.API_BASE + HEALTH_ENDPOINT);
+    if (!networkCheckPassed) {
+      attempts++;
+      yield delay(SECONDS_BETWEEN_ATTEMPTS * 1000);
+    }
+  } while (!networkCheckPassed && attempts < MAX_RECONNECT_ATTEMPTS);
+
+  if (networkCheckPassed) {
     yield put(NetworkActions.online());
+  } else {
+    yield put(NetworkActions.automaticReconnectFailed());
   }
 }
 
 function* networkSaga() {
   yield all([
+    takeEvery(NetworkActions.attemptToReconnectFailed, handle_ATTEMPT_TO_RECONNECT_FAILED),
+    takeEvery(NetworkActions.automaticReconnectFailed, handle_AUTOMATIC_RECONNECT_FAILED),
+    takeEvery(NetworkActions.checkInitConnection, handle_CHECK_INIT_CONNECTION),
+    takeLatest(NetworkActions.checkMobileNetworkStatus, handle_CHECK_MOBILE_NETWORK_STATUS),
     takeEvery(NetworkActions.offline, handle_NETWORK_GO_OFFLINE),
     takeEvery(NetworkActions.online, handle_NETWORK_GO_ONLINE),
-    takeEvery(NetworkActions.checkMobileNetworkStatus, handle_CHECK_MOBILE_NETWORK_STATUS)
+    takeLatest(NetworkActions.userLostConnection, handle_USER_LOST_CONNECTION)
   ]);
 }
 

--- a/app/src/state/sagas/network.ts
+++ b/app/src/state/sagas/network.ts
@@ -35,9 +35,9 @@ function* handle_CHECK_MOBILE_NETWORK_STATUS(cancel: PayloadAction<boolean>) {
   const MAX_ATTEMPTS = 5;
   const SECONDS_BETWEEN_CHECKS = 20;
   const SECONDS_BETWEEN_ATTEMPTS = 5;
+  const configuration = yield select(selectConfiguration);
 
   while (true) {
-    const configuration = yield select(selectConfiguration);
     let attempts: number = 0;
     let canConnect: boolean = false;
 

--- a/app/src/state/sagas/network.ts
+++ b/app/src/state/sagas/network.ts
@@ -7,59 +7,9 @@ import NetworkActions from 'state/actions/network/NetworkActions';
 import { MOBILE } from 'state/build-time-config';
 import { selectConfiguration } from 'state/reducers/configuration';
 import { OfflineActivitySyncState, selectOfflineActivity } from 'state/reducers/offlineActivity';
+import { selectNetworkState } from 'state/reducers/network';
 
-/**
- * @desc Handler for a Manual Reconnect attempt by user
- */
-function* handle_MANUAL_RECONNECT() {
-  const configuration = yield select(selectConfiguration);
-  if (yield canConnectToNetwork(configuration.API_BASE + HEALTH_ENDPOINT)) {
-    yield put(NetworkActions.online());
-  } else {
-    yield put(Alerts.create(networkAlertMessages.attemptToReconnectFailed));
-  }
-}
-function* handle_AUTOMATIC_RECONNECT_FAILED() {
-  yield put(Alerts.create(networkAlertMessages.automaticReconnectFailed));
-}
-
-/**
- * @desc Rolling function that targets the API to determine our online status.
- *       On failure to reach the API, attempts up to 5 times before determining we cannot proceed
- *       In event of this, disconnect the user and alert them of the incident.
- */
-function* handle_CHECK_MOBILE_NETWORK_STATUS(cancel: PayloadAction<boolean>) {
-  if (!MOBILE || cancel.payload) {
-    return;
-  }
-  const MAX_ATTEMPTS = 5;
-  const SECONDS_BETWEEN_CHECKS = 20;
-  const SECONDS_BETWEEN_ATTEMPTS = 5;
-  const configuration = yield select(selectConfiguration);
-
-  while (true) {
-    let attempts: number = 0;
-    let canConnect: boolean = false;
-
-    do {
-      canConnect = yield canConnectToNetwork(configuration.API_BASE + HEALTH_ENDPOINT);
-      if (!canConnect) {
-        attempts++;
-        yield delay(SECONDS_BETWEEN_ATTEMPTS * 1000);
-      }
-
-      if (yield cancelled()) {
-        return;
-      }
-    } while (!canConnect && attempts < MAX_ATTEMPTS);
-
-    if (!canConnect) {
-      yield put(NetworkActions.userLostConnection());
-      return;
-    }
-    yield delay(SECONDS_BETWEEN_CHECKS * 1000);
-  }
-}
+/* Utilities */
 
 /**
  * @desc Targets the API and checks for successful response.
@@ -73,25 +23,59 @@ const canConnectToNetwork = async (url: string): Promise<boolean> => {
 };
 
 /**
- * Initial Network Connectivity Check, determines to begin application online or offline
+ * @desc Get the time between ticks for polling the heartbeat
+ * @param heartbeatFailures Current number of failed network attempts
+ * @returns { number } Greater of two delay values
+ */
+const getTimeBetweenTicks = (heartbeatFailures: number): number => {
+  const BASE_SECONDS_BETWEEN_FAILURE = 20;
+  const BASE_SECONDS_BETWEEN_SUCCESS = 60;
+  return Math.max(
+    BASE_SECONDS_BETWEEN_FAILURE * 1000 * Math.pow(1.1, heartbeatFailures),
+    BASE_SECONDS_BETWEEN_SUCCESS * 1000
+  );
+};
+
+/* Sagas */
+
+/**
+ * @desc If administrative status enabled at launch, begin monitoring heartbeat
  */
 function* handle_CHECK_INIT_CONNECTION() {
-  if (!MOBILE) {
+  const { administrativeStatus } = yield select(selectNetworkState);
+  if (administrativeStatus) {
+    yield put(NetworkActions.monitorHeartbeat());
+  }
+}
+
+/**
+ * @desc Handles Manual reconnect attempt by user. Sets their administrative status to true
+ */
+function* handle_MANUAL_RECONNECT() {
+  const configuration = yield select(selectConfiguration);
+  yield put(NetworkActions.setAdministrativeStatus(true));
+  if (yield canConnectToNetwork(configuration.API_BASE + HEALTH_ENDPOINT)) {
+    yield put(NetworkActions.monitorHeartbeat());
+  } else {
+    yield put(Alerts.create(networkAlertMessages.attemptToReconnectFailed));
+  }
+}
+
+/**
+ * @desc Rolling function that targets the API to determine our online status.
+ */
+function* handle_MONITOR_HEARTBEAT(cancel: PayloadAction<boolean>) {
+  if (!MOBILE || cancel.payload) {
     return;
   }
   const configuration = yield select(selectConfiguration);
-  if (yield canConnectToNetwork(configuration.API_BASE + HEALTH_ENDPOINT)) {
-    yield put(NetworkActions.online());
-  } else {
-    yield put(NetworkActions.offline());
-  }
-}
-/**
- * @desc Handler for User manually going offline. Fires a cancellation event to stop rolling api checks.
- */
-function* handle_NETWORK_GO_OFFLINE() {
-  yield put(Alerts.create(networkAlertMessages.userWentOffline));
-  yield put(NetworkActions.checkMobileNetworkStatus(true));
+
+  do {
+    const { consecutiveHeartbeatFailures } = yield select(selectNetworkState);
+    const networkRequestSuccess = yield canConnectToNetwork(configuration.API_BASE + HEALTH_ENDPOINT);
+    yield put(NetworkActions.updateConnectionStatus(networkRequestSuccess));
+    yield delay(getTimeBetweenTicks(consecutiveHeartbeatFailures));
+  } while (!(yield cancelled()));
 }
 
 /**
@@ -108,47 +92,53 @@ function* handle_NETWORK_GO_ONLINE() {
   } else {
     yield put(Alerts.create(networkAlertMessages.userWentOnline));
   }
-  yield put(NetworkActions.checkMobileNetworkStatus());
 }
 
 /**
- * @desc Attempt to establish connection with the API. Abandons after ~3 minutes of disconnection.
- *       When this event fires, it cancels the rolling API checks
+ * @desc Handler for Administrative status.
+ *       When enabled, begin polling for heartbeat.
+ *       When disabled, notify user they're offline, cancel heartbeat polling,
+ * @param newStatus new Administrative status
  */
-function* handle_ATTEMPT_AUTOMATIC_RECONNECT() {
-  const MAX_RECONNECT_ATTEMPTS = 18;
-  const SECONDS_BETWEEN_ATTEMPTS = 10;
-
-  const configuration = yield select(selectConfiguration);
-  let attempts = 0;
-  let canReconnect: boolean;
-
-  yield put(Alerts.create(networkAlertMessages.userLostConnection));
-
-  do {
-    canReconnect = yield canConnectToNetwork(configuration.API_BASE + HEALTH_ENDPOINT);
-    if (!canReconnect) {
-      attempts++;
-      yield delay(SECONDS_BETWEEN_ATTEMPTS * 1000);
-    }
-  } while (!canReconnect && attempts < MAX_RECONNECT_ATTEMPTS);
-
-  if (canReconnect) {
-    yield put(NetworkActions.online());
+function* handle_SET_ADMINISTRATIVE_STATUS(newStatus: PayloadAction<boolean>) {
+  if (newStatus.payload) {
+    yield put(NetworkActions.monitorHeartbeat());
   } else {
-    yield put(NetworkActions.automaticReconnectFailed());
+    yield all([
+      put(NetworkActions.monitorHeartbeat(true)), // Cancel loop
+      put(Alerts.create(networkAlertMessages.userWentOffline)),
+      put(NetworkActions.updateConnectionStatus(true))
+    ]);
+  }
+}
+
+/**
+ * @desc Handler for updating current connection status given boolean flags.
+ *       In case of match, do nothing.
+ */
+function* handle_UPDATE_CONNECTION_STATUS() {
+  const { administrativeStatus, operationalStatus, connected } = yield select(selectNetworkState);
+
+  const networkLive = administrativeStatus && operationalStatus;
+  const disconnected = connected && administrativeStatus && !operationalStatus;
+  if (disconnected) {
+    yield put(Alerts.create(networkAlertMessages.userLostConnection));
+  }
+  if (connected && !networkLive) {
+    yield put(NetworkActions.offline());
+  } else if (!connected && networkLive) {
+    yield put(NetworkActions.online());
   }
 }
 
 function* networkSaga() {
   yield all([
     takeEvery(NetworkActions.manualReconnect, handle_MANUAL_RECONNECT),
-    takeEvery(NetworkActions.automaticReconnectFailed, handle_AUTOMATIC_RECONNECT_FAILED),
-    takeEvery(NetworkActions.checkInitConnection, handle_CHECK_INIT_CONNECTION),
-    takeLatest(NetworkActions.checkMobileNetworkStatus, handle_CHECK_MOBILE_NETWORK_STATUS),
-    takeEvery(NetworkActions.offline, handle_NETWORK_GO_OFFLINE),
+    takeLatest(NetworkActions.monitorHeartbeat, handle_MONITOR_HEARTBEAT),
     takeEvery(NetworkActions.online, handle_NETWORK_GO_ONLINE),
-    takeLatest(NetworkActions.userLostConnection, handle_ATTEMPT_AUTOMATIC_RECONNECT)
+    takeEvery(NetworkActions.setAdministrativeStatus, handle_SET_ADMINISTRATIVE_STATUS),
+    takeEvery(NetworkActions.updateConnectionStatus, handle_UPDATE_CONNECTION_STATUS),
+    takeEvery(NetworkActions.checkInitConnection, handle_CHECK_INIT_CONNECTION)
   ]);
 }
 

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -1,4 +1,4 @@
-import { configureStore, ThunkDispatch } from '@reduxjs/toolkit';
+import { configureStore } from '@reduxjs/toolkit';
 import createSagaMiddleware from 'redux-saga';
 import { createLogger } from 'redux-logger';
 import { createBrowserHistory } from 'history';
@@ -19,6 +19,7 @@ import userSettingsSaga from './sagas/userSettings';
 import { createSagaCrashHandler } from './sagas/error_handler';
 import { AppConfig } from './config';
 import { DEBUG } from './build-time-config';
+import NetworkActions from './actions/network/NetworkActions';
 
 const historySingleton = createBrowserHistory();
 
@@ -79,6 +80,7 @@ export function setupStore(configuration: AppConfig) {
   sagaMiddleware.run(emailTemplatesSaga);
   sagaMiddleware.run(networkSaga);
 
+  store.dispatch(NetworkActions.checkMobileNetworkStatus());
   store.dispatch({ type: AUTH_INITIALIZE_REQUEST });
 
   historySingleton.listen((location) => {

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -80,7 +80,7 @@ export function setupStore(configuration: AppConfig) {
   sagaMiddleware.run(emailTemplatesSaga);
   sagaMiddleware.run(networkSaga);
 
-  store.dispatch(NetworkActions.checkMobileNetworkStatus());
+  store.dispatch(NetworkActions.checkInitConnection());
   store.dispatch({ type: AUTH_INITIALIZE_REQUEST });
 
   historySingleton.listen((location) => {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

Handling These Network Scenarios
- Initial Network State
- Manual User Disconnect/Reconnect
- Rolling API checks to maintain current network status
- Automatic re-attempts to connect if disconnected

> All changes affect Mobile Only

- Closes #3715 
- If User determined offline, communicate to user, then attempt to reconnect in background.
- Introduce two flag approach to `connected` logic. Based on User Consent and Network Availability 
    - Ping network in intervals to determine network availability
        - Increase ping frequency with subsequent failures to avoid spamming to the void 
    - Enable/Disable Pings based on User consent (administrative status)
- Persist NetworkState values  in lieu of pinging immediately on load. 
