### PR TITLE
[INV-3793] Generic Base Class for Caching -- Merges into 3805

### DIFF
--- a/app/src/UI/LegacyMap/helpers/recordset-layers.ts
+++ b/app/src/UI/LegacyMap/helpers/recordset-layers.ts
@@ -24,9 +24,9 @@ export const createOfflineIappLayer = async (map: maplibregl.Map, layer: any) =>
     return;
   }
   const service = await RecordCacheServiceFactory.getPlatformInstance();
-  const repo = await service.fetchRepository(layer.recordSetID);
+  const repo = await service.getRepository(layer.recordSetID);
 
-  if (!repo.cachedGeoJson) {
+  if (!repo?.cachedGeoJson) {
     return;
   }
   const layerID = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
@@ -192,9 +192,9 @@ export const createOfflineActivityLayer = async (map: maplibregl.Map, layer: any
     return;
   }
   const service = await RecordCacheServiceFactory.getPlatformInstance();
-  const { cachedCentroid, cachedGeoJson } = await service.fetchRepository(layer.recordSetID);
+  const metadata = await service.getRepository(layer.recordSetID);
 
-  if (!cachedCentroid || !cachedGeoJson) {
+  if (!metadata?.cachedCentroid || !metadata?.cachedGeoJson) {
     return;
   }
 
@@ -203,8 +203,8 @@ export const createOfflineActivityLayer = async (map: maplibregl.Map, layer: any
   const CENTROID_ID = `${GEOJSON_ID}-centroid`;
   const color = getPaintBySchemeOrColor(layer);
 
-  const geoJsonSourceObj: GeoJSONSourceSpecification = cachedGeoJson;
-  const centroidSourceObj: GeoJSONSourceSpecification = cachedCentroid;
+  const geoJsonSourceObj: GeoJSONSourceSpecification = metadata.cachedGeoJson;
+  const centroidSourceObj: GeoJSONSourceSpecification = metadata.cachedCentroid;
 
   const circleMarkerZoomedOutLayerCentroid: CircleLayerSpecification = getCircleMarkerZoomedOutLayer(CENTROID_ID, {
     color,

--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -37,7 +37,7 @@ class RecordCache {
       const recordSet = state.UserSettings.recordSets[spec.setId];
       const bbox = await getBoundingBoxFromRecordsetFilters(recordSet);
 
-      const downloadCompleted = await service.downloadCache({
+      const downloadCompleted = await service.download({
         API_BASE: state.Configuration.current.API_BASE,
         bbox,
         idsToCache,

--- a/app/src/state/sagas/activity/offline.ts
+++ b/app/src/state/sagas/activity/offline.ts
@@ -74,7 +74,7 @@ export function* handle_ACTIVITY_GET_LOCAL_REQUEST(action: PayloadAction<string>
     }
   } else {
     try {
-      const service: RecordCacheService = yield RecordCacheServiceFactory.getPlatformInstance();
+      const service = yield RecordCacheServiceFactory.getPlatformInstance();
       const result = yield service.loadActivity(activityID);
 
       const datav2 = {

--- a/app/src/state/sagas/iappsite/dataAccess.ts
+++ b/app/src/state/sagas/iappsite/dataAccess.ts
@@ -15,7 +15,7 @@ export function* handle_IAPP_GET_REQUEST(iappId: PayloadAction<string>) {
   try {
     const connected = yield select(selectNetworkConnected);
     if (MOBILE && !connected) {
-      const service: RecordCacheService = yield RecordCacheServiceFactory.getPlatformInstance();
+      const service = yield RecordCacheServiceFactory.getPlatformInstance();
       const result = yield service.loadIapp(iappId.payload, IappRecordMode.Record);
       yield put(IappActions.getSuccess(result));
     } else {

--- a/app/src/state/sagas/map.ts
+++ b/app/src/state/sagas/map.ts
@@ -84,7 +84,7 @@ import { RecordCacheServiceFactory } from 'utils/record-cache/context';
 import bboxToPolygon from 'utils/bboxToPolygon';
 import IappActions from 'state/actions/activity/Iapp';
 import IappRecord from 'interfaces/IappRecord';
-import { RecordCacheAddSpec } from 'utils/record-cache';
+import { RepositoryMetadata } from 'utils/record-cache';
 import NetworkActions from 'state/actions/network/NetworkActions';
 
 function* handle_USER_SETTINGS_GET_INITIAL_STATE_SUCCESS(action) {
@@ -163,7 +163,7 @@ function* handle_WHATS_HERE_FEATURE(whatsHereFeature: PayloadAction<Feature>) {
       const service = yield RecordCacheServiceFactory.getPlatformInstance();
       const repos = yield service.listRepositories();
 
-      const recordSetsInBoundingBox = repos.filter((repo: RecordCacheAddSpec) => {
+      const recordSetsInBoundingBox = repos.filter((repo: RepositoryMetadata) => {
         const { status, bbox } = repo;
         return (
           status === UserRecordCacheStatus.CACHED &&
@@ -223,7 +223,7 @@ function* handle_WHATS_HERE_IAPP_ROWS_REQUEST() {
     let records: IappRecord[];
     if (MOBILE && !connected) {
       const service = yield RecordCacheServiceFactory.getPlatformInstance();
-      records = yield service.fetchPaginatedCachedIappRecords(
+      records = yield service.getPaginatedCachedIappRecords(
         whatsHere.IAPPIDs.map((id) => id.toString()),
         whatsHere.IAPPPage,
         whatsHere.IAPPLimit
@@ -313,7 +313,7 @@ function* handle_WHATS_HERE_ACTIVITY_ROWS_REQUEST() {
     let records: UserRecord[];
     if (MOBILE && !connected) {
       const service = yield RecordCacheServiceFactory.getPlatformInstance();
-      records = yield service.fetchPaginatedCachedRecords(
+      records = yield service.getPaginatedCachedActivityRecords(
         whatsHere.ActivityIDs,
         whatsHere.ActivityPage,
         whatsHere.ActivityLimit

--- a/app/src/state/sagas/map/dataAccess.ts
+++ b/app/src/state/sagas/map/dataAccess.ts
@@ -116,7 +116,7 @@ export function* handle_ACTIVITIES_GET_IDS_FOR_RECORDSET_REQUEST(action) {
       const recordSet = currentState.recordSets[action.payload.recordSetID] ?? null;
       if (recordSet.cacheMetadataStatus === UserRecordCacheStatus.CACHED) {
         const service = yield RecordCacheServiceFactory.getPlatformInstance();
-        const ids = yield service.fetchIdList(action.payload.recordSetID);
+        const ids = yield service.getIdList(action.payload.recordSetID);
 
         yield put({
           type: ACTIVITIES_GET_IDS_FOR_RECORDSET_SUCCESS,
@@ -160,7 +160,7 @@ export function* handle_IAPP_GET_IDS_FOR_RECORDSET_REQUEST(action) {
     } else {
       const service = yield RecordCacheServiceFactory.getPlatformInstance();
       if (yield service.isCached(action.payload.recordSetID)) {
-        const ids = yield service.fetchIdList(action.payload.recordSetID);
+        const ids = yield service.getIdList(action.payload.recordSetID);
         yield put({
           type: IAPP_GET_IDS_FOR_RECORDSET_SUCCESS,
           payload: {
@@ -237,8 +237,8 @@ export function* handle_ACTIVITIES_TABLE_ROWS_GET_REQUEST(action) {
 
     if (userMobileOffline) {
       const service = yield RecordCacheServiceFactory.getPlatformInstance();
-      const recordSetIdList = yield service.fetchIdList(recordSetID);
-      const records = yield service.fetchPaginatedCachedRecords(recordSetIdList, page, limit);
+      const recordSetIdList = yield service.getIdList(recordSetID);
+      const records = yield service.getPaginatedCachedActivityRecords(recordSetIdList, page, limit);
       yield put(
         Activity.getRowsSuccess({
           recordSetID: recordSetID,
@@ -289,8 +289,8 @@ export function* handle_IAPP_TABLE_ROWS_GET_REQUEST(action: PayloadAction<IappTa
     }
     if (userMobileOffline) {
       const service = yield RecordCacheServiceFactory.getPlatformInstance();
-      const recordSetIdList = yield service.fetchIdList(recordSetID) ?? [];
-      const records = yield service.fetchPaginatedCachedIappRecords(recordSetIdList, page, limit);
+      const recordSetIdList = yield service.getIdList(recordSetID.toString()) ?? [];
+      const records = yield service.getPaginatedCachedIappRecords(recordSetIdList, page, limit);
       yield put(
         IappActions.getRowsSuccess({
           recordSetID: recordSetID,

--- a/app/src/utils/base-classes/BaseCacheService.ts
+++ b/app/src/utils/base-classes/BaseCacheService.ts
@@ -1,0 +1,43 @@
+/**
+ * @desc Generic Base Class for All Caching actions using SQLite or LocalForage ensuring consistency between all Database implementations
+ * @property { RepoMetadata } _ All Details contained by a Metadata Entry
+ * @property { RepositoryDownloadRequestSpec } _ Information details for a Download e.g. API Url, Cache Targets, bounding boxes
+ * @property { ProgressCallbackParams } _ Details for Callback Functionality, used for Progress bars, updates
+ * @property { RepositoryStatusSchema } _ Enum for Cache Statuses, e.g. READY, CACHED, ERROR, etc
+ * @example Implementation abstract Class Demo extends BaseCacheService<
+ *            RepoMetadataType
+ *            RepositoryDownloadRequestSpecType
+ *            RepoProgressCallbackParamsType
+ *            RepositoryStatusSchemeType>
+ */
+abstract class BaseCacheService<
+  RepoMetadata,
+  RepositoryDownloadRequestSpec,
+  ProgressCallbackParams,
+  RepositoryStatusSchema
+> {
+  /** Update any details for a Repository */
+  protected abstract addOrUpdateRepository(repositoryId: RepoMetadata): Promise<void>;
+
+  /** Remove one Repository from the collection along with its contentes */
+  public abstract deleteRepository(repositoryId: string): Promise<void>;
+
+  /** Pull metadata for one Repository in the Collection */
+  public abstract getRepository(repositoryId: string): Promise<RepoMetadata | null>;
+
+  /** List metadata for all Repositories */
+  public abstract listRepositories(): Promise<RepoMetadata[]>;
+
+  /** Change the status for a given Repository */
+  public abstract setRepositoryStatus(repositoryId: string, status: RepositoryStatusSchema): Promise<void>;
+
+  /** Download a new Repository along with its contents */
+  public abstract download(
+    spec: RepositoryDownloadRequestSpec,
+    progressCallback?: (currentProgress: ProgressCallbackParams) => void
+  ): Promise<boolean | void>;
+
+  protected constructor() {}
+}
+
+export default BaseCacheService;

--- a/app/src/utils/record-cache/context.ts
+++ b/app/src/utils/record-cache/context.ts
@@ -1,9 +1,10 @@
 import { Platform, PLATFORM } from 'state/build-time-config';
+import { RecordCacheService } from 'utils/record-cache/index';
 import { SQLiteRecordCacheService } from 'utils/record-cache/sqlite-cache';
 import { LocalForageRecordCacheService } from 'utils/record-cache/localforage-cache';
 
 class RecordCacheServiceFactory {
-  static async getPlatformInstance() {
+  static async getPlatformInstance(): Promise<RecordCacheService> {
     if (PLATFORM == Platform.IOS) {
       return SQLiteRecordCacheService.getInstance();
     }

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -5,6 +5,7 @@ import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import { GeoJSONSourceSpecification } from 'maplibre-gl';
 import { getCurrentJWT } from 'state/sagas/auth/auth';
 import { getSelectColumnsByRecordSetType } from 'state/sagas/map/dataAccess';
+import BaseCacheService from 'utils/base-classes/BaseCacheService';
 import { RepositoryBoundingBoxSpec } from 'utils/tile-cache';
 
 export enum IappRecordMode {
@@ -25,7 +26,7 @@ export interface RecordCacheDownloadRequestSpec {
  * @property { GeoJSONSourceSpecification } cachedCentroid Cached Points for high map layers
  * @property { UserRecordCacheStatus } status Cache Status.
  */
-export interface RecordCacheAddSpec {
+export interface RepositoryMetadata {
   setId: string;
   cacheTime: Date;
   cachedIds: string[];
@@ -58,53 +59,57 @@ export interface CacheDownloadSpec {
   recordSetType: RecordSetType;
 }
 
-abstract class RecordCacheService {
+abstract class RecordCacheService extends BaseCacheService<
+  RepositoryMetadata,
+  CacheDownloadSpec,
+  RecordCacheProgressCallbackParameters,
+  UserRecordCacheStatus
+> {
   private readonly RECORDS_BETWEEN_PROGRESS_UPDATES = 25;
-  protected constructor() {}
+
+  protected constructor() {
+    super();
+  }
 
   static async getInstance(): Promise<RecordCacheService> {
     throw new Error('unimplemented in abstract base class');
   }
+  protected abstract addOrUpdateRepository(spec: RepositoryMetadata): Promise<void>;
 
-  abstract saveActivity(id: string, data: unknown): Promise<void>;
+  protected abstract deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void>;
 
-  abstract saveIapp(id: string, iappRecord: unknown, iappTableRow: unknown): Promise<void>;
+  /** */
+  public abstract loadActivity(id: string): Promise<unknown>;
 
-  abstract deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void>;
+  public abstract loadIapp(id: string, type: IappRecordMode): Promise<IappRecord | IappTableRow>;
 
-  abstract loadActivity(id: string): Promise<unknown>;
+  protected abstract saveActivity(id: string, data: unknown): Promise<void>;
 
-  abstract loadIapp(id: string, type: IappRecordMode): Promise<IappRecord | IappTableRow>;
+  protected abstract saveIapp(id: string, iappRecord: unknown, iappTableRow: unknown): Promise<void>;
 
-  abstract fetchPaginatedCachedIappRecords(
+  public abstract getPaginatedCachedActivityRecords(
+    recordSetIdList: string[],
+    page: number,
+    limit: number
+  ): Promise<UserRecord[]>;
+
+  public abstract getPaginatedCachedIappRecords(
     recordSetIdList: string[],
     page: number,
     limit: number
   ): Promise<IappRecord[]>;
 
-  abstract fetchPaginatedCachedRecords(recordSetIdList: string[], page: number, limit: number): Promise<UserRecord[]>;
+  public abstract isCached(repositoryId: string): Promise<boolean>;
 
-  abstract addOrUpdateRepository(spec: RecordCacheAddSpec): Promise<void>;
+  public abstract getIdList(repositoryId: string): Promise<string[]>;
 
-  abstract deleteRepository(repositoryId: string): Promise<void>;
+  protected abstract createIappRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata>;
 
-  abstract fetchRepository(repositoryId: string): Promise<RecordCacheAddSpec>;
-
-  abstract isCached(repositoryId: string): Promise<boolean>;
-
-  abstract fetchIdList(repositoryId: string): Promise<string[]>;
-
-  abstract listRepositories(): Promise<RecordCacheAddSpec[]>;
-
-  abstract loadIappRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata>;
-
-  abstract loadRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata>;
-
-  abstract setRepositoryStatus(repositoryId: string, status: UserRecordCacheStatus): Promise<void>;
+  protected abstract createActivityRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata>;
 
   abstract checkForAbort(id: string): Promise<boolean>;
 
-  async downloadCache(spec: CacheDownloadSpec): Promise<boolean> {
+  public async download(spec: CacheDownloadSpec): Promise<boolean> {
     const args = {
       idsToCache: spec.idsToCache,
       setId: spec.setId,
@@ -127,9 +132,9 @@ abstract class RecordCacheService {
 
     let downloadCompleted = true;
     if (spec.recordSetType === RecordSetType.Activity && (await this.downloadActivity(args))) {
-      Object.assign(responseData, await this.loadRecordsetSourceMetadata(spec.idsToCache));
+      Object.assign(responseData, await this.createActivityRecordsetSourceMetadata(spec.idsToCache));
     } else if (spec.recordSetType === RecordSetType.IAPP && (await this.downloadIapp(args))) {
-      Object.assign(responseData, await this.loadIappRecordsetSourceMetadata(spec.idsToCache));
+      Object.assign(responseData, await this.createIappRecordsetSourceMetadata(spec.idsToCache));
     } else {
       downloadCompleted = false;
       this.deleteRepository(spec.setId);
@@ -153,7 +158,7 @@ abstract class RecordCacheService {
    * Download Records for IAPP Given a list of IDs
    * @returns { boolean } download was successful
    */
-  async downloadIapp(
+  private async downloadIapp(
     spec: RecordCacheDownloadRequestSpec,
     progressCallback?: (currentProgress: RecordCacheProgressCallbackParameters) => void
   ): Promise<boolean> {
@@ -203,7 +208,7 @@ abstract class RecordCacheService {
    * Download Records for Activities Given a list of IDs
    * @returns { boolean } download was successful
    */
-  async downloadActivity(
+  private async downloadActivity(
     spec: RecordCacheDownloadRequestSpec,
     progressCallback?: (currentProgress: RecordCacheProgressCallbackParameters) => void
   ): Promise<boolean> {
@@ -224,7 +229,7 @@ abstract class RecordCacheService {
     }
     return !abort;
   }
-  async stopDownload(repositoryId: string): Promise<void> {
+  public async stopDownload(repositoryId: string): Promise<void> {
     const repositories = await this.listRepositories();
     const foundIndex = repositories.findIndex((repo) => repo.setId === repositoryId);
     if (foundIndex === -1) throw Error(`Repository ${repositoryId} wasn't found`);

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -3,7 +3,7 @@ import localForage from 'localforage';
 import centroid from '@turf/centroid';
 import {
   IappRecordMode,
-  RecordCacheAddSpec,
+  RepositoryMetadata,
   RecordCacheService,
   RecordSetSourceMetadata
 } from 'utils/record-cache/index';
@@ -34,13 +34,13 @@ class LocalForageRecordCacheService extends RecordCacheService {
 
   async isCached(repositoryId: string): Promise<boolean> {
     try {
-      return (await this.fetchRepository(repositoryId)).status === UserRecordCacheStatus.CACHED;
+      return (await this.getRepository(repositoryId)).status === UserRecordCacheStatus.CACHED;
     } catch (e) {
       return false;
     }
   }
 
-  async fetchRepository(repositoryId: string): Promise<RecordCacheAddSpec> {
+  async getRepository(repositoryId: string): Promise<RepositoryMetadata> {
     const repos = await this.listRepositories();
     const foundIndex = repos.findIndex((p) => p.setId === repositoryId);
     if (foundIndex === -1) throw Error(`Repository ${repositoryId} not found`);
@@ -48,8 +48,8 @@ class LocalForageRecordCacheService extends RecordCacheService {
     return repos[foundIndex];
   }
 
-  async fetchIdList(repositoryId: string): Promise<string[]> {
-    return (await this.fetchRepository(repositoryId)).cachedIds ?? [];
+  async getIdList(repositoryId: string): Promise<string[]> {
+    return (await this.getRepository(repositoryId)).cachedIds ?? [];
   }
 
   async saveActivity(id: string, data: unknown): Promise<void> {
@@ -80,6 +80,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
     }
     return true;
   }
+
   async saveIapp(id: string, iappRecord: IappRecord, iappTableRow: IappTableRow): Promise<void> {
     if (this.store == null) {
       throw new Error('cache not available');
@@ -99,7 +100,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
     return data[type];
   }
 
-  async fetchPaginatedCachedIappRecords(
+  async getPaginatedCachedIappRecords(
     recordSetIdList: string[],
     page: number,
     limit: number,
@@ -139,7 +140,11 @@ class LocalForageRecordCacheService extends RecordCacheService {
    * @param limit Maximum results per page
    * @returns { UserRecord[] } Filter Objects
    */
-  async fetchPaginatedCachedRecords(recordSetIdList: string[], page: number, limit: number): Promise<UserRecord[]> {
+  async getPaginatedCachedActivityRecords(
+    recordSetIdList: string[],
+    page: number,
+    limit: number
+  ): Promise<UserRecord[]> {
     if (recordSetIdList?.length === 0) {
       return [];
     }
@@ -159,7 +164,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
    * @param ids ids to filter
    * @returns { RecordSetSourceMetadata } Returns cached GeoJson, all IAPP Sites are Points.
    */
-  async loadIappRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata> {
+  async createIappRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata> {
     const geoJsonArr: any[] = [];
     for (const id of ids) {
       const data: IappRecord = await this.loadIapp(id, IappRecordMode.Row);
@@ -183,7 +188,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
    * @param ids ids to filter
    * @returns { RecordSetSourceMetadata } Two formatted queries for High/Low zoom layers
    */
-  async loadRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata> {
+  async createActivityRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata> {
     const centroidArr: any[] = [];
     const geoJsonArr: any[] = [];
 
@@ -257,7 +262,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
    * @desc Create or Update an entry in the cachedSet Repository
    * @param newSet Data to update
    */
-  async addOrUpdateRepository(newSet: RecordCacheAddSpec): Promise<void> {
+  async addOrUpdateRepository(newSet: RepositoryMetadata): Promise<void> {
     if (this.store == null) {
       throw new Error('cache not available');
     }
@@ -273,12 +278,12 @@ class LocalForageRecordCacheService extends RecordCacheService {
     await this.store.setItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY, cachedSets);
   }
 
-  async listRepositories(): Promise<RecordCacheAddSpec[]> {
+  async listRepositories(): Promise<RepositoryMetadata[]> {
     if (this.store == null) {
       return [];
     }
 
-    const metadata: RecordCacheAddSpec[] =
+    const metadata: RepositoryMetadata[] =
       (await this.store.getItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY)) ?? [];
     if (metadata == null) {
       console.error('expected key not found');

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -8,7 +8,7 @@ import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import { GeoJSONSourceSpecification } from 'maplibre-gl';
 import {
   IappRecordMode,
-  RecordCacheAddSpec,
+  RepositoryMetadata,
   RecordCacheService,
   RecordSetSourceMetadata
 } from 'utils/record-cache/index';
@@ -76,7 +76,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     return SQLiteRecordCacheService._instance;
   }
 
-  async addOrUpdateRepository(spec: RecordCacheAddSpec): Promise<void> {
+  async addOrUpdateRepository(spec: RepositoryMetadata): Promise<void> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
@@ -97,7 +97,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     }
   }
 
-  async fetchRepository(repositoryId: string): Promise<RecordCacheAddSpec> {
+  async getRepository(repositoryId: string): Promise<RepositoryMetadata> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
@@ -128,11 +128,11 @@ class SQLiteRecordCacheService extends RecordCacheService {
     return metadata?.values?.[0]?.['STATUS'] === UserRecordCacheStatus.CACHED;
   }
 
-  async fetchIdList(repositoryId: string): Promise<string[]> {
+  async getIdList(repositoryId: string): Promise<string[]> {
     if (this.cacheDB == null) {
       throw Error(CACHE_UNAVAILABLE);
     }
-    return (await this.fetchRepository(repositoryId)).cachedIds ?? [];
+    return (await this.getRepository(repositoryId)).cachedIds ?? [];
   }
 
   async deleteRepository(repositoryId: string): Promise<void> {
@@ -144,7 +144,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
       `SELECT DATA
        FROM CACHE_METADATA`
     );
-    const repositoryMetadata: RecordCacheAddSpec[] =
+    const repositoryMetadata: RepositoryMetadata[] =
       rawRepositoryMetadata?.values?.map((set) => JSON.parse(set['DATA'])) ?? [];
     const targetIndex = repositoryMetadata.findIndex((set) => set.setId === repositoryId);
 
@@ -170,7 +170,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     );
   }
 
-  async listRepositories(): Promise<RecordCacheAddSpec[]> {
+  async listRepositories(): Promise<RepositoryMetadata[]> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
@@ -179,7 +179,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
       `SELECT DATA
        FROM CACHE_METADATA`
     );
-    const response = repositories?.values?.map((entry) => JSON.parse(entry['DATA']) as RecordCacheAddSpec) ?? [];
+    const response = repositories?.values?.map((entry) => JSON.parse(entry['DATA']) as RepositoryMetadata) ?? [];
     return response;
   }
 
@@ -187,7 +187,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
-    const currData = await this.fetchRepository(repositoryId);
+    const currData = await this.getRepository(repositoryId);
     if (Object.keys(currData).length === 0) return; // Repo doesn't exist.
     currData.status = status;
 
@@ -226,7 +226,11 @@ class SQLiteRecordCacheService extends RecordCacheService {
    * @param limit Maximum results per page
    * @returns { UserRecord[] } Filter Objects
    */
-  async fetchPaginatedCachedRecords(recordSetIdList: string[], page: number, limit: number): Promise<UserRecord[]> {
+  async getPaginatedCachedActivityRecords(
+    recordSetIdList: string[],
+    page: number,
+    limit: number
+  ): Promise<UserRecord[]> {
     if (!recordSetIdList || recordSetIdList.length === 0) {
       return [];
     }
@@ -259,7 +263,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     return response;
   }
 
-  async fetchPaginatedCachedIappRecords(recordSetIdList: string[], page: number, limit: number): Promise<IappRecord[]> {
+  async getPaginatedCachedIappRecords(recordSetIdList: string[], page: number, limit: number): Promise<IappRecord[]> {
     if (!recordSetIdList || recordSetIdList.length === 0) {
       return [];
     }
@@ -381,7 +385,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     return JSON.parse(result.values[0][dataType]);
   }
 
-  async loadIappRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata> {
+  async createIappRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
@@ -403,7 +407,8 @@ class SQLiteRecordCacheService extends RecordCacheService {
     };
     return { cachedGeoJson };
   }
-  async loadRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata> {
+
+  async createActivityRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
@@ -428,6 +433,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
         console.error('Error parsing record:', e);
       }
     });
+
     const cachedCentroid: GeoJSONSourceSpecification = {
       type: 'geojson',
       data: {
@@ -444,6 +450,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     };
     return { cachedCentroid, cachedGeoJson };
   }
+
   async deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
@@ -473,6 +480,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
       throw e;
     }
   }
+
   private async initializeRecordCache(sqlite: SQLiteConnection) {
     // Hold Migrations as named variable so we can use length to update the Db version automagically
     // Note: toVersion must be an integer.

--- a/app/src/utils/tile-cache/context.ts
+++ b/app/src/utils/tile-cache/context.ts
@@ -5,7 +5,7 @@ import { SQLiteTileCacheService } from 'utils/tile-cache/sqlite-cache';
 import { LocalForageCacheService } from 'utils/tile-cache/localforage-cache';
 
 class TileCacheServiceFactory {
-  static async getPlatformInstance() {
+  static async getPlatformInstance(): Promise<TileCacheService> {
     if ([Platform.IOS, Platform.ANDROID].includes(PLATFORM)) {
       return SQLiteTileCacheService.getInstance();
     }

--- a/app/src/utils/tile-cache/index.ts
+++ b/app/src/utils/tile-cache/index.ts
@@ -1,3 +1,4 @@
+import BaseCacheService from 'utils/base-classes/BaseCacheService';
 import { base64toBuffer, lat2tile, long2tile } from 'utils/tile-cache/helpers';
 
 // base64-encoded blank tile image 256x256 (opaque, light blue)
@@ -42,7 +43,6 @@ enum RepositoryStatus {
   FAILED = 'FAILED',
   UNKNOWN = 'UNKNOWN'
 }
-
 interface TilePromise {
   id: string;
   url: string;
@@ -50,6 +50,7 @@ interface TilePromise {
   y: number;
   z: number;
 }
+
 export interface TileCacheProgressCallbackParameters {
   repository: string;
   message: string;
@@ -64,8 +65,15 @@ export interface RepositoryStatistics {
   tileCount: number;
 }
 
-abstract class TileCacheService {
-  protected constructor() {}
+abstract class TileCacheService extends BaseCacheService<
+  RepositoryMetadata,
+  RepositoryDownloadRequestSpec,
+  TileCacheProgressCallbackParameters,
+  RepositoryStatus
+> {
+  protected constructor() {
+    super();
+  }
 
   static generateFallbackTile(): TileData {
     return {
@@ -106,13 +114,7 @@ abstract class TileCacheService {
 
   abstract setTile(repository: string, z: number, x: number, y: number, tileData: Uint8Array): Promise<void>;
 
-  abstract getRepository(id: string): Promise<RepositoryMetadata | null>;
-
-  abstract listRepositories(): Promise<RepositoryMetadata[]>;
-
-  abstract deleteRepository(repository: string): Promise<void>;
-
-  abstract setRepositoryStatus(repository: string, status: RepositoryStatus): Promise<void>;
+  protected abstract addOrUpdateRepository(spec: RepositoryMetadata): Promise<void>;
 
   private async downloadTile(tileDetails: TilePromise): Promise<void> {
     const { id, url, x, y, z } = tileDetails;
@@ -151,7 +153,7 @@ abstract class TileCacheService {
     const executing = new Set();
 
     try {
-      await this.addRepository({
+      await this.addOrUpdateRepository({
         id: spec.id,
         status: RepositoryStatus.DOWNLOADING,
         maxZoom: spec.maxZoom,
@@ -234,8 +236,6 @@ abstract class TileCacheService {
   public abstract updateDescription(repository: string, newDescription: string): Promise<void>;
 
   protected abstract cleanupOrphanTiles(): Promise<void>;
-
-  protected abstract addRepository(spec: RepositoryMetadata): Promise<void>;
 }
 
 export { TileCacheService, FALLBACK_IMAGE, RepositoryStatus };

--- a/app/src/utils/tile-cache/localforage-cache.ts
+++ b/app/src/utils/tile-cache/localforage-cache.ts
@@ -222,7 +222,7 @@ class LocalForageCacheService extends TileCacheService {
     }
   }
 
-  protected async addRepository(spec: RepositoryMetadata) {
+  protected async addOrUpdateRepository(spec: RepositoryMetadata) {
     if (this.store == null) {
       throw new Error('cache not available');
     }
@@ -230,10 +230,10 @@ class LocalForageCacheService extends TileCacheService {
     const repositories = await this.listRepositories();
     const foundIndex = repositories.findIndex((p) => p.id == spec.id);
     if (foundIndex !== -1) {
-      throw new Error('repository already exists');
+      repositories[foundIndex] = spec;
+    } else {
+      repositories.push(spec);
     }
-
-    repositories.push(spec);
 
     await this.store.setItem(LocalForageCacheService.REPOSITORY_METADATA_KEY, repositories);
   }

--- a/app/src/utils/tile-cache/sqlite-cache.ts
+++ b/app/src/utils/tile-cache/sqlite-cache.ts
@@ -190,7 +190,7 @@ class SQLiteTileCacheService extends TileCacheService {
     );
   }
 
-  protected async addRepository(spec: RepositoryMetadata): Promise<void> {
+  protected async addOrUpdateRepository(spec: RepositoryMetadata): Promise<void> {
     if (this.cacheDB == null) {
       throw new Error('cache not available');
     }
@@ -207,7 +207,15 @@ class SQLiteTileCacheService extends TileCacheService {
                            MIN_LONGITUDE,
                            MAX_LONGITUDE)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-      `,
+       ON CONFLICT(TILESET)
+       DO UPDATE SET
+          DESCRIPTION = excluded.DESCRIPTION,
+          STATUS = excluded.STATUS,
+          MAX_ZOOM = excluded.MAX_ZOOM,
+          MIN_LATITUDE = excluded.MIN_LATITUDE,
+          MAX_LATITUDE = excluded.MAX_LATITUDE,
+          MIN_LONGITUDE = excluded.MIN_LONGITUDE,
+          MAX_LONGITUDE = excluded.MAX_LONGITUDE`,
       [
         spec.id,
         spec.description,


### PR DESCRIPTION
# Overview

>[!CAUTION]
> This PR is forked off of PR #3805. This Merge is to merge it into that PR!
> It was done this way to make differentiating the Two easier

> [!Important]
> If this Pr is declined but the other is approved, I will simply decouple this PR, make corrections, then open a new one. 

## Whats Here
- Create Generic Base class for Caching to bear some level of consistency between the caches. Class implements the shared functions between RecordCache and TileCache classes
    - Generic class takes in 4 Type Parameters for consistency across the sub Functionality
 
- Add typing to returns of Cache Factories, to typeguard when we instantiate these classes. Previously they'd show as `Any` in most cases.
- Update some function names
- The `only` functionality that was changed was the `createRepository` functionality in `TileCache` being changed to `createOrUpdateRepository` It now can update repositories. 

![image](https://github.com/user-attachments/assets/7ac5b4c3-c44e-44ae-ae6b-bca4944f6209)

![image](https://github.com/user-attachments/assets/d7b8b03b-3a16-4fd8-add7-f2c8b7ac81e8)

Shiny Type guards