### PR TITLE
[INV-3779] Use the LocalDB instances for Recordset CacheMetadata instead of Redux

### DIFF
--- a/api/src/paths/v2/iapp.ts
+++ b/api/src/paths/v2/iapp.ts
@@ -350,7 +350,6 @@ export function getIAPPSQLv2(filterObject: any) {
 
     return sqlStatement;
   } catch (e) {
-    console.log(e);
     defaultLog.debug({ label: 'getIAPPBySearchFilterCriteria', message: 'error', body: e.message });
     throw e;
   }

--- a/api/src/paths/v2/iapp.ts
+++ b/api/src/paths/v2/iapp.ts
@@ -337,8 +337,7 @@ export function getIAPPSQLv2(filterObject: any) {
       sqlStatement = offSetStatement(sqlStatement, filterObject);
     } else if (filterObject.vt_request) {
       sqlStatement.append(` ) SELECT ST_AsMVT(mvtgeom.*, 'data', 4096, 'geom', 'feature_id') as data from mvtgeom;`);
-    }
-    if (filterObject.boundingBoxOnly) {
+    } else if (filterObject.boundingBoxOnly) {
       // wrap the whole thing into a subquery for the aggregate function
       const wrappedStatement = SQL` WITH userQuery AS ( `.append(sqlStatement.text).append(` )
             SELECT ST_AsText(ST_Extent(geometry(geog))) as bbox
@@ -603,9 +602,7 @@ function whereStatement(sqlStatement: SQLStatement, filterObject: any) {
         break;
       case 'all_species_on_site':
         where.append(
-          `${filter.operator2} LOWER(sites.all_species_on_site) ${filter.operator === 'CONTAINS' ? 'like' : 'not like'}  LOWER('%${
-            filter.filter
-          }%') `
+          `${filter.operator2} LOWER(sites.all_species_on_site) ${filter.operator === 'CONTAINS' ? 'like' : 'not like'}  LOWER('%${filter.filter}%') `
         );
         break;
       case 'max_survey':

--- a/api/src/paths/v2/iapp.ts
+++ b/api/src/paths/v2/iapp.ts
@@ -331,17 +331,27 @@ export function getIAPPSQLv2(filterObject: any) {
     sqlStatement = fromStatement(sqlStatement, filterObject);
     sqlStatement = whereStatement(sqlStatement, filterObject);
     sqlStatement = groupByStatement(sqlStatement, filterObject);
-    if (!filterObject.vt_request) {
+    if (!filterObject.vt_request && !filterObject.boundingBoxOnly) {
       sqlStatement = orderByStatement(sqlStatement, filterObject);
       sqlStatement = limitStatement(sqlStatement, filterObject);
       sqlStatement = offSetStatement(sqlStatement, filterObject);
-    } else {
+    } else if (filterObject.vt_request) {
       sqlStatement.append(` ) SELECT ST_AsMVT(mvtgeom.*, 'data', 4096, 'geom', 'feature_id') as data from mvtgeom;`);
     }
+    if (filterObject.boundingBoxOnly) {
+      // wrap the whole thing into a subquery for the aggregate function
+      const wrappedStatement = SQL` WITH userQuery AS ( `.append(sqlStatement.text).append(` )
+            SELECT ST_AsText(ST_Extent(geometry(geog))) as bbox
+            FROM invasivesbc.iapp_spatial
+            WHERE geog IS not null
+              AND site_id in (SELECT site_id
+                              FROM userQuery) `);
+      return wrappedStatement;
+    }
 
-    //defaultLog.debug({ label: 'getIAPPBySearchFilterCriteria', message: 'sql', body: sqlStatement });
     return sqlStatement;
   } catch (e) {
+    console.log(e);
     defaultLog.debug({ label: 'getIAPPBySearchFilterCriteria', message: 'error', body: e.message });
     throw e;
   }

--- a/api/src/paths/v2/iapp/bbox.ts
+++ b/api/src/paths/v2/iapp/bbox.ts
@@ -1,0 +1,113 @@
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { SQLStatement } from 'sql-template-strings';
+import { ALL_ROLES, SECURITY_ON } from 'constants/misc';
+import { getLogger } from 'utils/logger';
+import { getDBConnection } from 'database/db';
+import { getIAPPSQLv2, sanitizeIAPPFilterObject } from '../iapp';
+
+const NAMESPACE = 'IAPP-bbox';
+
+const defaultLog = getLogger(NAMESPACE);
+export const POST: Operation = [postHandler()];
+
+POST.apiDoc = {
+  description: 'Fetch bounding box based on search criteria',
+  tags: [NAMESPACE],
+  security: SECURITY_ON ? [{ Bearer: ALL_ROLES }] : [],
+  requestBody: {
+    description: 'Recordset search filter criteria',
+    content: {
+      'application/json': {
+        schema: {
+          properties: {}
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Bounding box response object',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              bbox: {
+                type: 'string',
+                description: 'Bounding box for the given filters'
+              }
+            }
+          }
+        }
+      }
+    },
+    401: {
+      $ref: '#/components/responses/401'
+    },
+    503: {
+      $ref: '#/components/responses/503'
+    },
+    default: {
+      $ref: '#/components/responses/default'
+    }
+  }
+};
+
+/**
+ * @desc Create Bounding box based on the filter properties for a given recordset
+ */
+function postHandler(): RequestHandler {
+  return async (req, res) => {
+    const connection = await getDBConnection();
+    if (!connection) {
+      return res.status(503).json({
+        message: 'Database connection unavailable',
+        namespace: NAMESPACE,
+        code: 503
+      });
+    }
+    try {
+      defaultLog.debug({ label: NAMESPACE, message: 'postHandler', body: req.body });
+      if (req.body?.filterObjects?.[0]) {
+        const filterObject = sanitizeIAPPFilterObject(req.body.filterObjects[0], req);
+        filterObject.boundingBoxOnly = true;
+        const iappSql: SQLStatement = getIAPPSQLv2(filterObject);
+        const response = await connection.query(iappSql.text, iappSql.values);
+
+        if (response.rowCount > 0) {
+          return res.status(200).json(response.rows[0]);
+        } else {
+          return res.status(404).json({
+            message: 'No Results',
+            request: req.body,
+            namespace: NAMESPACE,
+            code: 404
+          });
+        }
+      } else {
+        return res.status(400).json({
+          message: 'Missing filter Objects from request',
+          request: req.body,
+          namespace: NAMESPACE,
+          code: 400
+        });
+      }
+    } catch (error) {
+      defaultLog.debug({
+        label: NAMESPACE,
+        message: 'error',
+        error
+      });
+      return res.status(500).json({
+        message: 'Server Error occured',
+        request: req.body,
+        namespace: NAMESPACE,
+        code: 500,
+        error
+      });
+    } finally {
+      connection.release();
+    }
+  };
+}

--- a/app/src/UI/LegacyMap/Map.tsx
+++ b/app/src/UI/LegacyMap/Map.tsx
@@ -27,7 +27,6 @@ import {
   rebuildLayersOnTableHashUpdate,
   refreshColoursOnColourUpdate,
   refreshVisibilityOnToggleUpdate,
-  removeDeletedRecordSetLayersOnRecordSetDelete,
   removeLayersOnNetworkConnectivityChange
 } from 'UI/LegacyMap/helpers/recordset-layers';
 import { addWMSLayersIfNotExist, refreshWMSOnToggle, hideWMSIfUnauthorized } from 'UI/LegacyMap/helpers/wms-layers';
@@ -207,7 +206,6 @@ export const Map = ({ children }) => {
     rebuildLayersOnTableHashUpdate(storeLayers, map.current, MapMode, API_BASE, connectedToNetwork);
     refreshColoursOnColourUpdate(storeLayers, map.current);
     refreshVisibilityOnToggleUpdate(storeLayers, map.current);
-    removeDeletedRecordSetLayersOnRecordSetDelete(storeLayers, map.current);
   }, [storeLayers, map.current, mapReady, connectedToNetwork, loggedInOrWorkingOffline]);
 
   // Layer picker:
@@ -440,6 +438,7 @@ export const Map = ({ children }) => {
   // toggle public map pmtile layer
   useEffect(() => {
     if (!mapReady) return;
+    if (!map.current) return;
     if (loggedInOrWorkingOffline) {
       toggleLayerOnBool(map.current, 'invasivesbc-pmtile-vector', false);
       toggleLayerOnBool(map.current, 'iapp-pmtile-vector', false);

--- a/app/src/UI/LegacyMap/helpers/recordset-layers.ts
+++ b/app/src/UI/LegacyMap/helpers/recordset-layers.ts
@@ -486,20 +486,3 @@ export const refreshVisibilityOnToggleUpdate = (storeLayers, map: maplibregl.Map
     });
   });
 };
-
-/** TODO: */
-export const removeDeletedRecordSetLayersOnRecordSetDelete = (storeLayers, map) => {
-  map.getLayersOrder().map((layer: any) => {
-    if (
-      storeLayers.filter((l: any) => l.recordSetID === layer).length === 0 &&
-      !['wms-test-layer', 'wms-test-layer2', 'invasives-vector', 'buildings'].includes(layer)
-    ) {
-      //map.current.removeLayer(layer);
-      //map.current.removeSource(layer);
-    }
-  });
-  storeLayers.map((layer) => {
-    // get matching layers for type
-    // update visibility if doesn't match
-  });
-};

--- a/app/src/UI/LegacyMap/helpers/recordset-layers.ts
+++ b/app/src/UI/LegacyMap/helpers/recordset-layers.ts
@@ -24,9 +24,9 @@ export const createOfflineIappLayer = async (map: maplibregl.Map, layer: any) =>
     return;
   }
   const service = await RecordCacheServiceFactory.getPlatformInstance();
-  const repo = await service.fetchRepository(layer.recordSetID);
+  const repo = await service.getRepository(layer.recordSetID);
 
-  if (!repo.cachedGeoJson) {
+  if (!repo?.cachedGeoJson) {
     return;
   }
   const layerID = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
@@ -192,9 +192,9 @@ export const createOfflineActivityLayer = async (map: maplibregl.Map, layer: any
     return;
   }
   const service = await RecordCacheServiceFactory.getPlatformInstance();
-  const { cachedCentroid, cachedGeoJson } = await service.fetchRepository(layer.recordSetID);
+  const metadata = await service.getRepository(layer.recordSetID);
 
-  if (!cachedCentroid || !cachedGeoJson) {
+  if (!metadata?.cachedCentroid || !metadata?.cachedGeoJson) {
     return;
   }
 
@@ -203,8 +203,8 @@ export const createOfflineActivityLayer = async (map: maplibregl.Map, layer: any
   const CENTROID_ID = `${GEOJSON_ID}-centroid`;
   const color = getPaintBySchemeOrColor(layer);
 
-  const geoJsonSourceObj: GeoJSONSourceSpecification = cachedGeoJson;
-  const centroidSourceObj: GeoJSONSourceSpecification = cachedCentroid;
+  const geoJsonSourceObj: GeoJSONSourceSpecification = metadata.cachedGeoJson;
+  const centroidSourceObj: GeoJSONSourceSpecification = metadata.cachedCentroid;
 
   const circleMarkerZoomedOutLayerCentroid: CircleLayerSpecification = getCircleMarkerZoomedOutLayer(CENTROID_ID, {
     color,

--- a/app/src/UI/LegacyMap/helpers/recordset-layers.ts
+++ b/app/src/UI/LegacyMap/helpers/recordset-layers.ts
@@ -10,20 +10,27 @@ import { LAYER_Z_BACKGROUND, LAYER_Z_FOREGROUND, LAYER_Z_MID } from 'UI/LegacyMa
 import { FALLBACK_COLOR } from 'UI/LegacyMap/helpers/constants';
 import { safelySetPaintProperty } from 'UI/LegacyMap/helpers/utility-functions';
 import { MOBILE } from 'state/build-time-config';
-import { RecordSetType } from 'interfaces/UserRecordSet';
+import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import VECTOR_MAP_FONT_FACE from 'constants/vectorMapFontFace';
+import { RecordCacheServiceFactory } from 'utils/record-cache/context';
 
 const LAYER_ID_PREFIX = 'recordset-layer-';
 /** DRY Handler for formatting LayerIDs */
 const formatLayerID = (recordSetID: string, tableFiltersHash: string): string =>
   `${LAYER_ID_PREFIX}${recordSetID}-hash-${tableFiltersHash}`;
 
-export const createOfflineIappLayer = (map: maplibregl.Map, layer: any) => {
-  if (!layer?.layerState?.cacheMetadata?.hasOwnProperty('cachedGeoJson')) {
+export const createOfflineIappLayer = async (map: maplibregl.Map, layer: any) => {
+  if (layer?.layerState?.cacheMetadataStatus !== UserRecordCacheStatus.CACHED || !layer.layerState.mapToggle) {
+    return;
+  }
+  const service = await RecordCacheServiceFactory.getPlatformInstance();
+  const repo = await service.fetchRepository(layer.recordSetID);
+
+  if (!repo.cachedGeoJson) {
     return;
   }
   const layerID = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
-  const source: GeoJSONSourceSpecification = layer.layerState.cacheMetadata.cachedGeoJson;
+  const source: GeoJSONSourceSpecification = repo.cachedGeoJson;
   const color: string = layer.layerState.color ?? FALLBACK_COLOR;
   const labelLayer: SymbolLayerSpecification = getLabelLayer(layerID, { color, minzoom: 10, get_tag: 'name' });
   const circleLayer: CircleLayerSpecification = getCircleMarkerZoomedOutLayer(layerID, { color });
@@ -177,20 +184,24 @@ const getLabelLayer = (layerID: string, options: LayerOptions): SymbolLayerSpeci
  * @desc Uses the device's recordset Cache data to display geoJson Layers on the map when offline
  *       Displays two layers: Points at high levels, and shapes at lower
  */
-export const createOfflineActivityLayer = (map: maplibregl.Map, layer: any) => {
-  if (
-    (['1', '2'].includes(layer.recordSetID) && !layer.layerState.colorScheme) ||
-    !layer?.layerState?.cacheMetadata?.hasOwnProperty('cachedGeoJson')
-  ) {
+export const createOfflineActivityLayer = async (map: maplibregl.Map, layer: any) => {
+  if (layer?.layerState?.cacheMetadataStatus !== UserRecordCacheStatus.CACHED || !layer.layerState.mapToggle) {
     return;
   }
+  const service = await RecordCacheServiceFactory.getPlatformInstance();
+  const { cachedCentroid, cachedGeoJson } = await service.fetchRepository(layer.recordSetID);
+
+  if (!cachedCentroid || !cachedGeoJson) {
+    return;
+  }
+
   const CENTROID_TO_GEOJSON_ZOOM = 12;
   const GEOJSON_ID = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
   const CENTROID_ID = `${GEOJSON_ID}-centroid`;
   const color = getPaintBySchemeOrColor(layer);
 
-  const geoJsonSourcObj: GeoJSONSourceSpecification = layer.layerState.cacheMetadata.cachedGeoJson;
-  const centroidSourceObj: GeoJSONSourceSpecification = layer.layerState.cacheMetadata.cachedCentroid;
+  const geoJsonSourceObj: GeoJSONSourceSpecification = cachedGeoJson;
+  const centroidSourceObj: GeoJSONSourceSpecification = cachedCentroid;
 
   const circleMarkerZoomedOutLayerCentroid: CircleLayerSpecification = getCircleMarkerZoomedOutLayer(CENTROID_ID, {
     color,
@@ -214,7 +225,7 @@ export const createOfflineActivityLayer = (map: maplibregl.Map, layer: any) => {
     get_tag: 'name'
   });
 
-  map.addSource(GEOJSON_ID, geoJsonSourcObj);
+  map.addSource(GEOJSON_ID, geoJsonSourceObj);
   map.addLayer(fillLayer, LAYER_Z_FOREGROUND);
   map.addLayer(borderLayer, LAYER_Z_FOREGROUND);
   map.addLayer(circleMarkerZoomedOutLayer, LAYER_Z_FOREGROUND);
@@ -375,13 +386,13 @@ export const rebuildLayersOnTableHashUpdate = (
   });
 
   // now update the layers that are in the store
-  storeLayers.map((layer: Record<PropertyKey, any>) => {
+  storeLayers.map(async (layer: Record<PropertyKey, any>) => {
     if ((layer.geoJSON && layer.loading === false) || (mode === 'VECTOR_ENDPOINT' && layer.filterObject)) {
       const sourceId = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
       deleteStaleRecordsetLayer(map, layer);
       const existingSource = map.getSource(sourceId);
       if (existingSource) return;
-      createMapLayer(map, layer, mode, API_BASE, MOBILE_OFFLINE);
+      await createMapLayer(map, layer, mode, API_BASE, MOBILE_OFFLINE);
     }
   });
 };
@@ -389,22 +400,22 @@ export const rebuildLayersOnTableHashUpdate = (
 /**
  * @desc Handler logic for creating a new layer based on Network condition and recordset type
  */
-const createMapLayer = (
+const createMapLayer = async (
   map: maplibregl.Map,
   layer: Record<PropertyKey, any>,
   mapMode: string,
   apiBase: string,
   isOfflineLayer: boolean
-): void => {
+): Promise<void> => {
   if (layer.type === RecordSetType.Activity) {
     if (isOfflineLayer) {
-      createOfflineActivityLayer(map, layer);
+      await createOfflineActivityLayer(map, layer);
     } else {
       createOnlineActivityLayer(map, layer, mapMode, apiBase);
     }
   } else if (layer.type === RecordSetType.IAPP) {
     if (isOfflineLayer) {
-      createOfflineIappLayer(map, layer);
+      await createOfflineIappLayer(map, layer);
     } else {
       createOnlineIappLayer(map, layer, mapMode, apiBase);
     }

--- a/app/src/UI/LegacyMap/helpers/recordset-layers.ts
+++ b/app/src/UI/LegacyMap/helpers/recordset-layers.ts
@@ -34,6 +34,9 @@ export const createOfflineIappLayer = async (map: maplibregl.Map, layer: any) =>
   const color: string = layer.layerState.color ?? FALLBACK_COLOR;
   const labelLayer: SymbolLayerSpecification = getLabelLayer(layerID, { color, minzoom: 10, get_tag: 'name' });
   const circleLayer: CircleLayerSpecification = getCircleMarkerZoomedOutLayer(layerID, { color });
+
+  const existingSource = map.getSource(layerID);
+  if (existingSource) return; // Due to the async nature of the local DB Calls, check the layer wasn't created during a re-render
   map.addSource(layerID, source);
   map.addLayer(circleLayer, LAYER_Z_FOREGROUND);
   map.addLayer(labelLayer, LAYER_Z_FOREGROUND);
@@ -225,6 +228,8 @@ export const createOfflineActivityLayer = async (map: maplibregl.Map, layer: any
     get_tag: 'name'
   });
 
+  const existingSource = map.getSource(GEOJSON_ID);
+  if (existingSource) return; // Due to the async nature of the local DB Calls, check the layer wasn't created during a re-render
   map.addSource(GEOJSON_ID, geoJsonSourceObj);
   map.addLayer(fillLayer, LAYER_Z_FOREGROUND);
   map.addLayer(borderLayer, LAYER_Z_FOREGROUND);
@@ -386,7 +391,7 @@ export const rebuildLayersOnTableHashUpdate = (
   });
 
   // now update the layers that are in the store
-  storeLayers.map(async (layer: Record<PropertyKey, any>) => {
+  storeLayers.forEach(async (layer: Record<PropertyKey, any>) => {
     if ((layer.geoJSON && layer.loading === false) || (mode === 'VECTOR_ENDPOINT' && layer.filterObject)) {
       const sourceId = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
       deleteStaleRecordsetLayer(map, layer);

--- a/app/src/UI/Overlay/Records/RecordSet/Filter.tsx
+++ b/app/src/UI/Overlay/Records/RecordSet/Filter.tsx
@@ -291,14 +291,16 @@ const Filter = ({ setID, id, userOfflineMobile }: PropTypes) => {
       <td>{input}</td>
       <td className="deleteButtonCell">
         <Tooltip classes={{ tooltip: 'toolTip' }} title="Delete the filter in this row, data will be refetched.">
-          <Button
-            className={'deleteButton'}
-            disabled={userOfflineMobile}
-            onClick={() => removeFilter('tableFilter')}
-            variant="contained"
-          >
-            Delete
-          </Button>
+          <span>
+            <Button
+              className={'deleteButton'}
+              disabled={userOfflineMobile}
+              onClick={() => removeFilter('tableFilter')}
+              variant="contained"
+            >
+              Delete
+            </Button>
+          </span>
         </Tooltip>
       </td>
     </tr>

--- a/app/src/UI/Overlay/Records/RecordSet/RecordSet.tsx
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordSet.tsx
@@ -58,53 +58,57 @@ export const RecordSet = (props) => {
       <div className="recordSet_filter_buttons_container">
         <div className="recordSet_clear_filter_button">
           <Tooltip classes={{ tooltip: 'toolTip' }} title="Clear all filters and refetch all data for this layer.">
-            <Button
-              size={'small'}
-              disabled={userOfflineMobile}
-              onClick={() => {
-                dispatch({
-                  type: RECORDSET_CLEAR_FILTERS,
-                  payload: {
-                    setID: props.setID
-                  }
-                });
-              }}
-              variant="contained"
-            >
-              Clear Filters
-              <FilterAltOffIcon />
-            </Button>
+            <span>
+              <Button
+                size={'small'}
+                disabled={userOfflineMobile}
+                onClick={() => {
+                  dispatch({
+                    type: RECORDSET_CLEAR_FILTERS,
+                    payload: {
+                      setID: props.setID
+                    }
+                  });
+                }}
+                variant="contained"
+              >
+                Clear Filters
+                <FilterAltOffIcon />
+              </Button>
+            </span>
           </Tooltip>
         </div>
         <div className="recordSet_toggleView_filter_button">
           <Tooltip classes={{ tooltip: 'toolTip' }} title="Toggle hiding filters - does not toggle applying them.">
-            <Button
-              size={'small'}
-              disabled={userOfflineMobile}
-              onClick={() => {
-                dispatch({
-                  type: RECORDSETS_TOGGLE_VIEW_FILTER
-                });
-              }}
-              variant="contained"
-            >
-              {viewFilters ? (
-                <>
-                  Hide Filters
-                  <VisibilityOffIcon />
-                  <FilterAltIcon />
-                </>
-              ) : (
-                <>
-                  Show Filters{' '}
-                  {(recordSet?.tableFilters?.length || 0) > 0 &&
-                    !onlyFilterIsForDrafts &&
-                    `(${recordSet?.tableFilters?.length})`}
-                  <VisibilityIcon />
-                  <FilterAltIcon />
-                </>
-              )}
-            </Button>
+            <span>
+              <Button
+                size={'small'}
+                disabled={userOfflineMobile}
+                onClick={() => {
+                  dispatch({
+                    type: RECORDSETS_TOGGLE_VIEW_FILTER
+                  });
+                }}
+                variant="contained"
+              >
+                {viewFilters ? (
+                  <>
+                    Hide Filters
+                    <VisibilityOffIcon />
+                    <FilterAltIcon />
+                  </>
+                ) : (
+                  <>
+                    Show Filters{' '}
+                    {(recordSet?.tableFilters?.length || 0) > 0 &&
+                      !onlyFilterIsForDrafts &&
+                      `(${recordSet?.tableFilters?.length})`}
+                    <VisibilityIcon />
+                    <FilterAltIcon />
+                  </>
+                )}
+              </Button>
+            </span>
           </Tooltip>
         </div>
         <div className="recordSet_new_filter_button">
@@ -112,27 +116,29 @@ export const RecordSet = (props) => {
             classes={{ tooltip: 'toolTip' }}
             title="Add a new filter, drawn, uploaded KML, or just text search on a field."
           >
-            <Button
-              size={'small'}
-              disabled={userOfflineMobile}
-              onClick={() => {
-                dispatch({
-                  type: RECORDSET_ADD_FILTER,
-                  payload: {
-                    filterType: 'tableFilter',
-                    // short id if activity record set otherwise site_ID
-                    field: tableType === 'Activity' ? 'short_id' : 'site_id',
-                    setID: props.setID,
-                    operator: 'CONTAINS',
-                    operator2: 'AND',
-                    blockFetchForNow: true
-                  }
-                });
-              }}
-              variant="contained"
-            >
-              Add Filter + <FilterAltIcon />
-            </Button>
+            <span>
+              <Button
+                size={'small'}
+                disabled={userOfflineMobile}
+                onClick={() => {
+                  dispatch({
+                    type: RECORDSET_ADD_FILTER,
+                    payload: {
+                      filterType: 'tableFilter',
+                      // short id if activity record set otherwise site_ID
+                      field: tableType === 'Activity' ? 'short_id' : 'site_id',
+                      setID: props.setID,
+                      operator: 'CONTAINS',
+                      operator2: 'AND',
+                      blockFetchForNow: true
+                    }
+                  });
+                }}
+                variant="contained"
+              >
+                Add Filter + <FilterAltIcon />
+              </Button>
+            </span>
           </Tooltip>
         </div>
       </div>

--- a/app/src/UI/Overlay/Records/RecordSetCacheButtons.tsx
+++ b/app/src/UI/Overlay/Records/RecordSetCacheButtons.tsx
@@ -18,7 +18,7 @@ const RecordSetCacheButtons = ({ recordSet, setId }: PropTypes) => {
 
   const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
-    switch (recordSet.cacheMetadata.status) {
+    switch (recordSet.cacheMetadataStatus) {
       case UserRecordCacheStatus.NOT_CACHED:
         downloadCache();
         break;
@@ -96,9 +96,9 @@ const RecordSetCacheButtons = ({ recordSet, setId }: PropTypes) => {
           UserRecordCacheStatus.NOT_CACHED,
           UserRecordCacheStatus.ERROR,
           UserRecordCacheStatus.DOWNLOADING
-        ].includes(recordSet.cacheMetadata?.status)
+        ].includes(recordSet.cacheMetadataStatus)
     );
-  }, [recordSet.cacheMetadata?.status, connected]);
+  }, [recordSet.cacheMetadataStatus, connected]);
 
   return (
     <Tooltip classes={{ tooltip: 'toolTip' }} title="Click to save this layer and it's records">
@@ -109,7 +109,7 @@ const RecordSetCacheButtons = ({ recordSet, setId }: PropTypes) => {
           onClick={handleClick}
           variant="outlined"
         >
-          {formatStatusKey(recordSet.cacheMetadata?.status)}
+          {formatStatusKey(recordSet.cacheMetadataStatus)}
           <SaveIcon />
         </Button>
       </span>

--- a/app/src/interfaces/UserRecordSet.ts
+++ b/app/src/interfaces/UserRecordSet.ts
@@ -1,6 +1,3 @@
-import { GeoJSONSourceSpecification } from 'maplibre-gl';
-import { RepositoryBoundingBoxSpec } from 'utils/tile-cache';
-
 export enum RecordSetType {
   IAPP = 'IAPP',
   Activity = 'Activity'
@@ -32,11 +29,5 @@ export interface UserRecordSet {
     name: string;
     server_id: any;
   };
-  cacheMetadata: {
-    status: UserRecordCacheStatus;
-    idList?: string[];
-    cachedGeoJson?: GeoJSONSourceSpecification;
-    cachedCentroid?: GeoJSONSourceSpecification;
-    bbox?: RepositoryBoundingBoxSpec;
-  };
+  cacheMetadataStatus: UserRecordCacheStatus;
 }

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -10,6 +10,7 @@ import { TileCacheService } from 'utils/tile-cache';
 import { Context, TileCacheServiceFactory } from 'utils/tile-cache/context';
 import { MOBILE } from 'state/build-time-config';
 import TileCache from 'state/actions/cache/TileCache';
+import { RecordCacheServiceFactory } from 'utils/record-cache/context';
 
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register(import.meta.env.MODE === 'production' ? '/worker.js' : '/dev-sw.js?dev-sw', {
@@ -21,8 +22,10 @@ async function mountApp(CONFIG) {
   const { store, persistor } = setupStore(CONFIG);
 
   let tileCache: TileCacheService | null = null;
+
   if (MOBILE) {
     tileCache = await TileCacheServiceFactory.getPlatformInstance();
+    await RecordCacheServiceFactory.getPlatformInstance();
     // load any caches present
     store.dispatch(TileCache.repositoryList());
   }

--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -30,10 +30,9 @@ class RecordCache {
     ) => {
       const service = await RecordCacheServiceFactory.getPlatformInstance();
       const state: RootState = getState() as RootState;
-
-      const idsToCache: string[] = state.Map.layers
-        .find((l) => l.recordSetID == spec.setId)
-        .IDList.map((id: string | number) => id.toString());
+      const idsToCache: string[] =
+        state.Map.layers.find((l) => l.recordSetID == spec.setId)?.IDList.map((id: string | number) => id.toString()) ??
+        [];
 
       const recordSet = state.UserSettings.recordSets[spec.setId];
       const bbox = await getBoundingBoxFromRecordsetFilters(recordSet);

--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -38,7 +38,7 @@ class RecordCache {
       const recordSet = state.UserSettings.recordSets[spec.setId];
       const bbox = await getBoundingBoxFromRecordsetFilters(recordSet);
 
-      const responseData = await service.downloadCache({
+      const downloadCompleted = await service.downloadCache({
         API_BASE: state.Configuration.current.API_BASE,
         bbox,
         idsToCache,
@@ -46,14 +46,9 @@ class RecordCache {
         setId: spec.setId
       });
 
-      // Will Refactor the current uses of Cache Metadata separately [Maintain only cache status]
       return {
-        status: UserRecordCacheStatus.CACHED,
-        idList: idsToCache,
-        bbox: bbox,
         setId: spec.setId,
-        cachedGeoJson: responseData.cachedGeoJson,
-        cachedCentroid: responseData.cachedCentroid
+        status: downloadCompleted ? UserRecordCacheStatus.CACHED : UserRecordCacheStatus.NOT_CACHED
       };
     }
   );

--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -37,7 +37,7 @@ class RecordCache {
       const recordSet = state.UserSettings.recordSets[spec.setId];
       const bbox = await getBoundingBoxFromRecordsetFilters(recordSet);
 
-      const downloadCompleted = await service.downloadCache({
+      const downloadCompleted = await service.download({
         API_BASE: state.Configuration.current.API_BASE,
         bbox,
         idsToCache,

--- a/app/src/state/actions/userSettings/RecordSet.ts
+++ b/app/src/state/actions/userSettings/RecordSet.ts
@@ -67,7 +67,7 @@ class RecordSet {
       if (
         MOBILE &&
         [UserRecordCacheStatus.CACHED, UserRecordCacheStatus.DOWNLOADING].includes(
-          recordSets[spec.setId]?.cacheMetadata?.status
+          recordSets[spec.setId].cacheMetadataStatus
         )
       ) {
         const deletionResult = await thunkAPI.dispatch(RecordCache.deleteCache(spec));
@@ -99,9 +99,7 @@ class RecordSet {
       name: '',
       server_id: 0
     },
-    cacheMetadata: {
-      status: UserRecordCacheStatus.NOT_CACHED
-    }
+    cacheMetadataStatus: UserRecordCacheStatus.NOT_CACHED
   });
 }
 

--- a/app/src/state/reducers/alertsAndPrompts.ts
+++ b/app/src/state/reducers/alertsAndPrompts.ts
@@ -6,6 +6,7 @@ import Prompt from 'state/actions/prompts/Prompt';
 import { PromptAction } from 'interfaces/prompt-interfaces';
 import RecordCache from 'state/actions/cache/RecordCache';
 import cacheAlertMessages from 'constants/alerts/cacheAlerts';
+import { UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 
 interface AlertsAndPromptsState {
   alerts: AlertMessage[];
@@ -50,12 +51,13 @@ export function createAlertsAndPromptsReducer(
       } else if (RegExp(Prompt.NEW_PROMPT).exec(action.type)) {
         const newPrompt: PromptAction = action.payload;
         draftState.prompts = addPrompt(state.prompts, newPrompt);
-      } else if (RecordCache.requestCaching.fulfilled.match(action)) {
+      } else if (
+        RecordCache.requestCaching.fulfilled.match(action) &&
+        action.payload.status === UserRecordCacheStatus.CACHED
+      ) {
         draftState.alerts = addAlert(state.alerts, cacheAlertMessages.recordsetCacheSuccess);
       } else if (RecordCache.requestCaching.rejected.match(action)) {
-        if (action?.error?.message !== 'Early Exit') {
-          draftState.alerts = addAlert(state.alerts, cacheAlertMessages.recordsetCacheFailed);
-        }
+        draftState.alerts = addAlert(state.alerts, cacheAlertMessages.recordsetCacheFailed);
       } else if (RecordCache.deleteCache.rejected.match(action)) {
         draftState.alerts = addAlert(state.alerts, cacheAlertMessages.recordsetDeleteCacheFailed);
       } else if (RecordCache.stopDownload.fulfilled.match(action)) {

--- a/app/src/state/reducers/map.ts
+++ b/app/src/state/reducers/map.ts
@@ -511,18 +511,21 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           page: 0
         });
       } else if (WhatsHere.server_filtered_ids_fetched.match(action)) {
-        draftState.whatsHere.serverActivityIDs = action.payload.activities;
-        draftState.whatsHere.serverIAPPIDs = action.payload.iapp;
+        const { iapp, activities } = action.payload;
+        draftState.whatsHere.serverActivityIDs = activities;
+        draftState.whatsHere.serverIAPPIDs = iapp;
         const toggledOnActivityLayers = draftState.layers.filter(
           ({ type, layerState }) => type === RecordSetType.Activity && layerState.mapToggle
         );
         const toggledOnIAPPLayers = draftState.layers.filter(
           ({ type, layerState }) => type === RecordSetType.IAPP && layerState.mapToggle
         );
+
         const localActivityIDs = toggledOnActivityLayers.flatMap((layer) => layer.IDList ?? []);
         const localIappIds = toggledOnIAPPLayers.flatMap((layer) => layer.IDList ?? []);
-        const iappIds = localIappIds.filter((l) => draftState.whatsHere.serverIAPPIDs.includes(l));
-        const activityIds = localActivityIDs.filter((l) => draftState.whatsHere.serverActivityIDs.includes(l));
+
+        const iappIds = localIappIds.filter((l) => iapp.includes(l) || iapp.includes(l.toString()));
+        const activityIds = localActivityIDs.filter((l) => activities.includes(l));
         draftState.whatsHere.ActivityIDs = Array.from(new Set(activityIds));
         draftState.whatsHere.IAPPIDs = Array.from(new Set(iappIds));
       } else if (RecordCache.requestCaching.fulfilled.match(action)) {
@@ -751,7 +754,7 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           case IAPP_GET_IDS_FOR_RECORDSET_REQUEST: {
             let index = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.recordSetID);
             if (!draftState.layers[index]) {
-              draftState.layers.push({ recordSetID: action.payload.recordSetID, type: RecordSetType.Activity });
+              draftState.layers.push({ recordSetID: action.payload.recordSetID, type: RecordSetType.IAPP });
               index = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.recordSetID);
             }
             draftState.layers[index].tableFiltersHash = action.payload.tableFiltersHash;

--- a/app/src/state/reducers/map.ts
+++ b/app/src/state/reducers/map.ts
@@ -60,7 +60,6 @@ import { SortFilter } from 'interfaces/filterParams';
 import TileCache from 'state/actions/cache/TileCache';
 import MapActions from 'state/actions/map';
 import GeoTracking from 'state/actions/geotracking/GeoTracking';
-import RecordCache from 'state/actions/cache/RecordCache';
 import IappActions from 'state/actions/activity/Iapp';
 import Activity from 'state/actions/activity/Activity';
 
@@ -471,14 +470,6 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
         for (const r of removalList) {
           draftState.enabledOverlayLayers.splice(draftState.enabledOverlayLayers.indexOf(r), 1);
         }
-      } else if (RecordCache.requestCaching.fulfilled.match(action)) {
-        const index = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.setId);
-        draftState.layers[index].layerState.cacheMetadata = {
-          ...draftState.layers[index].layerState.cacheMetadata,
-          cachedCentroid: action.payload.cachedCentroid,
-          cachedGeoJson: action.payload.cachedGeoJson,
-          bbox: action.payload.bbox
-        };
       } else if (UserSettings.InitState.getSuccess.match(action)) {
         Object.keys(action.payload.recordSets).forEach((setID) => {
           let layerIndex = draftState.layers.findIndex((layer) => layer.recordSetID === setID);

--- a/app/src/state/reducers/map.ts
+++ b/app/src/state/reducers/map.ts
@@ -62,6 +62,7 @@ import MapActions from 'state/actions/map';
 import GeoTracking from 'state/actions/geotracking/GeoTracking';
 import IappActions from 'state/actions/activity/Iapp';
 import Activity from 'state/actions/activity/Activity';
+import RecordCache from 'state/actions/cache/RecordCache';
 
 export enum LeafletWhosEditingEnum {
   ACTIVITY = 'ACTIVITY',
@@ -416,9 +417,11 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
        in) and builder.addCase instead of switches, although I assume you lose fallthrough cases then.
       */
     return createNextState(state, (draftState: Draft<MapState>) => {
-      if (UserSettings.RecordSet.remove.match(action)) {
-        const index = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload);
-        draftState.layers.splice(index, 1);
+      if (UserSettings.RecordSet.requestRemoval.fulfilled.match(action)) {
+        const index = draftState.layers.findIndex((layer) => layer.recordSetID === action.meta.arg.setId);
+        if (index !== -1) {
+          draftState.layers.splice(index, 1);
+        }
       } else if (UserSettings.RecordSet.set.match(action)) {
         const layerIndex = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.setName);
         Object.keys(action.payload.updatedSet).forEach((key) => {
@@ -516,16 +519,17 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
         const toggledOnIAPPLayers = draftState.layers.filter(
           ({ type, layerState }) => type === RecordSetType.IAPP && layerState.mapToggle
         );
-        const localActivityIDs = toggledOnActivityLayers.flatMap(
-          (layer) => layer.IDList ?? layer?.layerState?.cacheMetadata?.idList ?? []
-        );
-        const localIappIds = toggledOnIAPPLayers.flatMap(
-          (layer) => layer.IDList ?? layer?.layerState?.cacheMetadata?.idList ?? []
-        );
+        const localActivityIDs = toggledOnActivityLayers.flatMap((layer) => layer.IDList ?? []);
+        const localIappIds = toggledOnIAPPLayers.flatMap((layer) => layer.IDList ?? []);
         const iappIds = localIappIds.filter((l) => draftState.whatsHere.serverIAPPIDs.includes(l));
         const activityIds = localActivityIDs.filter((l) => draftState.whatsHere.serverActivityIDs.includes(l));
         draftState.whatsHere.ActivityIDs = Array.from(new Set(activityIds));
         draftState.whatsHere.IAPPIDs = Array.from(new Set(iappIds));
+      } else if (RecordCache.requestCaching.fulfilled.match(action)) {
+        const index = draftState.layers.findIndex((layer) => layer.recordSetID === action.meta.arg.setId);
+        if (index !== -1) {
+          draftState.layers[index].layerState.cacheMetadataStatus = action.payload.status;
+        }
       } else if (WhatsHere.sort_filter_update.match(action)) {
         const { field, direction } = action.payload;
         if (action.payload.type === RecordSetType.IAPP) {
@@ -803,8 +807,7 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
             if (!draftState.layers[index]) {
               draftState.layers.push({
                 recordSetID: action.payload.recordSetID,
-                type: action.payload.recordSetType,
-                cacheMetadata: action.payload.cacheMetadata
+                type: action.payload.recordSetType
               });
             }
             index = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.recordSetID);

--- a/app/src/state/reducers/userSettings.ts
+++ b/app/src/state/reducers/userSettings.ts
@@ -197,33 +197,15 @@ function createUserSettingsReducer(configuration: AppConfig): (UserSettingsState
       } else if (WhatsHere.toggle.match(action)) {
         draftState.recordsExpanded = action.payload ? false : draftState.recordsExpanded;
       } else if (RecordCache.requestCaching.pending.match(action)) {
-        draftState.recordSets[action.meta.arg.setId].cacheMetadata = {
-          status: UserRecordCacheStatus.DOWNLOADING
-        };
+        draftState.recordSets[action.meta.arg.setId].cacheMetadataStatus = UserRecordCacheStatus.DOWNLOADING;
       } else if (RecordCache.requestCaching.rejected.match(action) || RecordCache.deleteCache.rejected.match(action)) {
-        if (action.error.message === 'Early Exit') {
-          draftState.recordSets[action.meta.arg.setId].cacheMetadata = {
-            status: UserRecordCacheStatus.NOT_CACHED
-          };
-        } else {
-          draftState.recordSets[action.meta.arg.setId].cacheMetadata = {
-            status: UserRecordCacheStatus.ERROR
-          };
-        }
+        draftState.recordSets[action.meta.arg.setId].cacheMetadataStatus = UserRecordCacheStatus.ERROR;
       } else if (RecordCache.requestCaching.fulfilled.match(action)) {
-        draftState.recordSets[action.meta.arg.setId].cacheMetadata = {
-          status: UserRecordCacheStatus.CACHED,
-          idList: action.payload.idList,
-          bbox: action.payload.bbox,
-          cachedGeoJson: action.payload.cachedGeoJson,
-          cachedCentroid: action.payload.cachedCentroid
-        };
+        draftState.recordSets[action.meta.arg.setId].cacheMetadataStatus = action.payload.status;
       } else if (RecordCache.deleteCache.pending.match(action) || RecordCache.stopDownload.pending.match(action)) {
-        draftState.recordSets[action.meta.arg.setId].cacheMetadata.status = UserRecordCacheStatus.DELETING;
+        draftState.recordSets[action.meta.arg.setId].cacheMetadataStatus = UserRecordCacheStatus.DELETING;
       } else if (RecordCache.deleteCache.fulfilled.match(action)) {
-        draftState.recordSets[action.meta.arg.setId].cacheMetadata = {
-          status: UserRecordCacheStatus.NOT_CACHED
-        };
+        draftState.recordSets[action.meta.arg.setId].cacheMetadataStatus = UserRecordCacheStatus.NOT_CACHED;
       } else if (Activity.deleteSuccess.match(action)) {
         draftState.activeActivity = null;
         draftState.activeActivityDescription = null;

--- a/app/src/state/sagas/activity/offline.ts
+++ b/app/src/state/sagas/activity/offline.ts
@@ -74,7 +74,7 @@ export function* handle_ACTIVITY_GET_LOCAL_REQUEST(action: PayloadAction<string>
     }
   } else {
     try {
-      const service: RecordCacheService = yield RecordCacheServiceFactory.getPlatformInstance();
+      const service = yield RecordCacheServiceFactory.getPlatformInstance();
       const result = yield service.loadActivity(activityID);
 
       const datav2 = {

--- a/app/src/state/sagas/iappsite/dataAccess.ts
+++ b/app/src/state/sagas/iappsite/dataAccess.ts
@@ -15,7 +15,7 @@ export function* handle_IAPP_GET_REQUEST(iappId: PayloadAction<string>) {
   try {
     const connected = yield select(selectNetworkConnected);
     if (MOBILE && !connected) {
-      const service: RecordCacheService = yield RecordCacheServiceFactory.getPlatformInstance();
+      const service = yield RecordCacheServiceFactory.getPlatformInstance();
       const result = yield service.loadIapp(iappId.payload, IappRecordMode.Record);
       yield put(IappActions.getSuccess(result));
     } else {

--- a/app/src/state/sagas/map.ts
+++ b/app/src/state/sagas/map.ts
@@ -85,6 +85,7 @@ import bboxToPolygon from 'utils/bboxToPolygon';
 import IappActions from 'state/actions/activity/Iapp';
 import IappRecord from 'interfaces/IappRecord';
 import { RecordCacheAddSpec } from 'utils/record-cache';
+import NetworkActions from 'state/actions/network/NetworkActions';
 
 function* handle_USER_SETTINGS_GET_INITIAL_STATE_SUCCESS(action) {
   yield put({ type: MAP_INIT_REQUEST, payload: {} });
@@ -663,7 +664,6 @@ function* handle_MAP_INIT_FOR_RECORDSETS() {
   const newUninitializedLayers = newLayerIDs.map((layer) => {
     return { recordSetID: layer, recordSetType: userSettingsState.recordSets[layer].recordSetType };
   });
-
   // combined:
   const allUninitializedLayers = [...currentUninitializedLayers, ...newUninitializedLayers];
 
@@ -835,10 +835,13 @@ function* activitiesPageSaga() {
     takeEvery(DRAW_CUSTOM_LAYER, handle_DRAW_CUSTOM_LAYER),
     takeEvery(CUSTOM_LAYER_DRAWN, handle_CUSTOM_LAYER_DRAWN),
 
+    //Conditions where we may want to redraw the Map layers, fetch IDLists, so on
+    takeEvery(NetworkActions.online, handle_MAP_INIT_FOR_RECORDSETS),
+    takeEvery(UserSettings.RecordSet.add, handle_MAP_INIT_FOR_RECORDSETS),
+    takeEvery(MAP_INIT_FOR_RECORDSET, handle_MAP_INIT_FOR_RECORDSETS),
+
     takeEvery(REFETCH_SERVER_BOUNDARIES, refetchServerBoundaries),
     takeEvery(WhatsHere.server_filtered_ids_fetched, handle_WHATS_HERE_SERVER_FILTERED_IDS_FETCHED),
-
-    takeEvery(UserSettings.RecordSet.add, handle_MAP_INIT_FOR_RECORDSETS),
     takeEvery(UserSettings.RecordSet.cycleColourById, handle_RECORDSET_ROTATE_COLOUR),
     takeEvery(UserSettings.RecordSet.toggleVisibility, handle_RECORDSET_TOGGLE_VISIBILITY),
     takeEvery(UserSettings.RecordSet.toggleLabelVisibility, handle_RECORDSET_TOGGLE_LABEL_VISIBILITY),
@@ -847,7 +850,6 @@ function* activitiesPageSaga() {
     takeEvery(MAP_TOGGLE_GEOJSON_CACHE, handle_MAP_TOGGLE_GEOJSON_CACHE),
     takeEvery(UserSettings.InitState.getSuccess, handle_USER_SETTINGS_GET_INITIAL_STATE_SUCCESS),
     takeEvery(MAP_INIT_REQUEST, handle_MAP_INIT_REQUEST),
-    takeEvery(MAP_INIT_FOR_RECORDSET, handle_MAP_INIT_FOR_RECORDSETS),
     takeEvery(Activity.GeoJson.get, handle_ACTIVITIES_GEOJSON_GET_REQUEST),
     takeEvery(ACTIVITIES_GEOJSON_REFETCH_ONLINE, handle_ACTIVITIES_GEOJSON_REFETCH_ONLINE),
     takeEvery(IAPP_GEOJSON_GET_REQUEST, handle_IAPP_GEOJSON_GET_REQUEST),

--- a/app/src/state/sagas/map.ts
+++ b/app/src/state/sagas/map.ts
@@ -1,4 +1,4 @@
-import { bboxPolygon, Feature, buffer } from '@turf/turf';
+import { bboxPolygon, Feature, buffer, booleanContains } from '@turf/turf';
 import booleanIntersects from '@turf/boolean-intersects';
 import { all, call, debounce, fork, put, select, take, takeEvery, takeLatest } from 'redux-saga/effects';
 import { getSearchCriteriaFromFilters } from '../../utils/miscYankedFromComponents';
@@ -84,6 +84,7 @@ import { RecordCacheServiceFactory } from 'utils/record-cache/context';
 import bboxToPolygon from 'utils/bboxToPolygon';
 import IappActions from 'state/actions/activity/Iapp';
 import IappRecord from 'interfaces/IappRecord';
+import { RecordCacheAddSpec } from 'utils/record-cache';
 
 function* handle_USER_SETTINGS_GET_INITIAL_STATE_SUCCESS(action) {
   yield put({ type: MAP_INIT_REQUEST, payload: {} });
@@ -158,15 +159,21 @@ function* handle_WHATS_HERE_FEATURE(whatsHereFeature: PayloadAction<Feature>) {
       yield put(WhatsHere.server_filtered_ids_fetched(activitiesServerIDList, iappServerIDList));
     } else {
       // Get IDs from Offline Caches
-      const { recordSets } = yield select(selectUserSettings);
-      const recordSetsInBoundingBox = Object.keys(recordSets).filter((set) => {
-        const { bbox, status } = recordSets[set].cacheMetadata;
-        const recordSetIsCached = status === UserRecordCacheStatus.CACHED;
-        return recordSetIsCached && bbox && booleanIntersects(whatsHereFeature.payload, bboxToPolygon(bbox));
+      const service = yield RecordCacheServiceFactory.getPlatformInstance();
+      const repos = yield service.listRepositories();
+
+      const recordSetsInBoundingBox = repos.filter((repo: RecordCacheAddSpec) => {
+        const { status, bbox } = repo;
+        return (
+          status === UserRecordCacheStatus.CACHED &&
+          bbox &&
+          booleanIntersects(whatsHereFeature.payload, bboxToPolygon(bbox as any))
+        );
       });
+
       const overlappingRecords: string[] = [];
       recordSetsInBoundingBox.flatMap((set) =>
-        recordSets[set].cacheMetadata.cachedGeoJson.data.features.forEach((shape: Feature) => {
+        set.cachedGeoJson.data.features.forEach((shape: Feature) => {
           if (booleanIntersects(whatsHereFeature.payload, shape)) {
             overlappingRecords.push(shape?.properties?.description);
           }

--- a/app/src/state/sagas/map.ts
+++ b/app/src/state/sagas/map.ts
@@ -1,4 +1,4 @@
-import { bboxPolygon, Feature, buffer, booleanContains } from '@turf/turf';
+import { bboxPolygon, Feature, buffer } from '@turf/turf';
 import booleanIntersects from '@turf/boolean-intersects';
 import { all, call, debounce, fork, put, select, take, takeEvery, takeLatest } from 'redux-saga/effects';
 import { getSearchCriteriaFromFilters } from '../../utils/miscYankedFromComponents';
@@ -67,7 +67,7 @@ import { InvasivesAPI_Call } from 'hooks/useInvasivesApi';
 import { TRACKING_SAGA_HANDLERS } from 'state/sagas/map/tracking';
 import WhatsHere from 'state/actions/whatsHere/WhatsHere';
 import Prompt from 'state/actions/prompts/Prompt';
-import { RecordSetType, UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
+import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import UserSettings from 'state/actions/userSettings/UserSettings';
 import { SortFilter } from 'interfaces/filterParams';
 import Activity from 'state/actions/activity/Activity';
@@ -638,7 +638,7 @@ function* handle_PAGE_OR_LIMIT_UPDATE(action) {
   }
 }
 
-function* handle_MAP_INIT_FOR_RECORDSETS(action: PayloadAction<UserRecordSet>) {
+function* handle_MAP_INIT_FOR_RECORDSETS() {
   interface ActionType {
     type: string;
     payload: any;
@@ -730,14 +730,14 @@ function* handle_REMOVE_SERVER_BOUNDARY(action) {
   yield put(UserSettings.KML.delete(action.payload.id));
 }
 
-function* handle_DRAW_CUSTOM_LAYER(action) {
+function* handle_DRAW_CUSTOM_LAYER() {
   const panelState = yield select((state) => state.AppMode.panelOpen);
   if (panelState) {
     yield put({ type: TOGGLE_PANEL });
   }
 }
 
-function* handle_CUSTOM_LAYER_DRAWN(actions) {
+function* handle_CUSTOM_LAYER_DRAWN() {
   const panelState = yield select((state) => state.AppMode.panelOpen);
   if (!panelState) {
     yield put({ type: TOGGLE_PANEL });
@@ -780,7 +780,7 @@ function* handle_MAP_ON_SHAPE_UPDATE(action) {
   }
 }
 
-function handle_MAP_TOGGLE_GEOJSON_CACHE(action) {
+function handle_MAP_TOGGLE_GEOJSON_CACHE() {
   location.reload();
 }
 

--- a/app/src/state/sagas/map.ts
+++ b/app/src/state/sagas/map.ts
@@ -84,7 +84,7 @@ import { RecordCacheServiceFactory } from 'utils/record-cache/context';
 import bboxToPolygon from 'utils/bboxToPolygon';
 import IappActions from 'state/actions/activity/Iapp';
 import IappRecord from 'interfaces/IappRecord';
-import { RecordCacheAddSpec } from 'utils/record-cache';
+import { RepositoryMetadata } from 'utils/record-cache';
 import NetworkActions from 'state/actions/network/NetworkActions';
 
 function* handle_USER_SETTINGS_GET_INITIAL_STATE_SUCCESS(action) {
@@ -163,7 +163,7 @@ function* handle_WHATS_HERE_FEATURE(whatsHereFeature: PayloadAction<Feature>) {
       const service = yield RecordCacheServiceFactory.getPlatformInstance();
       const repos = yield service.listRepositories();
 
-      const recordSetsInBoundingBox = repos.filter((repo: RecordCacheAddSpec) => {
+      const recordSetsInBoundingBox = repos.filter((repo: RepositoryMetadata) => {
         const { status, bbox } = repo;
         return (
           status === UserRecordCacheStatus.CACHED &&
@@ -223,7 +223,7 @@ function* handle_WHATS_HERE_IAPP_ROWS_REQUEST() {
     let records: IappRecord[];
     if (MOBILE && !connected) {
       const service = yield RecordCacheServiceFactory.getPlatformInstance();
-      records = yield service.fetchPaginatedCachedIappRecords(
+      records = yield service.getPaginatedCachedIappRecords(
         whatsHere.IAPPIDs.map((id) => id.toString()),
         whatsHere.IAPPPage,
         whatsHere.IAPPLimit
@@ -313,7 +313,7 @@ function* handle_WHATS_HERE_ACTIVITY_ROWS_REQUEST() {
     let records: UserRecord[];
     if (MOBILE && !connected) {
       const service = yield RecordCacheServiceFactory.getPlatformInstance();
-      records = yield service.fetchPaginatedCachedRecords(
+      records = yield service.getPaginatedCachedActivityRecords(
         whatsHere.ActivityIDs,
         whatsHere.ActivityPage,
         whatsHere.ActivityLimit

--- a/app/src/state/sagas/map/dataAccess.ts
+++ b/app/src/state/sagas/map/dataAccess.ts
@@ -11,7 +11,8 @@ import {
   FILTERS_PREPPED_FOR_VECTOR_ENDPOINT,
   IAPP_GEOJSON_GET_ONLINE,
   IAPP_GEOJSON_GET_SUCCESS,
-  IAPP_GET_IDS_FOR_RECORDSET_ONLINE
+  IAPP_GET_IDS_FOR_RECORDSET_ONLINE,
+  IAPP_GET_IDS_FOR_RECORDSET_SUCCESS
 } from 'state/actions';
 import { ACTIVITY_GEOJSON_SOURCE_KEYS, selectMap } from 'state/reducers/map';
 import WhatsHere from 'state/actions/whatsHere/WhatsHere';
@@ -159,6 +160,17 @@ export function* handle_IAPP_GET_IDS_FOR_RECORDSET_REQUEST(action) {
         payload: {
           filterObj: filterObject,
           recordSetID: action.payload.recordSetID,
+          tableFiltersHash: action.payload.tableFiltersHash
+        }
+      });
+    } else {
+      const service = yield RecordCacheServiceFactory.getPlatformInstance();
+      const ids = yield service.fetchIdList(action.payload.recordSetID);
+      yield put({
+        type: IAPP_GET_IDS_FOR_RECORDSET_SUCCESS,
+        payload: {
+          recordSetID: action.payload.recordSetID,
+          IDList: ids,
           tableFiltersHash: action.payload.tableFiltersHash
         }
       });

--- a/app/src/state/sagas/map/dataAccess.ts
+++ b/app/src/state/sagas/map/dataAccess.ts
@@ -85,12 +85,6 @@ export function* handle_PREP_FILTERS_FOR_VECTOR_ENDPOINT(action) {
       recordSetType: recordset.recordSetType
     };
 
-    if (MOBILE) {
-      const recordService = yield RecordCacheServiceFactory.getPlatformInstance();
-      if (yield recordService.isCached(action.payload.recordSetID)) {
-        payload['cacheMetadata'] = yield recordService.fetchRepository(action.payload.recordSetID);
-      }
-    }
     yield put({ type: FILTERS_PREPPED_FOR_VECTOR_ENDPOINT, payload });
   } catch (e) {
     console.error(e);

--- a/app/src/state/sagas/map/dataAccess.ts
+++ b/app/src/state/sagas/map/dataAccess.ts
@@ -15,7 +15,7 @@ import {
 } from 'state/actions';
 import { ACTIVITY_GEOJSON_SOURCE_KEYS, selectMap } from 'state/reducers/map';
 import WhatsHere from 'state/actions/whatsHere/WhatsHere';
-import { RecordSetType, UserRecordSet } from 'interfaces/UserRecordSet';
+import { RecordSetType, UserRecordSet, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import { MOBILE } from 'state/build-time-config';
 import { RecordCacheServiceFactory } from 'utils/record-cache/context';
 import GeoShapes from 'constants/geoShapes';
@@ -77,16 +77,20 @@ export function* handle_PREP_FILTERS_FOR_VECTOR_ENDPOINT(action) {
       return;
     }
 
-    yield put({
-      type: FILTERS_PREPPED_FOR_VECTOR_ENDPOINT,
-      payload: {
-        filterObject: filterObject,
-        recordSetID: action.payload.recordSetID,
-        tableFiltersHash: action.payload.tableFiltersHash,
-        recordSetType: recordset.recordSetType,
-        cacheMetadata: recordset.cacheMetadata ?? null
+    const payload = {
+      filterObject: filterObject,
+      recordSetID: action.payload.recordSetID,
+      tableFiltersHash: action.payload.tableFiltersHash,
+      recordSetType: recordset.recordSetType
+    };
+
+    if (MOBILE) {
+      const recordService = yield RecordCacheServiceFactory.getPlatformInstance();
+      if (yield recordService.isCached(action.payload.recordSetID)) {
+        payload['cacheMetadata'] = yield recordService.fetchRepository(action.payload.recordSetID);
       }
-    });
+    }
+    yield put({ type: FILTERS_PREPPED_FOR_VECTOR_ENDPOINT, payload });
   } catch (e) {
     console.error(e);
     throw e;
@@ -115,12 +119,15 @@ export function* handle_ACTIVITIES_GET_IDS_FOR_RECORDSET_REQUEST(action) {
       });
     } else {
       const recordSet = currentState.recordSets[action.payload.recordSetID] ?? null;
-      if (recordSet?.cacheMetadata?.idList) {
+      if (recordSet.cacheMetadataStatus === UserRecordCacheStatus.CACHED) {
+        const service = yield RecordCacheServiceFactory.getPlatformInstance();
+        const ids = yield service.fetchIdList(action.payload.recordSetID);
+
         yield put({
           type: ACTIVITIES_GET_IDS_FOR_RECORDSET_SUCCESS,
           payload: {
             recordSetID: action.payload.recordSetID,
-            IDList: recordSet.cacheMetadata.idList ?? [],
+            IDList: ids ?? [],
             tableFiltersHash: action.payload.tableFiltersHash
           }
         });
@@ -221,10 +228,8 @@ export function* handle_ACTIVITIES_TABLE_ROWS_GET_REQUEST(action) {
     }
 
     if (userMobileOffline) {
-      const recordSetIdList = yield select(
-        (state) => state.UserSettings.recordSets[recordSetID].cacheMetadata.idList ?? []
-      );
       const service = yield RecordCacheServiceFactory.getPlatformInstance();
+      const recordSetIdList = yield service.fetchIdList(recordSetID);
       const records = yield service.fetchPaginatedCachedRecords(recordSetIdList, page, limit);
       yield put(
         Activity.getRowsSuccess({
@@ -275,8 +280,8 @@ export function* handle_IAPP_TABLE_ROWS_GET_REQUEST(action: PayloadAction<IappTa
       return;
     }
     if (userMobileOffline) {
-      const recordSetIdList = currentState.recordSets[recordSetID].cacheMetadata.idList ?? [];
       const service = yield RecordCacheServiceFactory.getPlatformInstance();
+      const recordSetIdList = yield service.fetchIdList(recordSetID) ?? [];
       const records = yield service.fetchPaginatedCachedIappRecords(recordSetIdList, page, limit);
       yield put(
         IappActions.getRowsSuccess({

--- a/app/src/state/sagas/map/dataAccess.ts
+++ b/app/src/state/sagas/map/dataAccess.ts
@@ -116,7 +116,7 @@ export function* handle_ACTIVITIES_GET_IDS_FOR_RECORDSET_REQUEST(action) {
       const recordSet = currentState.recordSets[action.payload.recordSetID] ?? null;
       if (recordSet.cacheMetadataStatus === UserRecordCacheStatus.CACHED) {
         const service = yield RecordCacheServiceFactory.getPlatformInstance();
-        const ids = yield service.fetchIdList(action.payload.recordSetID);
+        const ids = yield service.getIdList(action.payload.recordSetID);
 
         yield put({
           type: ACTIVITIES_GET_IDS_FOR_RECORDSET_SUCCESS,
@@ -160,7 +160,7 @@ export function* handle_IAPP_GET_IDS_FOR_RECORDSET_REQUEST(action) {
     } else {
       const service = yield RecordCacheServiceFactory.getPlatformInstance();
       if (yield service.isCached(action.payload.recordSetID)) {
-        const ids = yield service.fetchIdList(action.payload.recordSetID);
+        const ids = yield service.getIdList(action.payload.recordSetID);
         yield put({
           type: IAPP_GET_IDS_FOR_RECORDSET_SUCCESS,
           payload: {
@@ -237,8 +237,8 @@ export function* handle_ACTIVITIES_TABLE_ROWS_GET_REQUEST(action) {
 
     if (userMobileOffline) {
       const service = yield RecordCacheServiceFactory.getPlatformInstance();
-      const recordSetIdList = yield service.fetchIdList(recordSetID);
-      const records = yield service.fetchPaginatedCachedRecords(recordSetIdList, page, limit);
+      const recordSetIdList = yield service.getIdList(recordSetID);
+      const records = yield service.getPaginatedCachedActivityRecords(recordSetIdList, page, limit);
       yield put(
         Activity.getRowsSuccess({
           recordSetID: recordSetID,
@@ -289,8 +289,8 @@ export function* handle_IAPP_TABLE_ROWS_GET_REQUEST(action: PayloadAction<IappTa
     }
     if (userMobileOffline) {
       const service = yield RecordCacheServiceFactory.getPlatformInstance();
-      const recordSetIdList = yield service.fetchIdList(recordSetID) ?? [];
-      const records = yield service.fetchPaginatedCachedIappRecords(recordSetIdList, page, limit);
+      const recordSetIdList = yield service.getIdList(recordSetID.toString()) ?? [];
+      const records = yield service.getPaginatedCachedIappRecords(recordSetIdList, page, limit);
       yield put(
         IappActions.getRowsSuccess({
           recordSetID: recordSetID,

--- a/app/src/state/sagas/map/dataAccess.ts
+++ b/app/src/state/sagas/map/dataAccess.ts
@@ -159,15 +159,17 @@ export function* handle_IAPP_GET_IDS_FOR_RECORDSET_REQUEST(action) {
       });
     } else {
       const service = yield RecordCacheServiceFactory.getPlatformInstance();
-      const ids = yield service.fetchIdList(action.payload.recordSetID);
-      yield put({
-        type: IAPP_GET_IDS_FOR_RECORDSET_SUCCESS,
-        payload: {
-          recordSetID: action.payload.recordSetID,
-          IDList: ids,
-          tableFiltersHash: action.payload.tableFiltersHash
-        }
-      });
+      if (yield service.isCached(action.payload.recordSetID)) {
+        const ids = yield service.fetchIdList(action.payload.recordSetID);
+        yield put({
+          type: IAPP_GET_IDS_FOR_RECORDSET_SUCCESS,
+          payload: {
+            recordSetID: action.payload.recordSetID,
+            IDList: ids,
+            tableFiltersHash: action.payload.tableFiltersHash
+          }
+        });
+      }
     }
   } catch (e) {
     console.error(e);

--- a/app/src/state/sagas/userSettings.ts
+++ b/app/src/state/sagas/userSettings.ts
@@ -193,14 +193,9 @@ function* handle_GET_API_DOC_ONLINE(action) {
     console.dir(e);
   }
 }
-function* handle_RECORD_CACHING_FAILED(action: ReturnType<typeof RecordCache.requestCaching.rejected>) {
-  const service = yield RecordCacheServiceFactory.getPlatformInstance();
-  yield service.setRepositoryStatus(action.meta.arg.setId, UserRecordCacheStatus.ERROR);
-}
 
 function* userSettingsSaga() {
   yield all([
-    takeEvery(RecordCache.requestCaching.rejected, handle_RECORD_CACHING_FAILED),
     takeEvery(AUTH_INITIALIZE_COMPLETE, handle_APP_AUTH_READY),
     takeEvery(GET_API_DOC_REQUEST, handle_GET_API_DOC_REQUEST),
     takeEvery(GET_API_DOC_ONLINE, handle_GET_API_DOC_ONLINE),

--- a/app/src/state/sagas/userSettings.ts
+++ b/app/src/state/sagas/userSettings.ts
@@ -6,6 +6,8 @@ import { selectUserSettings } from 'state/reducers/userSettings';
 import UserSettings from 'state/actions/userSettings/UserSettings';
 import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import Activity from 'state/actions/activity/Activity';
+import RecordCache from 'state/actions/cache/RecordCache';
+import { RecordCacheServiceFactory } from 'utils/record-cache/context';
 
 function* handle_USER_SETTINGS_TOGGLE_RECORDS_EXPANDED_REQUEST(action) {
   yield put(UserSettings.toggleRecordExpandSuccess());
@@ -105,9 +107,7 @@ function* handle_USER_SETTINGS_GET_INITIAL_STATE_REQUEST(action) {
         Activity_Treatment_MechanicalPlantAquatic: '#c6c617',
         Activity_Treatment_MechanicalPlantTerrestrial: '#c6c617'
       },
-      cacheMetadata: {
-        status: UserRecordCacheStatus.NOT_CACHED
-      },
+      cacheMetadataStatus: UserRecordCacheStatus.NOT_ELIGIBLE,
       drawOrder: 1
     },
     '2': {
@@ -127,9 +127,7 @@ function* handle_USER_SETTINGS_GET_INITIAL_STATE_REQUEST(action) {
         Activity_Treatment_MechanicalPlantAquatic: '#c6c617',
         Activity_Treatment_MechanicalPlantTerrestrial: '#c6c617'
       },
-      cacheMetadata: {
-        status: UserRecordCacheStatus.NOT_ELIGIBLE
-      },
+      cacheMetadataStatus: UserRecordCacheStatus.NOT_ELIGIBLE,
       drawOrder: 2
     },
     '3': {
@@ -137,9 +135,7 @@ function* handle_USER_SETTINGS_GET_INITIAL_STATE_REQUEST(action) {
       recordSetName: 'All IAPP Records',
       color: '#21f34f',
       drawOrder: 3,
-      cacheMetadata: {
-        status: UserRecordCacheStatus.NOT_ELIGIBLE
-      }
+      cacheMetadataStatus: UserRecordCacheStatus.NOT_ELIGIBLE
     }
   };
 
@@ -197,9 +193,14 @@ function* handle_GET_API_DOC_ONLINE(action) {
     console.dir(e);
   }
 }
+function* handle_RECORD_CACHING_FAILED(action: ReturnType<typeof RecordCache.requestCaching.rejected>) {
+  const service = yield RecordCacheServiceFactory.getPlatformInstance();
+  yield service.setRepositoryStatus(action.meta.arg.setId, UserRecordCacheStatus.ERROR);
+}
 
 function* userSettingsSaga() {
   yield all([
+    takeEvery(RecordCache.requestCaching.rejected, handle_RECORD_CACHING_FAILED),
     takeEvery(AUTH_INITIALIZE_COMPLETE, handle_APP_AUTH_READY),
     takeEvery(GET_API_DOC_REQUEST, handle_GET_API_DOC_REQUEST),
     takeEvery(GET_API_DOC_ONLINE, handle_GET_API_DOC_ONLINE),

--- a/app/src/state/sagas/userSettings.ts
+++ b/app/src/state/sagas/userSettings.ts
@@ -6,8 +6,6 @@ import { selectUserSettings } from 'state/reducers/userSettings';
 import UserSettings from 'state/actions/userSettings/UserSettings';
 import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import Activity from 'state/actions/activity/Activity';
-import RecordCache from 'state/actions/cache/RecordCache';
-import { RecordCacheServiceFactory } from 'utils/record-cache/context';
 
 function* handle_USER_SETTINGS_TOGGLE_RECORDS_EXPANDED_REQUEST(action) {
   yield put(UserSettings.toggleRecordExpandSuccess());

--- a/app/src/utils/base-classes/BaseCacheService.ts
+++ b/app/src/utils/base-classes/BaseCacheService.ts
@@ -1,0 +1,43 @@
+/**
+ * @desc Generic Base Class for All Caching actions using SQLite or LocalForage ensuring consistency between all Database implementations
+ * @property { RepoMetadata } _ All Details contained by a Metadata Entry
+ * @property { RepositoryDownloadRequestSpec } _ Information details for a Download e.g. API Url, Cache Targets, bounding boxes
+ * @property { ProgressCallbackParams } _ Details for Callback Functionality, used for Progress bars, updates
+ * @property { RepositoryStatusSchema } _ Enum for Cache Statuses, e.g. READY, CACHED, ERROR, etc
+ * @example Implementation abstract Class Demo extends BaseCacheService<
+ *            RepoMetadataType
+ *            RepositoryDownloadRequestSpecType
+ *            RepoProgressCallbackParamsType
+ *            RepositoryStatusSchemeType>
+ */
+abstract class BaseCacheService<
+  RepoMetadata,
+  RepositoryDownloadRequestSpec,
+  ProgressCallbackParams,
+  RepositoryStatusSchema
+> {
+  /** Update any details for a Repository */
+  protected abstract addOrUpdateRepository(repositoryId: RepoMetadata): Promise<void>;
+
+  /** Remove one Repository from the collection along with its contentes */
+  public abstract deleteRepository(repositoryId: string): Promise<void>;
+
+  /** Pull metadata for one Repository in the Collection */
+  public abstract getRepository(repositoryId: string): Promise<RepoMetadata | null>;
+
+  /** List metadata for all Repositories */
+  public abstract listRepositories(): Promise<RepoMetadata[]>;
+
+  /** Change the status for a given Repository */
+  public abstract setRepositoryStatus(repositoryId: string, status: RepositoryStatusSchema): Promise<void>;
+
+  /** Download a new Repository along with its contents */
+  public abstract download(
+    spec: RepositoryDownloadRequestSpec,
+    progressCallback?: (currentProgress: ProgressCallbackParams) => void
+  ): Promise<boolean | void>;
+
+  protected constructor() {}
+}
+
+export default BaseCacheService;

--- a/app/src/utils/filterRecordsetsByNetworkState.ts
+++ b/app/src/utils/filterRecordsetsByNetworkState.ts
@@ -8,7 +8,7 @@ import { UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
  */
 const filterRecordsetsByNetworkState = (recordSets: Record<string, UserRecordSet>, userOffline: boolean): string[] =>
   Object.keys(recordSets).filter((set) => {
-    return !userOffline || recordSets[set].cacheMetadata.status === UserRecordCacheStatus.CACHED;
+    return !userOffline || recordSets[set].cacheMetadataStatus === UserRecordCacheStatus.CACHED;
   });
 
 export default filterRecordsetsByNetworkState;

--- a/app/src/utils/getBoundingBoxFromRecordsetFilters.ts
+++ b/app/src/utils/getBoundingBoxFromRecordsetFilters.ts
@@ -1,5 +1,5 @@
 import bbox from '@turf/bbox';
-import { UserRecordSet } from 'interfaces/UserRecordSet';
+import { RecordSetType, UserRecordSet } from 'interfaces/UserRecordSet';
 import { getCurrentJWT } from 'state/sagas/auth/auth';
 import { getSelectColumnsByRecordSetType } from 'state/sagas/map/dataAccess';
 import { parse } from 'wkt';
@@ -9,13 +9,16 @@ const getBoundingBoxFromRecordsetFilters = async (recordSet: UserRecordSet): Pro
   const { recordSetType } = recordSet;
   const filterObj = {
     recordSetType: recordSetType,
-    sortColumn: 'short_id',
+    sortColumn: recordSetType === RecordSetType.Activity ? 'short_id' : 'site_id',
     sortOrder: 'DESC',
     tableFilters: recordSet.tableFilters,
     selectColumns: getSelectColumnsByRecordSetType(recordSetType)
   };
-
-  const data = await fetch(`${CONFIGURATION_API_BASE}/api/v2/activities/bbox`, {
+  const url =
+    recordSetType === RecordSetType.Activity
+      ? `${CONFIGURATION_API_BASE}/api/v2/activities/bbox`
+      : `${CONFIGURATION_API_BASE}/api/v2/IAPP/bbox`;
+  const data = await fetch(url, {
     method: 'POST',
     headers: {
       Authorization: await getCurrentJWT(),

--- a/app/src/utils/getBoundingBoxFromRecordsetFilters.ts
+++ b/app/src/utils/getBoundingBoxFromRecordsetFilters.ts
@@ -29,10 +29,10 @@ const getBoundingBoxFromRecordsetFilters = async (recordSet: UserRecordSet): Pro
 
   const [minLongitude, minLatitude, maxLongitude, maxLatitude] = bbox(parse(data.bbox));
   return {
-    minLatitude: minLatitude,
-    maxLatitude: maxLongitude,
-    minLongitude: minLongitude,
-    maxLongitude: maxLatitude
+    minLatitude,
+    maxLatitude,
+    minLongitude,
+    maxLongitude
   };
 };
 

--- a/app/src/utils/record-cache/context.ts
+++ b/app/src/utils/record-cache/context.ts
@@ -1,9 +1,10 @@
 import { Platform, PLATFORM } from 'state/build-time-config';
+import { RecordCacheService } from 'utils/record-cache/index';
 import { SQLiteRecordCacheService } from 'utils/record-cache/sqlite-cache';
 import { LocalForageRecordCacheService } from 'utils/record-cache/localforage-cache';
 
 class RecordCacheServiceFactory {
-  static async getPlatformInstance() {
+  static async getPlatformInstance(): Promise<RecordCacheService> {
     if (PLATFORM == Platform.IOS) {
       return SQLiteRecordCacheService.getInstance();
     }

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -88,6 +88,12 @@ abstract class RecordCacheService {
 
   abstract deleteRepository(repositoryId: string): Promise<void>;
 
+  abstract fetchRepository(repositoryId: string): Promise<RecordCacheAddSpec>;
+
+  abstract isCached(repositoryId: string): Promise<boolean>;
+
+  abstract fetchIdList(repositoryId: string): Promise<string[]>;
+
   abstract listRepositories(): Promise<RecordCacheAddSpec[]>;
 
   abstract loadIappRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata>;
@@ -98,7 +104,7 @@ abstract class RecordCacheService {
 
   abstract checkForAbort(id: string): Promise<boolean>;
 
-  async downloadCache(spec: CacheDownloadSpec): Promise<Record<PropertyKey, any>> {
+  async downloadCache(spec: CacheDownloadSpec): Promise<boolean> {
     const args = {
       idsToCache: spec.idsToCache,
       setId: spec.setId,
@@ -119,27 +125,29 @@ abstract class RecordCacheService {
       bbox: spec.bbox
     });
 
+    let downloadCompleted = true;
     if (spec.recordSetType === RecordSetType.Activity && (await this.downloadActivity(args))) {
       Object.assign(responseData, await this.loadRecordsetSourceMetadata(spec.idsToCache));
     } else if (spec.recordSetType === RecordSetType.IAPP && (await this.downloadIapp(args))) {
       Object.assign(responseData, await this.loadIappRecordsetSourceMetadata(spec.idsToCache));
     } else {
+      downloadCompleted = false;
       this.deleteRepository(spec.setId);
-      throw Error('Early Exit');
     }
 
-    await this.addOrUpdateRepository({
-      setId: spec.setId,
-      cacheTime: new Date(),
-      cachedIds: spec.idsToCache,
-      recordSetType: spec.recordSetType,
-      status: UserRecordCacheStatus.CACHED,
-      cachedGeoJson: responseData.cachedGeoJson,
-      cachedCentroid: responseData.cachedCentroid,
-      bbox: spec.bbox
-    });
-
-    return responseData;
+    if (downloadCompleted) {
+      await this.addOrUpdateRepository({
+        setId: spec.setId,
+        cacheTime: new Date(),
+        cachedIds: spec.idsToCache,
+        recordSetType: spec.recordSetType,
+        status: UserRecordCacheStatus.CACHED,
+        cachedGeoJson: responseData.cachedGeoJson,
+        cachedCentroid: responseData.cachedCentroid,
+        bbox: spec.bbox
+      });
+    }
+    return downloadCompleted;
   }
   /**
    * Download Records for IAPP Given a list of IDs

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -5,6 +5,7 @@ import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import { GeoJSONSourceSpecification } from 'maplibre-gl';
 import { getCurrentJWT } from 'state/sagas/auth/auth';
 import { getSelectColumnsByRecordSetType } from 'state/sagas/map/dataAccess';
+import BaseCacheService from 'utils/base-classes/BaseCacheService';
 import { RepositoryBoundingBoxSpec } from 'utils/tile-cache';
 
 export enum IappRecordMode {
@@ -25,7 +26,7 @@ export interface RecordCacheDownloadRequestSpec {
  * @property { GeoJSONSourceSpecification } cachedCentroid Cached Points for high map layers
  * @property { UserRecordCacheStatus } status Cache Status.
  */
-export interface RecordCacheAddSpec {
+export interface RepositoryMetadata {
   setId: string;
   cacheTime: Date;
   cachedIds: string[];
@@ -58,53 +59,57 @@ export interface CacheDownloadSpec {
   recordSetType: RecordSetType;
 }
 
-abstract class RecordCacheService {
+abstract class RecordCacheService extends BaseCacheService<
+  RepositoryMetadata,
+  CacheDownloadSpec,
+  RecordCacheProgressCallbackParameters,
+  UserRecordCacheStatus
+> {
   private readonly RECORDS_BETWEEN_PROGRESS_UPDATES = 25;
-  protected constructor() {}
+
+  protected constructor() {
+    super();
+  }
 
   static async getInstance(): Promise<RecordCacheService> {
     throw new Error('unimplemented in abstract base class');
   }
+  protected abstract addOrUpdateRepository(spec: RepositoryMetadata): Promise<void>;
 
-  abstract saveActivity(id: string, data: unknown): Promise<void>;
+  protected abstract deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void>;
 
-  abstract saveIapp(id: string, iappRecord: unknown, iappTableRow: unknown): Promise<void>;
+  /** */
+  public abstract loadActivity(id: string): Promise<unknown>;
 
-  abstract deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void>;
+  public abstract loadIapp(id: string, type: IappRecordMode): Promise<IappRecord | IappTableRow>;
 
-  abstract loadActivity(id: string): Promise<unknown>;
+  protected abstract saveActivity(id: string, data: unknown): Promise<void>;
 
-  abstract loadIapp(id: string, type: IappRecordMode): Promise<IappRecord | IappTableRow>;
+  protected abstract saveIapp(id: string, iappRecord: unknown, iappTableRow: unknown): Promise<void>;
 
-  abstract fetchPaginatedCachedIappRecords(
+  public abstract getPaginatedCachedActivityRecords(
+    recordSetIdList: string[],
+    page: number,
+    limit: number
+  ): Promise<UserRecord[]>;
+
+  public abstract getPaginatedCachedIappRecords(
     recordSetIdList: string[],
     page: number,
     limit: number
   ): Promise<IappRecord[]>;
 
-  abstract fetchPaginatedCachedRecords(recordSetIdList: string[], page: number, limit: number): Promise<UserRecord[]>;
+  public abstract isCached(repositoryId: string): Promise<boolean>;
 
-  abstract addOrUpdateRepository(spec: RecordCacheAddSpec): Promise<void>;
+  public abstract getIdList(repositoryId: string): Promise<string[]>;
 
-  abstract deleteRepository(repositoryId: string): Promise<void>;
+  protected abstract createIappRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata>;
 
-  abstract fetchRepository(repositoryId: string): Promise<RecordCacheAddSpec>;
-
-  abstract isCached(repositoryId: string): Promise<boolean>;
-
-  abstract fetchIdList(repositoryId: string): Promise<string[]>;
-
-  abstract listRepositories(): Promise<RecordCacheAddSpec[]>;
-
-  abstract loadIappRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata>;
-
-  abstract loadRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata>;
-
-  abstract setRepositoryStatus(repositoryId: string, status: UserRecordCacheStatus): Promise<void>;
+  protected abstract createActivityRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata>;
 
   abstract checkForAbort(id: string): Promise<boolean>;
 
-  async downloadCache(spec: CacheDownloadSpec): Promise<boolean> {
+  public async download(spec: CacheDownloadSpec): Promise<boolean> {
     const args = {
       idsToCache: spec.idsToCache,
       setId: spec.setId,
@@ -127,9 +132,9 @@ abstract class RecordCacheService {
 
     let downloadCompleted = true;
     if (spec.recordSetType === RecordSetType.Activity && (await this.downloadActivity(args))) {
-      Object.assign(responseData, await this.loadRecordsetSourceMetadata(spec.idsToCache));
+      Object.assign(responseData, await this.createActivityRecordsetSourceMetadata(spec.idsToCache));
     } else if (spec.recordSetType === RecordSetType.IAPP && (await this.downloadIapp(args))) {
-      Object.assign(responseData, await this.loadIappRecordsetSourceMetadata(spec.idsToCache));
+      Object.assign(responseData, await this.createIappRecordsetSourceMetadata(spec.idsToCache));
     } else {
       downloadCompleted = false;
       this.deleteRepository(spec.setId);
@@ -153,7 +158,7 @@ abstract class RecordCacheService {
    * Download Records for IAPP Given a list of IDs
    * @returns { boolean } download was successful
    */
-  async downloadIapp(
+  private async downloadIapp(
     spec: RecordCacheDownloadRequestSpec,
     progressCallback?: (currentProgress: RecordCacheProgressCallbackParameters) => void
   ): Promise<boolean> {
@@ -203,7 +208,7 @@ abstract class RecordCacheService {
    * Download Records for Activities Given a list of IDs
    * @returns { boolean } download was successful
    */
-  async downloadActivity(
+  private async downloadActivity(
     spec: RecordCacheDownloadRequestSpec,
     progressCallback?: (currentProgress: RecordCacheProgressCallbackParameters) => void
   ): Promise<boolean> {
@@ -224,7 +229,7 @@ abstract class RecordCacheService {
     }
     return !abort;
   }
-  async stopDownload(repositoryId: string): Promise<void> {
+  public async stopDownload(repositoryId: string): Promise<void> {
     const repositories = await this.listRepositories();
     const foundIndex = repositories.findIndex((repo) => repo.setId === repositoryId);
     if (foundIndex === -1) throw Error(`Repository ${repositoryId} wasn't found`);

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -32,6 +32,26 @@ class LocalForageRecordCacheService extends RecordCacheService {
     return LocalForageRecordCacheService._instance;
   }
 
+  async isCached(repositoryId: string): Promise<boolean> {
+    try {
+      return (await this.fetchRepository(repositoryId)).status === UserRecordCacheStatus.CACHED;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  async fetchRepository(repositoryId: string): Promise<RecordCacheAddSpec> {
+    const repos = await this.listRepositories();
+    const foundIndex = repos.findIndex((p) => p.setId === repositoryId);
+    if (foundIndex === -1) throw Error('Repository not found');
+
+    return repos[foundIndex];
+  }
+
+  async fetchIdList(repositoryId: string): Promise<string[]> {
+    return (await this.fetchRepository(repositoryId)).cachedIds ?? [];
+  }
+
   async saveActivity(id: string, data: unknown): Promise<void> {
     if (this.store == null) {
       throw new Error('cache not available');

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -3,7 +3,7 @@ import localForage from 'localforage';
 import centroid from '@turf/centroid';
 import {
   IappRecordMode,
-  RecordCacheAddSpec,
+  RepositoryMetadata,
   RecordCacheService,
   RecordSetSourceMetadata
 } from 'utils/record-cache/index';
@@ -34,13 +34,13 @@ class LocalForageRecordCacheService extends RecordCacheService {
 
   async isCached(repositoryId: string): Promise<boolean> {
     try {
-      return (await this.fetchRepository(repositoryId)).status === UserRecordCacheStatus.CACHED;
+      return (await this.getRepository(repositoryId)).status === UserRecordCacheStatus.CACHED;
     } catch (e) {
       return false;
     }
   }
 
-  async fetchRepository(repositoryId: string): Promise<RecordCacheAddSpec> {
+  async getRepository(repositoryId: string): Promise<RepositoryMetadata> {
     const repos = await this.listRepositories();
     const foundIndex = repos.findIndex((p) => p.setId === repositoryId);
     if (foundIndex === -1) throw Error(`Repository ${repositoryId} not found`);
@@ -48,8 +48,8 @@ class LocalForageRecordCacheService extends RecordCacheService {
     return repos[foundIndex];
   }
 
-  async fetchIdList(repositoryId: string): Promise<string[]> {
-    return (await this.fetchRepository(repositoryId)).cachedIds ?? [];
+  async getIdList(repositoryId: string): Promise<string[]> {
+    return (await this.getRepository(repositoryId)).cachedIds ?? [];
   }
 
   async saveActivity(id: string, data: unknown): Promise<void> {
@@ -80,6 +80,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
     }
     return true;
   }
+
   async saveIapp(id: string, iappRecord: IappRecord, iappTableRow: IappTableRow): Promise<void> {
     if (this.store == null) {
       throw new Error('cache not available');
@@ -99,7 +100,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
     return data[type];
   }
 
-  async fetchPaginatedCachedIappRecords(
+  async getPaginatedCachedIappRecords(
     recordSetIdList: string[],
     page: number,
     limit: number,
@@ -139,7 +140,11 @@ class LocalForageRecordCacheService extends RecordCacheService {
    * @param limit Maximum results per page
    * @returns { UserRecord[] } Filter Objects
    */
-  async fetchPaginatedCachedRecords(recordSetIdList: string[], page: number, limit: number): Promise<UserRecord[]> {
+  async getPaginatedCachedActivityRecords(
+    recordSetIdList: string[],
+    page: number,
+    limit: number
+  ): Promise<UserRecord[]> {
     if (recordSetIdList?.length === 0) {
       return [];
     }
@@ -159,7 +164,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
    * @param ids ids to filter
    * @returns { RecordSetSourceMetadata } Returns cached GeoJson, all IAPP Sites are Points.
    */
-  async loadIappRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata> {
+  async createIappRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata> {
     const geoJsonArr: any[] = [];
     for (const id of ids) {
       const data: IappRecord = await this.loadIapp(id, IappRecordMode.Row);
@@ -183,7 +188,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
    * @param ids ids to filter
    * @returns { RecordSetSourceMetadata } Two formatted queries for High/Low zoom layers
    */
-  async loadRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata> {
+  async createActivityRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata> {
     const centroidArr: any[] = [];
     const geoJsonArr: any[] = [];
 
@@ -257,7 +262,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
    * @desc Create or Update an entry in the cachedSet Repository
    * @param newSet Data to update
    */
-  async addOrUpdateRepository(newSet: RecordCacheAddSpec): Promise<void> {
+  async addOrUpdateRepository(newSet: RepositoryMetadata): Promise<void> {
     if (this.store == null) {
       throw new Error('cache not available');
     }
@@ -273,12 +278,12 @@ class LocalForageRecordCacheService extends RecordCacheService {
     await this.store.setItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY, cachedSets);
   }
 
-  async listRepositories(): Promise<RecordCacheAddSpec[]> {
+  async listRepositories(): Promise<RepositoryMetadata[]> {
     if (this.store == null) {
       return [];
     }
 
-    const metadata: RecordCacheAddSpec[] =
+    const metadata: RepositoryMetadata[] =
       (await this.store.getItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY)) ?? [];
     if (metadata == null) {
       console.error('expected key not found');

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -43,7 +43,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
   async fetchRepository(repositoryId: string): Promise<RecordCacheAddSpec> {
     const repos = await this.listRepositories();
     const foundIndex = repos.findIndex((p) => p.setId === repositoryId);
-    if (foundIndex === -1) throw Error('Repository not found');
+    if (foundIndex === -1) throw Error(`Repository ${repositoryId} not found`);
 
     return repos[foundIndex];
   }

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -64,7 +64,6 @@ class SQLiteRecordCacheService extends RecordCacheService {
   private static _instance: SQLiteRecordCacheService;
 
   private cacheDB: SQLiteDBConnection | null = null;
-
   protected constructor() {
     super();
   }
@@ -98,6 +97,44 @@ class SQLiteRecordCacheService extends RecordCacheService {
     }
   }
 
+  async fetchRepository(repositoryId: string): Promise<RecordCacheAddSpec> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const repoData = await this.cacheDB.query(
+      //language=SQLite
+      `SELECT DATA
+       FROM CACHE_METADATA
+       WHERE SET_ID = ?
+       LIMIT 1`,
+      [repositoryId]
+    );
+    return JSON.parse(repoData?.values?.[0]['DATA']) ?? {};
+  }
+
+  async isCached(repositoryId: string): Promise<boolean> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const metadata = await this.cacheDB.query(
+      //language=SQLite
+      `SELECT STATUS
+       FROM CACHE_METADATA
+       WHERE SET_ID = ?
+       LIMIT 1
+      `,
+      [repositoryId]
+    );
+    return metadata?.values?.[0]?.['STATUS'] === UserRecordCacheStatus.CACHED;
+  }
+
+  async fetchIdList(repositoryId: string): Promise<string[]> {
+    if (this.cacheDB == null) {
+      throw Error(CACHE_UNAVAILABLE);
+    }
+    return (await this.fetchRepository(repositoryId)).cachedIds ?? [];
+  }
+
   async deleteRepository(repositoryId: string): Promise<void> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
@@ -111,7 +148,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
       rawRepositoryMetadata?.values?.map((set) => JSON.parse(set['DATA'])) ?? [];
     const targetIndex = repositoryMetadata.findIndex((set) => set.setId === repositoryId);
 
-    if (targetIndex === -1) throw Error(`Repository ${repositoryId} not found`);
+    if (targetIndex === -1) return;
 
     const { cachedIds, recordSetType } = repositoryMetadata[targetIndex];
 
@@ -139,44 +176,26 @@ class SQLiteRecordCacheService extends RecordCacheService {
     }
     const repositories = await this.cacheDB.query(
       //language=SQLite
-      `SELECT *
+      `SELECT DATA
        FROM CACHE_METADATA`
     );
-    return repositories?.values?.map((entry) => JSON.parse(entry['DATA']) as RecordCacheAddSpec) ?? [];
-  }
-
-  /**
-   * @desc Helper method to fetch and parse repo metadata
-   */
-  private async getRepoData(repositoryId: string) {
-    if (this.cacheDB == null) {
-      throw new Error(CACHE_UNAVAILABLE);
-    }
-    const repoData = await this.cacheDB.query(
-      //language=SQLite
-      `SELECT DATA
-       FROM CACHE_METADATA
-       WHERE SET_ID = ?`,
-      [repositoryId]
-    );
-    return JSON.parse(repoData?.values?.[0]['DATA']) ?? {};
+    const response = repositories?.values?.map((entry) => JSON.parse(entry['DATA']) as RecordCacheAddSpec) ?? [];
+    return response;
   }
 
   async setRepositoryStatus(repositoryId: string, status: UserRecordCacheStatus): Promise<void> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
-    const currData = await this.getRepoData(repositoryId);
+    const currData = await this.fetchRepository(repositoryId);
+    if (Object.keys(currData).length === 0) return; // Repo doesn't exist.
     currData.status = status;
-    await this.cacheDB.query(
-      //language=SQLite
-      `UPDATE CACHE_METADATA
-        SET STATUS = ?,
-            CACHE_TIME = ?,
-            DATA = ?
-        WHERE SET_ID = ?`,
-      [status, JSON.stringify(currData.cacheTime), JSON.stringify(currData), repositoryId]
-    );
+
+    this.addOrUpdateRepository({
+      ...currData,
+      setId: repositoryId,
+      status: status
+    });
   }
 
   async checkForAbort(repositoryId: string): Promise<boolean> {
@@ -302,6 +321,12 @@ class SQLiteRecordCacheService extends RecordCacheService {
     const stringified = JSON.stringify(data);
     const short_id = (data as Record<PropertyKey, Feature[]>)?.short_id;
     const geometry = (data as Record<PropertyKey, Feature[]>)?.geometry;
+    geometry.forEach((_, i) => {
+      geometry[i].properties = {
+        name: short_id,
+        description: id
+      };
+    });
     const geojson = JSON.stringify(geometry) ?? null;
     await this.cacheDB.query(
       //language=SQLite
@@ -395,9 +420,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
 
     results?.values?.forEach((item) => {
       try {
-        const label = item['SHORT_ID'];
         JSON.parse(item['GEOJSON'])?.forEach((feature: Feature) => {
-          feature.properties = { name: label };
           centroidArr.push(centroid(feature));
           geoJsonArr.push(feature);
         });
@@ -433,7 +456,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     const RECORD_TABLE = RecordsToTable[recordSetType];
     const BATCH_AMOUNT = 100;
 
-    this.cacheDB.beginTransaction();
+    await this.cacheDB.beginTransaction();
     try {
       for (let i = 0; i < idsToDelete.length; i += BATCH_AMOUNT) {
         const sliced = idsToDelete.slice(i, Math.min(i + BATCH_AMOUNT, idsToDelete.length));
@@ -444,9 +467,9 @@ class SQLiteRecordCacheService extends RecordCacheService {
           [...sliced]
         );
       }
-      this.cacheDB.commitTransaction();
+      await this.cacheDB.commitTransaction();
     } catch (e) {
-      this.cacheDB.rollbackTransaction();
+      await this.cacheDB.rollbackTransaction();
       throw e;
     }
   }

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -8,7 +8,7 @@ import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import { GeoJSONSourceSpecification } from 'maplibre-gl';
 import {
   IappRecordMode,
-  RecordCacheAddSpec,
+  RepositoryMetadata,
   RecordCacheService,
   RecordSetSourceMetadata
 } from 'utils/record-cache/index';
@@ -76,7 +76,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     return SQLiteRecordCacheService._instance;
   }
 
-  async addOrUpdateRepository(spec: RecordCacheAddSpec): Promise<void> {
+  async addOrUpdateRepository(spec: RepositoryMetadata): Promise<void> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
@@ -97,7 +97,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     }
   }
 
-  async fetchRepository(repositoryId: string): Promise<RecordCacheAddSpec> {
+  async getRepository(repositoryId: string): Promise<RepositoryMetadata> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
@@ -128,11 +128,11 @@ class SQLiteRecordCacheService extends RecordCacheService {
     return metadata?.values?.[0]?.['STATUS'] === UserRecordCacheStatus.CACHED;
   }
 
-  async fetchIdList(repositoryId: string): Promise<string[]> {
+  async getIdList(repositoryId: string): Promise<string[]> {
     if (this.cacheDB == null) {
       throw Error(CACHE_UNAVAILABLE);
     }
-    return (await this.fetchRepository(repositoryId)).cachedIds ?? [];
+    return (await this.getRepository(repositoryId)).cachedIds ?? [];
   }
 
   async deleteRepository(repositoryId: string): Promise<void> {
@@ -144,7 +144,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
       `SELECT DATA
        FROM CACHE_METADATA`
     );
-    const repositoryMetadata: RecordCacheAddSpec[] =
+    const repositoryMetadata: RepositoryMetadata[] =
       rawRepositoryMetadata?.values?.map((set) => JSON.parse(set['DATA'])) ?? [];
     const targetIndex = repositoryMetadata.findIndex((set) => set.setId === repositoryId);
 
@@ -170,7 +170,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     );
   }
 
-  async listRepositories(): Promise<RecordCacheAddSpec[]> {
+  async listRepositories(): Promise<RepositoryMetadata[]> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
@@ -179,7 +179,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
       `SELECT DATA
        FROM CACHE_METADATA`
     );
-    const response = repositories?.values?.map((entry) => JSON.parse(entry['DATA']) as RecordCacheAddSpec) ?? [];
+    const response = repositories?.values?.map((entry) => JSON.parse(entry['DATA']) as RepositoryMetadata) ?? [];
     return response;
   }
 
@@ -187,7 +187,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
-    const currData = await this.fetchRepository(repositoryId);
+    const currData = await this.getRepository(repositoryId);
     if (Object.keys(currData).length === 0) return; // Repo doesn't exist.
     currData.status = status;
 
@@ -226,7 +226,11 @@ class SQLiteRecordCacheService extends RecordCacheService {
    * @param limit Maximum results per page
    * @returns { UserRecord[] } Filter Objects
    */
-  async fetchPaginatedCachedRecords(recordSetIdList: string[], page: number, limit: number): Promise<UserRecord[]> {
+  async getPaginatedCachedActivityRecords(
+    recordSetIdList: string[],
+    page: number,
+    limit: number
+  ): Promise<UserRecord[]> {
     if (!recordSetIdList || recordSetIdList.length === 0) {
       return [];
     }
@@ -259,7 +263,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     return response;
   }
 
-  async fetchPaginatedCachedIappRecords(recordSetIdList: string[], page: number, limit: number): Promise<IappRecord[]> {
+  async getPaginatedCachedIappRecords(recordSetIdList: string[], page: number, limit: number): Promise<IappRecord[]> {
     if (!recordSetIdList || recordSetIdList.length === 0) {
       return [];
     }
@@ -381,7 +385,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     return JSON.parse(result.values[0][dataType]);
   }
 
-  async loadIappRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata> {
+  async createIappRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
@@ -403,7 +407,8 @@ class SQLiteRecordCacheService extends RecordCacheService {
     };
     return { cachedGeoJson };
   }
-  async loadRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata> {
+
+  async createActivityRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
@@ -428,6 +433,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
         console.error('Error parsing record:', e);
       }
     });
+
     const cachedCentroid: GeoJSONSourceSpecification = {
       type: 'geojson',
       data: {
@@ -444,6 +450,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     };
     return { cachedCentroid, cachedGeoJson };
   }
+
   async deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
@@ -473,6 +480,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
       throw e;
     }
   }
+
   private async initializeRecordCache(sqlite: SQLiteConnection) {
     // Hold Migrations as named variable so we can use length to update the Db version automagically
     // Note: toVersion must be an integer.

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -111,7 +111,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
       rawRepositoryMetadata?.values?.map((set) => JSON.parse(set['DATA'])) ?? [];
     const targetIndex = repositoryMetadata.findIndex((set) => set.setId === repositoryId);
 
-    if (targetIndex === -1) throw Error('Repository not found');
+    if (targetIndex === -1) throw Error(`Repository ${repositoryId} not found`);
 
     const { cachedIds, recordSetType } = repositoryMetadata[targetIndex];
 

--- a/app/src/utils/tile-cache/context.ts
+++ b/app/src/utils/tile-cache/context.ts
@@ -5,7 +5,7 @@ import { SQLiteTileCacheService } from 'utils/tile-cache/sqlite-cache';
 import { LocalForageCacheService } from 'utils/tile-cache/localforage-cache';
 
 class TileCacheServiceFactory {
-  static async getPlatformInstance() {
+  static async getPlatformInstance(): Promise<TileCacheService> {
     if ([Platform.IOS, Platform.ANDROID].includes(PLATFORM)) {
       return SQLiteTileCacheService.getInstance();
     }

--- a/app/src/utils/tile-cache/index.ts
+++ b/app/src/utils/tile-cache/index.ts
@@ -1,3 +1,4 @@
+import BaseCacheService from 'utils/base-classes/BaseCacheService';
 import { base64toBuffer, lat2tile, long2tile } from 'utils/tile-cache/helpers';
 
 // base64-encoded blank tile image 256x256 (opaque, light blue)
@@ -42,7 +43,6 @@ enum RepositoryStatus {
   FAILED = 'FAILED',
   UNKNOWN = 'UNKNOWN'
 }
-
 interface TilePromise {
   id: string;
   url: string;
@@ -50,6 +50,7 @@ interface TilePromise {
   y: number;
   z: number;
 }
+
 export interface TileCacheProgressCallbackParameters {
   repository: string;
   message: string;
@@ -64,8 +65,15 @@ export interface RepositoryStatistics {
   tileCount: number;
 }
 
-abstract class TileCacheService {
-  protected constructor() {}
+abstract class TileCacheService extends BaseCacheService<
+  RepositoryMetadata,
+  RepositoryDownloadRequestSpec,
+  TileCacheProgressCallbackParameters,
+  RepositoryStatus
+> {
+  protected constructor() {
+    super();
+  }
 
   static generateFallbackTile(): TileData {
     return {
@@ -106,13 +114,7 @@ abstract class TileCacheService {
 
   abstract setTile(repository: string, z: number, x: number, y: number, tileData: Uint8Array): Promise<void>;
 
-  abstract getRepository(id: string): Promise<RepositoryMetadata | null>;
-
-  abstract listRepositories(): Promise<RepositoryMetadata[]>;
-
-  abstract deleteRepository(repository: string): Promise<void>;
-
-  abstract setRepositoryStatus(repository: string, status: RepositoryStatus): Promise<void>;
+  protected abstract addOrUpdateRepository(spec: RepositoryMetadata): Promise<void>;
 
   private async downloadTile(tileDetails: TilePromise): Promise<void> {
     const { id, url, x, y, z } = tileDetails;
@@ -151,7 +153,7 @@ abstract class TileCacheService {
     const executing = new Set();
 
     try {
-      await this.addRepository({
+      await this.addOrUpdateRepository({
         id: spec.id,
         status: RepositoryStatus.DOWNLOADING,
         maxZoom: spec.maxZoom,
@@ -234,8 +236,6 @@ abstract class TileCacheService {
   public abstract updateDescription(repository: string, newDescription: string): Promise<void>;
 
   protected abstract cleanupOrphanTiles(): Promise<void>;
-
-  protected abstract addRepository(spec: RepositoryMetadata): Promise<void>;
 }
 
 export { TileCacheService, FALLBACK_IMAGE, RepositoryStatus };

--- a/app/src/utils/tile-cache/localforage-cache.ts
+++ b/app/src/utils/tile-cache/localforage-cache.ts
@@ -21,7 +21,7 @@ interface TileKey {
 class LocalForageCacheService extends TileCacheService {
   private static _instance: LocalForageCacheService;
 
-  private static REPOSITORY_METADATA_KEY = 'repositories';
+  private static readonly REPOSITORY_METADATA_KEY = 'repositories';
 
   private store: LocalForage | null = null;
 

--- a/app/src/utils/tile-cache/localforage-cache.ts
+++ b/app/src/utils/tile-cache/localforage-cache.ts
@@ -222,7 +222,7 @@ class LocalForageCacheService extends TileCacheService {
     }
   }
 
-  protected async addRepository(spec: RepositoryMetadata) {
+  protected async addOrUpdateRepository(spec: RepositoryMetadata) {
     if (this.store == null) {
       throw new Error('cache not available');
     }
@@ -230,10 +230,10 @@ class LocalForageCacheService extends TileCacheService {
     const repositories = await this.listRepositories();
     const foundIndex = repositories.findIndex((p) => p.id == spec.id);
     if (foundIndex !== -1) {
-      throw new Error('repository already exists');
+      repositories[foundIndex] = spec;
+    } else {
+      repositories.push(spec);
     }
-
-    repositories.push(spec);
 
     await this.store.setItem(LocalForageCacheService.REPOSITORY_METADATA_KEY, repositories);
   }

--- a/app/src/utils/tile-cache/sqlite-cache.ts
+++ b/app/src/utils/tile-cache/sqlite-cache.ts
@@ -190,7 +190,7 @@ class SQLiteTileCacheService extends TileCacheService {
     );
   }
 
-  protected async addRepository(spec: RepositoryMetadata): Promise<void> {
+  protected async addOrUpdateRepository(spec: RepositoryMetadata): Promise<void> {
     if (this.cacheDB == null) {
       throw new Error('cache not available');
     }
@@ -207,7 +207,15 @@ class SQLiteTileCacheService extends TileCacheService {
                            MIN_LONGITUDE,
                            MAX_LONGITUDE)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-      `,
+       ON CONFLICT(TILESET)
+       DO UPDATE SET
+          DESCRIPTION = excluded.DESCRIPTION,
+          STATUS = excluded.STATUS,
+          MAX_ZOOM = excluded.MAX_ZOOM,
+          MIN_LATITUDE = excluded.MIN_LATITUDE,
+          MAX_LATITUDE = excluded.MAX_LATITUDE,
+          MIN_LONGITUDE = excluded.MIN_LONGITUDE,
+          MAX_LONGITUDE = excluded.MAX_LONGITUDE`,
       [
         spec.id,
         spec.description,


### PR DESCRIPTION
# Overview

> [!IMPORTANT]
> Please do extra testing on IAPP Whats Here functionality when testing this due to the new Endpoint playing a role in it :) 

## Main highlights
- Whats Here working for Activity / IAPP Closes #3801 
- When a Recordset is deleted, the Layer goes along with it *[No persistence]*  Closes #3800
- cachedMetadata is no longer in Redux state Closes #3779
- Layers functioning properly when Starting from Offline state *[IDLists weren't being registered]*
- API Endpoint created for IAPP Bounding Boxes used in offline WhatsHere functionality

## Misc
- update Error messages in Caching to show names of caches failing
- [SQL] Adjust caching of Activities to more reflect IAPP (set GeoJSON shapes to include the label Data). Previously grabbed POST-cache
- increase cases where we call `handle_MAP_INIT_STATE` 
    - Fixes issues where newly cached Layers aren't available offline  (same session)
    - Fixes issues where opening the App offline, then going online makes IDLists not available to uncached records
- Initialize RecordCache Singleton at app load
    - Fixes issue where calling SQL caches to gather IDLists for Records causes a soft error of "cacheDB not found" due to `n` init calls  

>[!TIP]
> Primary Code duplication stems from creating a BBox endpoint for the IAPP Records.