### PR TITLE
Allow usage of photo from gallery/library

### DIFF
--- a/app/src/UI/Overlay/Records/Activity/PhotoContainer.tsx
+++ b/app/src/UI/Overlay/Records/Activity/PhotoContainer.tsx
@@ -98,7 +98,7 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
     }
   };
 
-  const chooseMultiplePhotosFromLibrary = async () => {
+  const choosePhotosFromLibrary = async () => {
     try {
       await checkPermissionsAndDisplayInfo(CameraSource.Photos);
       const multiplePhotos = await Camera.pickImages({
@@ -219,22 +219,12 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
                   variant="contained"
                   color="primary"
                   startIcon={<PhotoLibrary />}
-                  onClick={chooseMultiplePhotosFromLibrary}
+                  onClick={choosePhotosFromLibrary}
                 >
                   Choose from Gallery
                 </Button>
               </Grid>
             </Grid>
-            {/* <>
-              <Box mt={8}>
-                <u>
-                  <strong>To enable Camera and Photo permissions manually: </strong>
-                </u>
-              </Box>
-              <Box mt={4}>
-                <strong>To enable permissions: </strong> ....
-              </Box>
-            </> */}
           </Grid>
         </Box>
       )}

--- a/app/src/UI/Overlay/Records/Activity/PhotoContainer.tsx
+++ b/app/src/UI/Overlay/Records/Activity/PhotoContainer.tsx
@@ -1,4 +1,4 @@
-import { CameraResultType, CameraSource, Camera, Photo } from '@capacitor/camera';
+import { CameraResultType, CameraSource, Camera } from '@capacitor/camera';
 import {
   Box,
   Button,
@@ -43,26 +43,25 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
     // convert response into a blob
     const blob = await response.blob();
 
-    // read the blob as a dataUrl
     return new Promise((resolve, reject) => {
       const reader = new FileReader();
-      reader.onloadend = () => resolve(reader.result as string); // result is the dataUrl
+      reader.onloadend = () => resolve(reader.result as string); // result is a dataUrl
       reader.onerror = reject;
       reader.readAsDataURL(blob);
     });
   }
 
-  const checkPermissionsAndDisplayInfo = async (PhotoOption: CameraSource): Promise<void> => {
+  const checkPermissionsAndAlert = async (photoOption: CameraSource): Promise<void> => {
     try {
       const permissions = await Camera.checkPermissions();
 
-      if (PhotoOption === CameraSource.Camera) {
+      if (photoOption === CameraSource.Camera) {
         if (permissions.camera === 'denied') {
           alert('Camera access is denied. Please enable camera permissions in your device settings to take photos.');
         }
       }
 
-      if (PhotoOption === CameraSource.Photos) {
+      if (photoOption === CameraSource.Photos) {
         if (permissions.photos === 'denied') {
           alert(
             'Photo library access is denied. Please enable photo library permissions in your device settings to choose photos.'
@@ -76,7 +75,7 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
 
   const takePhotoFromCamera = async () => {
     try {
-      await checkPermissionsAndDisplayInfo(CameraSource.Camera);
+      await checkPermissionsAndAlert(CameraSource.Camera);
       const cameraPhoto = await Camera.getPhoto({
         presentationStyle: 'fullscreen',
         resultType: CameraResultType.DataUrl,
@@ -100,7 +99,7 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
 
   const choosePhotosFromLibrary = async () => {
     try {
-      await checkPermissionsAndDisplayInfo(CameraSource.Photos);
+      await checkPermissionsAndAlert(CameraSource.Photos);
       const multiplePhotos = await Camera.pickImages({
         quality: 100,
         limit: 10

--- a/app/src/UI/Overlay/Records/Activity/PhotoContainer.tsx
+++ b/app/src/UI/Overlay/Records/Activity/PhotoContainer.tsx
@@ -57,30 +57,26 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
     try {
       const permissions = await Camera.checkPermissions();
 
-      if (photoOption === CameraSource.Camera) {
-        if (permissions.camera === 'denied') {
-          dispatch(
-            Alerts.create({
-              content:
-                'Camera access is denied. Please enable camera permissions in your device settings to take photos.',
-              severity: AlertSeverity.Warning,
-              subject: AlertSubjects.Photo,
-              autoClose: 5
-            })
-          );
-        }
-      } else if (photoOption === CameraSource.Photos) {
-        if (permissions.photos === 'denied') {
-          dispatch(
-            Alerts.create({
-              content:
-                'Photo library access is denied. Please enable photo library permissions in your device settings to choose photos.',
-              severity: AlertSeverity.Warning,
-              subject: AlertSubjects.Photo,
-              autoClose: 5
-            })
-          );
-        }
+      if (photoOption === CameraSource.Camera && permissions.camera === 'denied') {
+        dispatch(
+          Alerts.create({
+            content:
+              'Camera access is denied. Please enable camera permissions in your device settings to take photos.',
+            severity: AlertSeverity.Warning,
+            subject: AlertSubjects.Photo,
+            autoClose: 5
+          })
+        );
+      } else if (photoOption === CameraSource.Photos && permissions.photos === 'denied') {
+        dispatch(
+          Alerts.create({
+            content:
+              'Photo library access is denied. Please enable photo library permissions in your device settings to choose photos.',
+            severity: AlertSeverity.Warning,
+            subject: AlertSubjects.Photo,
+            autoClose: 5
+          })
+        );
       }
     } catch (error) {
       console.error('Error checking permissions:', error);

--- a/app/src/UI/Overlay/Records/Activity/PhotoContainer.tsx
+++ b/app/src/UI/Overlay/Records/Activity/PhotoContainer.tsx
@@ -48,6 +48,41 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
     return photo;
   };
 
+  async function convertWebPathToDataUrl(webPath: string): Promise<string> {
+    const response = await fetch(webPath);
+
+    // convert response into a blob
+    const blob = await response.blob();
+
+    // read the blob as a dataUrl
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve(reader.result as string); // result is the dataUrl
+      reader.onerror = reject;
+      reader.readAsDataURL(blob);
+    });
+  }
+
+  const selectMultiplePhotos = async () => {
+    const multiplePhotos = await Camera.pickImages({
+      quality: 100,
+      limit: 30
+    });
+    console.log('HERE', multiplePhotos);
+    for (let i = 0; i < multiplePhotos.photos.length; i++) {
+      const fileName = new Date().getTime() + '.' + multiplePhotos.photos[i].format;
+      console.log(multiplePhotos.photos[i].webPath, multiplePhotos.photos[i].path);
+      const dataUrl = await convertWebPathToDataUrl(multiplePhotos.photos[i].webPath);
+      const photo: UploadedPhoto = {
+        file_name: fileName,
+        encoded_file: dataUrl,
+        description: 'untitled',
+        editing: false
+      };
+      dispatch(Activity.Photo.add(photo));
+    }
+  };
+
   const takePhotoFromCamera = async () => {
     try {
       const cameraPhoto = await Camera.getPhoto({
@@ -77,6 +112,44 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
       dispatch(Activity.Photo.add(photo));
     } catch (e) {
       console.error('User cancelled or other errors selecting photos', e);
+    }
+  };
+  const requestPhotoPermission = async () => {
+    try {
+      const permission = await Camera.requestPermissions({ permissions: ['photos'] });
+
+      if (permission.photos === 'granted') {
+        console.log('Permission granted for photo library');
+        return true;
+      } else {
+        console.log('Permission denied for photo library');
+        return false;
+      }
+    } catch (error) {
+      console.error('Error requesting permission', error);
+      return false;
+    }
+  };
+
+  const chooseMultiplePhotosFromLibrary = async () => {
+    try {
+      const permissions = await Camera.checkPermissions();
+      console.log('Permissions', permissions);
+      selectMultiplePhotos();
+      // if (permissions.photos === 'granted') {
+      //   console.log('Granted by default');
+      //   selectMultiplePhotos();
+      // } else {
+      //   const newPermissions = await Camera.requestPermissions({ permissions: ['photos'] });
+      //   if (newPermissions.photos === 'granted') {
+      //     console.log('Granted now');
+      //     selectMultiplePhotos();
+      //   } else {
+      //     console.log('Permission denied after request.');
+      //   }
+      // }
+    } catch (e) {
+      console.error('error occurred: ', e);
     }
   };
 
@@ -158,7 +231,7 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
                   variant="contained"
                   color="primary"
                   startIcon={<PhotoLibrary />}
-                  onClick={choosePhotoFromLibrary}
+                  onClick={chooseMultiplePhotosFromLibrary}
                 >
                   Choose from Gallery
                 </Button>

--- a/app/src/UI/Overlay/Records/Activity/PhotoContainer.tsx
+++ b/app/src/UI/Overlay/Records/Activity/PhotoContainer.tsx
@@ -1,4 +1,4 @@
-import { CameraResultType, CameraSource, Camera } from '@capacitor/camera';
+import { CameraResultType, CameraSource, Camera, Photo } from '@capacitor/camera';
 import {
   Box,
   Button,
@@ -13,7 +13,7 @@ import {
   Typography
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
-import { AddAPhoto, DeleteForever } from '@mui/icons-material';
+import { PhotoCamera, PhotoLibrary, DeleteForever } from '@mui/icons-material';
 import React, { useState } from 'react';
 import Activity from 'state/actions/activity/Activity';
 import UploadedPhoto from 'interfaces/UploadedPhoto';
@@ -37,7 +37,18 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
   const dispatch = useDispatch();
   const media = useSelector((state) => state.ActivityPage.activity?.media || []);
 
-  const takePhoto = async () => {
+  const preparePhoto = (photoToProcess: Photo) => {
+    const fileName = new Date().getTime() + '.' + photoToProcess.format;
+    const photo: UploadedPhoto = {
+      file_name: fileName,
+      encoded_file: photoToProcess.dataUrl,
+      description: 'untitled',
+      editing: false
+    };
+    return photo;
+  };
+
+  const takePhotoFromCamera = async () => {
     try {
       const cameraPhoto = await Camera.getPhoto({
         presentationStyle: 'fullscreen',
@@ -46,17 +57,26 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
         quality: 100
       });
 
-      const fileName = new Date().getTime() + '.' + cameraPhoto.format;
-      const photo: UploadedPhoto = {
-        file_name: fileName,
-        encoded_file: cameraPhoto.dataUrl,
-        description: 'untitled',
-        editing: false
-      };
-
+      const photo = preparePhoto(cameraPhoto);
       dispatch(Activity.Photo.add(photo));
     } catch (e) {
       console.error('user cancelled or other camera problem', e);
+    }
+  };
+
+  const choosePhotoFromLibrary = async () => {
+    try {
+      const libraryPhoto = await Camera.getPhoto({
+        quality: 90,
+        allowEditing: false,
+        resultType: CameraResultType.DataUrl,
+        source: CameraSource.Photos
+      });
+
+      const photo = preparePhoto(libraryPhoto);
+      dispatch(Activity.Photo.add(photo));
+    } catch (e) {
+      console.error('User cancelled or other errors selecting photos', e);
     }
   };
 
@@ -129,8 +149,18 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
           <Grid container>
             <Grid container item spacing={3} justifyContent="center">
               <Grid item>
-                <Button variant="contained" color="primary" startIcon={<AddAPhoto />} onClick={takePhoto}>
-                  Add A Photo
+                <Button variant="contained" color="primary" startIcon={<PhotoCamera />} onClick={takePhotoFromCamera}>
+                  Capture Photo
+                </Button>
+              </Grid>
+              <Grid item>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  startIcon={<PhotoLibrary />}
+                  onClick={choosePhotoFromLibrary}
+                >
+                  Choose from Gallery
                 </Button>
               </Grid>
             </Grid>

--- a/app/src/UI/Overlay/Records/Activity/PhotoContainer.tsx
+++ b/app/src/UI/Overlay/Records/Activity/PhotoContainer.tsx
@@ -67,7 +67,7 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
   const choosePhotoFromLibrary = async () => {
     try {
       const libraryPhoto = await Camera.getPhoto({
-        quality: 90,
+        quality: 100,
         allowEditing: false,
         resultType: CameraResultType.DataUrl,
         source: CameraSource.Photos

--- a/app/src/UI/Overlay/Records/Activity/PhotoContainer.tsx
+++ b/app/src/UI/Overlay/Records/Activity/PhotoContainer.tsx
@@ -63,8 +63,31 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
     });
   }
 
+  const checkPermissionsAndDisplayInfo = async (PhotoOption: CameraSource): Promise<void> => {
+    try {
+      const permissions = await Camera.checkPermissions();
+
+      if (PhotoOption === CameraSource.Camera) {
+        if (permissions.camera === 'denied') {
+          alert('Camera access is denied. Please enable camera permissions in your device settings to take photos.');
+        }
+      }
+
+      if (PhotoOption === CameraSource.Photos) {
+        if (permissions.photos === 'denied') {
+          alert(
+            'Photo library access is denied. Please enable photo library permissions in your device settings to choose photos.'
+          );
+        }
+      }
+    } catch (error) {
+      console.error('Error checking permissions:', error);
+    }
+  };
+
   const takePhotoFromCamera = async () => {
     try {
+      await checkPermissionsAndDisplayInfo(CameraSource.Camera);
       const cameraPhoto = await Camera.getPhoto({
         presentationStyle: 'fullscreen',
         resultType: CameraResultType.DataUrl,
@@ -79,45 +102,44 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
     }
   };
 
-  const choosePhotoFromLibrary = async () => {
-    try {
-      const libraryPhoto = await Camera.getPhoto({
-        quality: 100,
-        allowEditing: false,
-        resultType: CameraResultType.DataUrl,
-        source: CameraSource.Photos
-      });
-
-      const photo = preparePhoto(libraryPhoto);
-      dispatch(Activity.Photo.add(photo));
-    } catch (e) {
-      console.error('User cancelled or other errors selecting photos', e);
-    }
-  };
-
   const chooseMultiplePhotosFromLibrary = async () => {
     try {
-      const permissions = await Camera.checkPermissions();
-      console.log('Permissions', permissions);
-      // TODO: If permission is denied by user, display info on how to activate manually from settings
-      // TODO: Check for Camera permissions as well
+      await checkPermissionsAndDisplayInfo(CameraSource.Photos);
       const multiplePhotos = await Camera.pickImages({
         quality: 100,
-        limit: 30
+        limit: 10
       });
 
-      for (let i = 0; i < multiplePhotos.photos.length; i++) {
-        const fileName = new Date().getTime() + '.' + multiplePhotos.photos[i].format;
-        console.log(multiplePhotos.photos[i].webPath, multiplePhotos.photos[i].path);
-        const dataUrl = await convertWebPathToDataUrl(multiplePhotos.photos[i].webPath);
-        const photo: UploadedPhoto = {
-          file_name: fileName,
-          encoded_file: dataUrl,
-          description: 'untitled',
-          editing: false
-        };
-        dispatch(Activity.Photo.add(photo));
+      if (!multiplePhotos.photos.length) {
+        console.log('No photos selected');
+        return;
       }
+
+      // process all photos concurrently
+      const processedPhotos = await Promise.all(
+        multiplePhotos.photos.map(async (photo, index) => {
+          try {
+            const fileName = `${new Date().getTime()}-${index}.${photo.format}`;
+            const dataUrl = await convertWebPathToDataUrl(photo.webPath);
+
+            return {
+              file_name: fileName,
+              encoded_file: dataUrl,
+              description: 'untitled',
+              editing: false
+            } as UploadedPhoto;
+          } catch (error) {
+            console.error(`Error processing photo ${index + 1}:`, error);
+            return null; // skip photo on failure
+          }
+        })
+      );
+
+      // filter out failed photo conversions
+      const validPhotos = processedPhotos.filter((photo) => photo !== null);
+      validPhotos.forEach((photo) => {
+        if (photo) dispatch(Activity.Photo.add(photo));
+      });
     } catch (e) {
       console.error('error occurred: ', e);
     }
@@ -207,6 +229,16 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
                 </Button>
               </Grid>
             </Grid>
+            {/* <>
+              <Box mt={8}>
+                <u>
+                  <strong>To enable Camera and Photo permissions manually: </strong>
+                </u>
+              </Box>
+              <Box mt={4}>
+                <strong>To enable permissions: </strong> ....
+              </Box>
+            </> */}
           </Grid>
         </Box>
       )}

--- a/app/src/UI/Overlay/Records/Activity/PhotoContainer.tsx
+++ b/app/src/UI/Overlay/Records/Activity/PhotoContainer.tsx
@@ -63,26 +63,6 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
     });
   }
 
-  const selectMultiplePhotos = async () => {
-    const multiplePhotos = await Camera.pickImages({
-      quality: 100,
-      limit: 30
-    });
-    console.log('HERE', multiplePhotos);
-    for (let i = 0; i < multiplePhotos.photos.length; i++) {
-      const fileName = new Date().getTime() + '.' + multiplePhotos.photos[i].format;
-      console.log(multiplePhotos.photos[i].webPath, multiplePhotos.photos[i].path);
-      const dataUrl = await convertWebPathToDataUrl(multiplePhotos.photos[i].webPath);
-      const photo: UploadedPhoto = {
-        file_name: fileName,
-        encoded_file: dataUrl,
-        description: 'untitled',
-        editing: false
-      };
-      dispatch(Activity.Photo.add(photo));
-    }
-  };
-
   const takePhotoFromCamera = async () => {
     try {
       const cameraPhoto = await Camera.getPhoto({
@@ -114,40 +94,30 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
       console.error('User cancelled or other errors selecting photos', e);
     }
   };
-  const requestPhotoPermission = async () => {
-    try {
-      const permission = await Camera.requestPermissions({ permissions: ['photos'] });
-
-      if (permission.photos === 'granted') {
-        console.log('Permission granted for photo library');
-        return true;
-      } else {
-        console.log('Permission denied for photo library');
-        return false;
-      }
-    } catch (error) {
-      console.error('Error requesting permission', error);
-      return false;
-    }
-  };
 
   const chooseMultiplePhotosFromLibrary = async () => {
     try {
       const permissions = await Camera.checkPermissions();
       console.log('Permissions', permissions);
-      selectMultiplePhotos();
-      // if (permissions.photos === 'granted') {
-      //   console.log('Granted by default');
-      //   selectMultiplePhotos();
-      // } else {
-      //   const newPermissions = await Camera.requestPermissions({ permissions: ['photos'] });
-      //   if (newPermissions.photos === 'granted') {
-      //     console.log('Granted now');
-      //     selectMultiplePhotos();
-      //   } else {
-      //     console.log('Permission denied after request.');
-      //   }
-      // }
+      // TODO: If permission is denied by user, display info on how to activate manually from settings
+      // TODO: Check for Camera permissions as well
+      const multiplePhotos = await Camera.pickImages({
+        quality: 100,
+        limit: 30
+      });
+
+      for (let i = 0; i < multiplePhotos.photos.length; i++) {
+        const fileName = new Date().getTime() + '.' + multiplePhotos.photos[i].format;
+        console.log(multiplePhotos.photos[i].webPath, multiplePhotos.photos[i].path);
+        const dataUrl = await convertWebPathToDataUrl(multiplePhotos.photos[i].webPath);
+        const photo: UploadedPhoto = {
+          file_name: fileName,
+          encoded_file: dataUrl,
+          description: 'untitled',
+          editing: false
+        };
+        dispatch(Activity.Photo.add(photo));
+      }
     } catch (e) {
       console.error('error occurred: ', e);
     }

--- a/app/src/UI/Overlay/Records/Activity/PhotoContainer.tsx
+++ b/app/src/UI/Overlay/Records/Activity/PhotoContainer.tsx
@@ -37,17 +37,6 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
   const dispatch = useDispatch();
   const media = useSelector((state) => state.ActivityPage.activity?.media || []);
 
-  const preparePhoto = (photoToProcess: Photo) => {
-    const fileName = new Date().getTime() + '.' + photoToProcess.format;
-    const photo: UploadedPhoto = {
-      file_name: fileName,
-      encoded_file: photoToProcess.dataUrl,
-      description: 'untitled',
-      editing: false
-    };
-    return photo;
-  };
-
   async function convertWebPathToDataUrl(webPath: string): Promise<string> {
     const response = await fetch(webPath);
 
@@ -95,7 +84,14 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
         quality: 100
       });
 
-      const photo = preparePhoto(cameraPhoto);
+      const fileName = new Date().getTime() + '.' + cameraPhoto.format;
+      const photo: UploadedPhoto = {
+        file_name: fileName,
+        encoded_file: cameraPhoto.dataUrl,
+        description: 'untitled',
+        editing: false
+      };
+
       dispatch(Activity.Photo.add(photo));
     } catch (e) {
       console.error('user cancelled or other camera problem', e);

--- a/app/src/UI/Overlay/Records/Activity/PhotoContainer.tsx
+++ b/app/src/UI/Overlay/Records/Activity/PhotoContainer.tsx
@@ -19,6 +19,8 @@ import Activity from 'state/actions/activity/Activity';
 import UploadedPhoto from 'interfaces/UploadedPhoto';
 import { useDispatch, useSelector } from 'utils/use_selector';
 import './PhotoContainer.css';
+import Alerts from 'state/actions/alerts/Alerts';
+import { AlertSeverity, AlertSubjects } from 'constants/alertEnums';
 export interface IPhoto {
   file_name: string;
   webviewPath?: string;
@@ -57,14 +59,26 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
 
       if (photoOption === CameraSource.Camera) {
         if (permissions.camera === 'denied') {
-          alert('Camera access is denied. Please enable camera permissions in your device settings to take photos.');
+          dispatch(
+            Alerts.create({
+              content:
+                'Camera access is denied. Please enable camera permissions in your device settings to take photos.',
+              severity: AlertSeverity.Warning,
+              subject: AlertSubjects.Photo,
+              autoClose: 5
+            })
+          );
         }
-      }
-
-      if (photoOption === CameraSource.Photos) {
+      } else if (photoOption === CameraSource.Photos) {
         if (permissions.photos === 'denied') {
-          alert(
-            'Photo library access is denied. Please enable photo library permissions in your device settings to choose photos.'
+          dispatch(
+            Alerts.create({
+              content:
+                'Photo library access is denied. Please enable photo library permissions in your device settings to choose photos.',
+              severity: AlertSeverity.Warning,
+              subject: AlertSubjects.Photo,
+              autoClose: 5
+            })
           );
         }
       }


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Enable multiple selection of photos from gallery
- Process photos by converting webpath blob to dataurl before 
- Check permission for camera/photo gallery and alert accordingly

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
