### PR TITLE
[INV3777] Cache Wells for Offline Chemical Treatment use

### DIFF
--- a/app/src/UI/Overlay/TileCache/TileCacheCreationPanel.tsx
+++ b/app/src/UI/Overlay/TileCache/TileCacheCreationPanel.tsx
@@ -7,6 +7,7 @@ import TooltipWithIcon from 'UI/TooltipWithIcon/TooltipWithIcon';
 import CacheFileSize from './CacheFileSize';
 import { useTileSizeThresholds } from './tileSizeHook';
 import { APPROX_SIZE_PER_TILE, AVAILABLE_ZOOMS } from './constants';
+import WellCache from 'state/actions/cache/WellCache';
 
 const TileCacheCreationPanel = () => {
   const handleDownload = () => {
@@ -18,6 +19,7 @@ const TileCacheCreationPanel = () => {
         maxZoom: zoom
       })
     );
+    dispatch(WellCache.requestCaching(drawnShape));
     setCacheName('');
     setTimeout(() => {
       dispatch(TileCache.clearTileCacheShape());

--- a/app/src/UI/Overlay/TileCache/TileCacheListRow.tsx
+++ b/app/src/UI/Overlay/TileCache/TileCacheListRow.tsx
@@ -8,6 +8,7 @@ import { Delete, Edit, Visibility, VisibilityOff } from '@mui/icons-material';
 import Prompt from 'state/actions/prompts/Prompt';
 import { convertBytesToReadableString } from 'utils/tile-cache/helpers';
 import MapActions from 'state/actions/map';
+import WellCache from 'state/actions/cache/WellCache';
 
 const TileCacheListRow = ({ metadata, visible }) => {
   const handleToggleVisibility = (id: string) => dispatch(MapActions.toggleOverlay(id));
@@ -30,6 +31,8 @@ const TileCacheListRow = ({ metadata, visible }) => {
   const handleDelete = () => {
     const callback = (confirmation: boolean) => {
       if (confirmation) {
+        // Migrate as part of in https://github.com/bcgov/invasivesbc/issues/3807
+        dispatch(WellCache.deleteRepository(metadata.bounds));
         dispatch(TileCache.deleteRepository(metadata.id));
       }
     };

--- a/app/src/interfaces/WellData.ts
+++ b/app/src/interfaces/WellData.ts
@@ -1,0 +1,15 @@
+import { Feature } from '@turf/helpers';
+
+/**
+ * @desc Cleaned up Well data
+ */
+interface WellData {
+  id: number;
+  geometry: Feature;
+  properties: {
+    WELL_TAG_NUMBER: number;
+  };
+  [key: PropertyKey]: any;
+}
+
+export default WellData;

--- a/app/src/interfaces/WellData.ts
+++ b/app/src/interfaces/WellData.ts
@@ -6,9 +6,6 @@ import { Feature } from '@turf/helpers';
 interface WellData {
   id: number;
   geometry: Feature;
-  properties: {
-    WELL_TAG_NUMBER: number;
-  };
   [key: PropertyKey]: any;
 }
 

--- a/app/src/state/actions/cache/WellCache.ts
+++ b/app/src/state/actions/cache/WellCache.ts
@@ -27,13 +27,6 @@ class WellCache {
     const wellService = await WellCacheServiceFactory.getPlatformInstance();
     await wellService.deleteRepository(repository);
   });
-
-  static readonly fetchWellIdsInBounds = createAsyncThunk(
-    `${this.PREFIX}/fetchWellIdsInBounds`,
-    async (bounds: RepositoryBoundingBoxSpec) => {
-      throw new Error('Not yet implemented');
-    }
-  );
 }
 
 export default WellCache;

--- a/app/src/state/actions/cache/WellCache.ts
+++ b/app/src/state/actions/cache/WellCache.ts
@@ -1,0 +1,39 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { RootState } from 'state/reducers/rootReducer';
+import { RepositoryBoundingBoxSpec } from 'utils/tile-cache';
+import { WellCacheServiceFactory } from 'utils/well-cache/context';
+
+/**
+ * @desc Action Members for WellCaching
+ *       Used for Caching Well Metadata for use in offline Chemical treatment forms.
+ */
+class WellCache {
+  private static readonly PREFIX = 'WellCache';
+
+  static readonly requestCaching = createAsyncThunk(
+    `${this.PREFIX}/requestCaching`,
+
+    async (bounds: RepositoryBoundingBoxSpec, { getState }) => {
+      const state: RootState = getState() as RootState;
+      const wellService = await WellCacheServiceFactory.getPlatformInstance();
+      await wellService.download({
+        API_BASE: state.Configuration.current.API_BASE,
+        bounds
+      });
+    }
+  );
+
+  static readonly deleteRepository = createAsyncThunk(`${this.PREFIX}/requestCaching`, async (repository: string) => {
+    const wellService = await WellCacheServiceFactory.getPlatformInstance();
+    await wellService.deleteRepository(repository);
+  });
+
+  static readonly fetchWellIdsInBounds = createAsyncThunk(
+    `${this.PREFIX}/fetchWellIdsInBounds`,
+    async (bounds: RepositoryBoundingBoxSpec) => {
+      throw new Error('Not yet implemented');
+    }
+  );
+}
+
+export default WellCache;

--- a/app/src/state/sagas/map.ts
+++ b/app/src/state/sagas/map.ts
@@ -168,7 +168,7 @@ function* handle_WHATS_HERE_FEATURE(whatsHereFeature: PayloadAction<Feature>) {
         return (
           status === UserRecordCacheStatus.CACHED &&
           bbox &&
-          booleanIntersects(whatsHereFeature.payload, bboxToPolygon(bbox as any))
+          booleanIntersects(whatsHereFeature.payload, bboxToPolygon(bbox))
         );
       });
 

--- a/app/src/utils/bboxToPolygon.ts
+++ b/app/src/utils/bboxToPolygon.ts
@@ -6,7 +6,7 @@ import { RepositoryBoundingBoxSpec } from './tile-cache';
  * @param bbox Cached bounding box
  * @returns {Feature<Polygon>} Geojson Bounding box
  */
-function bboxToPolygon(bbox: Record<PropertyKey, number> | RepositoryBoundingBoxSpec): Feature<Polygon> {
+function bboxToPolygon(bbox: RepositoryBoundingBoxSpec): Feature<Polygon> {
   const { minLatitude, minLongitude, maxLatitude, maxLongitude } = bbox;
   return {
     type: 'Feature',

--- a/app/src/utils/bboxToPolygon.ts
+++ b/app/src/utils/bboxToPolygon.ts
@@ -1,11 +1,12 @@
 import { Feature, Polygon } from '@turf/helpers';
+import { RepositoryBoundingBoxSpec } from './tile-cache';
 
 /**
  * @desc Takes bounding from recordset metadata and convert into a Geojson Polygon
  * @param bbox Cached bounding box
  * @returns {Feature<Polygon>} Geojson Bounding box
  */
-function bboxToPolygon(bbox: Record<PropertyKey, number>): Feature<Polygon> {
+function bboxToPolygon(bbox: Record<PropertyKey, number> | RepositoryBoundingBoxSpec): Feature<Polygon> {
   const { minLatitude, minLongitude, maxLatitude, maxLongitude } = bbox;
   return {
     type: 'Feature',

--- a/app/src/utils/closestWellsHelpers.tsx
+++ b/app/src/utils/closestWellsHelpers.tsx
@@ -1,4 +1,4 @@
-import { polygon } from '@turf/helpers';
+import { Feature, polygon } from '@turf/helpers';
 import pointToLineDistance from '@turf/point-to-line-distance';
 import polygonToLine from '@turf/polygon-to-line';
 import inside from '@turf/inside';
@@ -6,6 +6,10 @@ import buffer from '@turf/buffer';
 import { getDataFromDataBCv2 } from './WFSConsumer';
 import { selectNetworkState } from 'state/reducers/network';
 import { select } from 'redux-saga/effects';
+import { WellCacheServiceFactory } from './well-cache/context';
+import GeoShapes from 'constants/geoShapes';
+import WellData from 'interfaces/WellData';
+import { LineString } from 'geojson';
 
 //gets layer data based on the layer name
 export function* getClosestWells(inputGeometry) {
@@ -24,16 +28,14 @@ export function* getClosestWells(inputGeometry) {
       return getWellsArray(returnVal.features, firstFeature);
     }
   } else {
-    /* TODO */
-    return { well_objects: [], areWellsInside: undefined };
+    const service = yield WellCacheServiceFactory.getPlatformInstance();
+    const wellsInArea = yield service.getNearbyWells(bufferedGeo) ?? [];
+    if (wellsInArea.length > 0) {
+      return getWellsArray(wellsInArea, firstFeature);
+    } else {
+      return { well_objects: [], areWellsInside: undefined };
+    }
   }
-  //if offline: try to get layer data from sqlite local storage
-  /*  else {
-    const allFeatures = await fetchLayerDataFromLocal(
-      'WHSE_WATER_MANAGEMENT.GW_WATER_WELLS_WRBC_SVW',
-      bufferedGeo,
-      databaseContext
-    );*/
 
   //if there is a geometry drawn, get closest wells and wells inside and label them
   // return getWellsArray(allFeatures, firstFeature);
@@ -45,7 +47,7 @@ export const getWellsArray = (arrayOfWells, inputGeometry) => {
     return;
   }
 
-  if (geoJSONFeature.geometry.type === 'Point') {
+  if (geoJSONFeature.geometry.type === GeoShapes.Point) {
     let radius = 100;
     if (geoJSONFeature.properties?.radius) {
       radius = geoJSONFeature.properties.radius;
@@ -53,17 +55,20 @@ export const getWellsArray = (arrayOfWells, inputGeometry) => {
     geoJSONFeature = buffer(geoJSONFeature, radius, { units: 'meters' });
   }
 
-  const outputWells = [];
+  const outputWells: WellData[] = [];
   let areWellsInside: boolean = false;
 
   const turfPolygon = polygon(geoJSONFeature.geometry.coordinates);
 
-  arrayOfWells.forEach((well, index) => {
+  arrayOfWells.forEach((well) => {
     if (inside(well, turfPolygon)) {
       areWellsInside = true;
       outputWells.push({ ...well, proximity: 0, inside: true });
     } else {
-      outputWells.push({ ...well, proximity: pointToLineDistance(well, polygonToLine(turfPolygon)) * 1000 });
+      outputWells.push({
+        ...well,
+        proximity: pointToLineDistance(well, polygonToLine(turfPolygon) as Feature<LineString>) * 1000
+      });
     }
   });
 
@@ -74,8 +79,8 @@ export const getWellsArray = (arrayOfWells, inputGeometry) => {
 
   outputWells[0] = { ...outputWells[0], closest: true };
 
-  const fiveClosest = [];
-  const insideGeoWells = [];
+  const fiveClosest: WellData[] = [];
+  const insideGeoWells: WellData[] = [];
 
   outputWells.forEach((well: any) => {
     if (well.inside) {

--- a/app/src/utils/well-cache/context.ts
+++ b/app/src/utils/well-cache/context.ts
@@ -1,15 +1,15 @@
 import React from 'react';
 import { Platform, PLATFORM } from 'state/build-time-config';
-// import { SQLiteWellCacheService } from 'utils/well-cache/sqlite-cache';
 import { LocalForageWellCacheService } from 'utils/well-cache/localforage-cache';
 import { WellCacheService } from '.';
+import SQLiteWellCacheService from './sqlite-cache';
 
 class WellCacheServiceFactory {
   static async getPlatformInstance(): Promise<WellCacheService> {
     if ([Platform.IOS, Platform.ANDROID].includes(PLATFORM)) {
-      // return SQLiteTileCacheService.getInstance();
+      return SQLiteWellCacheService.getInstance();
     }
-    return LocalForageWellCacheService.getInstance();
+    return await LocalForageWellCacheService.getInstance();
   }
 }
 

--- a/app/src/utils/well-cache/context.ts
+++ b/app/src/utils/well-cache/context.ts
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Platform, PLATFORM } from 'state/build-time-config';
+// import { SQLiteWellCacheService } from 'utils/well-cache/sqlite-cache';
+import { LocalForageWellCacheService } from 'utils/well-cache/localforage-cache';
+import { WellCacheService } from '.';
+
+class WellCacheServiceFactory {
+  static async getPlatformInstance(): Promise<WellCacheService> {
+    if ([Platform.IOS, Platform.ANDROID].includes(PLATFORM)) {
+      // return SQLiteTileCacheService.getInstance();
+    }
+    return LocalForageWellCacheService.getInstance();
+  }
+}
+
+const Context = React.createContext<WellCacheService | null>(null);
+
+export { WellCacheServiceFactory, Context };

--- a/app/src/utils/well-cache/index.ts
+++ b/app/src/utils/well-cache/index.ts
@@ -1,0 +1,106 @@
+import { nanoid } from '@reduxjs/toolkit';
+import { Feature } from '@turf/helpers';
+import WellData from 'interfaces/WellData';
+import BaseCacheService from 'utils/base-classes/BaseCacheService';
+import bboxToPolygon from 'utils/bboxToPolygon';
+import { RepositoryBoundingBoxSpec } from 'utils/tile-cache';
+import { buildURLForDataBC } from 'utils/WFSConsumer';
+
+export interface IWellRepositoryMetadata {
+  id: string;
+  status: WellRepositoryStatus;
+  bounds: RepositoryBoundingBoxSpec;
+  wellTagNumbers: number[];
+}
+
+export interface IWellRepositoryDownloadRequestSpec {
+  bounds: RepositoryBoundingBoxSpec;
+  API_BASE: string;
+}
+
+export interface IWellCacheProgressCallbackParameters {
+  repository: string;
+  message: string;
+  aborted: boolean;
+  normalizedProgress: number;
+  totalTiles: number;
+  processedTiles: number;
+}
+
+export enum WellRepositoryStatus {
+  CACHED,
+  DELETING,
+  DOWNLOADING,
+  ERROR,
+  NOT_CACHED
+}
+export interface ICachedWellData {
+  id: string;
+  geometry: Feature;
+}
+abstract class WellCacheService extends BaseCacheService<
+  IWellRepositoryMetadata,
+  IWellRepositoryDownloadRequestSpec,
+  IWellCacheProgressCallbackParameters,
+  WellRepositoryStatus
+> {
+  protected CACHE_UNAVAILABLE = 'Cache not available';
+
+  /**
+   * @desc Given a list of well Ids, delete wells in IndexDB.
+   * @param { number[] } wellTagNumbers Wells to be deleted
+   */
+  protected abstract deleteWellsFromIds(wellTagNumbers: number[]): Promise<void>;
+
+  /**
+   * @desc Save array of wells to storage
+   * @param {WellData[]} wellList Collection of Well Data
+   * @param progressCallback
+   */
+  protected abstract saveWells(
+    wellList: Record<PropertyKey, any>[],
+    progressCallback?: ((currentProgress: IWellCacheProgressCallbackParameters) => void) | undefined
+  ): Promise<void>;
+
+  /**
+   * @desc Save one well to local Database
+   * @param { WellData } wellData information pertaining to a well
+   */
+  protected abstract saveWell(wellData: WellData): Promise<void>;
+  /**
+   * @desc Given a bounding box, download a set of Well Records
+   * @param spec Details needed for download
+   * @param progressCallback Optional callback function for displaying progress updates in cache process
+   */
+  public async download(
+    spec: IWellRepositoryDownloadRequestSpec,
+    progressCallback?: ((currentProgress: IWellCacheProgressCallbackParameters) => void) | undefined
+  ): Promise<void> {
+    const WELL_WFS_LAYER = 'WHSE_WATER_MANAGEMENT.GW_WATER_WELLS_WRBC_SVW';
+    const url = encodeURIComponent(buildURLForDataBC(WELL_WFS_LAYER, bboxToPolygon(spec.bounds), true));
+    const response = await (await fetch(`${spec.API_BASE}/api/map-shaper?url=${url}&percentage=0.02`)).json();
+    const wellTagNumbers: number[] = response.result.features.map((well: WellData) => well.properties.WELL_TAG_NUMBER);
+    const id = `well-records-${nanoid()}`;
+
+    console.log('Bounds', bboxToPolygon(spec.bounds));
+    await this.addOrUpdateRepository({
+      bounds: spec.bounds,
+      id: id,
+      status: WellRepositoryStatus.DOWNLOADING,
+      wellTagNumbers: wellTagNumbers
+    });
+
+    await this.saveWells(response.result.features, progressCallback);
+    await this.setRepositoryStatus(id, WellRepositoryStatus.CACHED);
+  }
+
+  static async getInstance(): Promise<WellCacheService> {
+    throw new Error('unimplemented in abstract base class');
+  }
+
+  protected constructor() {
+    super();
+  }
+}
+
+export { WellCacheService };

--- a/app/src/utils/well-cache/index.ts
+++ b/app/src/utils/well-cache/index.ts
@@ -1,5 +1,6 @@
 import { nanoid } from '@reduxjs/toolkit';
-import { Feature } from '@turf/helpers';
+import booleanIntersects from '@turf/boolean-intersects';
+import { Feature, FeatureCollection } from '@turf/helpers';
 import WellData from 'interfaces/WellData';
 import BaseCacheService from 'utils/base-classes/BaseCacheService';
 import bboxToPolygon from 'utils/bboxToPolygon';
@@ -11,6 +12,7 @@ export interface IWellRepositoryMetadata {
   status: WellRepositoryStatus;
   bounds: RepositoryBoundingBoxSpec;
   wellTagNumbers: number[];
+  cachedGeoJson?: FeatureCollection;
 }
 
 export interface IWellRepositoryDownloadRequestSpec {
@@ -46,19 +48,37 @@ abstract class WellCacheService extends BaseCacheService<
 > {
   protected CACHE_UNAVAILABLE = 'Cache not available';
 
+  protected constructor() {
+    super();
+  }
+
+  static async getInstance(): Promise<WellCacheService> {
+    throw new Error('unimplemented in abstract class');
+  }
+
   /**
    * @desc Given a list of well Ids, delete wells in IndexDB.
    * @param { number[] } wellTagNumbers Wells to be deleted
    */
   protected abstract deleteWellsFromIds(wellTagNumbers: number[]): Promise<void>;
 
+  public abstract getRepository(repository: string | RepositoryBoundingBoxSpec): Promise<IWellRepositoryMetadata>;
+
   /**
-   * @desc Save array of wells to storage
+   * @desc Create GeoJson Data for a a repository used in quick lookups
+   * @param { string | RepositoryBoundingBoxSpec } repository Target Repo
+   */
+  protected abstract createFeatureCollectionFromMetadata(
+    repository: string | RepositoryBoundingBoxSpec
+  ): Promise<FeatureCollection>;
+
+  /**
+   * @desc Save array of wells to local database
    * @param {WellData[]} wellList Collection of Well Data
    * @param progressCallback
    */
   protected abstract saveWells(
-    wellList: Record<PropertyKey, any>[],
+    wellList: WellData[],
     progressCallback?: ((currentProgress: IWellCacheProgressCallbackParameters) => void) | undefined
   ): Promise<void>;
 
@@ -67,22 +87,27 @@ abstract class WellCacheService extends BaseCacheService<
    * @param { WellData } wellData information pertaining to a well
    */
   protected abstract saveWell(wellData: WellData): Promise<void>;
+
   /**
    * @desc Given a bounding box, download a set of Well Records
-   * @param spec Details needed for download
+   * @param spec Repository details
    * @param progressCallback Optional callback function for displaying progress updates in cache process
    */
   public async download(
     spec: IWellRepositoryDownloadRequestSpec,
     progressCallback?: ((currentProgress: IWellCacheProgressCallbackParameters) => void) | undefined
   ): Promise<void> {
+    const id = `well-records-${nanoid()}`;
     const WELL_WFS_LAYER = 'WHSE_WATER_MANAGEMENT.GW_WATER_WELLS_WRBC_SVW';
     const url = encodeURIComponent(buildURLForDataBC(WELL_WFS_LAYER, bboxToPolygon(spec.bounds), true));
     const response = await (await fetch(`${spec.API_BASE}/api/map-shaper?url=${url}&percentage=0.02`)).json();
     const wellTagNumbers: number[] = response.result.features.map((well: WellData) => well.properties.WELL_TAG_NUMBER);
-    const id = `well-records-${nanoid()}`;
 
-    console.log('Bounds', bboxToPolygon(spec.bounds));
+    const uncachedWellTags = await this.removeDuplicateWellsFromIdList(wellTagNumbers, spec.bounds);
+    const wellsToCache = response.result.features.filter((well) =>
+      uncachedWellTags.includes(well.properties.WELL_TAG_NUMBER)
+    );
+
     await this.addOrUpdateRepository({
       bounds: spec.bounds,
       id: id,
@@ -90,16 +115,61 @@ abstract class WellCacheService extends BaseCacheService<
       wellTagNumbers: wellTagNumbers
     });
 
-    await this.saveWells(response.result.features, progressCallback);
-    await this.setRepositoryStatus(id, WellRepositoryStatus.CACHED);
+    await this.saveWells(wellsToCache, progressCallback);
+    const featureCollection = await this.createFeatureCollectionFromMetadata(id);
+
+    await this.addOrUpdateRepository({
+      bounds: spec.bounds,
+      id: id,
+      status: WellRepositoryStatus.CACHED,
+      wellTagNumbers: wellTagNumbers,
+      cachedGeoJson: featureCollection
+    });
   }
 
-  static async getInstance(): Promise<WellCacheService> {
-    throw new Error('unimplemented in abstract base class');
+  /**
+   * @desc Return list of wells contained by shape
+   * @param geom Geometry to check for containing shapes
+   * @returns {Feature[]} Wells in area
+   */
+  public async getNearbyWells(geom: Feature): Promise<Feature[]> {
+    const containedShapes = (await this.getOverlappingRepositories(geom))
+      .flatMap((cr) => cr.cachedGeoJson!.features)
+      .filter((s) => booleanIntersects(geom, s));
+    return containedShapes;
   }
 
-  protected constructor() {
-    super();
+  /**
+   * @desc Find all well Ids already cached and remove them from list
+   *       Checks repositories that overlap with the new repo.
+   * @param wellTagNumbers List of wells in new repository.
+   * @param bounds Bounding box of new repository.
+   * @returns { number[] } List of WellTagNumbers not contained by other repositories
+   */
+  private async removeDuplicateWellsFromIdList(
+    wellTagNumbers: number[],
+    bounds: RepositoryBoundingBoxSpec
+  ): Promise<number[]> {
+    const boundsShape = bboxToPolygon(bounds);
+    const containedRepos = await this.getOverlappingRepositories(boundsShape);
+    const frequencyMap: Record<number, number> = {};
+    containedRepos
+      .flatMap((repo) => repo.wellTagNumbers)
+      .forEach((wtn) => {
+        frequencyMap[wtn] ??= 0;
+        frequencyMap[wtn]++;
+      });
+    return wellTagNumbers.filter((wtn) => !frequencyMap?.[wtn]);
+  }
+
+  /**
+   * @desc Get repositories filtered to a geographic area
+   * @param geom Area of target
+   * @returns Repositories overlapping with target area
+   */
+  public async getOverlappingRepositories(geom: Feature): Promise<IWellRepositoryMetadata[]> {
+    const repositories = await this.listRepositories();
+    return repositories.filter((r) => r.cachedGeoJson && booleanIntersects(bboxToPolygon(r.bounds), geom));
   }
 }
 

--- a/app/src/utils/well-cache/index.ts
+++ b/app/src/utils/well-cache/index.ts
@@ -57,7 +57,7 @@ abstract class WellCacheService extends BaseCacheService<
   }
 
   /**
-   * @desc Given a list of well Ids, delete wells in IndexDB.
+   * @desc Given a list of well Ids, delete wells in local db.
    * @param { number[] } wellTagNumbers Wells to be deleted
    */
   protected abstract deleteWellsFromIds(wellTagNumbers: number[]): Promise<void>;
@@ -101,8 +101,8 @@ abstract class WellCacheService extends BaseCacheService<
     const WELL_WFS_LAYER = 'WHSE_WATER_MANAGEMENT.GW_WATER_WELLS_WRBC_SVW';
     const url = encodeURIComponent(buildURLForDataBC(WELL_WFS_LAYER, bboxToPolygon(spec.bounds), true));
     const response = await (await fetch(`${spec.API_BASE}/api/map-shaper?url=${url}&percentage=0.02`)).json();
-    const wellTagNumbers: number[] = response.result.features.map((well: WellData) => well.properties.WELL_TAG_NUMBER);
-
+    const wellTagNumbers: number[] =
+      response?.result?.features?.map((well: WellData) => well.properties.WELL_TAG_NUMBER) ?? [];
     const uncachedWellTags = await this.removeDuplicateWellsFromIdList(wellTagNumbers, spec.bounds);
     const wellsToCache = response.result.features.filter((well) =>
       uncachedWellTags.includes(well.properties.WELL_TAG_NUMBER)
@@ -117,7 +117,6 @@ abstract class WellCacheService extends BaseCacheService<
 
     await this.saveWells(wellsToCache, progressCallback);
     const featureCollection = await this.createFeatureCollectionFromMetadata(id);
-
     await this.addOrUpdateRepository({
       bounds: spec.bounds,
       id: id,

--- a/app/src/utils/well-cache/localforage-cache.ts
+++ b/app/src/utils/well-cache/localforage-cache.ts
@@ -18,7 +18,7 @@ class LocalForageWellCacheService extends WellCacheService {
     super();
   }
 
-  static async getInstance(): Promise<LocalForageWellCacheService> {
+  static override async getInstance(): Promise<LocalForageWellCacheService> {
     if (LocalForageWellCacheService._instance == null) {
       LocalForageWellCacheService._instance = new LocalForageWellCacheService();
       await LocalForageWellCacheService._instance.initializeCache();
@@ -109,7 +109,6 @@ class LocalForageWellCacheService extends WellCacheService {
     // converts to String due to IndexDB Constraint requiring string keys
     const cleanedWellData: WellData = {
       id: id,
-      type: wellData.type,
       geometry: wellData.geometry
     };
 

--- a/app/src/utils/well-cache/localforage-cache.ts
+++ b/app/src/utils/well-cache/localforage-cache.ts
@@ -7,6 +7,7 @@ import {
 } from '.';
 import WellData from 'interfaces/WellData';
 import { RepositoryBoundingBoxSpec } from 'utils/tile-cache';
+import { Feature, FeatureCollection } from '@turf/helpers';
 
 class LocalForageWellCacheService extends WellCacheService {
   private static _instance: LocalForageWellCacheService;
@@ -25,21 +26,26 @@ class LocalForageWellCacheService extends WellCacheService {
     return LocalForageWellCacheService._instance;
   }
 
-  async deleteRepository(repositoryId: string) {
+  async deleteRepository(repository: string | RepositoryBoundingBoxSpec) {
     if (this.store == null) {
       throw new Error(this.CACHE_UNAVAILABLE);
     }
-    const cachedSets = await this.listRepositories();
-    const foundIndex = cachedSets.findIndex((r) => r.id === repositoryId);
+    const repositories = await this.listRepositories();
+    let foundIndex: number;
+    if (typeof repository === 'string') {
+      foundIndex = repositories.findIndex((r) => r.id === repository);
+    } else {
+      foundIndex = repositories.findIndex((r) => this.compareBounds(r.bounds, repository));
+    }
 
     if (foundIndex === -1) return;
 
-    await this.setRepositoryStatus(repositoryId, WellRepositoryStatus.DELETING);
+    await this.setRepositoryStatus(repositories[foundIndex].id, WellRepositoryStatus.DELETING);
 
-    const deleteList = cachedSets[foundIndex].wellTagNumbers;
+    const deleteList = repositories[foundIndex].wellTagNumbers;
     const ids: Record<PropertyKey, number> = {};
 
-    cachedSets
+    repositories
       .flatMap((set) => set.wellTagNumbers)
       .forEach((id) => {
         ids[id] ??= 0;
@@ -48,8 +54,8 @@ class LocalForageWellCacheService extends WellCacheService {
 
     const wellsToDelete = deleteList.filter((id) => ids[id] === 1);
     await this.deleteWellsFromIds(wellsToDelete);
-    cachedSets.splice(foundIndex, 1);
-    await this.store.setItem(LocalForageWellCacheService.REPOSITORY_METADATA_KEY, cachedSets);
+    repositories.splice(foundIndex, 1);
+    await this.store.setItem(LocalForageWellCacheService.REPOSITORY_METADATA_KEY, repositories);
   }
 
   protected async deleteWellsFromIds(wellTagNumbers: number[]) {
@@ -99,14 +105,14 @@ class LocalForageWellCacheService extends WellCacheService {
       throw new Error(this.CACHE_UNAVAILABLE);
     }
     const id = wellData.properties.WELL_TAG_NUMBER;
+    wellData.geometry.properties = { WELL_TAG_NUMBER: wellData.properties.WELL_TAG_NUMBER };
     // converts to String due to IndexDB Constraint requiring string keys
     const cleanedWellData: WellData = {
       id: id,
-      properties: { WELL_TAG_NUMBER: id },
       type: wellData.type,
       geometry: wellData.geometry
     };
-    console.log(cleanedWellData);
+
     await this.store.setItem(cleanedWellData.id.toString(), cleanedWellData);
   }
 
@@ -143,6 +149,24 @@ class LocalForageWellCacheService extends WellCacheService {
       Object.assign(cachedSets[foundIndex], { status });
       await this.store.setItem(LocalForageWellCacheService.REPOSITORY_METADATA_KEY, cachedSets);
     }
+  }
+
+  protected async createFeatureCollectionFromMetadata(
+    repository: string | RepositoryBoundingBoxSpec
+  ): Promise<FeatureCollection> {
+    const repo = await this.getRepository(repository);
+    const features: Feature[] = [];
+    for (const wtn of repo.wellTagNumbers) {
+      const well: WellData = (await this.store?.getItem(wtn.toString())) as WellData;
+      well.geometry.properties = {
+        WELL_TAG_NUMBER: well.id
+      };
+      features.push(well.geometry);
+    }
+    return {
+      type: 'FeatureCollection',
+      features: features
+    };
   }
 
   /**

--- a/app/src/utils/well-cache/localforage-cache.ts
+++ b/app/src/utils/well-cache/localforage-cache.ts
@@ -1,0 +1,175 @@
+import localForage from 'localforage';
+import {
+  IWellCacheProgressCallbackParameters,
+  IWellRepositoryMetadata,
+  WellCacheService,
+  WellRepositoryStatus
+} from '.';
+import WellData from 'interfaces/WellData';
+import { RepositoryBoundingBoxSpec } from 'utils/tile-cache';
+
+class LocalForageWellCacheService extends WellCacheService {
+  private static _instance: LocalForageWellCacheService;
+  private static readonly REPOSITORY_METADATA_KEY = 'well-repositories';
+  private store: LocalForage | null = null;
+
+  protected constructor() {
+    super();
+  }
+
+  static async getInstance(): Promise<LocalForageWellCacheService> {
+    if (LocalForageWellCacheService._instance == null) {
+      LocalForageWellCacheService._instance = new LocalForageWellCacheService();
+      await LocalForageWellCacheService._instance.initializeCache();
+    }
+    return LocalForageWellCacheService._instance;
+  }
+
+  async deleteRepository(repositoryId: string) {
+    if (this.store == null) {
+      throw new Error(this.CACHE_UNAVAILABLE);
+    }
+    const cachedSets = await this.listRepositories();
+    const foundIndex = cachedSets.findIndex((r) => r.id === repositoryId);
+
+    if (foundIndex === -1) return;
+
+    await this.setRepositoryStatus(repositoryId, WellRepositoryStatus.DELETING);
+
+    const deleteList = cachedSets[foundIndex].wellTagNumbers;
+    const ids: Record<PropertyKey, number> = {};
+
+    cachedSets
+      .flatMap((set) => set.wellTagNumbers)
+      .forEach((id) => {
+        ids[id] ??= 0;
+        ids[id]++;
+      });
+
+    const wellsToDelete = deleteList.filter((id) => ids[id] === 1);
+    await this.deleteWellsFromIds(wellsToDelete);
+    cachedSets.splice(foundIndex, 1);
+    await this.store.setItem(LocalForageWellCacheService.REPOSITORY_METADATA_KEY, cachedSets);
+  }
+
+  protected async deleteWellsFromIds(wellTagNumbers: number[]) {
+    if (this.store == null) {
+      throw new Error(this.CACHE_UNAVAILABLE);
+    }
+    for (const wellTagNumber of wellTagNumbers) {
+      await this.store.removeItem(wellTagNumber.toString());
+    }
+  }
+
+  /**
+   * @desc Compare two objects bounds to find a match
+   * @returns Bounds hold the same value
+   */
+  private compareBounds(objA: RepositoryBoundingBoxSpec, objB: RepositoryBoundingBoxSpec): boolean {
+    return Object.keys(objA).every((key) => objA[key] === objB[key]);
+  }
+
+  public async getRepository(repositoryId: string | RepositoryBoundingBoxSpec): Promise<IWellRepositoryMetadata> {
+    const repos = await this.listRepositories();
+    let foundIndex: number;
+    if (typeof repositoryId === 'string') {
+      foundIndex = repos.findIndex((p) => p.id === repositoryId);
+    } else {
+      foundIndex = repos.findIndex((p) => this.compareBounds(p.bounds, repositoryId));
+    }
+    if (foundIndex === -1) throw Error(`Repository ${repositoryId} not found`);
+
+    return repos[foundIndex];
+  }
+
+  protected async saveWells(
+    wellList: WellData[],
+    progressCallback?: ((currentProgress: IWellCacheProgressCallbackParameters) => void) | undefined
+  ): Promise<void> {
+    if (this.store == null) {
+      throw new Error(this.CACHE_UNAVAILABLE);
+    }
+    for (const well of wellList) {
+      await this.saveWell(well);
+    }
+  }
+
+  protected async saveWell(wellData: WellData): Promise<void> {
+    if (this.store == null) {
+      throw new Error(this.CACHE_UNAVAILABLE);
+    }
+    const id = wellData.properties.WELL_TAG_NUMBER;
+    // converts to String due to IndexDB Constraint requiring string keys
+    const cleanedWellData: WellData = {
+      id: id,
+      properties: { WELL_TAG_NUMBER: id },
+      type: wellData.type,
+      geometry: wellData.geometry
+    };
+    console.log(cleanedWellData);
+    await this.store.setItem(cleanedWellData.id.toString(), cleanedWellData);
+  }
+
+  /**
+   * @desc Get all Repository records in IndexDB
+   * @returns { IWellRepositoryMetadata } All metadata for well sets.
+   */
+  async listRepositories(): Promise<IWellRepositoryMetadata[]> {
+    if (this.store == null) {
+      return [];
+    }
+
+    const metadata: IWellRepositoryMetadata[] =
+      (await this.store.getItem(LocalForageWellCacheService.REPOSITORY_METADATA_KEY)) ?? [];
+    if (metadata == null) {
+      console.error('expected key not found');
+      return [];
+    }
+    return metadata;
+  }
+
+  /**
+   * @desc Update status of Well repository
+   * @param repositoryId Repository to update
+   * @param { WellRepositoryStatus } status New Status.
+   */
+  public async setRepositoryStatus(repositoryId: string, status: WellRepositoryStatus): Promise<void> {
+    if (this.store == null) {
+      throw Error(this.CACHE_UNAVAILABLE);
+    }
+    const cachedSets = await this.listRepositories();
+    const foundIndex = cachedSets.findIndex((r) => r.id === repositoryId);
+    if (foundIndex !== -1) {
+      Object.assign(cachedSets[foundIndex], { status });
+      await this.store.setItem(LocalForageWellCacheService.REPOSITORY_METADATA_KEY, cachedSets);
+    }
+  }
+
+  /**
+   * @desc Create or add new Repository to the repository metadata array
+   * @param { IWellRepositoryMetadata } spec Details
+   */
+  protected async addOrUpdateRepository(spec: IWellRepositoryMetadata) {
+    if (this.store == null) {
+      throw new Error(this.CACHE_UNAVAILABLE);
+    }
+
+    const repositories = await this.listRepositories();
+    const foundIndex = repositories.findIndex((p) => p.id == spec.id);
+    if (foundIndex !== -1) {
+      repositories[foundIndex] = spec;
+    } else {
+      repositories.push(spec);
+    }
+
+    await this.store.setItem(LocalForageWellCacheService.REPOSITORY_METADATA_KEY, repositories);
+  }
+  private async initializeCache() {
+    this.store = localForage.createInstance({
+      storeName: 'well-cache',
+      version: 20250120
+    });
+  }
+}
+
+export { LocalForageWellCacheService };

--- a/app/src/utils/well-cache/sqlite-cache.ts
+++ b/app/src/utils/well-cache/sqlite-cache.ts
@@ -51,7 +51,10 @@ class SQLiteWellCacheService extends WellCacheService {
     }
     const { id, status, bounds, wellTagNumbers, cachedGeoJson } = repository;
     const wtns = JSON.stringify(wellTagNumbers);
-    const bnds = JSON.stringify(bounds, Object.keys(bounds).sort());
+    const bnds = JSON.stringify(
+      bounds,
+      Object.keys(bounds).sort((a, b) => (a < b ? -1 : 1))
+    );
 
     if (cachedGeoJson) {
       const geojsn = JSON.stringify(cachedGeoJson);
@@ -170,7 +173,12 @@ class SQLiteWellCacheService extends WellCacheService {
       throw new Error(this.CACHE_UNAVAILABLE);
     }
     const identifier =
-      typeof repository === 'string' ? repository : JSON.stringify(repository, Object.keys(repository).sort());
+      typeof repository === 'string'
+        ? repository
+        : JSON.stringify(
+            repository,
+            Object.keys(repository).sort((a, b) => (a < b ? -1 : 1))
+          );
     const result = await this.cacheDB.query(
       //language=SQLite
       `SELECT 

--- a/app/src/utils/well-cache/sqlite-cache.ts
+++ b/app/src/utils/well-cache/sqlite-cache.ts
@@ -1,0 +1,300 @@
+import { FeatureCollection } from '@turf/helpers';
+import WellData from 'interfaces/WellData';
+import { RepositoryBoundingBoxSpec } from 'utils/tile-cache';
+import {
+  IWellCacheProgressCallbackParameters,
+  IWellRepositoryMetadata,
+  WellCacheService,
+  WellRepositoryStatus
+} from '.';
+import { SQLiteConnection, SQLiteDBConnection } from '@capacitor-community/sqlite';
+import { sqlite } from 'utils/sharedSQLiteInstance';
+
+const RECORD_CACHE_DB_MIGRATIONS_1 = [
+  `CREATE TABLE CACHE_METADATA
+  (
+    ID           VARCHAR(64) NOT NULL UNIQUE PRIMARY KEY,
+    BOUNDS           TEXT NOT NULL UNIQUE,
+    STATUS           TEXT NOT NULL,
+    WELL_TAG_NUMBERS TEXT NOT NULL,
+    GEOJSON          TEXT
+  );`,
+  `CREATE TABLE CACHED_WELLS
+  (
+    ID   INT UNIQUE PRIMARY KEY,
+    GEOM TEXT NOT NULL
+  );`
+];
+
+class SQLiteWellCacheService extends WellCacheService {
+  private readonly CACHE_DB_NAME = 'well_cache.db';
+  private readonly BATCH_AMOUNT = 100;
+  private static _instance: SQLiteWellCacheService;
+
+  private cacheDB: SQLiteDBConnection | null = null;
+
+  protected constructor() {
+    super();
+  }
+
+  static override async getInstance(): Promise<SQLiteWellCacheService> {
+    if (SQLiteWellCacheService._instance == null) {
+      SQLiteWellCacheService._instance = new SQLiteWellCacheService();
+      await SQLiteWellCacheService._instance.initializeRecordCache(sqlite);
+    }
+    return SQLiteWellCacheService._instance;
+  }
+
+  protected async addOrUpdateRepository(repository: IWellRepositoryMetadata): Promise<void> {
+    if (this.cacheDB == null) {
+      throw new Error(this.CACHE_UNAVAILABLE);
+    }
+    const { id, status, bounds, wellTagNumbers, cachedGeoJson } = repository;
+    const wtns = JSON.stringify(wellTagNumbers);
+    const bnds = JSON.stringify(bounds, Object.keys(bounds).sort());
+
+    if (cachedGeoJson) {
+      const geojsn = JSON.stringify(cachedGeoJson);
+      await this.cacheDB.query(
+        //language=SQLite
+        `INSERT INTO CACHE_METADATA(ID, BOUNDS, STATUS, WELL_TAG_NUMBERS, GEOJSON)
+           VALUES(?, ?, ?, ?, ?)
+         ON CONFLICT(ID)
+         DO UPDATE SET
+           STATUS = excluded.STATUS,
+           WELL_TAG_NUMBERS = excluded.WELL_TAG_NUMBERS,
+           GEOJSON = excluded.GEOJSON`,
+        [id, bnds, status, wtns, geojsn]
+      );
+    } else {
+      await this.cacheDB.query(
+        //language=SQLite
+        `INSERT INTO CACHE_METADATA(ID, BOUNDS, STATUS, WELL_TAG_NUMBERS)
+         VALUES(?, ?, ?, ?)
+           ON CONFLICT(ID)
+         DO UPDATE SET
+           STATUS = excluded.STATUS,
+           WELL_TAG_NUMBERS = excluded.WELL_TAG_NUMBERS`,
+        [id, bnds, status, wtns]
+      );
+    }
+  }
+
+  protected async createFeatureCollectionFromMetadata(
+    repository: string | RepositoryBoundingBoxSpec
+  ): Promise<FeatureCollection> {
+    if (this.cacheDB == null) {
+      throw new Error(this.CACHE_UNAVAILABLE);
+    }
+    const features: string[][] = [];
+    const { wellTagNumbers } = await this.getRepository(repository);
+    for (let i = 0; i < wellTagNumbers.length; i += this.BATCH_AMOUNT) {
+      const sliced = wellTagNumbers.slice(i, Math.min(i + this.BATCH_AMOUNT, wellTagNumbers.length));
+      const geometry: string[] =
+        (
+          await this.cacheDB.query(
+            //language=SQLite
+            `SELECT GEOM
+             FROM CACHED_WELLS
+             WHERE ID IN (${sliced.map((_) => '?').join(', ')})`,
+            [...sliced]
+          )
+        ).values ?? [];
+
+      features.push(geometry);
+    }
+    const featureCollection = {
+      type: 'FeatureCollection',
+      features: features.flatMap((f) => f).map((f) => JSON.parse(f['GEOM']))
+    } as FeatureCollection;
+    return featureCollection;
+  }
+
+  public async deleteRepository(identifier: string | RepositoryBoundingBoxSpec): Promise<void> {
+    if (this.cacheDB == null) {
+      throw new Error(this.CACHE_UNAVAILABLE);
+    }
+    const repo = await this.getRepository(identifier);
+    await this.setRepositoryStatus(repo.id, WellRepositoryStatus.DELETING);
+    const deleteList = repo.wellTagNumbers;
+
+    const ids: Record<number, number> = {};
+
+    const idLists =
+      (
+        await this.cacheDB.query(
+          //language=SQLite
+          `SELECT WELL_TAG_NUMBERS
+           FROM CACHE_METADATA`
+        )
+      )?.values?.flatMap((wtns) => JSON.parse(wtns['WELL_TAG_NUMBERS'])) ?? [];
+
+    idLists.forEach((id) => {
+      ids[id] ??= 0;
+      ids[id]++;
+    });
+
+    const wellsToDelete = deleteList.filter((id) => ids[id] <= 1);
+    await this.deleteWellsFromIds(wellsToDelete);
+    await this.cacheDB.query(
+      `DELETE FROM CACHE_METADATA
+      WHERE ID = ?`,
+      [repo.id]
+    );
+  }
+
+  protected async deleteWellsFromIds(wellTagNumbers: number[]): Promise<void> {
+    if (this.cacheDB == null) {
+      throw new Error(this.CACHE_UNAVAILABLE);
+    }
+    await this.cacheDB.beginTransaction();
+    try {
+      for (let i = 0; i < wellTagNumbers.length; i += this.BATCH_AMOUNT) {
+        const sliced = wellTagNumbers.slice(i, Math.min(i + this.BATCH_AMOUNT, wellTagNumbers.length));
+        await this.cacheDB.query(
+          //language=SQLite
+          `DELETE FROM CACHED_WELLS
+           WHERE ID IN (${sliced.map(() => '?').join(', ')})`,
+          [...sliced]
+        );
+      }
+      await this.cacheDB.commitTransaction();
+    } catch (e) {
+      this.cacheDB.rollbackTransaction();
+      throw e;
+    }
+  }
+
+  public async getRepository(repository: string | RepositoryBoundingBoxSpec): Promise<IWellRepositoryMetadata> {
+    if (this.cacheDB == null) {
+      throw new Error(this.CACHE_UNAVAILABLE);
+    }
+    const identifier =
+      typeof repository === 'string' ? repository : JSON.stringify(repository, Object.keys(repository).sort());
+    const result = await this.cacheDB.query(
+      //language=SQLite
+      `SELECT 
+        ID AS id,
+        STATUS as status,
+        BOUNDS as bounds,
+        WELL_TAG_NUMBERS as wellTagNumbers,
+        GEOJSON as cachedGeoJson
+       FROM CACHE_METADATA
+       WHERE ID = ?
+       OR BOUNDS = ?
+       LIMIT 1;`,
+      [identifier, identifier]
+    );
+    return this.cleanRepository(result.values?.[0]);
+  }
+
+  /** @desc Convert stringified keys from stored repository back into Objects */
+  private cleanRepository(repo: Record<PropertyKey, any>): IWellRepositoryMetadata {
+    if (!repo) throw Error('No Data provided');
+
+    repo.wellTagNumbers = JSON.parse(repo.wellTagNumbers);
+    repo.bounds = JSON.parse(repo.bounds);
+    if (repo?.cachedGeoJson) {
+      repo.cachedGeoJson = JSON.parse(repo.cachedGeoJson);
+    }
+    return repo as IWellRepositoryMetadata;
+  }
+
+  public async listRepositories(): Promise<IWellRepositoryMetadata[]> {
+    if (this.cacheDB == null) {
+      throw new Error(this.CACHE_UNAVAILABLE);
+    }
+    const repositories = await this.cacheDB.query(
+      //language=SQLite
+      `SELECT 
+        ID AS id,
+        STATUS as status,
+        BOUNDS as bounds,
+        WELL_TAG_NUMBERS as wellTagNumbers,
+        GEOJSON as cachedGeoJson
+       FROM CACHE_METADATA`
+    );
+    const response = repositories.values?.map((repo) => this.cleanRepository(repo)) ?? [];
+    return response;
+  }
+
+  protected async saveWell(wellData: WellData): Promise<void> {
+    if (this.cacheDB == null) {
+      throw new Error(this.CACHE_UNAVAILABLE);
+    }
+    const id = wellData.properties.WELL_TAG_NUMBER;
+    wellData.geometry.properties = { WELL_TAG_NUMBER: id };
+    const stringifiedGeo = JSON.stringify(wellData.geometry);
+
+    await this.cacheDB.query(
+      //language=SQLite
+      `INSERT INTO CACHED_WELLS(ID, GEOM)
+       VALUES (?, ?)
+       ON CONFLICT(ID)
+       DO UPDATE SET GEOM = excluded.GEOM`,
+      [id, stringifiedGeo]
+    );
+  }
+
+  protected async saveWells(
+    wellList: WellData[],
+    progressCallback?: ((currentProgress: IWellCacheProgressCallbackParameters) => void) | undefined
+  ): Promise<void> {
+    if (this.cacheDB == null) {
+      throw new Error(this.CACHE_UNAVAILABLE);
+    }
+    for (const well of wellList) {
+      await this.saveWell(well);
+      // Progress callback
+    }
+  }
+
+  public async setRepositoryStatus(repositoryId: string, status: WellRepositoryStatus): Promise<void> {
+    if (this.cacheDB == null) {
+      throw new Error(this.CACHE_UNAVAILABLE);
+    }
+    await this.cacheDB.query(
+      //language=SQLite
+      `UPDATE CACHE_METADATA
+       SET STATUS = ?
+       WHERE ID = ?`,
+      [status, repositoryId]
+    );
+  }
+
+  private async initializeRecordCache(sqlite: SQLiteConnection) {
+    // Hold Migrations as named variable so we can use length to update the Db version automagically
+    // Note: toVersion must be an integer.
+    const MIGRATIONS = [
+      {
+        toVersion: 1,
+        statements: RECORD_CACHE_DB_MIGRATIONS_1
+      }
+    ];
+    await sqlite.addUpgradeStatement(this.CACHE_DB_NAME, MIGRATIONS);
+
+    const ret = await sqlite.checkConnectionsConsistency();
+    const isConn = (await sqlite.isConnection(this.CACHE_DB_NAME, false)).result;
+
+    if (ret.result && isConn) {
+      this.cacheDB = await sqlite.retrieveConnection(this.CACHE_DB_NAME, false);
+    } else {
+      this.cacheDB = await sqlite.createConnection(
+        this.CACHE_DB_NAME,
+        false,
+        'no-encryption',
+        MIGRATIONS.length,
+        false
+      );
+    }
+    try {
+      await this.cacheDB.open().catch((e) => {
+        console.error(e);
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+}
+
+export default SQLiteWellCacheService;


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Implement SQLite and LocalForage for caching Well Data
- Well Repositories can be found by matching Bounding boxes or by ID
    - Future 'Plan my Trip' type functionality will let our caches share a common ID, but this is not that day.
- Well Records are cached at the same time as Map tiles are cached, sharing a common bounding box
- Well Records are deleted when Map tiles are deleted
- Incoming wells filter out from existing wells reducing DB Transactions in subsequent areas
- due to localforage constraints, well Ids are stored/gathered as strings and parsed on the way out.
- Closes #3777