### PR TITLE
Fix crash issue for `new` users

### DIFF
--- a/api/src/utils/auth-utils.ts
+++ b/api/src/utils/auth-utils.ts
@@ -154,8 +154,9 @@ export const authenticate = async (req: InvasivesRequest): Promise<void> => {
                     .catch((err: Error) => reject(err));
                 })
                 .catch((err: Error) => reject(err));
+            } else {
+              resolve();
             }
-            resolve();
           });
 
           createIfNeeded.then(() => {


### PR DESCRIPTION
# Overview
re-wrap `else` resolution. Was throwing errors for new users (did not affect existing users)