### PR TITLE
[INV-3788] IAPP layer causes crash

### DIFF
--- a/app/src/UI/Overlay/Records/RecordSet/RecordTable.tsx
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordTable.tsx
@@ -59,8 +59,8 @@ export const RecordTable = ({ setID, userOfflineMobile }: PropTypes) => {
                 View/Edit
               </th>
             )}
-            {tableType === 'Activity'
-              ? activityColumnsToDisplay.map((col: any, i) => (
+            {tableType === RecordSetType.Activity
+              ? activityColumnsToDisplay.map((col: any) => (
                   <th
                     className={'record_table_header_column'}
                     key={col.key}
@@ -106,7 +106,7 @@ export const RecordTable = ({ setID, userOfflineMobile }: PropTypes) => {
                       type: USER_CLICKED_RECORD,
                       payload: {
                         recordType: tableType,
-                        id: tableType === 'Activity' ? row.activity_id : row.site_id,
+                        id: tableType === RecordSetType.Activity ? row.activity_id : row.site_id,
                         row: row
                       }
                     });
@@ -119,13 +119,13 @@ export const RecordTable = ({ setID, userOfflineMobile }: PropTypes) => {
                     type: USER_TOUCHED_RECORD,
                     payload: {
                       recordType: tableType,
-                      id: tableType === 'Activity' ? row.activity_id : row.site_id,
+                      id: tableType === RecordSetType.Activity ? row.activity_id : row.site_id,
                       row: row
                     }
                   });
                 }}
                 className="record_table_row"
-                key={row?.activity_id}
+                key={row?.activity_id ?? row?.site_id}
               >
                 {isTouch && (
                   <td
@@ -134,7 +134,7 @@ export const RecordTable = ({ setID, userOfflineMobile }: PropTypes) => {
                         type: USER_CLICKED_RECORD,
                         payload: {
                           recordType: tableType,
-                          id: tableType === 'Activity' ? row.activity_id : row.site_id,
+                          id: tableType === RecordSetType.Activity ? row.activity_id : row.site_id,
                           row: row
                         }
                       });
@@ -145,7 +145,7 @@ export const RecordTable = ({ setID, userOfflineMobile }: PropTypes) => {
                     <VisibilityIcon />
                   </td>
                 )}
-                {tableType === 'Activity'
+                {tableType === RecordSetType.Activity
                   ? activityColumnsToDisplay.map((col) => {
                       return (
                         <td className="record_table_row_column" key={col.key + col.name}>

--- a/app/src/constants/offline_state_version.ts
+++ b/app/src/constants/offline_state_version.ts
@@ -1,5 +1,5 @@
 /*
 handle purging the offline storage on app version upgrade
  */
-export const CURRENT_MIGRATION_VERSION = 20241118;
+export const CURRENT_MIGRATION_VERSION = 20250113;
 export const MIGRATION_VERSION_KEY = '_persistedMigrationVersion';

--- a/app/src/state/actions/userSettings/RecordSet.ts
+++ b/app/src/state/actions/userSettings/RecordSet.ts
@@ -78,7 +78,7 @@ class RecordSet {
   static readonly removeFilter = createAction<IRemoveFilter>(`${this.PREFIX}/removeFilter`);
 
   private static readonly createDefaultRecordset = (type: RecordSetType): UserRecordSet => ({
-    tableFilters: null,
+    tableFilters: [],
     id: nanoid(),
     color: RECORD_COLOURS[0],
     drawOrder: 0,

--- a/app/src/state/sagas/map/dataAccess.ts
+++ b/app/src/state/sagas/map/dataAccess.ts
@@ -15,7 +15,7 @@ import {
 } from 'state/actions';
 import { ACTIVITY_GEOJSON_SOURCE_KEYS, selectMap } from 'state/reducers/map';
 import WhatsHere from 'state/actions/whatsHere/WhatsHere';
-import { RecordSetType } from 'interfaces/UserRecordSet';
+import { RecordSetType, UserRecordSet } from 'interfaces/UserRecordSet';
 import { MOBILE } from 'state/build-time-config';
 import { RecordCacheServiceFactory } from 'utils/record-cache/context';
 import GeoShapes from 'constants/geoShapes';
@@ -60,7 +60,7 @@ export function* handle_PREP_FILTERS_FOR_VECTOR_ENDPOINT(action) {
   try {
     const currentState = yield select((state) => state?.UserSettings);
     const clientBoundaries = yield select((state) => state.Map?.clientBoundaries);
-    const cacheMetadata = currentState.recordSets[action.payload.recordSetID].cacheMetadata;
+    const recordset: UserRecordSet = currentState.recordSets[action.payload.recordSetID];
     const filterObject = getRecordFilterObjectFromStateForAPI(
       action.payload.recordSetID,
       currentState,
@@ -83,8 +83,8 @@ export function* handle_PREP_FILTERS_FOR_VECTOR_ENDPOINT(action) {
         filterObject: filterObject,
         recordSetID: action.payload.recordSetID,
         tableFiltersHash: action.payload.tableFiltersHash,
-        recordSetType: action.payload.recordSetType,
-        cacheMetadata: cacheMetadata ?? null
+        recordSetType: recordset.recordSetType,
+        cacheMetadata: recordset.cacheMetadata ?? null
       }
     });
   } catch (e) {
@@ -404,7 +404,6 @@ export function* handle_MAP_WHATS_HERE_INIT_GET_ACTIVITY(action) {
 }
 
 export function getSelectColumnsByRecordSetType(recordSetType: any) {
-  //throw new Error('Function not implemented.');
   let columns: string[] = [];
   if (recordSetType === 'Activity') {
     columns = [


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Default Recordsets assign Filter Objects to Array [] instead of null
- Fixed JSX error where key was invalid for IAPP Records in Map function
    - modified instances of `Activity` to `RecordSetType.Activity` for consistency across app
- fix `handle_PREP_FILTERS_FOR_VECTOR_ENDPOINT`. RecordsetType is not an argument, and added optional chaining to obtain cacheMetadata 
    - This corrects the error shown in the screenshot on the bug ticket
- Closes #3788
