### PR TITLE
[INV-3823] Implement getRepositoryStatistics in SQLite

### DIFF
--- a/app/src/utils/tile-cache/sqlite-cache.ts
+++ b/app/src/utils/tile-cache/sqlite-cache.ts
@@ -172,7 +172,26 @@ class SQLiteTileCacheService extends TileCacheService {
   }
 
   async getRepositoryStatistics(id: string): Promise<RepositoryStatistics> {
-    throw new Error('unimplemented');
+    if (this.cacheDB == null) {
+      throw new Error('cache not available');
+    }
+
+    const results = await this.cacheDB.query(
+      //language=SQLite
+      `SELECT DATA
+      FROM CACHED_TILES
+      WHERE TILESET = ?`,
+      [id]
+    );
+    let sizeInBytes = 0;
+    const numberOfTiles = results?.values?.length ?? 0;
+    results?.values?.forEach((tile) => {
+      sizeInBytes += tile['DATA'].length ?? 0;
+    });
+    return {
+      sizeInBytes: sizeInBytes,
+      tileCount: numberOfTiles
+    };
   }
 
   public async updateDescription(repository: string, newDescription: string) {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):
- Populates the `TileCount` and `CacheSize` fields in the `Downloaded Maps` section of app
- Closes #3823

![image](https://github.com/user-attachments/assets/0702f409-8465-4864-8587-1dd7b060afc7)
