### PR TITLE
[INV-3630] cache download stops in progress, start emancipating from Redux State

### DIFF
--- a/app/src/UI/Overlay/Records/RecordSetCacheButtons.tsx
+++ b/app/src/UI/Overlay/Records/RecordSetCacheButtons.tsx
@@ -34,7 +34,7 @@ const RecordSetCacheButtons = ({ recordSet, setId }: PropTypes) => {
   const cancelCacheDownload = () => {
     const callback = (confirmation: boolean) => {
       if (confirmation) {
-        dispatch(RecordCache.deleteCache({ setId }));
+        dispatch(RecordCache.stopDownload({ setId }));
       }
     };
     dispatch(

--- a/app/src/UI/Overlay/Records/RecordSetCacheButtons.tsx
+++ b/app/src/UI/Overlay/Records/RecordSetCacheButtons.tsx
@@ -22,11 +22,28 @@ const RecordSetCacheButtons = ({ recordSet, setId }: PropTypes) => {
       case UserRecordCacheStatus.NOT_CACHED:
         downloadCache();
         break;
+      case UserRecordCacheStatus.DOWNLOADING:
+        cancelCacheDownload();
+        break;
       case UserRecordCacheStatus.ERROR:
       case UserRecordCacheStatus.CACHED:
         deleteCache();
         break;
     }
+  };
+  const cancelCacheDownload = () => {
+    const callback = (confirmation: boolean) => {
+      if (confirmation) {
+        dispatch(RecordCache.deleteCache({ setId }));
+      }
+    };
+    dispatch(
+      Prompt.confirmation({
+        title: 'Cancel Download',
+        prompt: 'Would you like to cancel the download in progress?',
+        callback
+      })
+    );
   };
   const downloadCache = () => {
     const callback = (confirmation: boolean) => {
@@ -74,9 +91,12 @@ const RecordSetCacheButtons = ({ recordSet, setId }: PropTypes) => {
   useEffect(() => {
     setCacheActionEnabled(
       connected &&
-        [UserRecordCacheStatus.CACHED, UserRecordCacheStatus.NOT_CACHED, UserRecordCacheStatus.ERROR].includes(
-          recordSet.cacheMetadata?.status
-        )
+        [
+          UserRecordCacheStatus.CACHED,
+          UserRecordCacheStatus.NOT_CACHED,
+          UserRecordCacheStatus.ERROR,
+          UserRecordCacheStatus.DOWNLOADING
+        ].includes(recordSet.cacheMetadata?.status)
     );
   }, [recordSet.cacheMetadata?.status, connected]);
 

--- a/app/src/constants/alerts/cacheAlerts.ts
+++ b/app/src/constants/alerts/cacheAlerts.ts
@@ -25,6 +25,12 @@ const cacheAlertMessages: Record<string, AlertMessage> = {
     severity: AlertSeverity.Success,
     subject: AlertSubjects.Cache,
     autoClose: 4
+  },
+  recordSetDownloadStoppedEarly: {
+    content: 'Recordset download stopped',
+    severity: AlertSeverity.Success,
+    subject: AlertSubjects.Cache,
+    autoClose: 4
   }
 };
 

--- a/app/src/interfaces/UserRecordSet.ts
+++ b/app/src/interfaces/UserRecordSet.ts
@@ -1,4 +1,4 @@
-import { RecordSetCachedShape } from 'utils/record-cache';
+import { GeoJSONSourceSpecification } from 'maplibre-gl';
 import { RepositoryBoundingBoxSpec } from 'utils/tile-cache';
 
 export enum RecordSetType {
@@ -35,8 +35,8 @@ export interface UserRecordSet {
   cacheMetadata: {
     status: UserRecordCacheStatus;
     idList?: string[];
-    cachedGeoJson?: RecordSetCachedShape[];
-    cachedCentroid?: RecordSetCachedShape[];
+    cachedGeoJson?: GeoJSONSourceSpecification;
+    cachedCentroid?: GeoJSONSourceSpecification;
     bbox?: RepositoryBoundingBoxSpec;
   };
 }

--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -1,5 +1,5 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
-import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
+import { UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import { RootState } from 'state/reducers/rootReducer';
 import getBoundingBoxFromRecordsetFilters from 'utils/getBoundingBoxFromRecordsetFilters';
 import { RecordCacheServiceFactory } from 'utils/record-cache/context';

--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -13,26 +13,7 @@ class RecordCache {
    */
   static readonly deleteCache = createAsyncThunk(`${this.PREFIX}/deleteCache`, async (spec: { setId: string }) => {
     const service = await RecordCacheServiceFactory.getPlatformInstance();
-    const sets = await service.listRepositories();
-    const deleteTarget = sets.find((p) => p.setId === spec.setId);
-    if (!deleteTarget) {
-      throw Error(`set ${spec.setId} was not found in Cache`);
-    }
-
-    const deleteList = deleteTarget?.cachedIds ?? [];
-    const ids: Record<PropertyKey, number> = {};
-    sets
-      .flatMap((set) => set.cachedIds)
-      .forEach((id) => {
-        ids[id] ??= 0;
-        ids[id]++;
-      });
-
-    const recordsToErase = deleteList.filter((id) => ids[id] === 1);
-    Promise.all([
-      await service.deleteCachedRecordsFromIds(recordsToErase, spec.setId, deleteTarget.recordSetType),
-      await service.deleteRepository(spec.setId)
-    ]);
+    await service.deleteRepository(spec.setId);
   });
 
   static readonly requestCaching = createAsyncThunk(
@@ -75,7 +56,7 @@ class RecordCache {
         Object.assign(responseData, await service.loadIappRecordsetSourceMetadata(idsToCache));
       } else {
         // All API calls have resolved at this stage, we can call record deletion to collect any orphans
-        await service.deleteCachedRecordsFromIds(idsToCache, spec.setId, recordSet.recordSetType);
+        await service.deleteCachedRecordsFromIds(idsToCache, recordSet.recordSetType);
         throw Error('Early Exit');
       }
 

--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -53,8 +53,8 @@ class RecordCache {
       };
       const bbox = await getBoundingBoxFromRecordsetFilters(tableFilters);
       let responseData: Record<PropertyKey, any> = {
-        cachedGeoJSON: [],
-        cachedCentroid: []
+        cachedGeoJSON: null,
+        cachedCentroid: null
       };
 
       await service.addOrUpdateCachedSet({
@@ -68,10 +68,10 @@ class RecordCache {
 
       if (recordSetType === RecordSetType.Activity) {
         await service.download(args);
-        responseData = await service.loadRecordsetSourceMetadata(idsToCache);
+        Object.assign(responseData, await service.loadRecordsetSourceMetadata(idsToCache));
       } else if (recordSetType === RecordSetType.IAPP) {
         await service.downloadIapp(args);
-        responseData = await service.loadIappRecordsetSourceMetadata(idsToCache);
+        Object.assign(responseData, await service.loadIappRecordsetSourceMetadata(idsToCache));
       }
 
       await service.addOrUpdateCachedSet({
@@ -81,7 +81,7 @@ class RecordCache {
         recordSetType: RecordSetType.IAPP,
         status: UserRecordCacheStatus.CACHED,
         cachedGeoJson: responseData.cachedGeoJson,
-        cachedCentroid: responseData.cachedCentroid ?? [],
+        cachedCentroid: responseData.cachedCentroid,
         bbox: bbox
       });
 

--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -1,5 +1,5 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
-import { RecordSetType, UserRecordSet } from 'interfaces/UserRecordSet';
+import { RecordSetType, UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
 import { RootState } from 'state/reducers/rootReducer';
 import getBoundingBoxFromRecordsetFilters from 'utils/getBoundingBoxFromRecordsetFilters';
 import { RecordCacheServiceFactory } from 'utils/record-cache/context';
@@ -57,6 +57,15 @@ class RecordCache {
         cachedCentroid: []
       };
 
+      await service.addOrUpdateCachedSet({
+        setId: spec.setId,
+        cacheTime: new Date(),
+        cachedIds: idsToCache,
+        recordSetType: RecordSetType.IAPP,
+        status: UserRecordCacheStatus.DOWNLOADING,
+        bbox: bbox
+      });
+
       if (recordSetType === RecordSetType.Activity) {
         await service.download(args);
         responseData = await service.loadRecordsetSourceMetadata(idsToCache);
@@ -64,12 +73,26 @@ class RecordCache {
         await service.downloadIapp(args);
         responseData = await service.loadIappRecordsetSourceMetadata(idsToCache);
       }
-      return {
-        cachedIds: idsToCache,
+
+      await service.addOrUpdateCachedSet({
         setId: spec.setId,
-        bbox,
+        cacheTime: new Date(),
+        cachedIds: idsToCache,
+        recordSetType: RecordSetType.IAPP,
+        status: UserRecordCacheStatus.CACHED,
         cachedGeoJson: responseData.cachedGeoJson,
-        cachedCentroid: responseData.cachedCentroid ?? []
+        cachedCentroid: responseData.cachedCentroid ?? [],
+        bbox: bbox
+      });
+
+      // Will Refactor the current uses of Cache Metadata separately
+      return {
+        status: UserRecordCacheStatus.CACHED,
+        idList: idsToCache,
+        bbox: bbox,
+        setId: spec.setId,
+        cachedGeoJson: responseData.cachedGeoJson,
+        cachedCentroid: responseData.cachedCentroid
       };
     }
   );

--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -30,48 +30,20 @@ class RecordCache {
     ) => {
       const service = await RecordCacheServiceFactory.getPlatformInstance();
       const state: RootState = getState() as RootState;
+
       const idsToCache: string[] = state.Map.layers
         .find((l) => l.recordSetID == spec.setId)
         .IDList.map((id: string | number) => id.toString());
+
       const recordSet = state.UserSettings.recordSets[spec.setId];
-      const args = {
-        idsToCache,
-        setId: spec.setId,
-        API_BASE: state.Configuration.current.API_BASE
-      };
       const bbox = await getBoundingBoxFromRecordsetFilters(recordSet);
-      let responseData: Record<PropertyKey, any> = {
-        cachedGeoJSON: null,
-        cachedCentroid: null
-      };
 
-      await service.addOrUpdateRepository({
-        setId: spec.setId,
-        cacheTime: new Date(),
-        cachedIds: idsToCache,
+      const responseData = await service.downloadCache({
+        API_BASE: state.Configuration.current.API_BASE,
+        bbox,
+        idsToCache,
         recordSetType: recordSet.recordSetType,
-        status: UserRecordCacheStatus.DOWNLOADING,
-        bbox: bbox
-      });
-
-      if (recordSet.recordSetType === RecordSetType.Activity && (await service.download(args))) {
-        Object.assign(responseData, await service.loadRecordsetSourceMetadata(idsToCache));
-      } else if (recordSet.recordSetType === RecordSetType.IAPP && (await service.downloadIapp(args))) {
-        Object.assign(responseData, await service.loadIappRecordsetSourceMetadata(idsToCache));
-      } else {
-        service.deleteRepository(spec.setId);
-        throw Error('Early Exit');
-      }
-
-      await service.addOrUpdateRepository({
-        setId: spec.setId,
-        cacheTime: new Date(),
-        cachedIds: idsToCache,
-        recordSetType: recordSet.recordSetType,
-        status: UserRecordCacheStatus.CACHED,
-        cachedGeoJson: responseData.cachedGeoJson,
-        cachedCentroid: responseData.cachedCentroid,
-        bbox: bbox
+        setId: spec.setId
       });
 
       // Will Refactor the current uses of Cache Metadata separately [Maintain only cache status]

--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -45,13 +45,13 @@ class RecordCache {
       const idsToCache: string[] = state.Map.layers
         .find((l) => l.recordSetID == spec.setId)
         .IDList.map((id: string | number) => id.toString());
-      const { recordSetType, tableFilters }: UserRecordSet = state.UserSettings.recordSets[spec.setId];
+      const recordSet = state.UserSettings.recordSets[spec.setId];
       const args = {
         idsToCache,
         setId: spec.setId,
         API_BASE: state.Configuration.current.API_BASE
       };
-      const bbox = await getBoundingBoxFromRecordsetFilters(tableFilters);
+      const bbox = await getBoundingBoxFromRecordsetFilters(recordSet);
       let responseData: Record<PropertyKey, any> = {
         cachedGeoJSON: null,
         cachedCentroid: null
@@ -61,31 +61,33 @@ class RecordCache {
         setId: spec.setId,
         cacheTime: new Date(),
         cachedIds: idsToCache,
-        recordSetType: RecordSetType.IAPP,
+        recordSetType: recordSet.recordSetType,
         status: UserRecordCacheStatus.DOWNLOADING,
         bbox: bbox
       });
 
-      if (recordSetType === RecordSetType.Activity) {
-        await service.download(args);
+      if (recordSet.recordSetType === RecordSetType.Activity && (await service.download(args))) {
         Object.assign(responseData, await service.loadRecordsetSourceMetadata(idsToCache));
-      } else if (recordSetType === RecordSetType.IAPP) {
-        await service.downloadIapp(args);
+      } else if (recordSet.recordSetType === RecordSetType.IAPP && (await service.downloadIapp(args))) {
         Object.assign(responseData, await service.loadIappRecordsetSourceMetadata(idsToCache));
+      } else {
+        // All API calls have resolved at this stage, we can call record deletion to collect any orphans
+        await service.deleteCachedRecordsFromIds(idsToCache, spec.setId, recordSet.recordSetType);
+        throw Error('Early Exit');
       }
 
       await service.addOrUpdateCachedSet({
         setId: spec.setId,
         cacheTime: new Date(),
         cachedIds: idsToCache,
-        recordSetType: RecordSetType.IAPP,
+        recordSetType: recordSet.recordSetType,
         status: UserRecordCacheStatus.CACHED,
         cachedGeoJson: responseData.cachedGeoJson,
         cachedCentroid: responseData.cachedCentroid,
         bbox: bbox
       });
 
-      // Will Refactor the current uses of Cache Metadata separately
+      // Will Refactor the current uses of Cache Metadata separately [Maintain only cache status]
       return {
         status: UserRecordCacheStatus.CACHED,
         idList: idsToCache,

--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -16,6 +16,10 @@ class RecordCache {
     await service.deleteRepository(spec.setId);
   });
 
+  static readonly stopDownload = createAsyncThunk(`${this.PREFIX}/stopDownload`, async (spec: { setId: string }) => {
+    await (await RecordCacheServiceFactory.getPlatformInstance()).stopDownload(spec.setId);
+  });
+
   static readonly requestCaching = createAsyncThunk(
     `${this.PREFIX}/requestCaching`,
     async (
@@ -55,8 +59,7 @@ class RecordCache {
       } else if (recordSet.recordSetType === RecordSetType.IAPP && (await service.downloadIapp(args))) {
         Object.assign(responseData, await service.loadIappRecordsetSourceMetadata(idsToCache));
       } else {
-        // All API calls have resolved at this stage, we can call record deletion to collect any orphans
-        await service.deleteCachedRecordsFromIds(idsToCache, recordSet.recordSetType);
+        service.deleteRepository(spec.setId);
         throw Error('Early Exit');
       }
 

--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -1,5 +1,5 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
-import { RecordSetType, UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
+import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import { RootState } from 'state/reducers/rootReducer';
 import getBoundingBoxFromRecordsetFilters from 'utils/getBoundingBoxFromRecordsetFilters';
 import { RecordCacheServiceFactory } from 'utils/record-cache/context';
@@ -13,7 +13,7 @@ class RecordCache {
    */
   static readonly deleteCache = createAsyncThunk(`${this.PREFIX}/deleteCache`, async (spec: { setId: string }) => {
     const service = await RecordCacheServiceFactory.getPlatformInstance();
-    const sets = await service.listCachedSets();
+    const sets = await service.listRepositories();
     const deleteTarget = sets.find((p) => p.setId === spec.setId);
     if (!deleteTarget) {
       throw Error(`set ${spec.setId} was not found in Cache`);
@@ -29,7 +29,10 @@ class RecordCache {
       });
 
     const recordsToErase = deleteList.filter((id) => ids[id] === 1);
-    await service.deleteCachedRecordsFromIds(recordsToErase, spec.setId, deleteTarget.recordSetType);
+    Promise.all([
+      await service.deleteCachedRecordsFromIds(recordsToErase, spec.setId, deleteTarget.recordSetType),
+      await service.deleteRepository(spec.setId)
+    ]);
   });
 
   static readonly requestCaching = createAsyncThunk(
@@ -57,7 +60,7 @@ class RecordCache {
         cachedCentroid: null
       };
 
-      await service.addOrUpdateCachedSet({
+      await service.addOrUpdateRepository({
         setId: spec.setId,
         cacheTime: new Date(),
         cachedIds: idsToCache,
@@ -76,7 +79,7 @@ class RecordCache {
         throw Error('Early Exit');
       }
 
-      await service.addOrUpdateCachedSet({
+      await service.addOrUpdateRepository({
         setId: spec.setId,
         cacheTime: new Date(),
         cachedIds: idsToCache,

--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -18,15 +18,16 @@ class RecordCache {
       const state = getState() as RootState;
       const { recordSets } = state.UserSettings;
       const deleteList = recordSets[spec.setId].cacheMetadata.idList ?? [];
-      const ids: Record<string, number> = {};
+      const ids: Record<PropertyKey, number> = {};
       Object.keys(recordSets)
         .flatMap((key) => recordSets[key].cacheMetadata.idList ?? [])
         .forEach((id) => {
           ids[id] ??= 0;
           ids[id]++;
         });
+
       const recordsToErase = deleteList.filter((id) => ids[id] === 1);
-      await service.deleteCachedRecordsFromIds(recordsToErase, recordSets[spec.setId].recordSetType);
+      await service.deleteCachedRecordsFromIds(recordsToErase, spec.setId, recordSets[spec.setId].recordSetType);
     }
   );
 

--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -11,25 +11,26 @@ class RecordCache {
    * @desc Deletes cached records for a recordset.
    *       determines duplicates with a frequency map to avoid duplicating records contained elsewhere
    */
-  static readonly deleteCache = createAsyncThunk(
-    `${this.PREFIX}/deleteCache`,
-    async (spec: { setId: string }, { getState }) => {
-      const service = await RecordCacheServiceFactory.getPlatformInstance();
-      const state = getState() as RootState;
-      const { recordSets } = state.UserSettings;
-      const deleteList = recordSets[spec.setId].cacheMetadata.idList ?? [];
-      const ids: Record<PropertyKey, number> = {};
-      Object.keys(recordSets)
-        .flatMap((key) => recordSets[key].cacheMetadata.idList ?? [])
-        .forEach((id) => {
-          ids[id] ??= 0;
-          ids[id]++;
-        });
-
-      const recordsToErase = deleteList.filter((id) => ids[id] === 1);
-      await service.deleteCachedRecordsFromIds(recordsToErase, spec.setId, recordSets[spec.setId].recordSetType);
+  static readonly deleteCache = createAsyncThunk(`${this.PREFIX}/deleteCache`, async (spec: { setId: string }) => {
+    const service = await RecordCacheServiceFactory.getPlatformInstance();
+    const sets = await service.listCachedSets();
+    const deleteTarget = sets.find((p) => p.setId === spec.setId);
+    if (!deleteTarget) {
+      throw Error(`set ${spec.setId} was not found in Cache`);
     }
-  );
+
+    const deleteList = deleteTarget?.cachedIds ?? [];
+    const ids: Record<PropertyKey, number> = {};
+    sets
+      .flatMap((set) => set.cachedIds)
+      .forEach((id) => {
+        ids[id] ??= 0;
+        ids[id]++;
+      });
+
+    const recordsToErase = deleteList.filter((id) => ids[id] === 1);
+    await service.deleteCachedRecordsFromIds(recordsToErase, spec.setId, deleteTarget.recordSetType);
+  });
 
   static readonly requestCaching = createAsyncThunk(
     `${this.PREFIX}/requestCaching`,

--- a/app/src/state/actions/userSettings/RecordSet.ts
+++ b/app/src/state/actions/userSettings/RecordSet.ts
@@ -50,7 +50,7 @@ class RecordSet {
         throw Error('no record cache service is available');
       }
 
-      const cachedSets = await service.listCachedSets();
+      const cachedSets = await service.listRepositories();
 
       // these will be passed to the reducer, which can then mark the record sets as cached
       return cachedSets.map((set) => {

--- a/app/src/state/actions/userSettings/RecordSet.ts
+++ b/app/src/state/actions/userSettings/RecordSet.ts
@@ -64,7 +64,12 @@ class RecordSet {
     async (spec: { setId: string }, thunkAPI) => {
       const state = thunkAPI.getState() as RootState;
       const { recordSets } = state.UserSettings;
-      if (MOBILE && recordSets[spec.setId].cacheMetadata.status == UserRecordCacheStatus.CACHED) {
+      if (
+        MOBILE &&
+        [UserRecordCacheStatus.CACHED, UserRecordCacheStatus.DOWNLOADING].includes(
+          recordSets[spec.setId]?.cacheMetadata?.status
+        )
+      ) {
         const deletionResult = await thunkAPI.dispatch(RecordCache.deleteCache(spec));
         if (RecordCache.deleteCache.rejected.match(deletionResult)) {
           throw Error('Cache failed to delete');

--- a/app/src/state/reducers/alertsAndPrompts.ts
+++ b/app/src/state/reducers/alertsAndPrompts.ts
@@ -53,7 +53,9 @@ export function createAlertsAndPromptsReducer(
       } else if (RecordCache.requestCaching.fulfilled.match(action)) {
         draftState.alerts = addAlert(state.alerts, cacheAlertMessages.recordsetCacheSuccess);
       } else if (RecordCache.requestCaching.rejected.match(action)) {
-        draftState.alerts = addAlert(state.alerts, cacheAlertMessages.recordsetCacheFailed);
+        if (action?.error?.message !== 'Early Exit') {
+          draftState.alerts = addAlert(state.alerts, cacheAlertMessages.recordsetCacheFailed);
+        }
       } else if (RecordCache.deleteCache.rejected.match(action)) {
         draftState.alerts = addAlert(state.alerts, cacheAlertMessages.recordsetDeleteCacheFailed);
       } else if (RecordCache.deleteCache.fulfilled.match(action)) {

--- a/app/src/state/reducers/alertsAndPrompts.ts
+++ b/app/src/state/reducers/alertsAndPrompts.ts
@@ -58,6 +58,8 @@ export function createAlertsAndPromptsReducer(
         }
       } else if (RecordCache.deleteCache.rejected.match(action)) {
         draftState.alerts = addAlert(state.alerts, cacheAlertMessages.recordsetDeleteCacheFailed);
+      } else if (RecordCache.stopDownload.fulfilled.match(action)) {
+        draftState.alerts = addAlert(state.alerts, cacheAlertMessages.recordSetDownloadStoppedEarly);
       } else if (RecordCache.deleteCache.fulfilled.match(action)) {
         draftState.alerts = addAlert(state.alerts, cacheAlertMessages.recordsetDeleteCacheSuccess);
       }

--- a/app/src/state/reducers/userSettings.ts
+++ b/app/src/state/reducers/userSettings.ts
@@ -201,9 +201,11 @@ function createUserSettingsReducer(configuration: AppConfig): (UserSettingsState
           status: UserRecordCacheStatus.DOWNLOADING
         };
       } else if (RecordCache.requestCaching.rejected.match(action) || RecordCache.deleteCache.rejected.match(action)) {
-        draftState.recordSets[action.meta.arg.setId].cacheMetadata = {
-          status: UserRecordCacheStatus.ERROR
-        };
+        if (action.error.message !== 'Early Exit') {
+          draftState.recordSets[action.meta.arg.setId].cacheMetadata = {
+            status: UserRecordCacheStatus.ERROR
+          };
+        }
       } else if (RecordCache.requestCaching.fulfilled.match(action)) {
         draftState.recordSets[action.meta.arg.setId].cacheMetadata = {
           status: UserRecordCacheStatus.CACHED,

--- a/app/src/state/reducers/userSettings.ts
+++ b/app/src/state/reducers/userSettings.ts
@@ -201,7 +201,11 @@ function createUserSettingsReducer(configuration: AppConfig): (UserSettingsState
           status: UserRecordCacheStatus.DOWNLOADING
         };
       } else if (RecordCache.requestCaching.rejected.match(action) || RecordCache.deleteCache.rejected.match(action)) {
-        if (action.error.message !== 'Early Exit') {
+        if (action.error.message === 'Early Exit') {
+          draftState.recordSets[action.meta.arg.setId].cacheMetadata = {
+            status: UserRecordCacheStatus.NOT_CACHED
+          };
+        } else {
           draftState.recordSets[action.meta.arg.setId].cacheMetadata = {
             status: UserRecordCacheStatus.ERROR
           };
@@ -214,7 +218,7 @@ function createUserSettingsReducer(configuration: AppConfig): (UserSettingsState
           cachedGeoJson: action.payload.cachedGeoJson,
           cachedCentroid: action.payload.cachedCentroid
         };
-      } else if (RecordCache.deleteCache.pending.match(action)) {
+      } else if (RecordCache.deleteCache.pending.match(action) || RecordCache.stopDownload.pending.match(action)) {
         draftState.recordSets[action.meta.arg.setId].cacheMetadata.status = UserRecordCacheStatus.DELETING;
       } else if (RecordCache.deleteCache.fulfilled.match(action)) {
         draftState.recordSets[action.meta.arg.setId].cacheMetadata = {

--- a/app/src/state/reducers/userSettings.ts
+++ b/app/src/state/reducers/userSettings.ts
@@ -207,7 +207,7 @@ function createUserSettingsReducer(configuration: AppConfig): (UserSettingsState
       } else if (RecordCache.requestCaching.fulfilled.match(action)) {
         draftState.recordSets[action.meta.arg.setId].cacheMetadata = {
           status: UserRecordCacheStatus.CACHED,
-          idList: action.payload.cachedIds,
+          idList: action.payload.idList,
           bbox: action.payload.bbox,
           cachedGeoJson: action.payload.cachedGeoJson,
           cachedCentroid: action.payload.cachedCentroid

--- a/app/src/state/sagas/map/dataAccess.ts
+++ b/app/src/state/sagas/map/dataAccess.ts
@@ -115,12 +115,12 @@ export function* handle_ACTIVITIES_GET_IDS_FOR_RECORDSET_REQUEST(action) {
       });
     } else {
       const recordSet = currentState.recordSets[action.payload.recordSetID] ?? null;
-      if (recordSet?.cachedMetadata?.idList) {
+      if (recordSet?.cacheMetadata?.idList) {
         yield put({
           type: ACTIVITIES_GET_IDS_FOR_RECORDSET_SUCCESS,
           payload: {
             recordSetID: action.payload.recordSetID,
-            IDList: recordSet.cachedMetadata.idList ?? [],
+            IDList: recordSet.cacheMetadata.idList ?? [],
             tableFiltersHash: action.payload.tableFiltersHash
           }
         });

--- a/app/src/utils/filterRecordsetsByNetworkState.ts
+++ b/app/src/utils/filterRecordsetsByNetworkState.ts
@@ -8,7 +8,7 @@ import { UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
  */
 const filterRecordsetsByNetworkState = (recordSets: Record<string, UserRecordSet>, userOffline: boolean): string[] =>
   Object.keys(recordSets).filter((set) => {
-    return recordSets[set].cacheMetadata.status === UserRecordCacheStatus.CACHED || !userOffline;
+    return !userOffline || recordSets[set].cacheMetadata.status === UserRecordCacheStatus.CACHED;
   });
 
 export default filterRecordsetsByNetworkState;

--- a/app/src/utils/getBoundingBoxFromRecordsetFilters.ts
+++ b/app/src/utils/getBoundingBoxFromRecordsetFilters.ts
@@ -1,17 +1,18 @@
 import bbox from '@turf/bbox';
-import { RecordSetType, UserRecordSet } from 'interfaces/UserRecordSet';
+import { UserRecordSet } from 'interfaces/UserRecordSet';
 import { getCurrentJWT } from 'state/sagas/auth/auth';
 import { getSelectColumnsByRecordSetType } from 'state/sagas/map/dataAccess';
 import { parse } from 'wkt';
 import { RepositoryBoundingBoxSpec } from './tile-cache';
 
 const getBoundingBoxFromRecordsetFilters = async (recordSet: UserRecordSet): Promise<RepositoryBoundingBoxSpec> => {
+  const { recordSetType } = recordSet;
   const filterObj = {
-    recordSetType: recordSet.recordSetType,
+    recordSetType: recordSetType,
     sortColumn: 'short_id',
     sortOrder: 'DESC',
     tableFilters: recordSet.tableFilters,
-    selectColumns: getSelectColumnsByRecordSetType(RecordSetType.Activity)
+    selectColumns: getSelectColumnsByRecordSetType(recordSetType)
   };
 
   const data = await fetch(`${CONFIGURATION_API_BASE}/api/v2/activities/bbox`, {

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -5,7 +5,7 @@ import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import { GeoJSONSourceSpecification } from 'maplibre-gl';
 import { getCurrentJWT } from 'state/sagas/auth/auth';
 import { getSelectColumnsByRecordSetType } from 'state/sagas/map/dataAccess';
-import { RepositoryBoundingBoxSpec, RepositoryStatus } from 'utils/tile-cache';
+import { RepositoryBoundingBoxSpec } from 'utils/tile-cache';
 
 export enum IappRecordMode {
   Record = 'record',

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -50,6 +50,14 @@ export interface RecordCacheProgressCallbackParameters {
   processedActivities: number;
 }
 
+export interface CacheDownloadSpec {
+  bbox: RepositoryBoundingBoxSpec;
+  idsToCache: string[];
+  setId: string;
+  API_BASE: string;
+  recordSetType: RecordSetType;
+}
+
 abstract class RecordCacheService {
   private readonly RECORDS_BETWEEN_PROGRESS_UPDATES = 25;
   protected constructor() {}
@@ -90,6 +98,49 @@ abstract class RecordCacheService {
 
   abstract checkForAbort(id: string): Promise<boolean>;
 
+  async downloadCache(spec: CacheDownloadSpec): Promise<Record<PropertyKey, any>> {
+    const args = {
+      idsToCache: spec.idsToCache,
+      setId: spec.setId,
+      API_BASE: spec.API_BASE
+    };
+
+    let responseData: Record<PropertyKey, any> = {
+      cachedGeoJSON: null,
+      cachedCentroid: null
+    };
+
+    await this.addOrUpdateRepository({
+      setId: spec.setId,
+      cacheTime: new Date(),
+      cachedIds: spec.idsToCache,
+      recordSetType: spec.recordSetType,
+      status: UserRecordCacheStatus.DOWNLOADING,
+      bbox: spec.bbox
+    });
+
+    if (spec.recordSetType === RecordSetType.Activity && (await this.downloadActivity(args))) {
+      Object.assign(responseData, await this.loadRecordsetSourceMetadata(spec.idsToCache));
+    } else if (spec.recordSetType === RecordSetType.IAPP && (await this.downloadIapp(args))) {
+      Object.assign(responseData, await this.loadIappRecordsetSourceMetadata(spec.idsToCache));
+    } else {
+      this.deleteRepository(spec.setId);
+      throw Error('Early Exit');
+    }
+
+    await this.addOrUpdateRepository({
+      setId: spec.setId,
+      cacheTime: new Date(),
+      cachedIds: spec.idsToCache,
+      recordSetType: spec.recordSetType,
+      status: UserRecordCacheStatus.CACHED,
+      cachedGeoJson: responseData.cachedGeoJson,
+      cachedCentroid: responseData.cachedCentroid,
+      bbox: spec.bbox
+    });
+
+    return responseData;
+  }
   /**
    * Download Records for IAPP Given a list of IDs
    * @returns { boolean } download was successful
@@ -144,7 +195,7 @@ abstract class RecordCacheService {
    * Download Records for Activities Given a list of IDs
    * @returns { boolean } download was successful
    */
-  async download(
+  async downloadActivity(
     spec: RecordCacheDownloadRequestSpec,
     progressCallback?: (currentProgress: RecordCacheProgressCallbackParameters) => void
   ): Promise<boolean> {

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -20,8 +20,8 @@ export interface RecordCacheDownloadRequestSpec {
  * @desc Cached Metadata for Recordsets
  * @property { string } setID Recordset ID
  * @property { string[] } cachedIds collection of activity_ids in Recordset
- * @property { RecordSetCachedShape[] } cachedGeoJSON  Cached Features for low map layers
- * @property { RecordSetCachedShape[] } cachedCentroid Cached Points for high map layers
+ * @property { GeoJSONSourceSpecification } cachedGeoJSON  Cached Features for low map layers
+ * @property { GeoJSONSourceSpecification } cachedCentroid Cached Points for high map layers
  */
 export interface RecordSetCacheMetadata {
   setId: string;

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -15,7 +15,14 @@ export interface RecordCacheDownloadRequestSpec {
   API_BASE: string;
   idsToCache: string[];
 }
+export interface RecordCacheAddSpec {
+  setId: string;
+  cacheTime: Date;
+  cachedIds: string[];
+  recordSetType: RecordSetType;
+}
 
+export interface CachedSetMetadata {}
 /**
  * @desc Cached Metadata for Recordsets
  * @property { string } setID Recordset ID
@@ -23,7 +30,7 @@ export interface RecordCacheDownloadRequestSpec {
  * @property { GeoJSONSourceSpecification } cachedGeoJSON  Cached Features for low map layers
  * @property { GeoJSONSourceSpecification } cachedCentroid Cached Points for high map layers
  */
-export interface RecordSetCacheMetadata {
+export interface ReduxRecordSetCacheMetadata {
   setId: string;
   cachedIds?: string[];
   cachedGeoJson: GeoJSONSourceSpecification;
@@ -54,7 +61,13 @@ abstract class RecordCacheService {
   abstract saveActivity(id: string, data: unknown): Promise<void>;
 
   abstract saveIapp(id: string, iappRecord: unknown, iappTableRow: unknown): Promise<void>;
-  abstract deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void>;
+
+  abstract deleteCachedRecordsFromIds(
+    idsToDelete: string[],
+    setId: string,
+    recordSetType: RecordSetType
+  ): Promise<void>;
+
   abstract loadActivity(id: string): Promise<unknown>;
   abstract loadIapp(id: string, type: IappRecordMode): Promise<IappRecord | IappTableRow>;
 
@@ -63,15 +76,27 @@ abstract class RecordCacheService {
     page: number,
     limit: number
   ): Promise<IappRecord[]>;
+
   abstract fetchPaginatedCachedRecords(recordSetIdList: string[], page: number, limit: number): Promise<UserRecord[]>;
 
+  abstract addCachedSet(spec: RecordCacheAddSpec): Promise<void>;
+
+  abstract listCachedSets(): Promise<RecordCacheAddSpec[]>;
+
   abstract loadIappRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata>;
+
   abstract loadRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata>;
 
   async downloadIapp(
     spec: RecordCacheDownloadRequestSpec,
     progressCallback?: (currentProgress: RecordCacheProgressCallbackParameters) => void
   ): Promise<void> {
+    await this.addCachedSet({
+      setId: spec.setId,
+      cacheTime: new Date(),
+      cachedIds: spec.idsToCache,
+      recordSetType: RecordSetType.IAPP
+    });
     for (const id of spec.idsToCache) {
       const authorization = await getCurrentJWT();
       const [iappRecord, tableRow] = await Promise.all([
@@ -110,6 +135,12 @@ abstract class RecordCacheService {
     spec: RecordCacheDownloadRequestSpec,
     progressCallback?: (currentProgress: RecordCacheProgressCallbackParameters) => void
   ): Promise<void> {
+    await this.addCachedSet({
+      setId: spec.setId,
+      cacheTime: new Date(),
+      cachedIds: spec.idsToCache,
+      recordSetType: RecordSetType.Activity
+    });
     for (const id of spec.idsToCache) {
       const rez = await fetch(`${spec.API_BASE}/api/activity/${id}`, {
         headers: {

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -5,7 +5,7 @@ import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import { GeoJSONSourceSpecification } from 'maplibre-gl';
 import { getCurrentJWT } from 'state/sagas/auth/auth';
 import { getSelectColumnsByRecordSetType } from 'state/sagas/map/dataAccess';
-import { RepositoryBoundingBoxSpec } from 'utils/tile-cache';
+import { RepositoryBoundingBoxSpec, RepositoryStatus } from 'utils/tile-cache';
 
 export enum IappRecordMode {
   Record = 'record',
@@ -51,6 +51,7 @@ export interface RecordCacheProgressCallbackParameters {
 }
 
 abstract class RecordCacheService {
+  private readonly TIME_BETWEEN_ABORT_CHECKS = 25;
   protected constructor() {}
 
   static async getInstance(): Promise<RecordCacheService> {
@@ -78,23 +79,34 @@ abstract class RecordCacheService {
 
   abstract fetchPaginatedCachedRecords(recordSetIdList: string[], page: number, limit: number): Promise<UserRecord[]>;
 
-  abstract addOrUpdateCachedSet(spec: RecordCacheAddSpec): Promise<void>;
+  abstract addOrUpdateRepository(spec: RecordCacheAddSpec): Promise<void>;
 
-  abstract listCachedSets(): Promise<RecordCacheAddSpec[]>;
+  abstract deleteRepository(repositoryId: string): Promise<void>;
+
+  abstract listRepositories(): Promise<RecordCacheAddSpec[]>;
 
   abstract loadIappRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata>;
 
   abstract loadRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata>;
 
+  abstract setRepositoryStatus(repositoryId: string, status: RepositoryStatus): Promise<void>;
+
+  abstract checkForAbort(id: string): Promise<boolean>;
+
+  /**
+   * Download Records for IAPP Given a list of IDs
+   * @returns { boolean } download was successful
+   */
   async downloadIapp(
     spec: RecordCacheDownloadRequestSpec,
     progressCallback?: (currentProgress: RecordCacheProgressCallbackParameters) => void
-  ): Promise<void> {
-    for (const id of spec.idsToCache) {
+  ): Promise<boolean> {
+    let abort = false;
+    for (let i = 0; i < spec.idsToCache.length && !abort; i++) {
       const authorization = await getCurrentJWT();
       const [iappRecord, tableRow] = await Promise.all([
         fetch(
-          `${spec.API_BASE}/api/points-of-interest/?query={"iappSiteID":"${id}","isIAPP":true,"site_id_only":false}`,
+          `${spec.API_BASE}/api/points-of-interest/?query={"iappSiteID":"${spec.idsToCache[i]}","isIAPP":true,"site_id_only":false}`,
           { headers: { authorization } }
         ).then(async (data) => await data.json()),
         fetch(`${spec.API_BASE}/api/v2/IAPP/`, {
@@ -109,7 +121,7 @@ abstract class RecordCacheService {
                 tableFilters: [
                   {
                     field: 'site_id',
-                    filter: id,
+                    filter: spec.idsToCache[i],
                     filterType: 'tableFilter',
                     operator: 'CONTAINS',
                     operator2: 'AND'
@@ -120,22 +132,41 @@ abstract class RecordCacheService {
           })
         }).then(async (data) => await data.json())
       ]);
-      await this.saveIapp(id.toString(), iappRecord, tableRow);
+      await this.saveIapp(spec.idsToCache[i].toString(), iappRecord, tableRow);
+      if (i % this.TIME_BETWEEN_ABORT_CHECKS === 0) {
+        abort = await this.checkForAbort(spec.setId);
+        /*
+          ProgressCallback Logic
+        */
+      }
     }
+    return !abort;
   }
 
+  /**
+   * Download Records for Activities Given a list of IDs
+   * @returns { boolean } download was successful
+   */
   async download(
     spec: RecordCacheDownloadRequestSpec,
     progressCallback?: (currentProgress: RecordCacheProgressCallbackParameters) => void
-  ): Promise<void> {
-    for (const id of spec.idsToCache) {
-      const rez = await fetch(`${spec.API_BASE}/api/activity/${id}`, {
+  ): Promise<boolean> {
+    let abort = false;
+    for (let i = 0; i < spec.idsToCache.length && !abort; i++) {
+      const rez = await fetch(`${spec.API_BASE}/api/activity/${spec.idsToCache[i]}`, {
         headers: {
           Authorization: await getCurrentJWT()
         }
       });
-      await this.saveActivity(id, await rez.json());
+      await this.saveActivity(spec.idsToCache[i], await rez.json());
+      if (i % this.TIME_BETWEEN_ABORT_CHECKS === 0) {
+        abort = await this.checkForAbort(spec.setId);
+        /*
+          ProgressCallback Logic
+        */
+      }
     }
+    return !abort;
   }
 }
 

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -65,6 +65,7 @@ abstract class RecordCacheService {
   abstract deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void>;
 
   abstract loadActivity(id: string): Promise<unknown>;
+
   abstract loadIapp(id: string, type: IappRecordMode): Promise<IappRecord | IappTableRow>;
 
   abstract fetchPaginatedCachedIappRecords(
@@ -85,7 +86,7 @@ abstract class RecordCacheService {
 
   abstract loadRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata>;
 
-  abstract setRepositoryStatus(repositoryId: string, status: RepositoryStatus): Promise<void>;
+  abstract setRepositoryStatus(repositoryId: string, status: UserRecordCacheStatus): Promise<void>;
 
   abstract checkForAbort(id: string): Promise<boolean>;
 
@@ -163,6 +164,17 @@ abstract class RecordCacheService {
       }
     }
     return !abort;
+  }
+  async stopDownload(repositoryId: string): Promise<void> {
+    const repositories = await this.listRepositories();
+    const foundIndex = repositories.findIndex((repo) => repo.setId === repositoryId);
+    if (foundIndex === -1) throw Error(`Repository ${repositoryId} wasn't found`);
+
+    if (repositories[foundIndex].status === UserRecordCacheStatus.DOWNLOADING) {
+      await this.setRepositoryStatus(repositoryId, UserRecordCacheStatus.DELETING);
+    } else if (repositories[foundIndex].status === UserRecordCacheStatus.CACHED) {
+      await this.deleteRepository(repositoryId);
+    }
   }
 }
 

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -1,10 +1,11 @@
 import IappRecord from 'interfaces/IappRecord';
 import IappTableRow from 'interfaces/IappTableRecord';
 import UserRecord from 'interfaces/UserRecord';
-import { RecordSetType } from 'interfaces/UserRecordSet';
+import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import { GeoJSONSourceSpecification } from 'maplibre-gl';
 import { getCurrentJWT } from 'state/sagas/auth/auth';
 import { getSelectColumnsByRecordSetType } from 'state/sagas/map/dataAccess';
+import { RepositoryBoundingBoxSpec } from 'utils/tile-cache';
 
 export enum IappRecordMode {
   Record = 'record',
@@ -15,26 +16,24 @@ export interface RecordCacheDownloadRequestSpec {
   API_BASE: string;
   idsToCache: string[];
 }
+/**
+ * @desc Cached Metadata for Recordsets
+ * @property { string } setID Recordset ID
+ * @property { string[] } cachedIds collection of activity_ids in Recordset
+ * @property { Date } cacheTime Timestamp of cache
+ * @property { GeoJSONSourceSpecification } cachedGeoJSON  Cached Features for low map layers
+ * @property { GeoJSONSourceSpecification } cachedCentroid Cached Points for high map layers
+ * @property { UserRecordCacheStatus } status Cache Status.
+ */
 export interface RecordCacheAddSpec {
   setId: string;
   cacheTime: Date;
   cachedIds: string[];
   recordSetType: RecordSetType;
-}
-
-export interface CachedSetMetadata {}
-/**
- * @desc Cached Metadata for Recordsets
- * @property { string } setID Recordset ID
- * @property { string[] } cachedIds collection of activity_ids in Recordset
- * @property { GeoJSONSourceSpecification } cachedGeoJSON  Cached Features for low map layers
- * @property { GeoJSONSourceSpecification } cachedCentroid Cached Points for high map layers
- */
-export interface ReduxRecordSetCacheMetadata {
-  setId: string;
-  cachedIds?: string[];
-  cachedGeoJson: GeoJSONSourceSpecification;
-  cachedCentroid: GeoJSONSourceSpecification;
+  cachedGeoJson?: GeoJSONSourceSpecification;
+  cachedCentroid?: GeoJSONSourceSpecification;
+  bbox?: RepositoryBoundingBoxSpec;
+  status: UserRecordCacheStatus;
 }
 
 export interface RecordSetSourceMetadata {
@@ -79,7 +78,7 @@ abstract class RecordCacheService {
 
   abstract fetchPaginatedCachedRecords(recordSetIdList: string[], page: number, limit: number): Promise<UserRecord[]>;
 
-  abstract addCachedSet(spec: RecordCacheAddSpec): Promise<void>;
+  abstract addOrUpdateCachedSet(spec: RecordCacheAddSpec): Promise<void>;
 
   abstract listCachedSets(): Promise<RecordCacheAddSpec[]>;
 
@@ -91,12 +90,6 @@ abstract class RecordCacheService {
     spec: RecordCacheDownloadRequestSpec,
     progressCallback?: (currentProgress: RecordCacheProgressCallbackParameters) => void
   ): Promise<void> {
-    await this.addCachedSet({
-      setId: spec.setId,
-      cacheTime: new Date(),
-      cachedIds: spec.idsToCache,
-      recordSetType: RecordSetType.IAPP
-    });
     for (const id of spec.idsToCache) {
       const authorization = await getCurrentJWT();
       const [iappRecord, tableRow] = await Promise.all([
@@ -135,12 +128,6 @@ abstract class RecordCacheService {
     spec: RecordCacheDownloadRequestSpec,
     progressCallback?: (currentProgress: RecordCacheProgressCallbackParameters) => void
   ): Promise<void> {
-    await this.addCachedSet({
-      setId: spec.setId,
-      cacheTime: new Date(),
-      cachedIds: spec.idsToCache,
-      recordSetType: RecordSetType.Activity
-    });
     for (const id of spec.idsToCache) {
       const rez = await fetch(`${spec.API_BASE}/api/activity/${id}`, {
         headers: {

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -51,7 +51,7 @@ export interface RecordCacheProgressCallbackParameters {
 }
 
 abstract class RecordCacheService {
-  private readonly TIME_BETWEEN_ABORT_CHECKS = 25;
+  private readonly RECORDS_BETWEEN_PROGRESS_UPDATES = 25;
   protected constructor() {}
 
   static async getInstance(): Promise<RecordCacheService> {
@@ -62,11 +62,7 @@ abstract class RecordCacheService {
 
   abstract saveIapp(id: string, iappRecord: unknown, iappTableRow: unknown): Promise<void>;
 
-  abstract deleteCachedRecordsFromIds(
-    idsToDelete: string[],
-    setId: string,
-    recordSetType: RecordSetType
-  ): Promise<void>;
+  abstract deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void>;
 
   abstract loadActivity(id: string): Promise<unknown>;
   abstract loadIapp(id: string, type: IappRecordMode): Promise<IappRecord | IappTableRow>;
@@ -133,7 +129,7 @@ abstract class RecordCacheService {
         }).then(async (data) => await data.json())
       ]);
       await this.saveIapp(spec.idsToCache[i].toString(), iappRecord, tableRow);
-      if (i % this.TIME_BETWEEN_ABORT_CHECKS === 0) {
+      if (i % this.RECORDS_BETWEEN_PROGRESS_UPDATES === 0 || i === spec.idsToCache.length - 1) {
         abort = await this.checkForAbort(spec.setId);
         /*
           ProgressCallback Logic
@@ -159,7 +155,7 @@ abstract class RecordCacheService {
         }
       });
       await this.saveActivity(spec.idsToCache[i], await rez.json());
-      if (i % this.TIME_BETWEEN_ABORT_CHECKS === 0) {
+      if (i % this.RECORDS_BETWEEN_PROGRESS_UPDATES === 0 || i === spec.idsToCache.length - 1) {
         abort = await this.checkForAbort(spec.setId);
         /*
           ProgressCallback Logic

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -11,7 +11,8 @@ import { Feature } from '@turf/helpers';
 import { GeoJSONSourceSpecification } from 'maplibre-gl';
 import IappRecord from 'interfaces/IappRecord';
 import IappTableRow from 'interfaces/IappTableRecord';
-import { RecordSetType } from 'interfaces/UserRecordSet';
+import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
+import { RepositoryStatus } from 'utils/tile-cache';
 
 class LocalForageRecordCacheService extends RecordCacheService {
   private static _instance: LocalForageRecordCacheService;
@@ -40,6 +41,26 @@ class LocalForageRecordCacheService extends RecordCacheService {
     await this.store.setItem(id, data);
   }
 
+  async setCacheStatus(cacheId: string, status: RepositoryStatus) {
+    if (this.store == null) {
+      throw Error('Cache not available');
+    }
+    const cachedSets = await this.listCachedSets();
+    const foundIndex = cachedSets.findIndex((p) => p.setId === cacheId);
+    if (foundIndex !== -1) {
+      Object.assign(cachedSets[foundIndex], { status });
+      await this.store.setItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY, cachedSets);
+    }
+  }
+
+  async checkForAbort(id: string): Promise<boolean> {
+    const sets = await this.listCachedSets();
+    const index = sets.findIndex((p) => p.setId === id);
+    if (index !== -1) {
+      return sets[index].status === UserRecordCacheStatus.DELETING;
+    }
+    return true;
+  }
   async saveIapp(id: string, iappRecord: IappRecord, iappTableRow: IappTableRow): Promise<void> {
     if (this.store == null) {
       throw new Error('cache not available');
@@ -178,8 +199,14 @@ class LocalForageRecordCacheService extends RecordCacheService {
     if (this.store == null) {
       throw new Error('cache not available');
     }
+    this.setCacheStatus(setId, RepositoryStatus.DELETING);
+
     for (const id of idsToDelete) {
-      await this.store.removeItem(id.toString());
+      try {
+        await this.store.removeItem(id.toString());
+      } catch {
+        // Item may not exist if a cache was quit while in progress.
+      }
     }
 
     const cachedSets = await this.listCachedSets();
@@ -190,6 +217,10 @@ class LocalForageRecordCacheService extends RecordCacheService {
     }
   }
 
+  /**
+   * @desc Create or Update an entry in the cachedSet Repository
+   * @param newSet Data to update
+   */
   async addOrUpdateCachedSet(newSet: RecordCacheAddSpec): Promise<void> {
     if (this.store == null) {
       throw new Error('cache not available');
@@ -198,10 +229,10 @@ class LocalForageRecordCacheService extends RecordCacheService {
     const cachedSets = (await this.listCachedSets()) ?? [];
     const foundIndex = cachedSets.findIndex((p) => p.setId === newSet.setId);
 
-    if (foundIndex !== -1) {
-      Object.assign(cachedSets[foundIndex], newSet);
-    } else {
+    if (foundIndex === -1) {
       cachedSets.push(newSet);
+    } else {
+      Object.assign(cachedSets[foundIndex], newSet);
     }
     await this.store.setItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY, cachedSets);
   }

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -1,7 +1,12 @@
 import UserRecord from 'interfaces/UserRecord';
 import localForage from 'localforage';
 import centroid from '@turf/centroid';
-import { IappRecordMode, RecordCacheService, RecordSetSourceMetadata } from 'utils/record-cache/index';
+import {
+  IappRecordMode,
+  RecordCacheAddSpec,
+  RecordCacheService,
+  RecordSetSourceMetadata
+} from 'utils/record-cache/index';
 import { Feature } from '@turf/helpers';
 import { GeoJSONSourceSpecification } from 'maplibre-gl';
 import IappRecord from 'interfaces/IappRecord';
@@ -169,13 +174,55 @@ class LocalForageRecordCacheService extends RecordCacheService {
     return { cachedCentroid, cachedGeoJson };
   }
 
-  async deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void> {
+  async deleteCachedRecordsFromIds(idsToDelete: string[], setId: string, recordSetType: RecordSetType): Promise<void> {
     if (this.store == null) {
       throw new Error('cache not available');
     }
     for (const id of idsToDelete) {
       await this.store.removeItem(id.toString());
     }
+
+    const cachedSets = await this.listCachedSets();
+    const foundIndex = cachedSets.findIndex((p) => p.setId === setId);
+    if (foundIndex !== -1) {
+      cachedSets.splice(foundIndex, 1);
+      await this.store.setItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY, cachedSets);
+    }
+  }
+
+  async addCachedSet(spec: RecordCacheAddSpec): Promise<void> {
+    if (this.store == null) {
+      throw new Error('cache not available');
+    }
+    const newEntry = {
+      setId: spec.setId,
+      cacheTime: new Date(),
+      cachedIds: spec.cachedIds,
+      recordSetType: spec.recordSetType
+    };
+
+    const cachedSets = (await this.listCachedSets()) ?? [];
+    const foundIndex = cachedSets.findIndex((p) => p.setId === spec.setId);
+    if (foundIndex !== -1) {
+      cachedSets[foundIndex] = newEntry;
+    } else {
+      cachedSets.push(newEntry);
+    }
+    await this.store.setItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY, cachedSets);
+  }
+
+  async listCachedSets(): Promise<RecordCacheAddSpec[]> {
+    if (this.store == null) {
+      return [];
+    }
+
+    const metadata: RecordCacheAddSpec[] =
+      (await this.store.getItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY)) ?? [];
+    if (metadata == null) {
+      console.error('expected key not found');
+      return [];
+    }
+    return metadata;
   }
 
   private async initializeCache() {

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -195,11 +195,10 @@ class LocalForageRecordCacheService extends RecordCacheService {
     return { cachedCentroid, cachedGeoJson };
   }
 
-  async deleteCachedRecordsFromIds(idsToDelete: string[], setId: string, recordSetType: RecordSetType): Promise<void> {
+  async deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void> {
     if (this.store == null) {
       throw new Error('cache not available');
     }
-    this.setRepositoryStatus(setId, RepositoryStatus.DELETING);
 
     for (const id of idsToDelete) {
       try {
@@ -214,14 +213,24 @@ class LocalForageRecordCacheService extends RecordCacheService {
     if (this.store == null) {
       throw new Error('cache not available');
     }
-
     const cachedSets = await this.listRepositories();
     const foundIndex = cachedSets.findIndex((p) => p.setId === repositoryId);
 
-    if (foundIndex !== -1) {
-      cachedSets.splice(foundIndex, 1);
-      await this.store.setItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY, cachedSets);
-    }
+    if (foundIndex === -1) return;
+    await this.setRepositoryStatus(repositoryId, RepositoryStatus.DELETING);
+    const deleteList = cachedSets[foundIndex].cachedIds;
+    const ids: Record<PropertyKey, number> = {};
+
+    cachedSets
+      .flatMap((set) => set.cachedIds)
+      .forEach((id) => {
+        ids[id] ??= 0;
+        ids[id]++;
+      });
+    const recordsToErase = deleteList.filter((id) => ids[id] === 1);
+    this.deleteCachedRecordsFromIds(recordsToErase, cachedSets[foundIndex].recordSetType);
+    cachedSets.splice(foundIndex, 1);
+    await this.store.setItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY, cachedSets);
   }
 
   /**

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -190,23 +190,18 @@ class LocalForageRecordCacheService extends RecordCacheService {
     }
   }
 
-  async addCachedSet(spec: RecordCacheAddSpec): Promise<void> {
+  async addOrUpdateCachedSet(newSet: RecordCacheAddSpec): Promise<void> {
     if (this.store == null) {
       throw new Error('cache not available');
     }
-    const newEntry = {
-      setId: spec.setId,
-      cacheTime: new Date(),
-      cachedIds: spec.cachedIds,
-      recordSetType: spec.recordSetType
-    };
 
     const cachedSets = (await this.listCachedSets()) ?? [];
-    const foundIndex = cachedSets.findIndex((p) => p.setId === spec.setId);
+    const foundIndex = cachedSets.findIndex((p) => p.setId === newSet.setId);
+
     if (foundIndex !== -1) {
-      cachedSets[foundIndex] = newEntry;
+      Object.assign(cachedSets[foundIndex], newSet);
     } else {
-      cachedSets.push(newEntry);
+      cachedSets.push(newSet);
     }
     await this.store.setItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY, cachedSets);
   }

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -12,7 +12,6 @@ import { GeoJSONSourceSpecification } from 'maplibre-gl';
 import IappRecord from 'interfaces/IappRecord';
 import IappTableRow from 'interfaces/IappTableRecord';
 import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
-import { RepositoryStatus } from 'utils/tile-cache';
 
 class LocalForageRecordCacheService extends RecordCacheService {
   private static _instance: LocalForageRecordCacheService;
@@ -41,7 +40,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
     await this.store.setItem(id, data);
   }
 
-  async setRepositoryStatus(cacheId: string, status: RepositoryStatus) {
+  async setRepositoryStatus(cacheId: string, status: UserRecordCacheStatus) {
     if (this.store == null) {
       throw Error('Cache not available');
     }
@@ -217,7 +216,8 @@ class LocalForageRecordCacheService extends RecordCacheService {
     const foundIndex = cachedSets.findIndex((p) => p.setId === repositoryId);
 
     if (foundIndex === -1) return;
-    await this.setRepositoryStatus(repositoryId, RepositoryStatus.DELETING);
+
+    await this.setRepositoryStatus(repositoryId, UserRecordCacheStatus.DELETING);
     const deleteList = cachedSets[foundIndex].cachedIds;
     const ids: Record<PropertyKey, number> = {};
 

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -41,11 +41,11 @@ class LocalForageRecordCacheService extends RecordCacheService {
     await this.store.setItem(id, data);
   }
 
-  async setCacheStatus(cacheId: string, status: RepositoryStatus) {
+  async setRepositoryStatus(cacheId: string, status: RepositoryStatus) {
     if (this.store == null) {
       throw Error('Cache not available');
     }
-    const cachedSets = await this.listCachedSets();
+    const cachedSets = await this.listRepositories();
     const foundIndex = cachedSets.findIndex((p) => p.setId === cacheId);
     if (foundIndex !== -1) {
       Object.assign(cachedSets[foundIndex], { status });
@@ -54,7 +54,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
   }
 
   async checkForAbort(id: string): Promise<boolean> {
-    const sets = await this.listCachedSets();
+    const sets = await this.listRepositories();
     const index = sets.findIndex((p) => p.setId === id);
     if (index !== -1) {
       return sets[index].status === UserRecordCacheStatus.DELETING;
@@ -199,18 +199,25 @@ class LocalForageRecordCacheService extends RecordCacheService {
     if (this.store == null) {
       throw new Error('cache not available');
     }
-    this.setCacheStatus(setId, RepositoryStatus.DELETING);
+    this.setRepositoryStatus(setId, RepositoryStatus.DELETING);
 
     for (const id of idsToDelete) {
       try {
         await this.store.removeItem(id.toString());
-      } catch {
+      } catch (e) {
         // Item may not exist if a cache was quit while in progress.
       }
     }
+  }
 
-    const cachedSets = await this.listCachedSets();
-    const foundIndex = cachedSets.findIndex((p) => p.setId === setId);
+  async deleteRepository(repositoryId: string) {
+    if (this.store == null) {
+      throw new Error('cache not available');
+    }
+
+    const cachedSets = await this.listRepositories();
+    const foundIndex = cachedSets.findIndex((p) => p.setId === repositoryId);
+
     if (foundIndex !== -1) {
       cachedSets.splice(foundIndex, 1);
       await this.store.setItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY, cachedSets);
@@ -221,12 +228,12 @@ class LocalForageRecordCacheService extends RecordCacheService {
    * @desc Create or Update an entry in the cachedSet Repository
    * @param newSet Data to update
    */
-  async addOrUpdateCachedSet(newSet: RecordCacheAddSpec): Promise<void> {
+  async addOrUpdateRepository(newSet: RecordCacheAddSpec): Promise<void> {
     if (this.store == null) {
       throw new Error('cache not available');
     }
 
-    const cachedSets = (await this.listCachedSets()) ?? [];
+    const cachedSets = (await this.listRepositories()) ?? [];
     const foundIndex = cachedSets.findIndex((p) => p.setId === newSet.setId);
 
     if (foundIndex === -1) {
@@ -237,7 +244,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
     await this.store.setItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY, cachedSets);
   }
 
-  async listCachedSets(): Promise<RecordCacheAddSpec[]> {
+  async listRepositories(): Promise<RecordCacheAddSpec[]> {
     if (this.store == null) {
       return [];
     }

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -4,9 +4,14 @@ import { Feature } from '@turf/helpers';
 import IappRecord from 'interfaces/IappRecord';
 import IappTableRow from 'interfaces/IappTableRecord';
 import UserRecord from 'interfaces/UserRecord';
-import { RecordSetType } from 'interfaces/UserRecordSet';
+import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import { GeoJSONSourceSpecification } from 'maplibre-gl';
-import { IappRecordMode, RecordCacheService, RecordSetSourceMetadata } from 'utils/record-cache/index';
+import {
+  IappRecordMode,
+  RecordCacheAddSpec,
+  RecordCacheService,
+  RecordSetSourceMetadata
+} from 'utils/record-cache/index';
 import { sqlite } from 'utils/sharedSQLiteInstance';
 
 const CACHE_DB_NAME = 'record_cache.db';
@@ -46,6 +51,15 @@ const RECORD_CACHE_DB_MIGRATIONS_3 = [
     GEOJSON     TEXT NOT NULL
   );`
 ];
+
+const RECORD_CACHE_DB_MIGRATIONS_4 = [
+  `ALTER TABLE CACHE_METADATA
+    ADD COLUMN CACHE_TIME TEXT NOT NULL;`,
+  `ALTER TABLE CACHE_METADATA
+    ADD COLUMN STATUS TEXT NOT NULL;`,
+  `ALTER TABLE CACHE_METADATA
+    ADD COLUMN DATA TEXT NOT NULL;`
+];
 class SQLiteRecordCacheService extends RecordCacheService {
   private static _instance: SQLiteRecordCacheService;
 
@@ -61,6 +75,129 @@ class SQLiteRecordCacheService extends RecordCacheService {
       await SQLiteRecordCacheService._instance.initializeRecordCache(sqlite);
     }
     return SQLiteRecordCacheService._instance;
+  }
+
+  async addOrUpdateRepository(spec: RecordCacheAddSpec): Promise<void> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    try {
+      await this.cacheDB.query(
+        //language=SQLite`
+        `INSERT INTO CACHE_METADATA(SET_ID, STATUS, CACHE_TIME, DATA)
+       VALUES(?, ?, ?, ?)
+       ON CONFLICT(SET_ID)
+       DO UPDATE SET
+         STATUS = excluded.STATUS,
+         CACHE_TIME = excluded.CACHE_TIME,
+         DATA = excluded.DATA`,
+        [spec.setId, spec.status, spec.cacheTime.toString(), JSON.stringify(spec)]
+      );
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  async deleteRepository(repositoryId: string): Promise<void> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const rawRepositoryMetadata = await this.cacheDB.query(
+      //language=SQLite
+      `SELECT DATA
+       FROM CACHE_METADATA`
+    );
+    const repositoryMetadata: RecordCacheAddSpec[] =
+      rawRepositoryMetadata?.values?.map((set) => JSON.parse(set['DATA'])) ?? [];
+    const targetIndex = repositoryMetadata.findIndex((set) => set.setId === repositoryId);
+
+    if (targetIndex === -1) throw Error('Repository not found');
+
+    const { cachedIds, recordSetType } = repositoryMetadata[targetIndex];
+
+    const ids: Record<PropertyKey, number> = {};
+    repositoryMetadata
+      .flatMap((set) => set.cachedIds)
+      .forEach((id) => {
+        ids[id] ??= 0;
+        ids[id]++;
+      });
+    const recordsToErase = cachedIds.filter((id) => ids[id] <= 1);
+
+    await this.deleteCachedRecordsFromIds(recordsToErase, recordSetType);
+    await this.cacheDB.query(
+      //language=SQLite
+      `DELETE FROM CACHE_METADATA
+       WHERE SET_ID = ?`,
+      [repositoryId]
+    );
+  }
+
+  async listRepositories(): Promise<RecordCacheAddSpec[]> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const repositories = await this.cacheDB.query(
+      //language=SQLite
+      `SELECT *
+       FROM CACHE_METADATA`
+    );
+    return repositories?.values?.map((entry) => JSON.parse(entry['DATA']) as RecordCacheAddSpec) ?? [];
+  }
+
+  /**
+   * @desc Helper method to fetch and parse repo metadata
+   */
+  private async getRepoData(repositoryId: string) {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const repoData = await this.cacheDB.query(
+      //language=SQLite
+      `SELECT DATA
+       FROM CACHE_METADATA
+       WHERE SET_ID = ?`,
+      [repositoryId]
+    );
+    return JSON.parse(repoData?.values?.[0]['DATA']) ?? {};
+  }
+
+  async setRepositoryStatus(repositoryId: string, status: UserRecordCacheStatus): Promise<void> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const currData = await this.getRepoData(repositoryId);
+    currData.status = status;
+    await this.cacheDB.query(
+      //language=SQLite
+      `UPDATE CACHE_METADATA
+        SET STATUS = ?,
+            CACHE_TIME = ?,
+            DATA = ?
+        WHERE SET_ID = ?`,
+      [status, JSON.stringify(currData.cacheTime), JSON.stringify(currData), repositoryId]
+    );
+  }
+
+  async checkForAbort(repositoryId: string): Promise<boolean> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const metadata = await this.cacheDB.query(
+      //language=SQLite
+      `SELECT STATUS
+       FROM CACHE_METADATA
+       WHERE SET_ID = ?
+       LIMIT 1
+      `,
+      [repositoryId]
+    );
+
+    const cacheStatus = metadata?.values?.[0]['STATUS'];
+    if (cacheStatus) {
+      return cacheStatus === UserRecordCacheStatus.DELETING;
+    }
+    return true;
   }
 
   /**
@@ -102,6 +239,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
 
     return response;
   }
+
   async fetchPaginatedCachedIappRecords(recordSetIdList: string[], page: number, limit: number): Promise<IappRecord[]> {
     if (!recordSetIdList || recordSetIdList.length === 0) {
       return [];
@@ -283,7 +421,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     };
     return { cachedCentroid, cachedGeoJson };
   }
-  async deleteCachedRecordsFromIds(idsToDelete: string[], setId: string, recordSetType: RecordSetType): Promise<void> {
+  async deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
@@ -327,6 +465,10 @@ class SQLiteRecordCacheService extends RecordCacheService {
       {
         toVersion: 3,
         statements: RECORD_CACHE_DB_MIGRATIONS_3
+      },
+      {
+        toVersion: 4,
+        statements: RECORD_CACHE_DB_MIGRATIONS_4
       }
     ];
     await sqlite.addUpgradeStatement(CACHE_DB_NAME, MIGRATIONS);

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -283,7 +283,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     };
     return { cachedCentroid, cachedGeoJson };
   }
-  async deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void> {
+  async deleteCachedRecordsFromIds(idsToDelete: string[], setId: string, recordSetType: RecordSetType): Promise<void> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }


### PR DESCRIPTION
# Details

This PR Includes the following changes:

- Users can cancel a Record cache download that is in progress.
    - Users are notified with a success alert upon termination 
- Record cache metadata is now persisted in the local DB (Previously just Redux)
- Method names changed to align more consistently with maptile (and future) methods
- If user deletes a cache that is in progress of downloading, the cache deletes
- Fix issue where a Download stops in progress immediately
    - This was caused by there being no filter object, causing the bbox functionality to throw an error and crash. This is now fixed. 
- Migrate business logic in async thunks, to appropriate Database methods, decoupling the two.
- Added stub placement for adding ProgressCallback functionality 

> [!IMPORTANT]
> This PR Starts the process of moving Redux Recordset metadata into DB storage. In the meantime both states (Redux and DB) have to be stored. Next iteration will be removing the redux data, keeping one source of truth. You may find weird consistencies and Error checks while both states are being managed.

 
- Closes #3630

## Testing

Tested the Following

> [!TIP]
> Additional Context: We don't download duplicate records, so when deleting we use a frequency map to ensure we don't delete Records used in multiple places
 
- Caching a recordset
- Caching two recordsets with the same filters then deleting one to make sure the second cache/records remains in tact
- Caching two recordsets with different filters then deleting one making sure there was **no cross-repo delete**
- Deleting a **cached recordset** to check cleanup
- Deleting a recordset **in progress** to check cleanup
- Cancelling a download that is in progress

Testing was done in both Firefox and the Simulator
Sum of records and Cache metadata was manually verified and counted through queries in their respective storages.

