### PR TITLE
[INV-3757] Clear Records from a Cache

### DIFF
--- a/app/src/UI/Overlay/Records/Records.tsx
+++ b/app/src/UI/Overlay/Records/Records.tsx
@@ -5,12 +5,13 @@ import { OverlayHeader } from '../OverlayHeader';
 import { useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'utils/use_selector';
 import UserSettings from 'state/actions/userSettings/UserSettings';
-import { RecordSetType } from 'interfaces/UserRecordSet';
+import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import Prompt from 'state/actions/prompts/Prompt';
 import RecordSetDetails from './RecordSetDetails';
 import RecordSetControl from './RecordSetControl';
 import { MOBILE } from 'state/build-time-config';
 import filterRecordsetsByNetworkState from 'utils/filterRecordsetsByNetworkState';
+import RecordCache from 'state/actions/cache/RecordCache';
 
 export const Records = () => {
   const DEFAULT_RECORD_TYPES = ['All InvasivesBC Activities', 'All IAPP Records', 'My Drafts'];
@@ -49,7 +50,10 @@ export const Records = () => {
     e.stopPropagation();
     const callback = (userConfirmation: boolean) => {
       if (userConfirmation) {
-        dispatch(UserSettings.RecordSet.remove(set));
+        if (recordSets[set]?.cacheMetadata?.status === UserRecordCacheStatus.CACHED) {
+          dispatch(RecordCache.deleteCache({ setId: set }));
+        }
+        setTimeout(() => dispatch(UserSettings.RecordSet.remove(set)), 250);
       }
     };
     dispatch(

--- a/app/src/UI/Overlay/Records/Records.tsx
+++ b/app/src/UI/Overlay/Records/Records.tsx
@@ -5,13 +5,12 @@ import { OverlayHeader } from '../OverlayHeader';
 import { useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'utils/use_selector';
 import UserSettings from 'state/actions/userSettings/UserSettings';
-import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
+import { RecordSetType } from 'interfaces/UserRecordSet';
 import Prompt from 'state/actions/prompts/Prompt';
 import RecordSetDetails from './RecordSetDetails';
 import RecordSetControl from './RecordSetControl';
 import { MOBILE } from 'state/build-time-config';
 import filterRecordsetsByNetworkState from 'utils/filterRecordsetsByNetworkState';
-import RecordCache from 'state/actions/cache/RecordCache';
 
 export const Records = () => {
   const DEFAULT_RECORD_TYPES = ['All InvasivesBC Activities', 'All IAPP Records', 'My Drafts'];
@@ -50,10 +49,7 @@ export const Records = () => {
     e.stopPropagation();
     const callback = (userConfirmation: boolean) => {
       if (userConfirmation) {
-        if (recordSets[set]?.cacheMetadata?.status === UserRecordCacheStatus.CACHED) {
-          dispatch(RecordCache.deleteCache({ setId: set }));
-        }
-        setTimeout(() => dispatch(UserSettings.RecordSet.remove(set)), 250);
+        dispatch(UserSettings.RecordSet.requestRemoval({ setId: set }));
       }
     };
     dispatch(

--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -7,11 +7,28 @@ import { RecordCacheServiceFactory } from 'utils/record-cache/context';
 class RecordCache {
   static readonly PREFIX = 'RecordCache';
 
-  static readonly deleteCache = createAsyncThunk(`${this.PREFIX}/deleteCache`, async (spec: { setId: string }) => {
-    const service = await RecordCacheServiceFactory.getPlatformInstance();
-
-    await service.deleteCachedSet(spec.setId);
-  });
+  /**
+   * @desc Deletes cached records for a recordset.
+   *       determines duplicates with a frequency map to avoid duplicating records contained elsewhere
+   */
+  static readonly deleteCache = createAsyncThunk(
+    `${this.PREFIX}/deleteCache`,
+    async (spec: { setId: string }, { getState }) => {
+      const service = await RecordCacheServiceFactory.getPlatformInstance();
+      const state = getState() as RootState;
+      const { recordSets } = state.UserSettings;
+      const deleteList = recordSets[spec.setId].cacheMetadata.idList ?? [];
+      const ids: Record<string, number> = {};
+      Object.keys(recordSets)
+        .flatMap((key) => recordSets[key].cacheMetadata.idList ?? [])
+        .forEach((id) => {
+          ids[id] ??= 0;
+          ids[id]++;
+        });
+      const recordsToErase = deleteList.filter((id) => ids[id] === 1);
+      await service.deleteCachedRecordsFromIds(recordsToErase, recordSets[spec.setId].recordSetType);
+    }
+  );
 
   static readonly requestCaching = createAsyncThunk(
     `${this.PREFIX}/requestCaching`,

--- a/app/src/state/actions/userSettings/RecordSet.ts
+++ b/app/src/state/actions/userSettings/RecordSet.ts
@@ -1,7 +1,10 @@
 import { createAction, createAsyncThunk, nanoid } from '@reduxjs/toolkit';
 import { RECORD_COLOURS } from 'constants/colors';
 import { RecordSetType, UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
+import { MOBILE } from 'state/build-time-config';
+import { RootState } from 'state/reducers/rootReducer';
 import { RecordCacheServiceFactory } from 'utils/record-cache/context';
+import RecordCache from '../cache/RecordCache';
 
 export interface IUpdateFilter {
   setID: string | number;
@@ -53,6 +56,21 @@ class RecordSet {
       return cachedSets.map((set) => {
         return { setId: set.setId };
       });
+    }
+  );
+
+  static readonly requestRemoval = createAsyncThunk(
+    `${this.PREFIX}/requestRemoval`,
+    async (spec: { setId: string }, thunkAPI) => {
+      const state = thunkAPI.getState() as RootState;
+      const { recordSets } = state.UserSettings;
+      if (MOBILE && recordSets[spec.setId].cacheMetadata.status == UserRecordCacheStatus.CACHED) {
+        const deletionResult = await thunkAPI.dispatch(RecordCache.deleteCache(spec));
+        if (RecordCache.deleteCache.rejected.match(deletionResult)) {
+          throw Error('Cache failed to delete');
+        }
+      }
+      return spec.setId;
     }
   );
 

--- a/app/src/state/reducers/userSettings.ts
+++ b/app/src/state/reducers/userSettings.ts
@@ -104,7 +104,7 @@ function createUserSettingsReducer(configuration: AppConfig): (UserSettingsState
         draftState.mapCenter = action.payload as [number, number];
       } else if (UserSettings.RecordSet.add.match(action)) {
         draftState.recordSets[Date.now().toString()] ??= action.payload;
-      } else if (UserSettings.RecordSet.remove.match(action)) {
+      } else if (UserSettings.RecordSet.requestRemoval.fulfilled.match(action)) {
         delete draftState.recordSets[action.payload];
       } else if (UserSettings.RecordSet.set.match(action)) {
         Object.keys(action.payload.updatedSet).forEach((key) => {
@@ -218,19 +218,6 @@ function createUserSettingsReducer(configuration: AppConfig): (UserSettingsState
         draftState.recordSets[action.meta.arg.setId].cacheMetadata = {
           status: UserRecordCacheStatus.NOT_CACHED
         };
-      } else if (UserSettings.RecordSet.syncCacheStatusWithCacheService.fulfilled.match(action)) {
-        const cacheStatus = action.payload;
-        for (const cachedSet of cacheStatus) {
-          if (draftState.recordSets[cachedSet.setId]) {
-            const { idList, cachedGeoJson, cachedCentroid } = draftState.recordSets[cachedSet.setId].cacheMetadata;
-            draftState.recordSets[cachedSet.setId].cacheMetadata = {
-              status: UserRecordCacheStatus.CACHED,
-              idList,
-              cachedGeoJson,
-              cachedCentroid
-            };
-          }
-        }
       } else if (Activity.deleteSuccess.match(action)) {
         draftState.activeActivity = null;
         draftState.activeActivityDescription = null;

--- a/app/src/state/reducers/userSettings.ts
+++ b/app/src/state/reducers/userSettings.ts
@@ -200,7 +200,7 @@ function createUserSettingsReducer(configuration: AppConfig): (UserSettingsState
         draftState.recordSets[action.meta.arg.setId].cacheMetadata = {
           status: UserRecordCacheStatus.DOWNLOADING
         };
-      } else if (RecordCache.requestCaching.rejected.match(action)) {
+      } else if (RecordCache.requestCaching.rejected.match(action) || RecordCache.deleteCache.rejected.match(action)) {
         draftState.recordSets[action.meta.arg.setId].cacheMetadata = {
           status: UserRecordCacheStatus.ERROR
         };
@@ -213,13 +213,7 @@ function createUserSettingsReducer(configuration: AppConfig): (UserSettingsState
           cachedCentroid: action.payload.cachedCentroid
         };
       } else if (RecordCache.deleteCache.pending.match(action)) {
-        draftState.recordSets[action.meta.arg.setId].cacheMetadata = {
-          status: UserRecordCacheStatus.DELETING
-        };
-      } else if (RecordCache.deleteCache.rejected.match(action)) {
-        draftState.recordSets[action.meta.arg.setId].cacheMetadata = {
-          status: UserRecordCacheStatus.ERROR
-        };
+        draftState.recordSets[action.meta.arg.setId].cacheMetadata.status = UserRecordCacheStatus.DELETING;
       } else if (RecordCache.deleteCache.fulfilled.match(action)) {
         draftState.recordSets[action.meta.arg.setId].cacheMetadata = {
           status: UserRecordCacheStatus.NOT_CACHED

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -54,7 +54,7 @@ abstract class RecordCacheService {
   abstract saveActivity(id: string, data: unknown): Promise<void>;
 
   abstract saveIapp(id: string, iappRecord: unknown, iappTableRow: unknown): Promise<void>;
-
+  abstract deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void>;
   abstract loadActivity(id: string): Promise<unknown>;
   abstract loadIapp(id: string, type: IappRecordMode): Promise<IappRecord | IappTableRow>;
 

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -16,10 +16,6 @@ export interface RecordCacheDownloadRequestSpec {
   idsToCache: string[];
 }
 
-export interface RecordCacheAddSpec {
-  setId: string;
-  idsToCache: string[];
-}
 /**
  * @desc Cached Metadata for Recordsets
  * @property { string } setID Recordset ID
@@ -61,12 +57,6 @@ abstract class RecordCacheService {
 
   abstract loadActivity(id: string): Promise<unknown>;
   abstract loadIapp(id: string, type: IappRecordMode): Promise<IappRecord | IappTableRow>;
-
-  abstract addCachedSet(spec: RecordCacheAddSpec): Promise<void>;
-
-  abstract listCachedSets(): Promise<RecordSetCacheMetadata[]>;
-
-  abstract deleteCachedSet(id: string): Promise<void>;
 
   abstract fetchPaginatedCachedIappRecords(
     recordSetIdList: string[],

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -6,6 +6,7 @@ import { Feature } from '@turf/helpers';
 import { GeoJSONSourceSpecification } from 'maplibre-gl';
 import IappRecord from 'interfaces/IappRecord';
 import IappTableRow from 'interfaces/IappTableRecord';
+import { RecordSetType } from 'interfaces/UserRecordSet';
 
 class LocalForageRecordCacheService extends RecordCacheService {
   private static _instance: LocalForageRecordCacheService;
@@ -168,7 +169,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
     return { cachedCentroid, cachedGeoJson };
   }
 
-  async deleteCachedRecordsFromIds(idsToDelete: string[]): Promise<void> {
+  async deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void> {
     if (this.store == null) {
       throw new Error('cache not available');
     }

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -1,13 +1,7 @@
 import UserRecord from 'interfaces/UserRecord';
 import localForage from 'localforage';
 import centroid from '@turf/centroid';
-import {
-  IappRecordMode,
-  RecordCacheAddSpec,
-  RecordCacheService,
-  RecordSetCacheMetadata,
-  RecordSetSourceMetadata
-} from 'utils/record-cache/index';
+import { IappRecordMode, RecordCacheService, RecordSetSourceMetadata } from 'utils/record-cache/index';
 import { Feature } from '@turf/helpers';
 import { GeoJSONSourceSpecification } from 'maplibre-gl';
 import IappRecord from 'interfaces/IappRecord';
@@ -92,24 +86,6 @@ class LocalForageRecordCacheService extends RecordCacheService {
     return data;
   }
 
-  async addCachedSet(spec: RecordCacheAddSpec): Promise<void> {
-    if (this.store == null) {
-      throw new Error('cache not available');
-    }
-
-    const cachedSets = await this.listCachedSets();
-    const foundIndex = cachedSets.findIndex((p) => p.setId == spec.setId);
-    if (foundIndex !== -1) {
-      throw new Error('cached set already exists');
-    }
-
-    cachedSets.push({
-      setId: spec.setId,
-      cachedIds: spec.idsToCache
-    });
-    await this.store.setItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY, cachedSets);
-  }
-
   /**
    * @desc fetch `n` records for a given recordset, supporting pagination
    * @param recordSetID Recordset to filter from
@@ -129,21 +105,6 @@ class LocalForageRecordCacheService extends RecordCacheService {
       results.push(entry);
     }
     return results;
-  }
-
-  async listCachedSets(): Promise<RecordSetCacheMetadata[]> {
-    if (this.store == null) {
-      return [];
-    }
-
-    const metadata = (await this.store.getItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY)) as
-      | RecordSetCacheMetadata[]
-      | null;
-    if (metadata == null) {
-      console.error('expected key not found');
-      return [];
-    }
-    return metadata;
   }
 
   /**
@@ -207,51 +168,12 @@ class LocalForageRecordCacheService extends RecordCacheService {
     return { cachedCentroid, cachedGeoJson };
   }
 
-  async deleteCachedSet(id: string): Promise<void> {
+  async deleteCachedRecordsFromIds(idsToDelete: string[]): Promise<void> {
     if (this.store == null) {
       throw new Error('cache not available');
     }
-
-    const cachedSets = await this.listCachedSets();
-    const foundIndex = cachedSets.findIndex((p) => p.setId == id);
-    if (foundIndex !== -1) {
-      cachedSets.splice(foundIndex, 1);
-    }
-    try {
-      await this.cleanupOrphanActivities();
-    } finally {
-      await this.store.setItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY, cachedSets);
-    }
-  }
-
-  private async cleanupOrphanActivities(): Promise<void> {
-    if (this.store == null) {
-      throw new Error('cache not available');
-    }
-    const cachedSets = await this.listCachedSets();
-
-    const allKeys = await this.store.keys();
-    const deletionQueue: string[] = [];
-    for (const k of allKeys) {
-      if (k == LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY) {
-        continue;
-      }
-      let referenced = false;
-      for (const set of cachedSets) {
-        if (set.cachedIds?.includes(k)) {
-          referenced = true;
-        }
-      }
-      if (!referenced) {
-        deletionQueue.push(k);
-      }
-    }
-    for (const d of deletionQueue) {
-      try {
-        await this.store.removeItem(d);
-      } catch (e) {
-        console.error(e);
-      }
+    for (const id of idsToDelete) {
+      await this.store.removeItem(id.toString());
     }
   }
 

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -5,13 +5,7 @@ import IappRecord from 'interfaces/IappRecord';
 import IappTableRow from 'interfaces/IappTableRecord';
 import UserRecord from 'interfaces/UserRecord';
 import { GeoJSONSourceSpecification } from 'maplibre-gl';
-import {
-  IappRecordMode,
-  RecordCacheAddSpec,
-  RecordCacheService,
-  RecordSetCacheMetadata,
-  RecordSetSourceMetadata
-} from 'utils/record-cache/index';
+import { IappRecordMode, RecordCacheService, RecordSetSourceMetadata } from 'utils/record-cache/index';
 import { sqlite } from 'utils/sharedSQLiteInstance';
 
 const CACHE_DB_NAME = 'record_cache.db';
@@ -68,74 +62,6 @@ class SQLiteRecordCacheService extends RecordCacheService {
     return SQLiteRecordCacheService._instance;
   }
 
-  async addCachedSet(spec: RecordCacheAddSpec): Promise<void> {
-    if (this.cacheDB == null) {
-      throw new Error(CACHE_UNAVAILABLE);
-    }
-    try {
-      await this.cacheDB.beginTransaction();
-
-      await this.cacheDB.query(
-        //language=SQLite
-        `
-          INSERT INTO (SET_ID)
-          VALUES (?)`,
-        [spec.setId]
-      );
-      for (const s of spec.idsToCache) {
-        await this.cacheDB.query(
-          //language=SQLite
-          `
-            INSERT INTO CACHED_RECORD_TO_CACHE_METADATA (CACHE_METADATA_ID, RECORD_ID)
-            VALUES (?, ?)`,
-          [spec.setId, s]
-        );
-      }
-      await this.cacheDB.commitTransaction();
-    } catch (e) {
-      await this.cacheDB.rollbackTransaction();
-    }
-  }
-
-  async deleteCachedSet(id: string): Promise<void> {
-    if (this.cacheDB == null) {
-      throw new Error(CACHE_UNAVAILABLE);
-    }
-    try {
-      await this.cacheDB.beginTransaction();
-
-      // delete the record of this set
-      await this.cacheDB.query(
-        //language=SQLite
-        `DELETE
-         FROM CACHED_RECORD_TO_CACHE_METADATA
-         WHERE CACHE_METADATA_ID = ?`,
-        [id]
-      );
-
-      // delete the associations
-      await this.cacheDB.query(
-        //language=SQLite
-        `DELETE
-         FROM CACHE_METADATA
-         WHERE SET_ID = ?`,
-        [id]
-      );
-
-      // delete and records that are now unreferenced
-      // won't delete records that are still referenced by another cache set (in case a record exists in more than one)
-      await this.cacheDB.query(
-        //language=SQLite
-        `DELETE
-         FROM CACHED_RECORDS
-         WHERE ID NOT IN (SELECT RECORD_ID FROM CACHED_RECORD_TO_CACHE_METADATA)`
-      );
-
-      await this.cacheDB.commitTransaction();
-    } catch (e) {
-      await this.cacheDB.rollbackTransaction();
-    }
-  }
   /**
    * @desc fetch `n` records for a given recordset, supporting pagination
    * @param recordSetID Recordset to filter from
@@ -204,33 +130,6 @@ class SQLiteRecordCacheService extends RecordCacheService {
       })
       .filter((record) => record !== null);
     return response;
-  }
-  async listCachedSets(): Promise<RecordSetCacheMetadata[]> {
-    if (this.cacheDB == null) {
-      throw new Error(CACHE_UNAVAILABLE);
-    }
-
-    try {
-      await this.cacheDB.beginTransaction();
-
-      const rows = await this.cacheDB.query(`SELECT SET_ID
-                                             FROM CACHE_METADATA`);
-
-      const cachedSets: RecordSetCacheMetadata[] = [];
-
-      if (rows.values) {
-        for (const row of rows.values) {
-          cachedSets.push({ setId: row['SET_ID'] });
-        }
-      }
-
-      await this.cacheDB.commitTransaction();
-
-      return cachedSets;
-    } catch (e) {
-      await this.cacheDB.rollbackTransaction();
-      throw new Error('error while querying cache');
-    }
   }
 
   async loadActivity(id: string): Promise<unknown> {

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -4,6 +4,7 @@ import { Feature } from '@turf/helpers';
 import IappRecord from 'interfaces/IappRecord';
 import IappTableRow from 'interfaces/IappTableRecord';
 import UserRecord from 'interfaces/UserRecord';
+import { RecordSetType } from 'interfaces/UserRecordSet';
 import { GeoJSONSourceSpecification } from 'maplibre-gl';
 import { IappRecordMode, RecordCacheService, RecordSetSourceMetadata } from 'utils/record-cache/index';
 import { sqlite } from 'utils/sharedSQLiteInstance';
@@ -282,7 +283,22 @@ class SQLiteRecordCacheService extends RecordCacheService {
     };
     return { cachedCentroid, cachedGeoJson };
   }
-
+  async deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const RecordsToTable = {
+      [RecordSetType.Activity]: 'CACHED_RECORDS',
+      [RecordSetType.IAPP]: 'CACHED_IAPP_RECORDS'
+    };
+    const RECORD_TABLE = RecordsToTable[recordSetType];
+    await this.cacheDB.query(
+      // language=SQLite
+      `DELETE FROM ${RECORD_TABLE}
+       WHERE ID IN (${idsToDelete.map(() => '?').join(', ')})`,
+      [...idsToDelete]
+    );
+  }
   private async initializeRecordCache(sqlite: SQLiteConnection) {
     // Hold Migrations as named variable so we can use length to update the Db version automagically
     // Note: toVersion must be an integer.

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -287,17 +287,30 @@ class SQLiteRecordCacheService extends RecordCacheService {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
+
     const RecordsToTable = {
       [RecordSetType.Activity]: 'CACHED_RECORDS',
       [RecordSetType.IAPP]: 'CACHED_IAPP_RECORDS'
     };
     const RECORD_TABLE = RecordsToTable[recordSetType];
-    await this.cacheDB.query(
-      // language=SQLite
-      `DELETE FROM ${RECORD_TABLE}
-       WHERE ID IN (${idsToDelete.map(() => '?').join(', ')})`,
-      [...idsToDelete]
-    );
+    const BATCH_AMOUNT = 100;
+
+    this.cacheDB.beginTransaction();
+    try {
+      for (let i = 0; i < idsToDelete.length; i += BATCH_AMOUNT) {
+        const sliced = idsToDelete.slice(i, Math.min(i + BATCH_AMOUNT, idsToDelete.length));
+        await this.cacheDB.query(
+          // language=SQLite
+          `DELETE FROM ${RECORD_TABLE}
+           WHERE ID IN (${sliced.map(() => '?').join(', ')})`,
+          [...sliced]
+        );
+      }
+      this.cacheDB.commitTransaction();
+    } catch (e) {
+      this.cacheDB.rollbackTransaction();
+      throw e;
+    }
   }
   private async initializeRecordCache(sqlite: SQLiteConnection) {
     // Hold Migrations as named variable so we can use length to update the Db version automagically


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):
- Implement a Frequency Map on Cache clear actions to avoid deleting records shared with other recordsets.
- Fix issue where clearing `a` cache deletes `ALL` cached records.
- Remove functionality around Cachelists as they were unused.
- Trigger Cache delete when a Recordset is deleted to avoid dead recordsets being stored.
- Closes #3757 

## EDITS
- Convert RecordSet.remove to `Recordset.requestRemoval` now using Thunk.
- Paginate deletion of records in Sqlite in batches of 100 with transactions
    - Tested caching 1000 records, Ran with an arbitrary error being thrown after 300 deletes to test transaction handling.
    - Validated Record counts in CLI
