### PR TITLE
[INV-3778] Apply Concurrency to Record downloads

### DIFF
--- a/app/src/utils/base-classes/BaseCacheService.ts
+++ b/app/src/utils/base-classes/BaseCacheService.ts
@@ -39,6 +39,29 @@ abstract class BaseCacheService<
     progressCallback?: (currentProgress: ProgressCallbackParams) => void
   ): Promise<CacheDownloadMode | void>;
 
+  /**
+   * @desc Concurrency helper. If one call fails, makes a second attempt before failing over.
+   * @param executing Promises in progress
+   * @param promiseFn Promises to Execute
+   */
+  protected async processNext(executing: Set<Promise<void>>, promiseFn: () => Promise<void>) {
+    const promise = promiseFn();
+    executing.add(promise);
+    try {
+      await promise;
+    } catch (e) {
+      console.error(e);
+      try {
+        await promise;
+      } catch (e) {
+        console.error('Failed second attempt at Promise');
+        throw e;
+      }
+    } finally {
+      executing.delete(promise);
+    }
+  }
+
   protected constructor() {}
 }
 

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -121,30 +121,6 @@ abstract class RecordCacheService extends BaseCacheService<
 
   abstract checkPauseOrAbort(id: string): Promise<CacheDownloadMode>;
 
-  /**
-   * @desc Concurrency helper for downloading Activity/IAPP records.
-   *       If one call fails, makes a second attempt before failing over.
-   * @param executing Promises in progress
-   * @param promiseFn Promise to Execute (Network Calls and DB Transaction)
-   */
-  private async processNext(executing: Set<Promise<void>>, promiseFn: () => Promise<void>) {
-    const promise = promiseFn();
-    executing.add(promise);
-    try {
-      await promise;
-    } catch (e) {
-      console.error(e);
-      try {
-        await promise;
-      } catch (e) {
-        console.error('Failed second attempt at fetching record');
-        throw e;
-      }
-    } finally {
-      executing.delete(promise);
-    }
-  }
-
   public async download(
     spec: CacheDownloadSpec,
     progressCallback?: (currentProgress: RecordCacheProgressCallbackParameters) => void

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -77,6 +77,8 @@ abstract class RecordCacheService extends BaseCacheService<
   RecordCacheProgressCallbackParameters,
   UserRecordCacheStatus
 > {
+  private readonly CONCURRENCY_LIMIT = 4;
+
   protected constructor() {
     super();
   }
@@ -118,6 +120,30 @@ abstract class RecordCacheService extends BaseCacheService<
   protected abstract createActivityRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata>;
 
   abstract checkPauseOrAbort(id: string): Promise<CacheDownloadMode>;
+
+  /**
+   * @desc Concurrency helper for downloading Activity/IAPP records.
+   *       If one call fails, makes a second attempt before failing over.
+   * @param executing Promises in progress
+   * @param promiseFn Promise to Execute (Network Calls and DB Transaction)
+   */
+  private async processNext(executing: Set<Promise<void>>, promiseFn: () => Promise<void>) {
+    const promise = promiseFn();
+    executing.add(promise);
+    try {
+      await promise;
+    } catch (e) {
+      console.error(e);
+      try {
+        await promise;
+      } catch (e) {
+        console.error('Failed second attempt at fetching record');
+        throw e;
+      }
+    } finally {
+      executing.delete(promise);
+    }
+  }
 
   public async download(
     spec: CacheDownloadSpec,
@@ -172,7 +198,6 @@ abstract class RecordCacheService extends BaseCacheService<
     } else if (downloadMode == CacheDownloadMode.ABORT) {
       this.deleteRepository(spec.setId);
     }
-
     return downloadMode;
   }
 
@@ -184,44 +209,53 @@ abstract class RecordCacheService extends BaseCacheService<
     spec: RecordCacheDownloadRequestSpec,
     progressCallback?: (currentProgress: RecordCacheProgressCallbackParameters) => void
   ): Promise<CacheDownloadMode> {
+    // IAPP Records use O(n*2) Requests compared to activities.
+    const IAPP_CONCURRENCY_LIMIT = Math.ceil(this.CONCURRENCY_LIMIT / 2);
+    const executing: Set<Promise<void>> = new Set();
+
     let pauseOrAbort: CacheDownloadMode = CacheDownloadMode.DEFAULT;
     let processedCaches = spec.processedActivities;
 
     let lastProgressCallback: null | number = null;
     let totalRecordsToCache = spec.idsToCache.length;
     let startIdx = spec.pausedActivityIdx == -1 ? 0 : spec.pausedActivityIdx;
-    for (let i = startIdx; i < spec.idsToCache.length && pauseOrAbort === CacheDownloadMode.DEFAULT; i++) {
-      const authorization = await getCurrentJWT();
-      const [iappRecord, tableRow] = await Promise.all([
-        fetch(
-          `${spec.API_BASE}/api/points-of-interest/?query={"iappSiteID":"${spec.idsToCache[i]}","isIAPP":true,"site_id_only":false}`,
-          { headers: { authorization } }
-        ).then(async (data) => await data.json()),
-        fetch(`${spec.API_BASE}/api/v2/IAPP/`, {
-          method: 'POST',
-          headers: { authorization, 'Content-type': 'application/json' },
-          body: JSON.stringify({
-            filterObjects: [
-              {
-                limit: 1,
-                recordSetType: RecordSetType.IAPP,
-                selectColumns: getSelectColumnsByRecordSetType(RecordSetType.IAPP),
-                tableFilters: [
-                  {
-                    field: 'site_id',
-                    filter: spec.idsToCache[i],
-                    filterType: 'tableFilter',
-                    operator: 'CONTAINS',
-                    operator2: 'AND'
-                  }
-                ]
-              }
-            ]
-          })
-        }).then(async (data) => await data.json())
-      ]);
-      await this.saveIapp(spec.idsToCache[i].toString(), iappRecord, tableRow);
 
+    for (let i = startIdx; i < spec.idsToCache.length && pauseOrAbort === CacheDownloadMode.DEFAULT; i++) {
+      if (executing.size >= IAPP_CONCURRENCY_LIMIT) {
+        await Promise.race(executing);
+      }
+      this.processNext(executing, async () => {
+        const authorization = await getCurrentJWT();
+        const [iappRecord, tableRow] = await Promise.all([
+          fetch(
+            `${spec.API_BASE}/api/points-of-interest/?query={"iappSiteID":"${spec.idsToCache[i]}","isIAPP":true,"site_id_only":false}`,
+            { headers: { authorization } }
+          ).then(async (data) => await data.json()),
+          fetch(`${spec.API_BASE}/api/v2/IAPP/`, {
+            method: 'POST',
+            headers: { authorization, 'Content-type': 'application/json' },
+            body: JSON.stringify({
+              filterObjects: [
+                {
+                  limit: 1,
+                  recordSetType: RecordSetType.IAPP,
+                  selectColumns: getSelectColumnsByRecordSetType(RecordSetType.IAPP),
+                  tableFilters: [
+                    {
+                      field: 'site_id',
+                      filter: spec.idsToCache[i],
+                      filterType: 'tableFilter',
+                      operator: 'CONTAINS',
+                      operator2: 'AND'
+                    }
+                  ]
+                }
+              ]
+            })
+          }).then(async (data) => await data.json())
+        ]);
+        await this.saveIapp(spec.idsToCache[i].toString(), iappRecord, tableRow);
+      });
       processedCaches++;
       const currentProgress = processedCaches / totalRecordsToCache;
 
@@ -248,6 +282,7 @@ abstract class RecordCacheService extends BaseCacheService<
         }
       }
     }
+    await Promise.all(executing);
     return pauseOrAbort;
   }
 
@@ -265,14 +300,21 @@ abstract class RecordCacheService extends BaseCacheService<
     let lastProgressCallback: null | number = null;
     let totalRecordsToCache = spec.idsToCache.length;
     let startIdx = spec.pausedActivityIdx == -1 ? 0 : spec.pausedActivityIdx;
-    for (let i = startIdx; i < spec.idsToCache.length && pauseOrAbort === CacheDownloadMode.DEFAULT; i++) {
-      const rez = await fetch(`${spec.API_BASE}/api/activity/${spec.idsToCache[i]}`, {
-        headers: {
-          Authorization: await getCurrentJWT()
-        }
-      });
-      await this.saveActivity(spec.idsToCache[i], await rez.json());
+    const executing: Set<Promise<void>> = new Set();
 
+    for (let i = startIdx; i < spec.idsToCache.length && pauseOrAbort === CacheDownloadMode.DEFAULT; i++) {
+      if (executing.size >= this.CONCURRENCY_LIMIT) {
+        await Promise.race(executing);
+      }
+
+      this.processNext(executing, async () => {
+        const rez = await fetch(`${spec.API_BASE}/api/activity/${spec.idsToCache[i]}`, {
+          headers: {
+            Authorization: await getCurrentJWT()
+          }
+        });
+        await this.saveActivity(spec.idsToCache[i], await rez.json());
+      });
       processedCaches++;
       const currentProgress = processedCaches / totalRecordsToCache;
 
@@ -299,7 +341,7 @@ abstract class RecordCacheService extends BaseCacheService<
         }
       }
     }
-
+    await Promise.all(executing);
     return pauseOrAbort;
   }
 

--- a/app/src/utils/tile-cache/index.ts
+++ b/app/src/utils/tile-cache/index.ts
@@ -126,23 +126,6 @@ abstract class TileCacheService extends BaseCacheService<
     spec: RepositoryDownloadRequestSpec,
     progressCallback?: (currentProgress: TileCacheProgressCallbackParameters) => void
   ): Promise<void> {
-    const processNext = async (promiseFn) => {
-      const promise = promiseFn();
-      executing.add(promise);
-      try {
-        await promise;
-      } catch (e) {
-        console.error(e);
-        try {
-          await promise;
-        } catch (e) {
-          console.error('Failed second attempt at fetching tile');
-        }
-      } finally {
-        executing.delete(promise);
-      }
-    };
-
     const CONCURRENCY_LIMIT = 10;
     const totalTiles = TileCacheService.computeTileCount(spec.bounds, spec.maxZoom);
     let abort = false;
@@ -150,7 +133,7 @@ abstract class TileCacheService extends BaseCacheService<
     let lastProgressCallback: null | number = null;
     let lastProgressCallbackTimestamp: number | null = null;
     const tileUrls: TilePromise[] = [];
-    const executing = new Set();
+    const executing = new Set<Promise<void>>();
 
     try {
       await this.addOrUpdateRepository({
@@ -180,7 +163,7 @@ abstract class TileCacheService extends BaseCacheService<
           await Promise.race(executing);
         }
 
-        processNext(promises[i]);
+        this.processNext(executing, promises[i]);
         processedTiles++;
         const currentProgress = processedTiles / totalTiles;
         const currTime = Date.now();


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Move `processNext` to BaseCacheService as protected member, removing from TileCache
- Add concurrency to Record Downloads 
- Closes #3778