### PR TITLE
Minor application consistency fixes

### DIFF
--- a/app/src/UI/LegacyMap/LayerPicker/LpRecordSet/LpRecordSetOption.tsx
+++ b/app/src/UI/LegacyMap/LayerPicker/LpRecordSet/LpRecordSetOption.tsx
@@ -48,7 +48,7 @@ const LpRecordSetOption = ({
             </Tooltip>
           )}
         </div>
-        <p>{recordSet?.recordSetName ?? 'Recordset name is null'}</p>
+        <p>{recordSet?.recordSetName || `New Recordset - ${recordSet.recordSetType}`}</p>
       </li>
       {!lastChild && (
         <li>

--- a/app/src/UI/LegacyMap/helpers/components/PositionMarkers.tsx
+++ b/app/src/UI/LegacyMap/helpers/components/PositionMarkers.tsx
@@ -7,6 +7,7 @@ import { useSelector } from 'utils/use_selector';
 import circle from '@turf/circle';
 import { MapContext } from 'UI/LegacyMap/helpers/components/MapContext';
 import { handlePositionTracking } from 'UI/LegacyMap/helpers/functional/position-tracking';
+import { MOBILE } from 'state/build-time-config';
 
 const PositionMarkers = ({ mapReady }) => {
   const map = useContext(MapContext);
@@ -30,7 +31,7 @@ const PositionMarkers = ({ mapReady }) => {
   // Draw tools - determine who needs edit and where the geos get dispatched, what tools to display etc
   const whatsHereFeature = useSelector((state) => state.Map.whatsHere?.feature);
   const whatsHereMarker = new maplibregl.Marker({ element: whatsHereMarkerEl });
-  
+
   const appModeUrl = useSelector((state) => state.AppMode.url);
   // also used with current marker below:
   const activityGeo = useSelector((state) => state.ActivityPage.activity?.geometry);
@@ -121,7 +122,7 @@ const PositionMarkers = ({ mapReady }) => {
 };
 
 const positionMarkerEl = document.createElement('div');
-positionMarkerEl.className = 'userTrackingMarker';
+positionMarkerEl.className = MOBILE ? 'userTrackingMarker userTrackingMarkerCone' : 'userTrackingMarker';
 positionMarkerEl.innerHTML = `<img src='/assets/icon/circle.svg' />`;
 
 const activityMarkerEl = document.createElement('div');

--- a/app/src/UI/LegacyMap/map.css
+++ b/app/src/UI/LegacyMap/map.css
@@ -3,6 +3,18 @@
   height: 64px;
   width: 64px;
   border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  & > img {
+    height: 32px;
+    width: 32px;
+    filter: drop-shadow(1px 1px 1px black);
+  }
+}
+
+.userTrackingMarkerCone {
   background-image: conic-gradient(
     #00b0ff20 0deg,
     #00b0ff95 60deg,
@@ -11,14 +23,6 @@
     #00b0ff95 300deg,
     #00b0ff20 360deg
   );
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  & > img {
-    height: 32px;
-    width: 32px;
-    filter: drop-shadow(1px 1px 1px black);
-  }
 }
 
 .whatsHereMarkerEl {

--- a/app/src/state/reducers/map.ts
+++ b/app/src/state/reducers/map.ts
@@ -63,6 +63,7 @@ import GeoTracking from 'state/actions/geotracking/GeoTracking';
 import IappActions from 'state/actions/activity/Iapp';
 import Activity from 'state/actions/activity/Activity';
 import RecordCache from 'state/actions/cache/RecordCache';
+import { RECORD_COLOURS } from 'constants/colors';
 
 export enum LeafletWhosEditingEnum {
   ACTIVITY = 'ACTIVITY',
@@ -744,7 +745,7 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
             draftState.layers[index].loading = true;
             if (!draftState.layers[index].layerState) {
               draftState.layers[index].layerState = {
-                color: 'blue',
+                color: RECORD_COLOURS[0],
                 drawOrder: 0,
                 mapToggle: false
               };
@@ -761,7 +762,7 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
             draftState.layers[index].loading = true;
             if (!draftState.layers[index].layerState) {
               draftState.layers[index].layerState = {
-                color: 'blue',
+                color: RECORD_COLOURS[0],
                 drawOrder: 0,
                 mapToggle: false
               };


### PR DESCRIPTION
# Overview

- [Fix] Recordset names appear in the 'New Recordset -- [TYPE]' format, in LayerPicker when not customized
    - [Issue] was blank previously 
- [Fix] Initial map layer when creating a new recordset is the first colour of the colours array
    - [Issue] Previously would be `blue` which does not exist in colours array. Reloading the app then changes it to the first colour of the colours array.
- [Fix] Don't display Direction cone on Nav marker when on desktop.
    - [Issue] Direction of the cone relies on the Bearing value of the GPS. Desktops don't have this, so it always points North. 
![image](https://github.com/user-attachments/assets/1c5a399a-72a1-410b-84b3-a6c908a693a6)
