### PR TITLE
[INV-3795] Prefilter Records before caching to remove duplicates

### DIFF
--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -22,7 +22,7 @@ class RecordCache {
   });
 
   static readonly downloadProgressEvent = createAction<RecordCacheProgressCallbackParameters>(
-    'RECORD_CACHE_DOWNLOAD_PROGRESS_EVENT'
+    `${this.PREFIX}/downloadProgressEvent`
   );
 
   static readonly pauseDownload = createAsyncThunk(`${this.PREFIX}/pauseDownload`, async (spec: { setId: string }) => {

--- a/app/src/state/actions/cache/TileCache.ts
+++ b/app/src/state/actions/cache/TileCache.ts
@@ -13,7 +13,7 @@ class TileCache {
   static readonly clearTileCacheShape = createAction(`${this.PREFIX}/clearShape`);
 
   static readonly downloadProgressEvent = createAction<TileCacheProgressCallbackParameters>(
-    'TILE_CACHE_DOWNLOAD_PROGRESS_EVENT'
+    `${this.PREFIX}/downloadProgressEvent`
   );
 
   static readonly repositoryList = createAsyncThunk(`${this.PREFIX}/repoList`, async () => {

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -1,8 +1,8 @@
+import { GeoJSONSourceSpecification } from 'maplibre-gl';
 import IappRecord from 'interfaces/IappRecord';
 import IappTableRow from 'interfaces/IappTableRecord';
 import UserRecord from 'interfaces/UserRecord';
 import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
-import { GeoJSONSourceSpecification } from 'maplibre-gl';
 import { getCurrentJWT } from 'state/sagas/auth/auth';
 import { getSelectColumnsByRecordSetType } from 'state/sagas/map/dataAccess';
 import BaseCacheService from 'utils/base-classes/BaseCacheService';
@@ -111,6 +111,8 @@ abstract class RecordCacheService extends BaseCacheService<
     limit: number
   ): Promise<IappRecord[]>;
 
+  protected abstract getAllCachedIds(): Promise<string[]>;
+
   public abstract isCached(repositoryId: string): Promise<boolean>;
 
   public abstract getIdList(repositoryId: string): Promise<string[]>;
@@ -133,7 +135,7 @@ abstract class RecordCacheService extends BaseCacheService<
       processedActivities: spec.processedActivities
     };
 
-    let responseData: Record<PropertyKey, any> = {
+    const responseData: Record<PropertyKey, any> = {
       cachedGeoJSON: null,
       cachedCentroid: null
     };
@@ -188,15 +190,14 @@ abstract class RecordCacheService extends BaseCacheService<
     // IAPP Records use O(n*2) Requests compared to activities.
     const IAPP_CONCURRENCY_LIMIT = Math.ceil(this.CONCURRENCY_LIMIT / 2);
     const executing: Set<Promise<void>> = new Set();
-
+    const uncachedRecords = await this.filterIds('exclusive', spec.idsToCache);
+    const lengthDifference = spec.idsToCache.length - uncachedRecords.length;
     let pauseOrAbort: CacheDownloadMode = CacheDownloadMode.DEFAULT;
     let processedCaches = spec.processedActivities;
+    const lastProgressCallback: null | number = null;
+    const totalRecordsToCache = uncachedRecords.length;
 
-    let lastProgressCallback: null | number = null;
-    let totalRecordsToCache = spec.idsToCache.length;
-    let startIdx = spec.pausedActivityIdx == -1 ? 0 : spec.pausedActivityIdx;
-
-    for (let i = startIdx; i < spec.idsToCache.length && pauseOrAbort === CacheDownloadMode.DEFAULT; i++) {
+    for (let i = 0; i < uncachedRecords.length && pauseOrAbort === CacheDownloadMode.DEFAULT; i++) {
       if (executing.size >= IAPP_CONCURRENCY_LIMIT) {
         await Promise.race(executing);
       }
@@ -204,7 +205,7 @@ abstract class RecordCacheService extends BaseCacheService<
         const authorization = await getCurrentJWT();
         const [iappRecord, tableRow] = await Promise.all([
           fetch(
-            `${spec.API_BASE}/api/points-of-interest/?query={"iappSiteID":"${spec.idsToCache[i]}","isIAPP":true,"site_id_only":false}`,
+            `${spec.API_BASE}/api/points-of-interest/?query={"iappSiteID":"${uncachedRecords[i]}","isIAPP":true,"site_id_only":false}`,
             { headers: { authorization } }
           ).then(async (data) => await data.json()),
           fetch(`${spec.API_BASE}/api/v2/IAPP/`, {
@@ -219,7 +220,7 @@ abstract class RecordCacheService extends BaseCacheService<
                   tableFilters: [
                     {
                       field: 'site_id',
-                      filter: spec.idsToCache[i],
+                      filter: uncachedRecords[i],
                       filterType: 'tableFilter',
                       operator: 'CONTAINS',
                       operator2: 'AND'
@@ -230,7 +231,7 @@ abstract class RecordCacheService extends BaseCacheService<
             })
           }).then(async (data) => await data.json())
         ]);
-        await this.saveIapp(spec.idsToCache[i].toString(), iappRecord, tableRow);
+        await this.saveIapp(uncachedRecords[i].toString(), iappRecord, tableRow);
       });
       processedCaches++;
       const currentProgress = processedCaches / totalRecordsToCache;
@@ -247,11 +248,11 @@ abstract class RecordCacheService extends BaseCacheService<
           progressCallback({
             setId: spec.setId,
             message: !pauseOrAbort
-              ? `${processedCaches.toLocaleString()}/${totalRecordsToCache.toLocaleString()} Records`
+              ? `${(processedCaches + lengthDifference).toLocaleString()}/${(totalRecordsToCache + lengthDifference).toLocaleString()} Records`
               : `Mode: ${pauseOrAbort.toLocaleString().toUpperCase()} Caching`,
             downloadMode: pauseOrAbort,
             pausedActivityIdx: pauseOrAbort !== CacheDownloadMode.PAUSE ? -1 : i + 1,
-            normalizedProgress: processedCaches / totalRecordsToCache,
+            normalizedProgress: (processedCaches + lengthDifference) / (totalRecordsToCache + lengthDifference),
             totalActivities: totalRecordsToCache,
             processedActivities: processedCaches
           });
@@ -270,26 +271,27 @@ abstract class RecordCacheService extends BaseCacheService<
     spec: RecordCacheDownloadRequestSpec,
     progressCallback?: (currentProgress: RecordCacheProgressCallbackParameters) => void
   ): Promise<CacheDownloadMode> {
+    const executing: Set<Promise<void>> = new Set();
+    const uncachedRecords = await this.filterIds('exclusive', spec.idsToCache);
+    const lengthDifference = spec.idsToCache.length - uncachedRecords.length;
+
     let pauseOrAbort: CacheDownloadMode = CacheDownloadMode.DEFAULT;
     let processedCaches = spec.processedActivities;
+    const lastProgressCallback: null | number = null;
+    const totalRecordsToCache = uncachedRecords.length;
 
-    let lastProgressCallback: null | number = null;
-    let totalRecordsToCache = spec.idsToCache.length;
-    let startIdx = spec.pausedActivityIdx == -1 ? 0 : spec.pausedActivityIdx;
-    const executing: Set<Promise<void>> = new Set();
-
-    for (let i = startIdx; i < spec.idsToCache.length && pauseOrAbort === CacheDownloadMode.DEFAULT; i++) {
+    for (let i = 0; i < uncachedRecords.length && pauseOrAbort === CacheDownloadMode.DEFAULT; i++) {
       if (executing.size >= this.CONCURRENCY_LIMIT) {
         await Promise.race(executing);
       }
 
       this.processNext(executing, async () => {
-        const rez = await fetch(`${spec.API_BASE}/api/activity/${spec.idsToCache[i]}`, {
+        const rez = await fetch(`${spec.API_BASE}/api/activity/${uncachedRecords[i]}`, {
           headers: {
             Authorization: await getCurrentJWT()
           }
         });
-        await this.saveActivity(spec.idsToCache[i], await rez.json());
+        await this.saveActivity(uncachedRecords[i], await rez.json());
       });
       processedCaches++;
       const currentProgress = processedCaches / totalRecordsToCache;
@@ -302,10 +304,10 @@ abstract class RecordCacheService extends BaseCacheService<
       ) {
         pauseOrAbort = await this.checkPauseOrAbort(spec.setId);
 
-        let normalizedProgress = processedCaches / totalRecordsToCache;
-        let progressLabel =
+        const normalizedProgress = (processedCaches + lengthDifference) / (totalRecordsToCache + lengthDifference);
+        const progressLabel =
           normalizedProgress * 100 < 1
-            ? `${processedCaches.toLocaleString()}/${totalRecordsToCache.toLocaleString()} Records`
+            ? `${(processedCaches + lengthDifference).toLocaleString()}/${(totalRecordsToCache + lengthDifference).toLocaleString()} Records`
             : `${Math.round(normalizedProgress * 100)}% completed`;
 
         if (progressCallback) {
@@ -323,6 +325,25 @@ abstract class RecordCacheService extends BaseCacheService<
     }
     await Promise.all(executing);
     return pauseOrAbort;
+  }
+
+  /**
+   * @desc compare list of Ids against currently stored keys
+   * @param filterMode if response should contain list of supplied Ids
+   * @param idsToCache Ids to be measured against the database
+   * @returns List of IDs [not] currently contained stored the local database
+   */
+  protected async filterIds(filterMode: 'inclusive' | 'exclusive', idsToCache: Array<string>) {
+    const ids: Record<PropertyKey, number> = {};
+    (await this.getAllCachedIds()).forEach((id) => {
+      ids[id] ??= 0;
+      ids[id]++;
+    });
+
+    if (filterMode === 'inclusive') {
+      return idsToCache.filter((id) => !!ids[id]);
+    }
+    return idsToCache.filter((id) => !ids[id]);
   }
 
   public async stopDownload(repositoryId: string): Promise<void> {

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -193,7 +193,7 @@ abstract class RecordCacheService extends BaseCacheService<
     const uncachedRecords = await this.filterIds('exclusive', spec.idsToCache);
     const lengthDifference = spec.idsToCache.length - uncachedRecords.length;
     let pauseOrAbort: CacheDownloadMode = CacheDownloadMode.DEFAULT;
-    let processedCaches = spec.processedActivities;
+    let processedCaches = lengthDifference;
     const lastProgressCallback: null | number = null;
     const totalRecordsToCache = uncachedRecords.length;
 
@@ -248,11 +248,11 @@ abstract class RecordCacheService extends BaseCacheService<
           progressCallback({
             setId: spec.setId,
             message: !pauseOrAbort
-              ? `${(processedCaches + lengthDifference).toLocaleString()}/${(totalRecordsToCache + lengthDifference).toLocaleString()} Records`
+              ? `${processedCaches.toLocaleString()}/${(totalRecordsToCache + lengthDifference).toLocaleString()} Records`
               : `Mode: ${pauseOrAbort.toLocaleString().toUpperCase()} Caching`,
             downloadMode: pauseOrAbort,
             pausedActivityIdx: pauseOrAbort !== CacheDownloadMode.PAUSE ? -1 : i + 1,
-            normalizedProgress: (processedCaches + lengthDifference) / (totalRecordsToCache + lengthDifference),
+            normalizedProgress: processedCaches / (totalRecordsToCache + lengthDifference),
             totalActivities: totalRecordsToCache,
             processedActivities: processedCaches
           });
@@ -274,9 +274,8 @@ abstract class RecordCacheService extends BaseCacheService<
     const executing: Set<Promise<void>> = new Set();
     const uncachedRecords = await this.filterIds('exclusive', spec.idsToCache);
     const lengthDifference = spec.idsToCache.length - uncachedRecords.length;
-
     let pauseOrAbort: CacheDownloadMode = CacheDownloadMode.DEFAULT;
-    let processedCaches = spec.processedActivities;
+    let processedCaches = lengthDifference;
     const lastProgressCallback: null | number = null;
     const totalRecordsToCache = uncachedRecords.length;
 
@@ -287,9 +286,7 @@ abstract class RecordCacheService extends BaseCacheService<
 
       this.processNext(executing, async () => {
         const rez = await fetch(`${spec.API_BASE}/api/activity/${uncachedRecords[i]}`, {
-          headers: {
-            Authorization: await getCurrentJWT()
-          }
+          headers: { Authorization: await getCurrentJWT() }
         });
         await this.saveActivity(uncachedRecords[i], await rez.json());
       });
@@ -304,10 +301,10 @@ abstract class RecordCacheService extends BaseCacheService<
       ) {
         pauseOrAbort = await this.checkPauseOrAbort(spec.setId);
 
-        const normalizedProgress = (processedCaches + lengthDifference) / (totalRecordsToCache + lengthDifference);
+        const normalizedProgress = processedCaches / (totalRecordsToCache + lengthDifference);
         const progressLabel =
           normalizedProgress * 100 < 1
-            ? `${(processedCaches + lengthDifference).toLocaleString()}/${(totalRecordsToCache + lengthDifference).toLocaleString()} Records`
+            ? `${processedCaches.toLocaleString()}/${(totalRecordsToCache + lengthDifference).toLocaleString()} Records`
             : `${Math.round(normalizedProgress * 100)}% completed`;
 
         if (progressCallback) {

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -191,11 +191,10 @@ abstract class RecordCacheService extends BaseCacheService<
     const IAPP_CONCURRENCY_LIMIT = Math.ceil(this.CONCURRENCY_LIMIT / 2);
     const executing: Set<Promise<void>> = new Set();
     const uncachedRecords = await this.filterIds('exclusive', spec.idsToCache);
-    const lengthDifference = spec.idsToCache.length - uncachedRecords.length;
     let pauseOrAbort: CacheDownloadMode = CacheDownloadMode.DEFAULT;
-    let processedCaches = lengthDifference;
+    let processedCaches = spec.idsToCache.length - uncachedRecords.length;
     const lastProgressCallback: null | number = null;
-    const totalRecordsToCache = uncachedRecords.length;
+    const totalRecordsToCache = spec.idsToCache.length;
 
     for (let i = 0; i < uncachedRecords.length && pauseOrAbort === CacheDownloadMode.DEFAULT; i++) {
       if (executing.size >= IAPP_CONCURRENCY_LIMIT) {
@@ -248,11 +247,11 @@ abstract class RecordCacheService extends BaseCacheService<
           progressCallback({
             setId: spec.setId,
             message: !pauseOrAbort
-              ? `${processedCaches.toLocaleString()}/${(totalRecordsToCache + lengthDifference).toLocaleString()} Records`
+              ? `${processedCaches.toLocaleString()}/${totalRecordsToCache.toLocaleString()} Records`
               : `Mode: ${pauseOrAbort.toLocaleString().toUpperCase()} Caching`,
             downloadMode: pauseOrAbort,
             pausedActivityIdx: pauseOrAbort !== CacheDownloadMode.PAUSE ? -1 : i + 1,
-            normalizedProgress: processedCaches / (totalRecordsToCache + lengthDifference),
+            normalizedProgress: processedCaches / totalRecordsToCache,
             totalActivities: totalRecordsToCache,
             processedActivities: processedCaches
           });
@@ -273,11 +272,10 @@ abstract class RecordCacheService extends BaseCacheService<
   ): Promise<CacheDownloadMode> {
     const executing: Set<Promise<void>> = new Set();
     const uncachedRecords = await this.filterIds('exclusive', spec.idsToCache);
-    const lengthDifference = spec.idsToCache.length - uncachedRecords.length;
     let pauseOrAbort: CacheDownloadMode = CacheDownloadMode.DEFAULT;
-    let processedCaches = lengthDifference;
+    let processedCaches = spec.idsToCache.length - uncachedRecords.length;
     const lastProgressCallback: null | number = null;
-    const totalRecordsToCache = uncachedRecords.length;
+    const totalRecordsToCache = spec.idsToCache.length;
 
     for (let i = 0; i < uncachedRecords.length && pauseOrAbort === CacheDownloadMode.DEFAULT; i++) {
       if (executing.size >= this.CONCURRENCY_LIMIT) {
@@ -301,10 +299,10 @@ abstract class RecordCacheService extends BaseCacheService<
       ) {
         pauseOrAbort = await this.checkPauseOrAbort(spec.setId);
 
-        const normalizedProgress = processedCaches / (totalRecordsToCache + lengthDifference);
+        const normalizedProgress = processedCaches / totalRecordsToCache;
         const progressLabel =
           normalizedProgress * 100 < 1
-            ? `${processedCaches.toLocaleString()}/${(totalRecordsToCache + lengthDifference).toLocaleString()} Records`
+            ? `${processedCaches.toLocaleString()}/${totalRecordsToCache.toLocaleString()} Records`
             : `${Math.round(normalizedProgress * 100)}% completed`;
 
         if (progressCallback) {

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -1,6 +1,7 @@
-import UserRecord from 'interfaces/UserRecord';
 import localForage from 'localforage';
 import centroid from '@turf/centroid';
+import { Feature } from '@turf/helpers';
+import { GeoJSONSourceSpecification } from 'maplibre-gl';
 import {
   IappRecordMode,
   RepositoryMetadata,
@@ -8,11 +9,10 @@ import {
   RecordSetSourceMetadata,
   CacheDownloadMode
 } from 'utils/record-cache/index';
-import { Feature } from '@turf/helpers';
-import { GeoJSONSourceSpecification } from 'maplibre-gl';
+import UserRecord from 'interfaces/UserRecord';
 import IappRecord from 'interfaces/IappRecord';
 import IappTableRow from 'interfaces/IappTableRecord';
-import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
+import { UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 
 class LocalForageRecordCacheService extends RecordCacheService {
   private static _instance: LocalForageRecordCacheService;
@@ -221,7 +221,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
     return { cachedCentroid, cachedGeoJson };
   }
 
-  async deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void> {
+  override async deleteCachedRecordsFromIds(idsToDelete: string[]): Promise<void> {
     if (this.store == null) {
       throw new Error('cache not available');
     }
@@ -255,11 +255,18 @@ class LocalForageRecordCacheService extends RecordCacheService {
         ids[id]++;
       });
     const recordsToErase = deleteList.filter((id) => ids[id] === 1);
-    this.deleteCachedRecordsFromIds(recordsToErase, cachedSets[foundIndex].recordSetType);
+    this.deleteCachedRecordsFromIds(recordsToErase);
     cachedSets.splice(foundIndex, 1);
     await this.store.setItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY, cachedSets);
   }
 
+  protected async getAllCachedIds(): Promise<string[]> {
+    if (this.store == null) {
+      throw new Error('cache not available');
+    }
+    const keys = (await this.store.keys()) ?? [];
+    return keys.filter((key) => key !== LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY);
+  }
   /**
    * @desc Create or Update an entry in the cachedSet Repository
    * @param newSet Data to update

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -1,11 +1,11 @@
 import { SQLiteConnection, SQLiteDBConnection } from '@capacitor-community/sqlite';
 import centroid from '@turf/centroid';
 import { Feature } from '@turf/helpers';
+import { GeoJSONSourceSpecification } from 'maplibre-gl';
 import IappRecord from 'interfaces/IappRecord';
 import IappTableRow from 'interfaces/IappTableRecord';
 import UserRecord from 'interfaces/UserRecord';
 import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
-import { GeoJSONSourceSpecification } from 'maplibre-gl';
 import {
   IappRecordMode,
   RepositoryMetadata,
@@ -508,6 +508,29 @@ class SQLiteRecordCacheService extends RecordCacheService {
       await this.cacheDB.rollbackTransaction();
       throw e;
     }
+  }
+
+  protected async getAllCachedIds(): Promise<string[]> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const [act, iapp] = await Promise.all([
+      (
+        await this.cacheDB.query(
+          //language=SQLite
+          `SELECT ID
+      FROM CACHED_RECORDS`
+        )
+      )?.values ?? [],
+      (
+        await this.cacheDB.query(
+          //language=SQLite
+          `SELECT ID
+      FROM CACHED_IAPP_RECORDS`
+        )
+      )?.values ?? []
+    ]);
+    return [act, iapp].flatMap((id) => id['ID']);
   }
 
   private async initializeRecordCache(sqlite: SQLiteConnection) {

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -519,14 +519,14 @@ class SQLiteRecordCacheService extends RecordCacheService {
         await this.cacheDB.query(
           //language=SQLite
           `SELECT ID
-      FROM CACHED_RECORDS`
+           FROM CACHED_RECORDS`
         )
       )?.values ?? [],
       (
         await this.cacheDB.query(
           //language=SQLite
           `SELECT ID
-      FROM CACHED_IAPP_RECORDS`
+           FROM CACHED_IAPP_RECORDS`
         )
       )?.values ?? []
     ]);


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Rename two Thunk actions to be inline with current naming convention
- Implement functionality to fetch all IDs currently cached, and filter them for inclusive/exclusive matches
- Modify localForage `deleteCachedRecordsFromIds()` to remove ESLint errors 
- Closes #3795 