### PR TITLE
[INV-3835] Custom Layers work for Record caching

### DIFF
--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -1,6 +1,7 @@
 import { createAction, createAsyncThunk } from '@reduxjs/toolkit';
 import { UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import { RootState } from 'state/reducers/rootReducer';
+import { getRecordFilterObjectFromStateForAPI } from 'state/sagas/map/dataAccess';
 import getBoundingBoxFromRecordsetFilters from 'utils/getBoundingBoxFromRecordsetFilters';
 import { CacheDownloadMode, RecordCacheProgressCallbackParameters } from 'utils/record-cache';
 import { RecordCacheServiceFactory } from 'utils/record-cache/context';
@@ -42,8 +43,14 @@ class RecordCache {
       const idsToCache: string[] =
         state.Map.layers.find((l) => l.recordSetID == spec.setId)?.IDList.map((id: string | number) => id.toString()) ??
         [];
+      const recordSet = JSON.parse(JSON.stringify(state.UserSettings.recordSets[spec.setId]));
 
-      const recordSet = state.UserSettings.recordSets[spec.setId];
+      recordSet.tableFilters = getRecordFilterObjectFromStateForAPI(
+        spec.setId,
+        state.UserSettings,
+        state.Map.clientBoundaries
+      );
+
       const bbox = await getBoundingBoxFromRecordsetFilters(recordSet);
 
       const downloadMode: CacheDownloadMode = await service.download(


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

> [!NOTE]
> Pulling in the state via thunk is `read-only`, so it's stringified/parsed to be modifiable for the function


- in `RecordCache.requestCaching` modify the handling of tableFilters using `getRecordFilterObjectFromStateForAPI`
- Closes #3835 

This remedies being able to download recordsets using a spatial filter

![image](https://github.com/user-attachments/assets/4acc642d-5ee3-44ed-af21-df8183ffbb46)

Created Via the Layer Pickers custom layers 

![image](https://github.com/user-attachments/assets/4d893972-9b58-4dc3-8536-cb839ceb1b71)

