### PR TITLE
[INV-3856] Show Linked ID's in Monitoring forms when Offline

### DIFF
--- a/app/src/UI/App.css
+++ b/app/src/UI/App.css
@@ -91,6 +91,7 @@ body {
 }
 
 .overlay-content {
+  height: calc(100% - var(--overlay-grip-height));
   position: sticky;
   width: 100%;
   box-sizing: border-box;

--- a/app/src/UI/Overlay/Records/RecordSet/RecordTable.tsx
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordTable.tsx
@@ -46,9 +46,9 @@ export const RecordTable = ({ setID, userOfflineMobile }: PropTypes) => {
     return mappedRow;
   });
 
-  const sortColumn = useSelector((state: any) => state.UserSettings?.recordSets?.[setID]?.sortColumn);
-  const sortOrder = useSelector((state: any) => state.UserSettings?.recordSets?.[setID]?.sortOrder);
-  if (mappedRows?.length === 0) {
+  const sortColumn = useSelector((state) => state.UserSettings?.recordSets?.[setID]?.sortColumn);
+  const sortOrder = useSelector((state) => state.UserSettings?.recordSets?.[setID]?.sortOrder);
+  if (!mappedRows || mappedRows?.length === 0) {
     return (
       <div className="no-records">
         <p>There are no records matching your current filters.</p>
@@ -66,7 +66,7 @@ export const RecordTable = ({ setID, userOfflineMobile }: PropTypes) => {
               </th>
             )}
             {tableType === RecordSetType.Activity
-              ? activityColumnsToDisplay.map((col: any) => (
+              ? activityColumnsToDisplay.map((col) => (
                   <th
                     className={'record_table_header_column'}
                     key={col.key}
@@ -77,12 +77,12 @@ export const RecordTable = ({ setID, userOfflineMobile }: PropTypes) => {
                     }}
                   >
                     {col.name}{' '}
-                    {activitySortColumns.includes(sortColumn) &&
+                    {activitySortColumns.includes(sortColumn!) &&
                       sortColumn === col.key &&
                       (sortOrder === 'ASC' ? '▲' : '▼')}
                   </th>
                 ))
-              : iappColumnsToDisplay.map((col: any) => (
+              : iappColumnsToDisplay.map((col) => (
                   <th
                     className="record_table_header_column"
                     key={col.key}
@@ -93,7 +93,7 @@ export const RecordTable = ({ setID, userOfflineMobile }: PropTypes) => {
                     }}
                   >
                     {col.name}{' '}
-                    {iappSortColumns.includes(sortColumn) &&
+                    {iappSortColumns.includes(sortColumn!) &&
                       sortColumn === col.key &&
                       (sortOrder === 'ASC' ? '▲' : '▼')}
                   </th>

--- a/app/src/UI/Overlay/Records/RecordSet/RecordTable.tsx
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordTable.tsx
@@ -77,8 +77,8 @@ export const RecordTable = ({ setID, userOfflineMobile }: PropTypes) => {
                     }}
                   >
                     {col.name}{' '}
-                    {activitySortColumns.includes(sortColumn!) &&
-                      sortColumn === col.key &&
+                    {sortColumn === col.key &&
+                      activitySortColumns.includes(sortColumn) &&
                       (sortOrder === 'ASC' ? '▲' : '▼')}
                   </th>
                 ))
@@ -93,8 +93,8 @@ export const RecordTable = ({ setID, userOfflineMobile }: PropTypes) => {
                     }}
                   >
                     {col.name}{' '}
-                    {iappSortColumns.includes(sortColumn!) &&
-                      sortColumn === col.key &&
+                    {sortColumn === col.key &&
+                      iappSortColumns.includes(sortColumn) &&
                       (sortOrder === 'ASC' ? '▲' : '▼')}
                   </th>
                 ))}

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -1,4 +1,4 @@
-import { call, put, select, take } from 'redux-saga/effects';
+import { all, call, put, select, take } from 'redux-saga/effects';
 import center from '@turf/center';
 import centroid from '@turf/centroid';
 import {
@@ -9,9 +9,10 @@ import {
   MAX_AREA,
   populateSpeciesArrays
 } from 'sharedAPI';
-import { FeatureCollection, kinks } from '@turf/turf';
+import { Feature, FeatureCollection, kinks } from '@turf/turf';
 
 import { PayloadAction } from '@reduxjs/toolkit';
+import booleanIntersects from '@turf/boolean-intersects';
 import {
   autoFillNameByPAC,
   autoFillSlopeAspect,
@@ -38,7 +39,7 @@ import { getClosestWells } from 'utils/closestWellsHelpers';
 import { calc_utm } from 'utils/utm';
 import { calculateGeometryArea, calculateLatLng } from 'utils/geometryHelpers';
 import { InvasivesAPI_Call } from 'hooks/useInvasivesApi';
-import { selectNetworkConnected } from 'state/reducers/network';
+import { selectNetworkConnected, selectNetworkState } from 'state/reducers/network';
 import GeoShapes from 'constants/geoShapes';
 import geomWithinBC from 'utils/geomWithinBC';
 import mappingAlertMessages from 'constants/alerts/mappingAlerts';
@@ -49,8 +50,12 @@ import Prompt from 'state/actions/prompts/Prompt';
 import UserSettings from 'state/actions/userSettings/UserSettings';
 import Activity, { INewActivity } from 'state/actions/activity/Activity';
 import UploadedPhoto from 'interfaces/UploadedPhoto';
+import { RecordCacheServiceFactory } from 'utils/record-cache/context';
+import { RepositoryMetadata } from 'utils/record-cache';
+import { UserRecordCacheStatus } from 'interfaces/UserRecordSet';
+import bboxToPolygon from 'utils/bboxToPolygon';
 
-export function* handle_ACTIVITY_GET_REQUEST(action: PayloadAction<string>) {
+function* handle_ACTIVITY_GET_REQUEST(action: PayloadAction<string>) {
   try {
     if (MOBILE) {
       yield put(Activity.getLocal(action.payload));
@@ -63,7 +68,7 @@ export function* handle_ACTIVITY_GET_REQUEST(action: PayloadAction<string>) {
   }
 }
 
-export function* handle_ACTIVITY_COPY_REQUEST() {
+function* handle_ACTIVITY_COPY_REQUEST() {
   try {
     const activityState = yield select(selectActivity);
     const activityData = { ...activityState.activity.form_data.activity_data };
@@ -233,7 +238,7 @@ export function* handle_ACTIVITY_UPDATE_GEO_REQUEST(action: Record<string, any>)
   }
 }
 
-export function* handle_ACTIVITY_SAVE_SUCCESS(action) {
+export function* handle_ACTIVITY_SAVE_SUCCESS() {
   const activity_id = yield select((state) => state.ActivityPage.activity.activity_id);
   try {
     yield put(Activity.get(activity_id));
@@ -280,7 +285,7 @@ export function* handle_ACTIVITY_CREATE_REQUEST(action: PayloadAction<INewActivi
 
     const username = authState.username;
     const displayName = authState.displayName;
-  
+
     const newActivity = yield call(
       activity_create_function,
       action.payload.type,
@@ -444,7 +449,7 @@ export function* handle_GET_SUGGESTED_JURISDICTIONS_REQUEST(action) {
   }
 }
 
-export function* handle_ACTIVITY_GET_SUGGESTED_PERSONS_REQUEST(action) {
+export function* handle_ACTIVITY_GET_SUGGESTED_PERSONS_REQUEST() {
   const connected = yield select(selectNetworkConnected);
 
   try {
@@ -459,7 +464,8 @@ export function* handle_ACTIVITY_GET_SUGGESTED_PERSONS_REQUEST(action) {
 
 export function* handle_ACTIVITY_GET_SUGGESTED_TREATMENT_IDS_REQUEST(action) {
   const payloadActivity = action.payload;
-  const AuthState = yield select(selectAuth);
+  const [AuthState, networkState] = yield all([yield select(selectAuth), yield select(selectNetworkState)]);
+
   try {
     // filter Treatments and/or Biocontrol
     const linkedActivitySubtypes: ActivitySubtype[] = (() => {
@@ -482,13 +488,47 @@ export function* handle_ACTIVITY_GET_SUGGESTED_TREATMENT_IDS_REQUEST(action) {
       : false;
 
     if (linkedActivitySubtypes.length > 0 && search_feature) {
-      yield put(
-        Activity.Suggestions.treatmentIdsRequestOnline({
-          activity_subtype: linkedActivitySubtypes,
-          user_roles: AuthState.accessRoles,
-          search_feature
-        })
-      );
+      if (networkState.connected) {
+        yield put(
+          Activity.Suggestions.treatmentIdsRequestOnline({
+            activity_subtype: linkedActivitySubtypes,
+            user_roles: AuthState.accessRoles,
+            search_feature
+          })
+        );
+      } else {
+        const service = yield RecordCacheServiceFactory.getPlatformInstance();
+        const repos = yield service.listRepositories();
+        const recordSetsInBoundingBox = repos.filter((repo: RepositoryMetadata) => {
+          const { status, bbox } = repo;
+          return (
+            status === UserRecordCacheStatus.CACHED &&
+            bbox &&
+            booleanIntersects(search_feature.features[0], bboxToPolygon(bbox))
+          );
+        });
+        const treatmentIds: string[] = [];
+        recordSetsInBoundingBox.flatMap((set) =>
+          set.cachedGeoJson.data.features.forEach((shape: Feature) => {
+            if (booleanIntersects(search_feature.features[0], shape)) {
+              treatmentIds.push(shape?.properties?.description);
+            }
+          })
+        );
+        const records = yield service.getPaginatedCachedActivityRecords(treatmentIds, 0, treatmentIds.length);
+        console.log(records);
+        yield put(
+          Activity.Suggestions.treatmentIdsSuccess(
+            records.map((record, i) => ({
+              label: record.short_id,
+              title: record.short_id,
+              value: record.activity_id,
+              'x-code_sort_order': i + 1
+            }))
+          )
+        );
+        // yield put(Activity.Suggestions.treatmentIdsSuccess())
+      }
     }
   } catch (e) {
     console.error(e);
@@ -496,12 +536,12 @@ export function* handle_ACTIVITY_GET_SUGGESTED_TREATMENT_IDS_REQUEST(action) {
   }
 }
 
-export function* handle_PAN_AND_ZOOM_TO_ACTIVITY(action) {
+export function* handle_PAN_AND_ZOOM_TO_ACTIVITY() {
   const activityState = yield select(selectActivity);
 
   const geometry = activityState?.activity?.geometry?.[0];
   if (geometry) {
-    const isPoint = geometry.geometry?.type === 'Point';
+    const isPoint = geometry.geometry?.type === GeoShapes.Point;
     let target;
     if (isPoint) {
       target = geometry.geometry;
@@ -642,3 +682,5 @@ export function* handle_ACTIVITY_EDIT_PHOTO_REQUEST(action) {
     yield put(Activity.Photo.editFailure);
   }
 }
+
+export { handle_ACTIVITY_GET_REQUEST, handle_ACTIVITY_COPY_REQUEST };

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -51,9 +51,7 @@ import UserSettings from 'state/actions/userSettings/UserSettings';
 import Activity, { INewActivity } from 'state/actions/activity/Activity';
 import UploadedPhoto from 'interfaces/UploadedPhoto';
 import { RecordCacheServiceFactory } from 'utils/record-cache/context';
-import { RepositoryMetadata } from 'utils/record-cache';
-import { UserRecordCacheStatus } from 'interfaces/UserRecordSet';
-import bboxToPolygon from 'utils/bboxToPolygon';
+import UserRecord from 'interfaces/UserRecord';
 
 function* handle_ACTIVITY_GET_REQUEST(action: PayloadAction<string>) {
   try {
@@ -498,28 +496,22 @@ export function* handle_ACTIVITY_GET_SUGGESTED_TREATMENT_IDS_REQUEST(action) {
         );
       } else {
         const service = yield RecordCacheServiceFactory.getPlatformInstance();
-        const repos = yield service.listRepositories();
-        const recordSetsInBoundingBox = repos.filter((repo: RepositoryMetadata) => {
-          const { status, bbox } = repo;
-          return (
-            status === UserRecordCacheStatus.CACHED &&
-            bbox &&
-            booleanIntersects(search_feature.features[0], bboxToPolygon(bbox))
-          );
-        });
-        const treatmentIds: string[] = [];
-        recordSetsInBoundingBox.flatMap((set) =>
+        const overlappingRecords: string[] = [];
+
+        (yield service.getOverlappingRepositories(search_feature.features[0])).flatMap((set) =>
           set.cachedGeoJson.data.features.forEach((shape: Feature) => {
             if (booleanIntersects(search_feature.features[0], shape)) {
-              treatmentIds.push(shape?.properties?.description);
+              overlappingRecords.push(shape?.properties?.description);
             }
           })
         );
-        const records = yield service.getPaginatedCachedActivityRecords(treatmentIds, 0, treatmentIds.length);
-        console.log(records);
+        const treatmentRecords: UserRecord[] = (yield service.getPaginatedCachedActivityRecords(
+          overlappingRecords
+        )).filter((record: UserRecord) => record.activity_type === ActivityType.Treatment);
+
         yield put(
           Activity.Suggestions.treatmentIdsSuccess(
-            records.map((record, i) => ({
+            treatmentRecords.map((record, i) => ({
               label: record.short_id,
               title: record.short_id,
               value: record.activity_id,
@@ -527,7 +519,6 @@ export function* handle_ACTIVITY_GET_SUGGESTED_TREATMENT_IDS_REQUEST(action) {
             }))
           )
         );
-        // yield put(Activity.Suggestions.treatmentIdsSuccess())
       }
     }
   } catch (e) {

--- a/app/src/state/sagas/map.ts
+++ b/app/src/state/sagas/map.ts
@@ -67,7 +67,7 @@ import { InvasivesAPI_Call } from 'hooks/useInvasivesApi';
 import { TRACKING_SAGA_HANDLERS } from 'state/sagas/map/tracking';
 import WhatsHere from 'state/actions/whatsHere/WhatsHere';
 import Prompt from 'state/actions/prompts/Prompt';
-import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
+import { RecordSetType } from 'interfaces/UserRecordSet';
 import UserSettings from 'state/actions/userSettings/UserSettings';
 import { SortFilter } from 'interfaces/filterParams';
 import Activity from 'state/actions/activity/Activity';
@@ -80,10 +80,8 @@ import { selectNetworkConnected, selectNetworkState } from 'state/reducers/netwo
 import UserRecord from 'interfaces/UserRecord';
 import { MOBILE } from 'state/build-time-config';
 import { RecordCacheServiceFactory } from 'utils/record-cache/context';
-import bboxToPolygon from 'utils/bboxToPolygon';
 import IappActions from 'state/actions/activity/Iapp';
 import IappRecord from 'interfaces/IappRecord';
-import { RepositoryMetadata } from 'utils/record-cache';
 import NetworkActions from 'state/actions/network/NetworkActions';
 
 function* handle_USER_SETTINGS_GET_INITIAL_STATE_SUCCESS() {
@@ -160,19 +158,8 @@ function* handle_WHATS_HERE_FEATURE(whatsHereFeature: PayloadAction<Feature>) {
     } else {
       // Get IDs from Offline Caches
       const service = yield RecordCacheServiceFactory.getPlatformInstance();
-      const repos = yield service.listRepositories();
-
-      const recordSetsInBoundingBox = repos.filter((repo: RepositoryMetadata) => {
-        const { status, bbox } = repo;
-        return (
-          status === UserRecordCacheStatus.CACHED &&
-          bbox &&
-          booleanIntersects(whatsHereFeature.payload, bboxToPolygon(bbox))
-        );
-      });
-
       const overlappingRecords: string[] = [];
-      recordSetsInBoundingBox.flatMap((set) =>
+      (yield service.getOverlappingRepositories(whatsHereFeature.payload)).flatMap((set) =>
         set.cachedGeoJson.data.features.forEach((shape: Feature) => {
           if (booleanIntersects(whatsHereFeature.payload, shape)) {
             overlappingRecords.push(shape?.properties?.description);

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -1,4 +1,6 @@
 import { GeoJSONSourceSpecification } from 'maplibre-gl';
+import booleanIntersects from '@turf/boolean-intersects';
+import { Feature } from '@turf/helpers';
 import IappRecord from 'interfaces/IappRecord';
 import IappTableRow from 'interfaces/IappTableRecord';
 import UserRecord from 'interfaces/UserRecord';
@@ -7,6 +9,7 @@ import { getCurrentJWT } from 'state/sagas/auth/auth';
 import { getSelectColumnsByRecordSetType } from 'state/sagas/map/dataAccess';
 import BaseCacheService from 'utils/base-classes/BaseCacheService';
 import { RepositoryBoundingBoxSpec } from 'utils/tile-cache';
+import bboxToPolygon from 'utils/bboxToPolygon';
 
 export enum IappRecordMode {
   Record = 'record',
@@ -364,6 +367,18 @@ abstract class RecordCacheService extends BaseCacheService<
     if (repositories[foundIndex].status === UserRecordCacheStatus.DOWNLOADING) {
       await this.setRepositoryStatus(repositoryId, UserRecordCacheStatus.PAUSED);
     }
+  }
+
+  /**
+   * @desc Get repositories filtered to a geographic area
+   * @param geom Area of target
+   * @returns Repositories overlapping with target area
+   */
+  public async getOverlappingRepositories(geom: Feature): Promise<RepositoryMetadata[]> {
+    return (await this.listRepositories()).filter(
+      (r) =>
+        r.status === UserRecordCacheStatus.CACHED && r.cachedGeoJson && booleanIntersects(bboxToPolygon(r.bbox!), geom)
+    );
   }
 }
 

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -144,8 +144,8 @@ class LocalForageRecordCacheService extends RecordCacheService {
    */
   async getPaginatedCachedActivityRecords(
     recordSetIdList: string[],
-    page: number,
-    limit: number
+    page: number = 0,
+    limit: number = recordSetIdList.length
   ): Promise<UserRecord[]> {
     if (recordSetIdList?.length === 0) {
       return [];

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -256,8 +256,8 @@ class SQLiteRecordCacheService extends RecordCacheService {
    */
   async getPaginatedCachedActivityRecords(
     recordSetIdList: string[],
-    page: number,
-    limit: number
+    page: number = 0,
+    limit: number = recordSetIdList.length
   ): Promise<UserRecord[]> {
     if (!recordSetIdList || recordSetIdList.length === 0) {
       return [];


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Add getOverlappingRepositories method to Record Sets
- Add offline workflow for Linked ID's
- Add default arguments to `getPaginatedCachedActivityRecords` 
- Refactor Offline Whats Here workflow to use getOverlappingRepositories
- Misc. ESLint fixes
    - Removing Unused params (`action`)
    - Removing `: any` from typed useSelectors 
- Closes #3856 