### PR TITLE
[N/A] Refactor getRepositoryStatistics to boost speed

### DIFF
--- a/app/src/utils/tile-cache/sqlite-cache.ts
+++ b/app/src/utils/tile-cache/sqlite-cache.ts
@@ -178,19 +178,15 @@ class SQLiteTileCacheService extends TileCacheService {
 
     const results = await this.cacheDB.query(
       //language=SQLite
-      `SELECT DATA
-      FROM CACHED_TILES
-      WHERE TILESET = ?`,
+      `SELECT SUM(LENGTH(DATA)) AS SIZE_IN_BYTES,
+       COUNT(*) AS TOTAL_TILES
+       FROM CACHED_TILES
+       WHERE TILESET = ?`,
       [id]
     );
-    let sizeInBytes = 0;
-    const numberOfTiles = results?.values?.length ?? 0;
-    results?.values?.forEach((tile) => {
-      sizeInBytes += tile['DATA'].length ?? 0;
-    });
     return {
-      sizeInBytes: sizeInBytes,
-      tileCount: numberOfTiles
+      sizeInBytes: results.values?.[0]['SIZE_IN_BYTES'],
+      tileCount: results.values?.[0]['TOTAL_TILES']
     };
   }
 


### PR DESCRIPTION
# Overview

During testing I noticed that the getRepositoryStatistics function was pretty non-performant, and that was causing a slow down for maptiles render. Refactored it to use the SQL statement to do calculations.

The original implementation I had based off the localForage rendition, which doesn't have access to SQL commands.
 
This PR includes the following proposed change(s):
- Remove Object Parsing / summation in favour of much more performant SQL command.

Large time improvement in going from Cold Start -> Turning on a Map tile from cache.
