### PR TITLE
[INV-3807] Stub Functionality for 'Plan My Trip'

### DIFF
--- a/app/src/UI/Overlay/TileCache/TileCacheCreationPanel.tsx
+++ b/app/src/UI/Overlay/TileCache/TileCacheCreationPanel.tsx
@@ -7,19 +7,12 @@ import TooltipWithIcon from 'UI/TooltipWithIcon/TooltipWithIcon';
 import CacheFileSize from './CacheFileSize';
 import { useTileSizeThresholds } from './tileSizeHook';
 import { APPROX_SIZE_PER_TILE, AVAILABLE_ZOOMS } from './constants';
-import WellCache from 'state/actions/cache/WellCache';
+import PlanMyTrip from 'state/actions/planMyTrip/PlanMyTrip';
 
 const TileCacheCreationPanel = () => {
   const handleDownload = () => {
-    if (!drawnShape) return;
-    dispatch(
-      TileCache.requestCaching({
-        description: cacheName ?? '',
-        bounds: drawnShape,
-        maxZoom: zoom
-      })
-    );
-    dispatch(WellCache.requestCaching(drawnShape));
+    if (!drawnShape || !cacheName) return;
+    dispatch(PlanMyTrip.create({ wellData: true, zoom: zoom, name: cacheName }));
     setCacheName('');
     setTimeout(() => {
       dispatch(TileCache.clearTileCacheShape());

--- a/app/src/UI/Overlay/TileCache/TileCacheListRow.tsx
+++ b/app/src/UI/Overlay/TileCache/TileCacheListRow.tsx
@@ -8,7 +8,7 @@ import { Delete, Edit, Visibility, VisibilityOff } from '@mui/icons-material';
 import Prompt from 'state/actions/prompts/Prompt';
 import { convertBytesToReadableString } from 'utils/tile-cache/helpers';
 import MapActions from 'state/actions/map';
-import WellCache from 'state/actions/cache/WellCache';
+import PlanMyTrip from 'state/actions/planMyTrip/PlanMyTrip';
 
 const TileCacheListRow = ({ metadata, visible }) => {
   const handleToggleVisibility = (id: string) => dispatch(MapActions.toggleOverlay(id));
@@ -31,9 +31,7 @@ const TileCacheListRow = ({ metadata, visible }) => {
   const handleDelete = () => {
     const callback = (confirmation: boolean) => {
       if (confirmation) {
-        // Migrate as part of in https://github.com/bcgov/invasivesbc/issues/3807
-        dispatch(WellCache.deleteRepository(metadata.bounds));
-        dispatch(TileCache.deleteRepository(metadata.id));
+        dispatch(PlanMyTrip.delete(metadata.id));
       }
     };
     dispatch(

--- a/app/src/state/actions/cache/TileCache.ts
+++ b/app/src/state/actions/cache/TileCache.ts
@@ -39,15 +39,16 @@ class TileCache {
         description: string;
         maxZoom: number;
         bounds: RepositoryBoundingBoxSpec;
-        id: string;
+        id?: string;
       },
       { dispatch }
     ) => {
       const service = await TileCacheServiceFactory.getPlatformInstance();
+      const id = spec.id ?? nanoid();
 
       await service.download(
         {
-          id: spec.id,
+          id: id,
           maxZoom: spec.maxZoom,
           bounds: spec.bounds,
           description: spec.description,

--- a/app/src/state/actions/cache/TileCache.ts
+++ b/app/src/state/actions/cache/TileCache.ts
@@ -39,15 +39,15 @@ class TileCache {
         description: string;
         maxZoom: number;
         bounds: RepositoryBoundingBoxSpec;
+        id: string;
       },
       { dispatch }
     ) => {
       const service = await TileCacheServiceFactory.getPlatformInstance();
-      const name = `cache-${nanoid()}`;
 
       await service.download(
         {
-          id: name,
+          id: spec.id,
           maxZoom: spec.maxZoom,
           bounds: spec.bounds,
           description: spec.description,

--- a/app/src/state/actions/cache/TileCache.ts
+++ b/app/src/state/actions/cache/TileCache.ts
@@ -44,7 +44,7 @@ class TileCache {
       { dispatch }
     ) => {
       const service = await TileCacheServiceFactory.getPlatformInstance();
-      const id = spec.id ?? nanoid();
+      const id = spec.id ?? `well-cache-${nanoid()}`;
 
       await service.download(
         {

--- a/app/src/state/actions/cache/WellCache.ts
+++ b/app/src/state/actions/cache/WellCache.ts
@@ -14,7 +14,7 @@ class WellCache {
     `${this.PREFIX}/requestCaching`,
 
     async (spec: { bounds: RepositoryBoundingBoxSpec; id?: string }, { getState }) => {
-      const id = spec.id ?? nanoid();
+      const id = spec.id ?? `well-records-${nanoid()}`;
       const state: RootState = getState() as RootState;
       const wellService = await WellCacheServiceFactory.getPlatformInstance();
 

--- a/app/src/state/actions/cache/WellCache.ts
+++ b/app/src/state/actions/cache/WellCache.ts
@@ -1,4 +1,4 @@
-import { createAsyncThunk } from '@reduxjs/toolkit';
+import { createAsyncThunk, nanoid } from '@reduxjs/toolkit';
 import { RootState } from 'state/reducers/rootReducer';
 import { RepositoryBoundingBoxSpec } from 'utils/tile-cache';
 import { WellCacheServiceFactory } from 'utils/well-cache/context';
@@ -13,13 +13,15 @@ class WellCache {
   static readonly requestCaching = createAsyncThunk(
     `${this.PREFIX}/requestCaching`,
 
-    async (spec: { bounds: RepositoryBoundingBoxSpec; id: string }, { getState }) => {
+    async (spec: { bounds: RepositoryBoundingBoxSpec; id?: string }, { getState }) => {
+      const id = spec.id ?? nanoid();
       const state: RootState = getState() as RootState;
       const wellService = await WellCacheServiceFactory.getPlatformInstance();
+
       await wellService.download({
         API_BASE: state.Configuration.current.API_BASE,
         bounds: spec.bounds,
-        id: spec.id
+        id: id
       });
     }
   );

--- a/app/src/state/actions/cache/WellCache.ts
+++ b/app/src/state/actions/cache/WellCache.ts
@@ -13,12 +13,13 @@ class WellCache {
   static readonly requestCaching = createAsyncThunk(
     `${this.PREFIX}/requestCaching`,
 
-    async (bounds: RepositoryBoundingBoxSpec, { getState }) => {
+    async (spec: { bounds: RepositoryBoundingBoxSpec; id: string }, { getState }) => {
       const state: RootState = getState() as RootState;
       const wellService = await WellCacheServiceFactory.getPlatformInstance();
       await wellService.download({
         API_BASE: state.Configuration.current.API_BASE,
-        bounds
+        bounds: spec.bounds,
+        id: spec.id
       });
     }
   );

--- a/app/src/state/actions/planMyTrip/PlanMyTrip.ts
+++ b/app/src/state/actions/planMyTrip/PlanMyTrip.ts
@@ -6,38 +6,48 @@ import { RepositoryBoundingBoxSpec } from 'utils/tile-cache';
 
 /**
  * @desc Parameters for a user planning their trip
- * @property { boolean } iapp include download for IAPP records
+ * @property { boolean } [activities] include download for Activity records
+ * @property { boolean } [iapp] include download for IAPP records
  * @property { string } name non-unique user friendly identifier
+ * @property { number } [zoom] Zoom level for caching Map tile data
+ * @property { boolean } [wellData] include Well Data for area.
+ * @property { boolean } [wmsLayers] include currently toggled WMS layers in dataset.
  */
 export interface ICreateMyTrip {
+  activities?: boolean;
   iapp?: boolean;
   name: string;
-  records?: boolean;
+  zoom?: number;
   wellData?: boolean;
   wmsLayers?: boolean;
-  zoom: number;
 }
 
 class PlanMyTrip {
   static readonly PREFIX = 'PlanMyTrip';
 
+  /**
+   * @desc Calls the caching mechanisms synchronously to avoid overloading our concurrent calls.
+   *       Creates and uses a common ID to track all sub-caches during the delete.
+   * @param { ICreateMyTrip } spec Trip details with boolean flags for datasets requested.
+   */
   static readonly create = createAsyncThunk(
     `${this.PREFIX}/create`,
     async (spec: ICreateMyTrip, { dispatch, getState }) => {
       const tripId = `pmt-${nanoid()}`;
       const state: RootState = getState() as RootState;
-
       if (!state.TileCache?.drawnShapeBounds) throw Error('No shape for Trip');
 
       const shape = state.TileCache.drawnShapeBounds as RepositoryBoundingBoxSpec;
-      await dispatch(
-        TileCache.requestCaching({
-          description: spec.name,
-          id: tripId,
-          bounds: shape,
-          maxZoom: spec.zoom
-        })
-      );
+      if (spec?.zoom) {
+        await dispatch(
+          TileCache.requestCaching({
+            description: spec.name,
+            id: tripId,
+            bounds: shape,
+            maxZoom: spec.zoom
+          })
+        );
+      }
       if (spec?.wellData) {
         await dispatch(
           WellCache.requestCaching({
@@ -49,9 +59,12 @@ class PlanMyTrip {
     }
   );
 
+  /**
+   * @desc Delete a Planned Trip and all of its subcaches synchronously.
+   */
   static readonly delete = createAsyncThunk(`${this.PREFIX}/delete`, async (id: string, { dispatch }) => {
-    await dispatch(WellCache.deleteRepository(id));
-    await dispatch(TileCache.deleteRepository(id));
+    dispatch(WellCache.deleteRepository(id));
+    dispatch(TileCache.deleteRepository(id));
   });
 }
 export default PlanMyTrip;

--- a/app/src/state/actions/planMyTrip/PlanMyTrip.ts
+++ b/app/src/state/actions/planMyTrip/PlanMyTrip.ts
@@ -6,12 +6,12 @@ import { RepositoryBoundingBoxSpec } from 'utils/tile-cache';
 
 /**
  * @desc Parameters for a user planning their trip
- * @property { boolean } [activities] include download for Activity records
- * @property { boolean } [iapp] include download for IAPP records
+ * @property { boolean } [ activities ] include download for Activity records
+ * @property { boolean } [ iapp ] include download for IAPP records
  * @property { string } name non-unique user friendly identifier
- * @property { number } [zoom] Zoom level for caching Map tile data
- * @property { boolean } [wellData] include Well Data for area.
- * @property { boolean } [wmsLayers] include currently toggled WMS layers in dataset.
+ * @property { boolean } [ wellData ] include Well Data for area.
+ * @property { boolean } [ wmsLayers ] include currently toggled WMS layers in dataset.
+ * @property { number } [ zoom ] Zoom level for caching Map tile data
  */
 export interface ICreateMyTrip {
   activities?: boolean;

--- a/app/src/state/actions/planMyTrip/PlanMyTrip.ts
+++ b/app/src/state/actions/planMyTrip/PlanMyTrip.ts
@@ -1,0 +1,57 @@
+import { createAsyncThunk, nanoid } from '@reduxjs/toolkit';
+import TileCache from '../cache/TileCache';
+import { RootState } from 'state/reducers/rootReducer';
+import WellCache from '../cache/WellCache';
+import { RepositoryBoundingBoxSpec } from 'utils/tile-cache';
+
+/**
+ * @desc Parameters for a user planning their trip
+ * @property { boolean } iapp include download for IAPP records
+ * @property { string } name non-unique user friendly identifier
+ */
+export interface ICreateMyTrip {
+  iapp?: boolean;
+  name: string;
+  records?: boolean;
+  wellData?: boolean;
+  wmsLayers?: boolean;
+  zoom: number;
+}
+
+class PlanMyTrip {
+  static readonly PREFIX = 'PlanMyTrip';
+
+  static readonly create = createAsyncThunk(
+    `${this.PREFIX}/create`,
+    async (spec: ICreateMyTrip, { dispatch, getState }) => {
+      const tripId = `pmt-${nanoid()}`;
+      const state: RootState = getState() as RootState;
+
+      if (!state.TileCache?.drawnShapeBounds) throw Error('No shape for Trip');
+
+      const shape = state.TileCache.drawnShapeBounds as RepositoryBoundingBoxSpec;
+      await dispatch(
+        TileCache.requestCaching({
+          description: spec.name,
+          id: tripId,
+          bounds: shape,
+          maxZoom: spec.zoom
+        })
+      );
+      if (spec?.wellData) {
+        await dispatch(
+          WellCache.requestCaching({
+            bounds: shape,
+            id: tripId
+          })
+        );
+      }
+    }
+  );
+
+  static readonly delete = createAsyncThunk(`${this.PREFIX}/delete`, async (id: string, { dispatch }) => {
+    await dispatch(WellCache.deleteRepository(id));
+    await dispatch(TileCache.deleteRepository(id));
+  });
+}
+export default PlanMyTrip;

--- a/app/src/utils/well-cache/index.ts
+++ b/app/src/utils/well-cache/index.ts
@@ -1,4 +1,3 @@
-import { nanoid } from '@reduxjs/toolkit';
 import booleanIntersects from '@turf/boolean-intersects';
 import { Feature, FeatureCollection } from '@turf/helpers';
 import WellData from 'interfaces/WellData';
@@ -16,8 +15,9 @@ export interface IWellRepositoryMetadata {
 }
 
 export interface IWellRepositoryDownloadRequestSpec {
-  bounds: RepositoryBoundingBoxSpec;
   API_BASE: string;
+  bounds: RepositoryBoundingBoxSpec;
+  id: string;
 }
 
 export interface IWellCacheProgressCallbackParameters {
@@ -97,7 +97,6 @@ abstract class WellCacheService extends BaseCacheService<
     spec: IWellRepositoryDownloadRequestSpec,
     progressCallback?: ((currentProgress: IWellCacheProgressCallbackParameters) => void) | undefined
   ): Promise<void> {
-    const id = `well-records-${nanoid()}`;
     const WELL_WFS_LAYER = 'WHSE_WATER_MANAGEMENT.GW_WATER_WELLS_WRBC_SVW';
     const url = encodeURIComponent(buildURLForDataBC(WELL_WFS_LAYER, bboxToPolygon(spec.bounds), true));
     const response = await (await fetch(`${spec.API_BASE}/api/map-shaper?url=${url}&percentage=0.02`)).json();
@@ -110,16 +109,16 @@ abstract class WellCacheService extends BaseCacheService<
 
     await this.addOrUpdateRepository({
       bounds: spec.bounds,
-      id: id,
+      id: spec.id,
       status: WellRepositoryStatus.DOWNLOADING,
       wellTagNumbers: wellTagNumbers
     });
 
     await this.saveWells(wellsToCache, progressCallback);
-    const featureCollection = await this.createFeatureCollectionFromMetadata(id);
+    const featureCollection = await this.createFeatureCollectionFromMetadata(spec.id);
     await this.addOrUpdateRepository({
       bounds: spec.bounds,
-      id: id,
+      id: spec.id,
       status: WellRepositoryStatus.CACHED,
       wellTagNumbers: wellTagNumbers,
       cachedGeoJson: featureCollection


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):
- Stub `Plan My Trip` amalgamation of Caching functionality
- Convert the current Map/Well cache calls to PlanMyTrip in the meantime (no other way to cache well data)
- Add Override able id key for Map and Well Caching, so they can share a common thread for Trip planning build/teardown
- Closes #3807