### PR TITLE
[N/A] MINOR** Fix CSS overflowing in Records Filters

### DIFF
--- a/app/src/UI/Overlay/Records/RecordSet/RecordTable.css
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordTable.css
@@ -1,7 +1,18 @@
 .no-records {
-  border: 1pt solid black;
   border-radius: 10pt;
-  padding: 15pt;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  p {
+    width: 100%;
+    max-width: 375pt;
+    padding: 1em;
+    border: 1pt solid black;
+    border-radius: 10pt;
+    box-sizing: content-box;
+  }
 }
 
 .record_table_container {
@@ -11,6 +22,7 @@
   overflow-x: scroll;
   margin-bottom: var(--record-table-footer-height);
   border: 1pt solid black;
+  box-sizing: border-box;
 
   .record_table {
     white-space: nowrap;


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

Fixes minor issues missed in Filters work due to browser caching.

- Fix the 2px overflow in the Recordset Table that allowed for wonky behaviour when user scrolled with touch 
- Modify CSS so border applies to P tag, and containing div centers it. 