### PR TITLE
[INV-3846] Add Semaphors to Caching mechanisms

### DIFF
--- a/app/src/constants/alerts/cacheAlerts.ts
+++ b/app/src/constants/alerts/cacheAlerts.ts
@@ -31,6 +31,12 @@ const cacheAlertMessages: Record<string, AlertMessage> = {
     severity: AlertSeverity.Success,
     subject: AlertSubjects.Cache,
     autoClose: 4
+  },
+  addedToQueue: {
+    content: 'Download added to queue',
+    severity: AlertSeverity.Info,
+    subject: AlertSubjects.Cache,
+    autoClose: 3
   }
 };
 

--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -1,4 +1,5 @@
 import { createAction, createAsyncThunk } from '@reduxjs/toolkit';
+import DownloadActions from '../downloads/DownloadActions';
 import { UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import { RootState } from 'state/reducers/rootReducer';
 import { getRecordFilterObjectFromStateForAPI } from 'state/sagas/map/dataAccess';
@@ -38,8 +39,18 @@ class RecordCache {
       },
       { getState, dispatch }
     ) => {
-      const service = await RecordCacheServiceFactory.getPlatformInstance();
+      await dispatch(DownloadActions.request());
       const state: RootState = getState() as RootState;
+      const currStatus = state.UserSettings.recordSets?.[spec.setId].cacheMetadataStatus;
+      // Check if cancelled while in queue
+      if (currStatus !== UserRecordCacheStatus.DOWNLOADING) {
+        return {
+          status: UserRecordCacheStatus.NOT_CACHED,
+          setId: spec.setId
+        };
+      }
+
+      const service = await RecordCacheServiceFactory.getPlatformInstance();
       const idsToCache: string[] =
         state.Map.layers.find((l) => l.recordSetID == spec.setId)?.IDList.map((id: string | number) => id.toString()) ??
         [];

--- a/app/src/state/actions/cache/TileCache.ts
+++ b/app/src/state/actions/cache/TileCache.ts
@@ -1,5 +1,6 @@
 import { createAction, createAsyncThunk, nanoid } from '@reduxjs/toolkit';
 import { GeoJSON } from 'geojson';
+import DownloadActions from '../downloads/DownloadActions';
 import { TileCacheServiceFactory } from 'utils/tile-cache/context';
 import { TileCacheProgressCallbackParameters, RepositoryBoundingBoxSpec } from 'utils/tile-cache';
 
@@ -43,9 +44,9 @@ class TileCache {
       },
       { dispatch }
     ) => {
+      await dispatch(DownloadActions.request());
       const service = await TileCacheServiceFactory.getPlatformInstance();
-      const id = spec.id ?? `well-cache-${nanoid()}`;
-
+      const id = spec.id ?? `tile-cache-${nanoid()}`;
       await service.download(
         {
           id: id,

--- a/app/src/state/actions/cache/WellCache.ts
+++ b/app/src/state/actions/cache/WellCache.ts
@@ -1,4 +1,5 @@
 import { createAsyncThunk, nanoid } from '@reduxjs/toolkit';
+import DownloadActions from '../downloads/DownloadActions';
 import { RootState } from 'state/reducers/rootReducer';
 import { RepositoryBoundingBoxSpec } from 'utils/tile-cache';
 import { WellCacheServiceFactory } from 'utils/well-cache/context';
@@ -12,8 +13,8 @@ class WellCache {
 
   static readonly requestCaching = createAsyncThunk(
     `${this.PREFIX}/requestCaching`,
-
-    async (spec: { bounds: RepositoryBoundingBoxSpec; id?: string }, { getState }) => {
+    async (spec: { bounds: RepositoryBoundingBoxSpec; id?: string }, { getState, dispatch }) => {
+      await dispatch(DownloadActions.request());
       const id = spec.id ?? `well-records-${nanoid()}`;
       const state: RootState = getState() as RootState;
       const wellService = await WellCacheServiceFactory.getPlatformInstance();

--- a/app/src/state/actions/downloads/DownloadActions.ts
+++ b/app/src/state/actions/downloads/DownloadActions.ts
@@ -1,0 +1,27 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import Alerts from '../alerts/Alerts';
+import { RootState } from 'state/reducers/rootReducer';
+import cacheAlertMessages from 'constants/alerts/cacheAlerts';
+
+class DownloadActions {
+  public static readonly PREFIX = 'DownloadActions';
+  private static readonly BASE_DELAY_IN_MS = 2000;
+  /**
+   * @desc Waits for Semaphor to be available to resolve. Checks queue to avoid cutting in line
+   */
+  public static readonly request = createAsyncThunk(
+    `${this.PREFIX}/request`,
+    async (_, { getState, dispatch, requestId }) => {
+      let state = (getState() as RootState).DownloadState;
+      if (state.semaphores <= 0) {
+        dispatch(Alerts.create(cacheAlertMessages.addedToQueue));
+      }
+      while (state.semaphores <= 0 || state.queue?.[0] !== requestId) {
+        state = (getState() as RootState).DownloadState;
+        await new Promise((resolve) => setTimeout(resolve, DownloadActions.BASE_DELAY_IN_MS * state.queue.length));
+      }
+    }
+  );
+}
+
+export default DownloadActions;

--- a/app/src/state/reducers/downloads.ts
+++ b/app/src/state/reducers/downloads.ts
@@ -1,0 +1,46 @@
+import { createNextState, Draft } from '@reduxjs/toolkit';
+import { RootState } from './rootReducer';
+import DownloadActions from 'state/actions/downloads/DownloadActions';
+import TileCache from 'state/actions/cache/TileCache';
+import RecordCache from 'state/actions/cache/RecordCache';
+import WellCache from 'state/actions/cache/WellCache';
+
+const MAX_SEMAPHORS = 2;
+
+/**
+ * @property { number } semaphores Synchronization primitive
+ * @property { string[] } queue Download requests in wait.
+ */
+interface DownloadState {
+  semaphores: number;
+  queue: string[];
+}
+
+const initialState: DownloadState = {
+  semaphores: MAX_SEMAPHORS,
+  queue: []
+};
+
+function createDownloadStateReducer(state = initialState, action) {
+  return createNextState(state, (draftState: Draft<DownloadState>) => {
+    if (DownloadActions.request.pending.match(action)) {
+      draftState.queue = [...draftState.queue, action.meta.requestId];
+    } else if (DownloadActions.request.fulfilled.match(action)) {
+      draftState.semaphores--;
+      draftState.queue = draftState.queue.slice(1);
+    } else if (
+      TileCache.requestCaching.fulfilled.match(action) ||
+      TileCache.requestCaching.rejected.match(action) ||
+      RecordCache.requestCaching.fulfilled.match(action) ||
+      RecordCache.requestCaching.rejected.match(action) ||
+      WellCache.requestCaching.fulfilled.match(action) ||
+      WellCache.requestCaching.rejected.match(action)
+    ) {
+      draftState.semaphores++;
+    }
+  });
+}
+
+const selectDownloadState: (state: RootState) => DownloadState = (state) => state.DownloadState;
+
+export { createDownloadStateReducer, selectDownloadState };

--- a/app/src/state/reducers/rootReducer.ts
+++ b/app/src/state/reducers/rootReducer.ts
@@ -19,6 +19,7 @@ import { createUserInfoReducer } from './userInfo';
 import { errorHandlerReducer } from './error_handler';
 import { createOfflineActivityReducer, OfflineActivityState } from './offlineActivity';
 import { createAlertsAndPromptsReducer } from './alertsAndPrompts';
+import { createDownloadStateReducer } from './downloads';
 import { AppConfig } from 'state/config';
 import { CURRENT_MIGRATION_VERSION, MIGRATION_VERSION_KEY } from 'constants/offline_state_version';
 import { createTileCacheReducer } from 'state/reducers/tile_cache';
@@ -77,6 +78,7 @@ function createRootReducer(config: AppConfig) {
     AppMode: appMode,
     AlertsAndPrompts: createAlertsAndPromptsReducer(config),
     Configuration: createConfigurationReducerWithDefaultState(config),
+    DownloadState: createDownloadStateReducer,
     Auth: persistReducer<AuthState>(
       {
         key: 'auth',

--- a/app/src/utils/tile-cache/index.ts
+++ b/app/src/utils/tile-cache/index.ts
@@ -1,3 +1,4 @@
+import { DEBUG } from 'state/build-time-config';
 import BaseCacheService from 'utils/base-classes/BaseCacheService';
 import { base64toBuffer, lat2tile, long2tile } from 'utils/tile-cache/helpers';
 
@@ -71,6 +72,7 @@ abstract class TileCacheService extends BaseCacheService<
   TileCacheProgressCallbackParameters,
   RepositoryStatus
 > {
+  CONCURRENCY_LIMIT = DEBUG ? 10 : 6; // Throttle for Mobile launches, boost for development.
   protected constructor() {
     super();
   }
@@ -126,7 +128,6 @@ abstract class TileCacheService extends BaseCacheService<
     spec: RepositoryDownloadRequestSpec,
     progressCallback?: (currentProgress: TileCacheProgressCallbackParameters) => void
   ): Promise<void> {
-    const CONCURRENCY_LIMIT = 10;
     const totalTiles = TileCacheService.computeTileCount(spec.bounds, spec.maxZoom);
     let abort = false;
     let processedTiles = 0;
@@ -159,7 +160,7 @@ abstract class TileCacheService extends BaseCacheService<
       const promises = tileUrls.map((config) => () => this.downloadTile(config));
 
       for (let i = 0; i < promises.length && !abort; i++) {
-        if (executing.size >= CONCURRENCY_LIMIT) {
+        if (executing.size >= this.CONCURRENCY_LIMIT) {
           await Promise.race(executing);
         }
 


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Implement Semaphors to download caches
    -  Set current Limit to 2 downloads per time
    - Alert user if Cache request is added to queue
- Lower concurrency on Map caching
    - Concurrency limit was bottlenecking Map tile downloads on physical devices. Lowering limit shouldn't see much change in results. Reducing also opens up having 2 semaphors available
    - use original concurrency for map tiles when in a developer environment. 
- Implement Queue for Downloads
    - Use Timeouts to set place in line. 
- Records Check cache status before beginning download
    - If Records are cancelled while in the queue, downloads will immediately exit when its their turn. 
- Closes #3846