### PR TITLE
[INV-3771] Speed up maptile caching

### DIFF
--- a/app/src/UI/Overlay/TileCache/TileCacheDownloadProgress.tsx
+++ b/app/src/UI/Overlay/TileCache/TileCacheDownloadProgress.tsx
@@ -24,10 +24,12 @@ const TileCacheDownloadProgress = () => {
     <section>
       <table>
         <thead>
-          <th>Cache Name</th>
-          <th>Download Status</th>
-          <th>Progress</th>
-          <th>Cancel</th>
+          <tr>
+            <th>Cache Name</th>
+            <th>Download Status</th>
+            <th>Progress</th>
+            <th>Cancel</th>
+          </tr>
         </thead>
         <tbody>
           {Object.keys(downloadProgress).map((k) => (

--- a/app/src/UI/Overlay/TileCache/TileCacheListRow.tsx
+++ b/app/src/UI/Overlay/TileCache/TileCacheListRow.tsx
@@ -76,7 +76,7 @@ const TileCacheListRow = ({ metadata, visible }) => {
       </td>
       <td>{metadata.description || metadata.id}</td>
       <td>{metadata.status}</td>
-      <td>{stats?.tileCount}</td>
+      <td>{stats?.tileCount?.toLocaleString('en-US')}</td>
       <td>{stats && convertBytesToReadableString(stats.sizeInBytes)}</td>
       <td>
         <IconButton color={'primary'} onClick={handleEditCacheDescription}>

--- a/app/src/UI/Overlay/TileCache/TileCacheListRow.tsx
+++ b/app/src/UI/Overlay/TileCache/TileCacheListRow.tsx
@@ -76,7 +76,7 @@ const TileCacheListRow = ({ metadata, visible }) => {
       </td>
       <td>{metadata.description || metadata.id}</td>
       <td>{metadata.status}</td>
-      <td>{stats?.tileCount?.toLocaleString('en-US')}</td>
+      <td>{stats?.tileCount?.toLocaleString()}</td>
       <td>{stats && convertBytesToReadableString(stats.sizeInBytes)}</td>
       <td>
         <IconButton color={'primary'} onClick={handleEditCacheDescription}>

--- a/app/src/utils/tile-cache/index.ts
+++ b/app/src/utils/tile-cache/index.ts
@@ -203,9 +203,7 @@ abstract class TileCacheService {
           if (progressCallback) {
             progressCallback({
               repository: spec.id,
-              message: abort
-                ? `Aborting`
-                : `${processedTiles.toLocaleString('en-US')}/${totalTiles.toLocaleString('en-US')} Tiles`,
+              message: abort ? `Aborting` : `${processedTiles.toLocaleString()}/${totalTiles.toLocaleString()} Tiles`,
               aborted: abort,
               normalizedProgress: processedTiles / totalTiles,
               processedTiles,

--- a/app/src/utils/tile-cache/index.ts
+++ b/app/src/utils/tile-cache/index.ts
@@ -43,6 +43,13 @@ enum RepositoryStatus {
   UNKNOWN = 'UNKNOWN'
 }
 
+interface TilePromise {
+  id: string;
+  url: string;
+  x: number;
+  y: number;
+  z: number;
+}
 export interface TileCacheProgressCallbackParameters {
   repository: string;
   message: string;
@@ -107,75 +114,108 @@ abstract class TileCacheService {
 
   abstract setRepositoryStatus(repository: string, status: RepositoryStatus): Promise<void>;
 
+  private async downloadTile(tileDetails: TilePromise): Promise<void> {
+    const { id, url, x, y, z } = tileDetails;
+    const responseData = await fetch(url).then(async (r) => await r.arrayBuffer());
+    await this.setTile(id, z, x, y, new Uint8Array(responseData));
+  }
+
   async download(
     spec: RepositoryDownloadRequestSpec,
     progressCallback?: (currentProgress: TileCacheProgressCallbackParameters) => void
   ): Promise<void> {
-    await this.addRepository({
-      id: spec.id,
-      status: RepositoryStatus.DOWNLOADING,
-      maxZoom: spec.maxZoom,
-      bounds: spec.bounds,
-      description: spec.description
-    });
+    const processNext = async (promiseFn) => {
+      const promise = promiseFn();
+      executing.add(promise);
+      try {
+        await promise;
+      } catch (e) {
+        console.error(e);
+        try {
+          await promise;
+        } catch (e) {
+          console.error('Failed second attempt at fetching tile');
+        }
+      } finally {
+        executing.delete(promise);
+      }
+    };
 
+    const CONCURRENCY_LIMIT = 10;
     const totalTiles = TileCacheService.computeTileCount(spec.bounds, spec.maxZoom);
-
     let abort = false;
-
     let processedTiles = 0;
     let lastProgressCallback: null | number = null;
     let lastProgressCallbackTimestamp: number | null = null;
+    const tileUrls: TilePromise[] = [];
+    const executing = new Set();
 
     try {
+      await this.addRepository({
+        id: spec.id,
+        status: RepositoryStatus.DOWNLOADING,
+        maxZoom: spec.maxZoom,
+        bounds: spec.bounds,
+        description: spec.description
+      });
+
       for (let z = 0; z <= spec.maxZoom && !abort; z++) {
         const startTileLat = lat2tile(spec.bounds.minLatitude, z);
         const startTileLng = long2tile(spec.bounds.minLongitude, z);
-
         const endTileLat = lat2tile(spec.bounds.maxLatitude, z);
         const endTileLng = long2tile(spec.bounds.maxLongitude, z);
 
         for (let x = Math.min(startTileLng, endTileLng); x <= Math.max(startTileLng, endTileLng) && !abort; x++) {
           for (let y = Math.min(startTileLat, endTileLat); y <= Math.max(startTileLat, endTileLat) && !abort; y++) {
-            const url = spec.tileURL(x, y, z);
-            const response = await fetch(url);
-            const data = await response.arrayBuffer();
-
-            await this.setTile(spec.id, z, x, y, new Uint8Array(data));
-            processedTiles++;
-
-            const currentProgress = processedTiles / totalTiles;
-            // trigger a callback on the first run, on the last run, every 1%, and every 200ms
-            if (
-              lastProgressCallback == null ||
-              lastProgressCallbackTimestamp == null ||
-              currentProgress - lastProgressCallback > 0.01 ||
-              processedTiles == totalTiles ||
-              Date.now() - lastProgressCallbackTimestamp > 200
-            ) {
-              // take advantage of the periodic callback to check if we should abort (because the repo was concurrently deleted)
-              const updatedRepositoryState = await this.getRepository(spec.id);
-              if (updatedRepositoryState == null || updatedRepositoryState.status == RepositoryStatus.DELETING) {
-                abort = true;
-              }
-
-              lastProgressCallback = currentProgress;
-              lastProgressCallbackTimestamp = Date.now();
-
-              if (progressCallback) {
-                progressCallback({
-                  repository: spec.id,
-                  message: abort ? `Aborting` : `Zoom ${z}/${spec.maxZoom}, ${processedTiles}/${totalTiles} Tiles`,
-                  aborted: abort,
-                  normalizedProgress: processedTiles / totalTiles,
-                  processedTiles,
-                  totalTiles
-                });
-              }
-            }
+            tileUrls.push({ id: spec.id, url: spec.tileURL(x, y, z), x, y, z });
           }
         }
       }
+      const promises = tileUrls.map((config) => () => this.downloadTile(config));
+
+      for (let i = 0; i < promises.length && !abort; i++) {
+        if (executing.size >= CONCURRENCY_LIMIT) {
+          await Promise.race(executing);
+        }
+
+        processNext(promises[i]);
+        processedTiles++;
+        const currentProgress = processedTiles / totalTiles;
+        const currTime = Date.now();
+
+        // trigger a callback on the first run, on the last run, every 1%, and every 200ms
+        if (
+          lastProgressCallback == null ||
+          lastProgressCallbackTimestamp == null ||
+          currentProgress - lastProgressCallback > 0.01 ||
+          processedTiles == totalTiles ||
+          currTime - lastProgressCallbackTimestamp > 500
+        ) {
+          // take advantage of the periodic callback to check if we should abort (because the repo was concurrently deleted)
+          const updatedRepositoryState = await this.getRepository(spec.id);
+          if (updatedRepositoryState == null || updatedRepositoryState.status == RepositoryStatus.DELETING) {
+            abort = true;
+          }
+
+          lastProgressCallback = currentProgress;
+          lastProgressCallbackTimestamp = currTime;
+
+          if (progressCallback) {
+            progressCallback({
+              repository: spec.id,
+              message: abort
+                ? `Aborting`
+                : `${processedTiles.toLocaleString('en-US')}/${totalTiles.toLocaleString('en-US')} Tiles`,
+              aborted: abort,
+              normalizedProgress: processedTiles / totalTiles,
+              processedTiles,
+              totalTiles
+            });
+          }
+        }
+      }
+
+      await Promise.all(executing);
       await this.setRepositoryStatus(spec.id, RepositoryStatus.READY);
     } catch (e) {
       try {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Modify the download method of Map tiles to run a Concurrency limit of 10 instead of 1.
- Modify the Download method to retry once on failure (previously 0)
- Fix HTML Semantic Issue about missing `tr` in `thead`
- add toLocaleString to tIlecounts to better display info (adds commas).
- Increased time between Callback updates 200 -> 500ms
- Closes #3771

Its hard to establish how much the download speed will really improve by for Mobile when using a Simulator. Given the Simulator is constrained by my System the speed is much slower than the below.

Testing in Browser cached 205,587 tiles (2.8GiB)  in 33:18.
Originally ~2300 tiles (36.7MiB) would take 2:34. Scaled up that translates to ~3.6 hours

`(205k / 2,300) * 154sec / 60 / 60`

Testing in a Simulator cached 1,000 tiles in 1:37
Originally 1,000 tiles would take 2:15
I'm not testing for high values because a simulator is more throttled than a physical device so the metrics mean less.
Based on the simulator this completes the same number of tiles in 71.85% of  the time. 

**During Caching I periodically navigated through the app testing for any noticeable slowdown, If you have the Network tab open you'll get some, due to how many Network requests are being logged, but if you don't, There isn't any..