### PR TITLE
[INV-3863] Show status `Queue` on Records to be downloaded

### DIFF
--- a/app/src/UI/Overlay/Records/RecordSetCacheButtons.tsx
+++ b/app/src/UI/Overlay/Records/RecordSetCacheButtons.tsx
@@ -31,16 +31,18 @@ const RecordSetCacheButtons = ({ recordSet, setId, onCacheStateChange }: PropTyp
   const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     switch (recordSet.cacheMetadataStatus) {
-      case UserRecordCacheStatus.NOT_CACHED:
-        downloadCache();
-        break;
       case UserRecordCacheStatus.DOWNLOADING:
+      case UserRecordCacheStatus.QUEUED:
         cancelCacheDownload();
         break;
-      case UserRecordCacheStatus.ERROR:
       case UserRecordCacheStatus.CACHED:
+      case UserRecordCacheStatus.DELETING:
+      case UserRecordCacheStatus.ERROR:
       case UserRecordCacheStatus.PAUSED:
         deleteCache();
+        break;
+      case UserRecordCacheStatus.NOT_CACHED:
+        downloadCache();
         break;
     }
   };
@@ -126,7 +128,9 @@ const RecordSetCacheButtons = ({ recordSet, setId, onCacheStateChange }: PropTyp
           UserRecordCacheStatus.CACHED,
           UserRecordCacheStatus.NOT_CACHED,
           UserRecordCacheStatus.ERROR,
-          UserRecordCacheStatus.DOWNLOADING
+          UserRecordCacheStatus.DOWNLOADING,
+          UserRecordCacheStatus.QUEUED,
+          UserRecordCacheStatus.PAUSED
         ].includes(recordSet.cacheMetadataStatus)
     );
   }, [recordSet.cacheMetadataStatus, connected]);

--- a/app/src/interfaces/UserRecordSet.ts
+++ b/app/src/interfaces/UserRecordSet.ts
@@ -7,13 +7,14 @@ export enum RecordSetType {
 }
 
 export enum UserRecordCacheStatus {
+  CACHED = 'CACHED',
+  DELETING = 'DELETING',
+  DOWNLOADING = 'DOWNLOADING',
+  ERROR = 'ERROR',
   NOT_CACHED = 'NOT_CACHED',
   NOT_ELIGIBLE = 'NOT_ELIGIBLE',
-  DOWNLOADING = 'DOWNLOADING',
   PAUSED = 'PAUSED',
-  ERROR = 'ERROR',
-  CACHED = 'CACHED',
-  DELETING = 'DELETING'
+  QUEUED = 'QUEUED'
 }
 
 export interface UserRecordSet {

--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -31,6 +31,8 @@ class RecordCache {
     await (await RecordCacheServiceFactory.getPlatformInstance()).pauseDownload(spec.setId);
   });
 
+  static readonly startDownload = createAction<string | number>(`${this.PREFIX}/startDownload`);
+
   static readonly requestCaching = createAsyncThunk(
     `${this.PREFIX}/requestCaching`,
     async (
@@ -43,12 +45,13 @@ class RecordCache {
       const state: RootState = getState() as RootState;
       const currStatus = state.UserSettings.recordSets?.[spec.setId].cacheMetadataStatus;
       // Check if cancelled while in queue
-      if (currStatus !== UserRecordCacheStatus.DOWNLOADING) {
+      if (currStatus !== UserRecordCacheStatus.QUEUED) {
         return {
           status: UserRecordCacheStatus.NOT_CACHED,
           setId: spec.setId
         };
       }
+      dispatch(RecordCache.startDownload(spec.setId));
 
       const service = await RecordCacheServiceFactory.getPlatformInstance();
       const idsToCache: string[] =

--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -31,7 +31,7 @@ class RecordCache {
     await (await RecordCacheServiceFactory.getPlatformInstance()).pauseDownload(spec.setId);
   });
 
-  static readonly startDownload = createAction<string | number>(`${this.PREFIX}/startDownload`);
+  static readonly startDownload = createAction<PropertyKey>(`${this.PREFIX}/startDownload`);
 
   static readonly requestCaching = createAsyncThunk(
     `${this.PREFIX}/requestCaching`,

--- a/app/src/state/actions/downloads/DownloadActions.ts
+++ b/app/src/state/actions/downloads/DownloadActions.ts
@@ -18,7 +18,9 @@ class DownloadActions {
       }
       while (state.semaphores <= 0 || state.queue?.[0] !== requestId) {
         state = (getState() as RootState).DownloadState;
-        await new Promise((resolve) => setTimeout(resolve, DownloadActions.BASE_DELAY_IN_MS * state.queue.length));
+        await new Promise((resolve) =>
+          setTimeout(resolve, DownloadActions.BASE_DELAY_IN_MS * (state.queue?.[0] === requestId ? 1 : 3))
+        );
       }
     }
   );

--- a/app/src/state/actions/userSettings/RecordSet.ts
+++ b/app/src/state/actions/userSettings/RecordSet.ts
@@ -1,10 +1,10 @@
 import { createAction, createAsyncThunk, nanoid } from '@reduxjs/toolkit';
+import RecordCache from '../cache/RecordCache';
 import { RECORD_COLOURS } from 'constants/colors';
 import { RecordSetType, UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
 import { MOBILE } from 'state/build-time-config';
 import { RootState } from 'state/reducers/rootReducer';
 import { RecordCacheServiceFactory } from 'utils/record-cache/context';
-import RecordCache from '../cache/RecordCache';
 import { CacheDownloadMode } from 'utils/record-cache';
 
 export interface IUpdateFilter extends Partial<IFilter> {
@@ -73,7 +73,7 @@ class RecordSet {
       const { recordSets } = state.UserSettings;
       if (
         MOBILE &&
-        [UserRecordCacheStatus.CACHED, UserRecordCacheStatus.DOWNLOADING].includes(
+        [UserRecordCacheStatus.CACHED, UserRecordCacheStatus.DOWNLOADING, UserRecordCacheStatus.QUEUED].includes(
           recordSets[spec.setId].cacheMetadataStatus
         )
       ) {

--- a/app/src/state/reducers/rootReducer.ts
+++ b/app/src/state/reducers/rootReducer.ts
@@ -65,6 +65,8 @@ const pauseDownloadOnRehydration = createTransform(
           outboundState[key].cacheDownloadProgress.downloadMode = CacheDownloadMode.PAUSE;
           outboundState[key].cacheDownloadProgress.message =
             `Mode: ${CacheDownloadMode.PAUSE.toLocaleString().toUpperCase()} Caching`;
+        } else if (outboundState[key].cacheMetadataStatus === UserRecordCacheStatus.QUEUED) {
+          outboundState[key].cacheMetadataStatus = UserRecordCacheStatus.NOT_CACHED;
         }
       });
     }

--- a/app/src/state/reducers/rootReducer.ts
+++ b/app/src/state/reducers/rootReducer.ts
@@ -53,7 +53,7 @@ const purgeOldStateOnVersionUpgrade = async (state: any) => {
 };
 
 // executes during app restart or when the page reloads
-const pauseDownloadOnRehydration = createTransform(
+const handleActiveDownloadsOnRehydration = createTransform(
   (inboundState) => inboundState,
 
   (outboundState) => {
@@ -131,7 +131,7 @@ function createRootReducer(config: AppConfig) {
           'layerPickerIsAccordion',
           'mapCenter'
         ],
-        transforms: [pauseDownloadOnRehydration]
+        transforms: [handleActiveDownloadsOnRehydration]
       },
       createUserSettingsReducer(config)
     ),

--- a/app/src/state/reducers/userSettings.ts
+++ b/app/src/state/reducers/userSettings.ts
@@ -142,7 +142,9 @@ function createUserSettingsReducer(configuration: AppConfig): (UserSettingsState
       } else if (WhatsHere.toggle.match(action)) {
         draftState.recordsExpanded = action.payload ? false : draftState.recordsExpanded;
       } else if (RecordCache.requestCaching.pending.match(action)) {
-        draftState.recordSets[action.meta.arg.setId].cacheMetadataStatus = UserRecordCacheStatus.DOWNLOADING;
+        draftState.recordSets[action.meta.arg.setId].cacheMetadataStatus = UserRecordCacheStatus.QUEUED;
+      } else if (RecordCache.startDownload.match(action)) {
+        draftState.recordSets[action.payload].cacheMetadataStatus = UserRecordCacheStatus.DOWNLOADING;
       } else if (
         RecordCache.requestCaching.rejected.match(action) ||
         RecordCache.deleteCache.rejected.match(action) ||

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -347,8 +347,9 @@ abstract class RecordCacheService extends BaseCacheService<
     if (foundIndex === -1) throw Error(`Repository ${repositoryId} wasn't found`);
 
     if (
-      repositories[foundIndex].status === UserRecordCacheStatus.DOWNLOADING ||
-      repositories[foundIndex].status === UserRecordCacheStatus.PAUSED
+      [UserRecordCacheStatus.DOWNLOADING, UserRecordCacheStatus.PAUSED, UserRecordCacheStatus.QUEUED].includes(
+        repositories[foundIndex].status
+      )
     ) {
       await this.setRepositoryStatus(repositoryId, UserRecordCacheStatus.DELETING);
     } else if (repositories[foundIndex].status === UserRecordCacheStatus.CACHED) {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Show new Record Status `Queued` for downloads awaiting semaphore
    - Queue has been added to all relevant areas where checks on Record status exist. 
- Adapt Pause transformer to cancel queued items
    - Rename `pauseDownloadOnRehydration` to `handleActiveDownloadsOnRehydration` to reflect change
-  add createAction for flipping status from Queued -> Downloading
- Refactor The time between queue checks that mistakingly made the wait time of all records `n` seconds. Now the record in first position will check more frequently than the rest.
    - This was deemed more performant than finding the index of the id and scaling the count to match, per cycle.  
- Closes #3863