### PR TITLE
[INV-3808] Unhandled Promise rejections in Auth

### DIFF
--- a/api/src/middleware/bearerHandler.ts
+++ b/api/src/middleware/bearerHandler.ts
@@ -1,8 +1,9 @@
+import { Request } from 'express';
 import { MDC, MDCAsyncLocal } from 'mdc';
 import { authenticate, InvasivesRequest } from 'utils/auth-utils';
 import { getLogger } from 'utils/logger';
 
-const bearerHandler = async (req) => {
+const bearerHandler = async (req: Request) => {
   const logger = getLogger('Error');
   try {
     let mdc = MDCAsyncLocal.getStore();

--- a/api/src/utils/auth-utils.ts
+++ b/api/src/utils/auth-utils.ts
@@ -138,71 +138,73 @@ export const authenticate = async (req: InvasivesRequest): Promise<void> => {
         reject(rejectWithErr('Invalid token - Missing idir_userid or bceid_userid'));
       }
 
-      getUserByKeycloakID(accountType, id).then((user) => {
-        const createIfNeeded = new Promise((resolve: any) => {
-          if (!user) {
-            defaultLog.info({ label: 'authenticate', message: `first creating new user ${id}` });
-            createUser(decoded, accountType, id)
+      getUserByKeycloakID(accountType, id)
+        .then((user) => {
+          const createIfNeeded = new Promise((resolve: any) => {
+            if (!user) {
+              defaultLog.info({ label: 'authenticate', message: `first creating new user ${id}` });
+              createUser(decoded, accountType, id)
+                .then(() => {
+                  getUserByKeycloakID(accountType, id)
+                    .then((newUser) => {
+                      user = newUser;
+                      resolve();
+                    })
+                    .catch((err: Error) => {
+                      reject(err);
+                    });
+                })
+                .catch((err: Error) => reject(err));
+            }
+            resolve();
+          });
+
+          createIfNeeded.then(() => {
+            req.authContext = {
+              preferredUsername: null,
+              friendlyUsername: null,
+              user: null,
+              roles: [],
+              filterForSelectable: false
+            };
+            req.authContext.preferredUsername = decoded?.preferred_username;
+            if (decoded?.idir_username) {
+              req.authContext.friendlyUsername = decoded.idir_username.toLowerCase() + '@idir';
+            }
+            if (decoded?.bceid_username) {
+              req.authContext.friendlyUsername = decoded.bceid_username.toLowerCase() + '@bceid-business';
+            }
+
+            req.authContext.filterForSelectable = filterForSelectable;
+            req.authContext.user = user;
+
+            MDC.request.user = req.authContext.preferredUsername || 'unresolved';
+
+            getRolesForUser(user.user_id)
+              .then((roles) => {
+                req.authContext.roles = roles;
+                MDC.additionalContext.authContext = req.authContext;
+              })
+              .catch((error: Error) => {
+                defaultLog.error({ label: 'authenticate', message: 'failed looking up roles', error });
+                reject(error);
+              })
               .then(() => {
-                getUserByKeycloakID(accountType, id)
-                  .then((newUser) => {
-                    user = newUser;
+                // check if user has beta access
+                getV2BetaAccessForUser(user.user_id)
+                  .then((betaAccess) => {
+                    defaultLog.debug({ label: 'authenticate', message: 'looked up v2beta', betaAccess });
+                    req.authContext.v2beta = betaAccess;
                     resolve();
                   })
-                  .catch((err: Error) => {
-                    reject(err);
+                  .catch((error: Error) => {
+                    defaultLog.error({ label: 'authenticate', message: 'failed looking up beta access', error });
+                    reject(error);
                   });
-              })
-              .catch((err: Error) => reject(err));
-          }
-          resolve();
-        });
-
-        createIfNeeded.then(() => {
-          req.authContext = {
-            preferredUsername: null,
-            friendlyUsername: null,
-            user: null,
-            roles: [],
-            filterForSelectable: false
-          };
-          req.authContext.preferredUsername = decoded?.preferred_username;
-          if (decoded?.idir_username) {
-            req.authContext.friendlyUsername = decoded.idir_username.toLowerCase() + '@idir';
-          }
-          if (decoded?.bceid_username) {
-            req.authContext.friendlyUsername = decoded.bceid_username.toLowerCase() + '@bceid-business';
-          }
-
-          req.authContext.filterForSelectable = filterForSelectable;
-          req.authContext.user = user;
-
-          MDC.request.user = req.authContext.preferredUsername || 'unresolved';
-
-          getRolesForUser(user.user_id)
-            .then((roles) => {
-              req.authContext.roles = roles;
-              MDC.additionalContext.authContext = req.authContext;
-            })
-            .catch((error: Error) => {
-              defaultLog.error({ label: 'authenticate', message: 'failed looking up roles', error });
-              reject(error);
-            })
-            .then(() => {
-              // check if user has beta access
-              getV2BetaAccessForUser(user.user_id)
-                .then((betaAccess) => {
-                  defaultLog.debug({ label: 'authenticate', message: 'looked up v2beta', betaAccess });
-                  req.authContext.v2beta = betaAccess;
-                  resolve();
-                })
-                .catch((error: Error) => {
-                  defaultLog.error({ label: 'authenticate', message: 'failed looking up beta access', error });
-                  reject(error);
-                });
-            });
-        });
-      });
+              });
+          });
+        })
+        .catch((err: Error) => reject(err));
     });
   });
 };

--- a/api/src/utils/auth-utils.ts
+++ b/api/src/utils/auth-utils.ts
@@ -17,6 +17,15 @@ const APP_CERTIFICATE_URL =
   process.env.APP_CERTIFICATE_URL ||
   'https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/certs';
 
+const rejectWithErr = (issue: string, code: number = 401) =>
+  new Error(issue, {
+    cause: {
+      code: code,
+      message: issue,
+      namespace: 'auth-utils'
+    }
+  });
+
 // so we have type information available to endpoints
 export interface InvasivesRequest extends Request {
   keycloakToken: any;
@@ -57,12 +66,12 @@ function retrieveKey(header, callback) {
   });
 }
 
-export const authenticate = async (req: InvasivesRequest) => {
+export const authenticate = async (req: InvasivesRequest): Promise<void> => {
   const MDC = MDCAsyncLocal.getStore();
 
   defaultLog.debug({ label: 'authenticate', message: 'authenticating user' });
 
-  const filterForSelectable = req.header('filterforselectable') === 'true' ? true : false;
+  const filterForSelectable = req.header('filterforselectable') === 'true';
   const authHeader = req.header('Authorization');
 
   const isPublicURL = [
@@ -81,11 +90,7 @@ export const authenticate = async (req: InvasivesRequest) => {
   } catch (error) {
     defaultLog.info({ label: 'authenticate', message: 'malformed auth token received' });
 
-    throw {
-      code: 400,
-      message: 'Authorization header parse failure',
-      namespace: 'auth-utils'
-    };
+    throw rejectWithErr('Authorization header parse failure', 400);
   }
 
   if (isPublicURL && (req.method === 'GET' || req.method === 'POST') && !token) {
@@ -104,91 +109,53 @@ export const authenticate = async (req: InvasivesRequest) => {
 
   if (!token) {
     defaultLog.info({ label: 'authenticate', message: 'missing or malformed auth token received' });
-
-    throw {
-      code: 401,
-      message: 'Authorization header parse failure',
-      namespace: 'auth-utils'
-    };
+    throw rejectWithErr('Authorization header parse failure');
   }
 
   return new Promise<void>((resolve, reject) => {
     verify(token, retrieveKey, {}, function (error, decoded: Record<string, any>) {
-      if (error) {
-        defaultLog.error({ label: 'authenticate', message: 'token verification failure', error });
-        reject({
-          code: 401,
-          message: 'Token decode failure',
-          namespace: 'auth-utils'
-        });
-        return;
+      if (!decoded || error) {
+        if (error) defaultLog.error({ label: 'authenticate', message: 'token verification failure', error });
+        reject(rejectWithErr('Token decode Failure'));
       }
-      if (!decoded) {
-        reject({
-          code: 401,
-          message: 'Token decode failure',
-          namespace: 'auth-utils'
-        });
-        return;
-      }
-
       req.keycloakToken = decoded;
 
       let accountType, id;
 
-      if (!decoded['identity_provider']) {
-        reject({
-          code: 401,
-          message: 'Invalid token - missing identity provider',
-          namespace: 'auth-utils'
-        });
-        return;
-      }
-
-      if (decoded.identity_provider === 'idir') {
+      if (decoded?.identity_provider === 'idir') {
         accountType = KeycloakAccountType.idir;
-        if (!decoded['idir_user_guid']) {
-          reject({
-            code: 401,
-            message: 'Invalid token - missing idir guid',
-            namespace: 'auth-utils'
-          });
-          return;
+        if (!decoded?.idir_user_guid) {
+          reject(rejectWithErr('Invalid token - missing idir guid'));
         }
         id = decoded.idir_user_guid;
       } else if (decoded.identity_provider === 'bceidbusiness') {
         accountType = KeycloakAccountType.bceid;
-        if (!decoded['bceid_user_guid']) {
-          reject({
-            code: 401,
-            message: 'Invalid token - missing bceid guid',
-            namespace: 'auth-utils'
-          });
-          return;
+        if (!decoded?.bceid_user_guid) {
+          reject(rejectWithErr('Invalid token - missing bceid guid'));
         }
         id = decoded.bceid_user_guid;
       } else {
-        reject({
-          code: 401,
-          message: 'Invalid token - missing idir_userid or bceid_userid',
-          namespace: 'auth-utils'
-        });
-        return;
+        reject(rejectWithErr('Invalid token - Missing idir_userid or bceid_userid'));
       }
 
       getUserByKeycloakID(accountType, id).then((user) => {
         const createIfNeeded = new Promise((resolve: any) => {
           if (!user) {
             defaultLog.info({ label: 'authenticate', message: `first creating new user ${id}` });
-            createUser(decoded, accountType, id).then(() => {
-              getUserByKeycloakID(accountType, id).then((newUser) => {
-                user = newUser;
-                resolve();
-              });
-            });
-          } else {
-            resolve();
+            createUser(decoded, accountType, id)
+              .then(() => {
+                getUserByKeycloakID(accountType, id)
+                  .then((newUser) => {
+                    user = newUser;
+                    resolve();
+                  })
+                  .catch((err: Error) => {
+                    reject(err);
+                  });
+              })
+              .catch((err: Error) => reject(err));
           }
+          resolve();
         });
 
         createIfNeeded.then(() => {
@@ -199,12 +166,12 @@ export const authenticate = async (req: InvasivesRequest) => {
             roles: [],
             filterForSelectable: false
           };
-          req.authContext.preferredUsername = decoded['preferred_username'];
-          if (decoded['idir_username']) {
-            req.authContext.friendlyUsername = decoded['idir_username'].toLowerCase() + '@idir';
+          req.authContext.preferredUsername = decoded?.preferred_username;
+          if (decoded?.idir_username) {
+            req.authContext.friendlyUsername = decoded.idir_username.toLowerCase() + '@idir';
           }
-          if (decoded['bceid_username']) {
-            req.authContext.friendlyUsername = decoded['bceid_username'].toLowerCase() + '@bceid-business';
+          if (decoded?.bceid_username) {
+            req.authContext.friendlyUsername = decoded.bceid_username.toLowerCase() + '@bceid-business';
           }
 
           req.authContext.filterForSelectable = filterForSelectable;
@@ -217,7 +184,7 @@ export const authenticate = async (req: InvasivesRequest) => {
               req.authContext.roles = roles;
               MDC.additionalContext.authContext = req.authContext;
             })
-            .catch((error) => {
+            .catch((error: Error) => {
               defaultLog.error({ label: 'authenticate', message: 'failed looking up roles', error });
               reject(error);
             })
@@ -227,10 +194,9 @@ export const authenticate = async (req: InvasivesRequest) => {
                 .then((betaAccess) => {
                   defaultLog.debug({ label: 'authenticate', message: 'looked up v2beta', betaAccess });
                   req.authContext.v2beta = betaAccess;
-                  //req.authContext.user.v2beta = betaAccess;
                   resolve();
                 })
-                .catch((error) => {
+                .catch((error: Error) => {
                   defaultLog.error({ label: 'authenticate', message: 'failed looking up beta access', error });
                   reject(error);
                 });

--- a/api/src/utils/user-utils.ts
+++ b/api/src/utils/user-utils.ts
@@ -10,23 +10,22 @@ export enum KeycloakAccountType {
   idir = 'idir',
   bceid = 'bceid'
 }
-
-export async function createUser(keycloakToken: any, accountType, id): Promise<any> {
-  defaultLog.debug({
-    message: 'Keycloak token in user-utils',
-    params: {
-      keycloakToken
+const rejectWithErr = (issue: string, code: number = 401) =>
+  new Error(issue, {
+    cause: {
+      code: code,
+      message: issue,
+      namespace: 'user-utils'
     }
   });
 
+export async function createUser(keycloakToken: any, accountType, id): Promise<any> {
+  defaultLog.debug({ message: 'Keycloak token in user-utils', params: { keycloakToken } });
   const connection = await getDBConnection();
+
   if (!connection) {
     defaultLog.error({ message: 'No connection!' });
-    throw {
-      code: 503,
-      message: 'Failed to establish database connection',
-      namespace: 'user-utils'
-    };
+    throw rejectWithErr('Failed to establish database connection', 503);
   }
   try {
     const sqlStatement: SQLStatement = createUserSQL(
@@ -35,66 +34,37 @@ export async function createUser(keycloakToken: any, accountType, id): Promise<a
       keycloakToken.preferred_username,
       keycloakToken.email
     );
-    defaultLog.debug({
-      message: 'SQL statement to create user',
-      sqlStatement
-    });
-    if (!sqlStatement) {
-      throw {
-        code: 500,
-        message: 'Failed to generate SQL statement',
-        namespace: 'user-utils'
-      };
-    }
+    defaultLog.debug({ message: 'SQL statement to create user', sqlStatement });
+    if (!sqlStatement) throw rejectWithErr('Failed to generate SQL statement', 500);
+
     const response = await connection.query(sqlStatement.text, sqlStatement.values);
-    const result = (response && response.rows) || null;
+    const result = response?.rows;
+
     return result;
   } catch (error) {
     defaultLog.debug({ label: 'create', message: 'error', error });
-    throw {
-      code: 500,
-      message: 'Failed to create user',
-      namespace: 'user-utils'
-    };
+    throw rejectWithErr('Failed to create user', 500);
   } finally {
     connection.release();
   }
 }
 
 export async function getUserByKeycloakID(accountType: KeycloakAccountType, id: string) {
-  defaultLog.debug({ label: '{' + accountType + '}', message: 'getUserByKeycloakID' });
+  defaultLog.debug({ label: `{${accountType}}`, message: 'getUserByKeycloakID' });
   const connection = await getDBConnection();
-  if (!connection) {
-    throw {
-      code: 503,
-      message: 'Failed to establish database connection',
-      namespace: 'user-utils'
-    };
-  }
+  if (!connection) throw rejectWithErr('Failed to establish database connection', 503);
+
   try {
     const sqlStatement: SQLStatement =
       accountType === KeycloakAccountType.idir ? getUserByIDIRSQL(id) : getUserByBCEIDSQL(id);
-    if (!sqlStatement) {
-      throw {
-        code: 400,
-        message: 'Failed to build SQL statement',
-        namespace: 'user-utils'
-      };
-    }
+    if (!sqlStatement) throw rejectWithErr('Failed to build SQL statement', 400);
+
     const response = await connection.query(sqlStatement.text, sqlStatement.values);
-    const result = (response && response.rows) || null;
-    if (result) {
-      return result[0];
-    } else {
-      return null;
-    }
+    const result = response?.rows;
+    return result?.[0];
   } catch (error) {
     defaultLog.debug({ label: 'getUserByKeycloakID', message: 'error', error });
-    throw {
-      code: 500,
-      message: 'Failed to get user by Keycloak ID',
-      namespace: 'user-utils'
-    };
+    throw rejectWithErr('Failed to get user by Keycloak ID', 500);
   } finally {
     connection.release();
   }
@@ -102,32 +72,16 @@ export async function getUserByKeycloakID(accountType: KeycloakAccountType, id: 
 
 export async function getRolesForUser(userId) {
   const connection = await getDBConnection();
-  if (!connection) {
-    throw {
-      code: 503,
-      message: 'Failed to establish database connection',
-      namespace: 'user-utils'
-    };
-  }
+  if (!connection) throw rejectWithErr('Failed to establish database connection', 503);
   try {
     const sqlStatement: SQLStatement = getRolesForUserSQL(userId);
-    if (!sqlStatement) {
-      throw {
-        code: 400,
-        message: 'Failed to build SQL statement',
-        namespace: 'user-utils'
-      };
-    }
+    if (!sqlStatement) throw rejectWithErr('Failed to build SQL statement', 400);
     const response = await connection.query(sqlStatement.text, sqlStatement.values);
-    const result = (response && response.rows) || null;
+    const result = response?.rows;
     return result;
   } catch (error) {
     defaultLog.debug({ label: 'getRolesForUser', message: 'error', error });
-    throw {
-      code: 500,
-      message: 'Failed to get roles for user',
-      namespace: 'user-utils'
-    };
+    throw rejectWithErr('Failed to get roles for user', 500);
   } finally {
     connection.release();
   }
@@ -135,35 +89,19 @@ export async function getRolesForUser(userId) {
 
 export async function getV2BetaAccessForUser(userId) {
   const connection = await getDBConnection();
-  if (!connection) {
-    throw {
-      code: 503,
-      message: 'Failed to establish database connection',
-      namespace: 'user-utils'
-    };
-  }
+  if (!connection) throw rejectWithErr('Failed to establish database connection', 503);
   try {
     const sqlStatement: SQLStatement = getBetaAccessForUserSQL(userId);
-    if (!sqlStatement) {
-      throw {
-        code: 400,
-        message: 'Failed to build SQL statement',
-        namespace: 'user-utils'
-      };
-    }
+    if (!sqlStatement) throw rejectWithErr('Failed to build SQL statement', 400);
+
     const response = await connection.query(sqlStatement.text, sqlStatement.values);
     defaultLog.debug({ label: 'getBetaAccessForUserSQL', message: 'v2access', response });
 
-    const result = (response?.rows?.[0]?.v2beta as unknown as boolean) || false;
-    defaultLog.debug({ label: 'getBetaAccessForUserSQL', message: 'v2access', result });
+    const result = !!response?.rows?.[0]?.v2beta;
     return result;
   } catch (error) {
     defaultLog.debug({ label: 'getBetaAccessForUserSQL', message: 'error', error });
-    throw {
-      code: 500,
-      message: 'Failed getBetaAccessForUserSQL',
-      namespace: 'user-utils'
-    };
+    throw rejectWithErr('Failed getBetaAccessForUserSQL', 500);
   } finally {
     connection.release();
   }


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- reduce all the error code in Auth to be more DRY using `rejectWithErr`
- Modify thrown objects to be errors instead of regular objects
- Handle Rejected Promises (Source of errors)
- Reduce code smells
- Closes #3808

Original User with issue was able to resolve their malformed tokens and they are in working order now, these changes help strengthen our API to handle these issues as they come in, and not break. 