### PR TITLE
[INV-3862] Show/Hide Columns in Record Tables

### DIFF
--- a/app/src/UI/Overlay/Records/RecordSet/RecordTable.css
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordTable.css
@@ -17,6 +17,7 @@
 
 .record_table_container {
   display: flex;
+  flex-direction: column;
   width: 100%;
   height: 300pt;
   overflow-x: scroll;

--- a/app/src/UI/Overlay/Records/RecordSet/RecordTable.tsx
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordTable.tsx
@@ -1,11 +1,6 @@
 import { useDispatch } from 'react-redux';
 import './RecordTable.css';
-import {
-  activityColumnsToDisplay,
-  getUnnestedFieldsForActivity,
-  getUnnestedFieldsForIAPP,
-  iappColumnsToDisplay
-} from './RecordTableHelpers';
+import { getUnnestedFieldsForActivity, getUnnestedFieldsForIAPP } from './RecordTableHelpers';
 import { RECORDSET_SET_SORT, USER_CLICKED_RECORD, USER_HOVERED_RECORD, USER_TOUCHED_RECORD } from 'state/actions';
 import { validActivitySortColumns, validIAPPSortColumns } from 'sharedAPI/src/misc/sortColumns';
 import { detectTouchDevice } from 'utils/detectTouch';
@@ -13,6 +8,7 @@ import VisibilityIcon from '@mui/icons-material/Visibility';
 import { RecordSetType } from 'interfaces/UserRecordSet';
 import { useSelector } from 'utils/use_selector';
 import UserRecord from 'interfaces/UserRecord';
+import RecordTableColumnSelect from './RecordTableColumnSelect/RecordTableColumnSelect';
 
 type PropTypes = {
   setID: string;
@@ -24,30 +20,42 @@ export const RecordTable = ({ setID, userOfflineMobile }: PropTypes) => {
     dispatch({
       type: USER_HOVERED_RECORD,
       payload: {
-        recordType: tableType,
-        id: tableType === RecordSetType.Activity ? row.activity_id : row.site_id,
+        recordType: recordSetType,
+        id: recordSetType === RecordSetType.Activity ? row.activity_id : row.site_id,
         row: row
       }
     });
   };
+
+  const recordSetType = useSelector((state) => state.UserSettings?.recordSets?.[setID].recordSetType);
+  const tableColumns = useSelector((state) =>
+    state.UserSettings?.tableColumns[recordSetType].filter((col) => !col.hide)
+  );
   const unmappedRows = useSelector((state) => state.Map?.recordTables?.[setID]?.rows);
-  const tableType = useSelector((state) => state.UserSettings?.recordSets?.[setID].recordSetType);
-  const activitySortColumns = userOfflineMobile ? [] : validActivitySortColumns;
-  const iappSortColumns = userOfflineMobile ? [] : validIAPPSortColumns;
+  const sortColumn = useSelector((state) => state.UserSettings?.recordSets?.[setID]?.sortColumn);
+  const sortOrder = useSelector((state) => state.UserSettings?.recordSets?.[setID]?.sortOrder);
   const dispatch = useDispatch();
+
   const isTouch = detectTouchDevice();
   const mappedRows = unmappedRows?.map((row) => {
     const unnestedRow =
-      tableType === RecordSetType.Activity ? getUnnestedFieldsForActivity(row) : getUnnestedFieldsForIAPP(row);
+      recordSetType === RecordSetType.Activity ? getUnnestedFieldsForActivity(row) : getUnnestedFieldsForIAPP(row);
     const mappedRow = {};
     Object.keys(unnestedRow).forEach((key) => {
       mappedRow[key] = unnestedRow[key];
     });
     return mappedRow;
   });
+  const sortColumns = (() => {
+    if (userOfflineMobile) return [];
+    switch (recordSetType) {
+      case RecordSetType.IAPP:
+        return validIAPPSortColumns;
+      case RecordSetType.Activity:
+        return validActivitySortColumns;
+    }
+  })();
 
-  const sortColumn = useSelector((state) => state.UserSettings?.recordSets?.[setID]?.sortColumn);
-  const sortOrder = useSelector((state) => state.UserSettings?.recordSets?.[setID]?.sortOrder);
   if (!mappedRows || mappedRows?.length === 0) {
     return (
       <div className="no-records">
@@ -56,121 +64,95 @@ export const RecordTable = ({ setID, userOfflineMobile }: PropTypes) => {
     );
   }
   return (
-    <div className="record_table_container">
-      <table className="record_table">
-        <tbody>
-          <tr className="record_table_header">
-            {isTouch && (
-              <th className="record_table_header_column" style={{ width: '50px' }}>
-                View/Edit
-              </th>
-            )}
-            {tableType === RecordSetType.Activity
-              ? activityColumnsToDisplay.map((col) => (
-                  <th
-                    className={'record_table_header_column'}
-                    key={col.key}
-                    onClick={() => {
-                      if (activitySortColumns.includes(col.key)) {
-                        dispatch({ type: RECORDSET_SET_SORT, payload: { setID: setID, sortColumn: col.key } });
-                      }
-                    }}
-                  >
-                    {col.name}{' '}
-                    {sortColumn === col.key &&
-                      activitySortColumns.includes(sortColumn) &&
-                      (sortOrder === 'ASC' ? '▲' : '▼')}
-                  </th>
-                ))
-              : iappColumnsToDisplay.map((col) => (
-                  <th
-                    className="record_table_header_column"
-                    key={col.key}
-                    onClick={() => {
-                      if (iappSortColumns.includes(col.key)) {
-                        dispatch({ type: RECORDSET_SET_SORT, payload: { setID: setID, sortColumn: col.key } });
-                      }
-                    }}
-                  >
-                    {col.name}{' '}
-                    {sortColumn === col.key &&
-                      iappSortColumns.includes(sortColumn) &&
-                      (sortOrder === 'ASC' ? '▲' : '▼')}
-                  </th>
-                ))}
-          </tr>
-          {mappedRows?.map((row: UserRecord) => {
-            return (
-              <tr
-                onContextMenu={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                }}
-                onClick={() => {
-                  if (!isTouch) {
-                    dispatch({
-                      type: USER_CLICKED_RECORD,
-                      payload: {
-                        recordType: tableType,
-                        id: tableType === RecordSetType.Activity ? row.activity_id : row.site_id,
-                        row: row
-                      }
-                    });
-                  }
-                }}
-                onMouseOver={() => onUserHoveredRecord(row)}
-                onFocus={() => onUserHoveredRecord(row)}
-                onTouchStart={() => {
-                  dispatch({
-                    type: USER_TOUCHED_RECORD,
-                    payload: {
-                      recordType: tableType,
-                      id: tableType === RecordSetType.Activity ? row.activity_id : row.site_id,
-                      row: row
+    <div>
+      <RecordTableColumnSelect recordSetType={recordSetType} />
+      <div className="record_table_container">
+        <table className="record_table">
+          <tbody>
+            <tr className="record_table_header">
+              {isTouch && (
+                <th className="record_table_header_column" style={{ width: '50px' }}>
+                  View/Edit
+                </th>
+              )}
+              {tableColumns.map((col) => (
+                <th
+                  className="record_table_header_column"
+                  key={col.key}
+                  onClick={() => {
+                    if (sortColumns.includes(col.key)) {
+                      dispatch({ type: RECORDSET_SET_SORT, payload: { setID: setID, sortColumn: col.key } });
                     }
-                  });
-                }}
-                className="record_table_row"
-                key={row?.activity_id ?? row?.site_id}
-              >
-                {isTouch && (
-                  <td
-                    onTouchStart={() => {
+                  }}
+                >
+                  {col.name}{' '}
+                  {sortColumn === col.key && sortColumns.includes(sortColumn) && (sortOrder === 'ASC' ? '▲' : '▼')}
+                </th>
+              ))}
+            </tr>
+            {mappedRows?.map((row: UserRecord) => {
+              return (
+                <tr
+                  onContextMenu={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                  }}
+                  onClick={() => {
+                    if (!isTouch) {
                       dispatch({
                         type: USER_CLICKED_RECORD,
                         payload: {
-                          recordType: tableType,
-                          id: tableType === RecordSetType.Activity ? row.activity_id : row.site_id,
+                          recordType: recordSetType,
+                          id: recordSetType === RecordSetType.Activity ? row.activity_id : row.site_id,
                           row: row
                         }
                       });
-                    }}
-                    className="record_table_row_column"
-                    style={{ width: '50px' }}
-                  >
-                    <VisibilityIcon />
-                  </td>
-                )}
-                {tableType === RecordSetType.Activity
-                  ? activityColumnsToDisplay.map((col) => {
-                      return (
-                        <td className="record_table_row_column" key={col.key + col.name}>
-                          {row[col.key]}
-                        </td>
-                      );
-                    })
-                  : iappColumnsToDisplay.map((col) => {
-                      return (
-                        <td className="record_table_row_column" key={col.key + col.name}>
-                          {row[col.key]}
-                        </td>
-                      );
-                    })}
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+                    }
+                  }}
+                  onMouseOver={() => onUserHoveredRecord(row)}
+                  onFocus={() => onUserHoveredRecord(row)}
+                  onTouchStart={() => {
+                    dispatch({
+                      type: USER_TOUCHED_RECORD,
+                      payload: {
+                        recordType: recordSetType,
+                        id: recordSetType === RecordSetType.Activity ? row.activity_id : row.site_id,
+                        row: row
+                      }
+                    });
+                  }}
+                  className="record_table_row"
+                  key={row?.activity_id ?? row?.site_id}
+                >
+                  {isTouch && (
+                    <td
+                      onTouchStart={() => {
+                        dispatch({
+                          type: USER_CLICKED_RECORD,
+                          payload: {
+                            recordType: recordSetType,
+                            id: recordSetType === RecordSetType.Activity ? row.activity_id : row.site_id,
+                            row: row
+                          }
+                        });
+                      }}
+                      className="record_table_row_column"
+                      style={{ width: '50px' }}
+                    >
+                      <VisibilityIcon />
+                    </td>
+                  )}
+                  {tableColumns.map((col) => (
+                    <td className="record_table_row_column" key={col.key + col.name}>
+                      {row[col.key]}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 };

--- a/app/src/UI/Overlay/Records/RecordSet/RecordTableColumnSelect/RecordTableColumnSelect.css
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordTableColumnSelect/RecordTableColumnSelect.css
@@ -1,0 +1,62 @@
+.custom-popover {
+  button {
+    display: flex;
+  }
+  button:hover {
+    cursor: pointer;
+  }
+}
+
+.popover-content {
+  display: flex;
+  flex-direction: column;
+  width: 250pt;
+  max-height: 300pt;
+  padding: 5pt 0;
+  box-sizing: border-box;
+
+  .popover-search {
+    margin-bottom: 5pt;
+    padding: 0 5pt;
+    input {
+      height: 20pt;
+      border-radius: 4pt;
+      border: 1pt solid black;
+      padding: 2pt 5pt;
+      font-size: 12pt;
+    }
+  }
+  .popover-list {
+    list-style-type: none;
+    padding: 0;
+    height: 100%;
+    margin: 0;
+    width: 100%;
+    overflow: auto;
+    box-sizing: border-box;
+    scrollbar-width: thin;
+
+    .column-option {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      width: 100%;
+      text-align: left;
+      justify-content: left;
+      & > p {
+        margin: 0;
+      }
+    }
+    .column-option:nth-child(odd) {
+      background-color: #eeeeee95;
+    }
+  }
+  .popover-show-hide {
+    width: 100%;
+    display: flex;
+    justify-content: space-around;
+    button:hover {
+      cursor: pointer;
+    }
+  }
+}

--- a/app/src/UI/Overlay/Records/RecordSet/RecordTableColumnSelect/RecordTableColumnSelect.tsx
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordTableColumnSelect/RecordTableColumnSelect.tsx
@@ -1,0 +1,77 @@
+import { Button, Popover, Switch } from '@mui/material';
+import { MouseEvent, TouchEvent, useState } from 'react';
+import { ViewColumn } from '@mui/icons-material';
+import './RecordTableColumnSelect.css';
+import { RecordSetType } from 'interfaces/UserRecordSet';
+import { useDispatch, useSelector } from 'utils/use_selector';
+import UserSettings from 'state/actions/userSettings/UserSettings';
+
+type PropTypes = {
+  recordSetType: RecordSetType;
+};
+const RecordTableColumnSelect = ({ recordSetType }: PropTypes) => {
+  const handleClick = (event: MouseEvent<HTMLButtonElement> | TouchEvent<HTMLButtonElement>) =>
+    setAnchorEl(event.currentTarget);
+
+  const dispatch = useDispatch();
+  const columns = useSelector((state) => state.UserSettings.tableColumns[recordSetType]);
+
+  const [filter, setFilter] = useState<string>('');
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+
+  const shownColumns = !filter ? columns : columns.filter((col) => new RegExp(filter, 'i').test(col.name));
+
+  const id = 'table-column-select';
+  return (
+    <div className="custom-popover">
+      <Button aria-describedby={id} size={'small'} onClick={handleClick}>
+        <ViewColumn /> Columns
+      </Button>
+
+      <Popover
+        open={!!anchorEl}
+        id={id}
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'left'
+        }}
+        onClose={() => setAnchorEl(null)}
+      >
+        <div className="popover-content">
+          <div className="popover-search">
+            <input
+              type="text"
+              placeholder="Find Column"
+              value={filter}
+              onChange={(evt) => setFilter(evt.target.value)}
+            ></input>
+          </div>
+          <ul className="popover-list">
+            {shownColumns.map(({ hide, key, name }) => (
+              <li className="column-option" key={key}>
+                <Switch
+                  color={'primary'}
+                  size={'medium'}
+                  checked={!hide}
+                  onChange={() => dispatch(UserSettings.RecordSet.toggleRecordColumn(recordSetType, key))}
+                />
+                {name}
+              </li>
+            ))}
+          </ul>
+          <div className="popover-show-hide">
+            <Button onClick={() => dispatch(UserSettings.RecordSet.toggleAllRecordColumns(recordSetType, true))}>
+              Hide All
+            </Button>
+            <Button onClick={() => dispatch(UserSettings.RecordSet.toggleAllRecordColumns(recordSetType, false))}>
+              Show All
+            </Button>
+          </div>
+        </div>
+      </Popover>
+    </div>
+  );
+};
+
+export default RecordTableColumnSelect;

--- a/app/src/UI/Overlay/Records/RecordSet/RecordTableHelpers.tsx
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordTableHelpers.tsx
@@ -88,162 +88,51 @@ export const getUnnestedFieldsForIAPP = (record) => {
 };
 
 export const activityColumnsToDisplay = [
-  {
-    key: 'short_id',
-    name: 'Activity ID',
-    displayWidget: 'div'
-  },
-  {
-    key: 'activity_type',
-    name: 'Activity Type'
-  },
-  {
-    key: 'activity_subtype',
-    name: 'Activity Sub Type'
-  },
-  {
-    key: 'activity_date',
-    name: 'Activity Date'
-  },
-  {
-    key: 'project_code',
-    name: 'Project Code'
-  },
-  {
-    key: 'jurisdiction_display',
-    name: 'Jurisdiction'
-  },
-  {
-    key: 'invasive_plant',
-    name: 'Invasive Plant'
-  },
-  {
-    key: 'species_positive_full',
-    name: 'All Positive'
-  },
-  {
-    key: 'species_negative_full',
-    name: 'All Negative'
-  },
-  {
-    key: 'has_current_positive',
-    name: 'Has Current Positive'
-  },
-  {
-    key: 'current_positive_species',
-    name: 'Current Positive Species'
-  },
-  {
-    key: 'has_current_negative',
-    name: 'Has Current Negative'
-  },
-  {
-    key: 'current_negative_species',
-    name: 'Current Negative Species'
-  },
-  {
-    key: 'species_treated_full',
-    name: 'Species Treated'
-  },
-  {
-    key: 'species_biocontrol_full',
-    name: 'Biocontrol Species'
-  },
-  { key: 'created_by', name: 'Created By' },
-  { key: 'updated_by', name: 'Updated By' },
-  {
-    key: 'agency',
-    name: 'Agency'
-  },
+  { key: 'short_id', name: 'Activity ID', displayWidget: 'div', hide: false },
+  { key: 'activity_type', name: 'Activity Type', hide: false },
+  { key: 'activity_subtype', name: 'Activity Sub Type', hide: false },
+  { key: 'activity_date', name: 'Activity Date', hide: false },
+  { key: 'project_code', name: 'Project Code', hide: false },
+  { key: 'jurisdiction_display', name: 'Jurisdiction', hide: false },
+  { key: 'invasive_plant', name: 'Invasive Plant', hide: false },
+  { key: 'species_positive_full', name: 'All Positive', hide: false },
+  { key: 'species_negative_full', name: 'All Negative', hide: false },
+  { key: 'has_current_positive', name: 'Has Current Positive', hide: false },
+  { key: 'current_positive_species', name: 'Current Positive Species', hide: false },
+  { key: 'has_current_negative', name: 'Has Current Negative', hide: false },
+  { key: 'current_negative_species', name: 'Current Negative Species', hide: false },
+  { key: 'species_treated_full', name: 'Species Treated', hide: false },
+  { key: 'species_biocontrol_full', name: 'Biocontrol Species', hide: false },
+  { key: 'created_by', name: 'Created By', hide: false },
+  { key: 'updated_by', name: 'Updated By', hide: false },
+  { key: 'agency', name: 'Agency', hide: false },
   {
     key: 'regional_invasive_species_organization_areas',
-    name: 'Regional Invasive Species Organization Areas'
+    name: 'Regional Invasive Species Organization Areas',
+    hide: false
   },
-  {
-    key: 'regional_districts',
-    name: 'Regional Districts'
-  },
-  {
-    key: 'invasive_plant_management_areas',
-    name: 'Invasive Plant Management Areas'
-  },
-  {
-    key: 'biogeoclimatic_zones',
-    name: 'Bio Geo Climatic Zones'
-  },
-  {
-    key: 'elevation',
-    name: 'Elevation'
-  },
-  {
-    key: 'batch_id',
-    name: 'Batch ID'
-  }
-];
+  { key: 'regional_districts', name: 'Regional Districts', hide: false },
+  { key: 'invasive_plant_management_areas', name: 'Invasive Plant Management Areas', hide: false },
+  { key: 'biogeoclimatic_zones', name: 'Bio Geo Climatic Zones', hide: false },
+  { key: 'elevation', name: 'Elevation', hide: false },
+  { key: 'batch_id', name: 'Batch ID', hide: false }
+].sort((a, b) => a.name.localeCompare(b.name));
 
 export const iappColumnsToDisplay = [
-  {
-    key: 'site_id',
-    name: 'Site ID'
-  },
-  {
-    key: 'site_paper_file_id',
-    name: 'Site Paper File ID'
-  },
-  {
-    key: 'jurisdictions_flattened',
-    name: 'Jurisdictions'
-  },
-  {
-    key: 'min_survey',
-    name: 'Site Create Date'
-  },
-  {
-    key: 'all_species_on_site',
-    name: 'Invasive Plants'
-  },
-  {
-    key: 'biological_agent',
-    name: 'Biological Agent'
-  },
-  {
-    key: 'max_survey',
-    name: 'Last Surveyed Date'
-  },
-  {
-    key: 'agencies',
-    name: 'Agencies'
-  },
-  {
-    key: 'has_biological_treatments',
-    name: 'Biocontrol Release'
-  },
-  {
-    key: 'has_chemical_treatments',
-    name: 'Chemical Treatment'
-  },
-  {
-    key: 'has_mechanical_treatments',
-    name: 'Mechanical Treatment'
-  },
-  {
-    key: 'has_biological_dispersals',
-    name: 'Biocontrol Dispersal'
-  },
-  {
-    key: 'monitored',
-    name: 'Monitored'
-  },
-  {
-    key: 'regional_district',
-    name: 'Regional District'
-  },
-  {
-    key: 'regional_invasive_species_organization',
-    name: 'Regional Invasive Species Organization'
-  },
-  {
-    key: 'invasive_plant_management_area',
-    name: 'Invasive Plant Management Area'
-  }
-];
+  { key: 'site_id', name: 'Site ID', hide: false },
+  { key: 'site_paper_file_id', name: 'Site Paper File ID', hide: false },
+  { key: 'jurisdictions_flattened', name: 'Jurisdictions', hide: false },
+  { key: 'min_survey', name: 'Site Create Date', hide: false },
+  { key: 'all_species_on_site', name: 'Invasive Plants', hide: false },
+  { key: 'biological_agent', name: 'Biological Agent', hide: false },
+  { key: 'max_survey', name: 'Last Surveyed Date', hide: false },
+  { key: 'agencies', name: 'Agencies', hide: false },
+  { key: 'has_biological_treatments', name: 'Biocontrol Release', hide: false },
+  { key: 'has_chemical_treatments', name: 'Chemical Treatment', hide: false },
+  { key: 'has_mechanical_treatments', name: 'Mechanical Treatment', hide: false },
+  { key: 'has_biological_dispersals', name: 'Biocontrol Dispersal', hide: false },
+  { key: 'monitored', name: 'Monitored', hide: false },
+  { key: 'regional_district', name: 'Regional District', hide: false },
+  { key: 'regional_invasive_species_organization', name: 'Regional Invasive Species Organization', hide: false },
+  { key: 'invasive_plant_management_area', name: 'Invasive Plant Management Area', hide: false }
+].sort((a, b) => a.name.localeCompare(b.name));

--- a/app/src/state/actions/userSettings/RecordSet.ts
+++ b/app/src/state/actions/userSettings/RecordSet.ts
@@ -49,6 +49,14 @@ class RecordSet {
   static readonly toggleVisibility = createAction<string>(`${this.PREFIX}/toggleVisibility`);
   static readonly toggleLabelVisibility = createAction<string>(`${this.PREFIX}/toggleLabelVisibility`);
 
+  static readonly toggleRecordColumn = createAction(
+    `${this.PREFIX}.toggleRecordColumn`,
+    (recordType: RecordSetType, key: string) => ({ payload: { recordType, key } })
+  );
+  static readonly toggleAllRecordColumns = createAction(
+    `${this.PREFIX}/toggleAllColumns`,
+    (recordType: RecordSetType, hide: boolean) => ({ payload: { recordType, hide } })
+  );
   static readonly syncCacheStatusWithCacheService = createAsyncThunk(
     `${this.PREFIX}/syncCacheStatusWithCacheService`,
     async () => {

--- a/app/src/state/reducers/rootReducer.ts
+++ b/app/src/state/reducers/rootReducer.ts
@@ -126,11 +126,11 @@ function createRootReducer(config: AppConfig) {
           'recordSets',
           'recordsExpanded',
           'newRecordDialogState',
-          'darkTheme',
           'boundaries',
           'layerPickerIsAccordion',
           'mapCenter',
-          'offlineDocs'
+          'offlineDocs',
+          'tableColumns'
         ],
         transforms: [handleActiveDownloadsOnRehydration]
       },

--- a/app/src/state/reducers/userSettings.ts
+++ b/app/src/state/reducers/userSettings.ts
@@ -5,7 +5,7 @@ import { AppConfig } from 'state/config';
 import { CLOSE_NEW_RECORD_MENU, OPEN_NEW_RECORD_MENU, RECORDSET_SET_SORT } from 'state/actions';
 
 import { CURRENT_MIGRATION_VERSION, MIGRATION_VERSION_KEY } from 'constants/offline_state_version';
-import { UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
+import { RecordSetType, UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
 import UserSettings from 'state/actions/userSettings/UserSettings';
 import Boundary from 'interfaces/Boundary';
 import WhatsHere from 'state/actions/whatsHere/WhatsHere';
@@ -14,6 +14,7 @@ import RecordCache from 'state/actions/cache/RecordCache';
 import IappActions from 'state/actions/activity/Iapp';
 import { CacheDownloadMode } from 'utils/record-cache';
 import { APIDocs } from 'state/actions/userSettings/APIDocs';
+import { activityColumnsToDisplay, iappColumnsToDisplay } from 'UI/Overlay/Records/RecordSet/RecordTableHelpers';
 
 export interface UserSettingsState {
   [MIGRATION_VERSION_KEY]: number;
@@ -38,7 +39,10 @@ export interface UserSettingsState {
   boundaries: Boundary[];
   layerPickerIsAccordion: boolean;
   darkTheme: boolean;
-
+  tableColumns: {
+    [RecordSetType.IAPP]: Array<{ key: string; name: string; displayWidget?: string; hide: boolean }>;
+    [RecordSetType.Activity]: Array<{ key: string; name: string; displayWidget?: string; hide: boolean }>;
+  };
   offlineDocs: { displayName: string; apiDocsWithViewOptions: object; apiDocsWithSelectOptions: object }[];
 }
 
@@ -64,6 +68,10 @@ const initialState: UserSettingsState = {
     recordCategory: '',
     recordType: '',
     recordSubtype: ''
+  },
+  tableColumns: {
+    [RecordSetType.Activity]: activityColumnsToDisplay,
+    [RecordSetType.IAPP]: iappColumnsToDisplay
   },
   offlineDocs: []
 };
@@ -143,6 +151,17 @@ function createUserSettingsReducer(
         draftState.recordSets[action.payload.setID].tableFiltersHash = Md5.hashStr(
           JSON.stringify(tableFiltersNotBlank)
         );
+      } else if (UserSettings.RecordSet.toggleRecordColumn.match(action)) {
+        const { recordType, key } = action.payload;
+        const index = draftState.tableColumns[recordType].findIndex((item) => item.key === key);
+        draftState.tableColumns[recordType][index].hide = !draftState.tableColumns[recordType][index].hide;
+        draftState.tableColumns[recordType] = [...draftState.tableColumns[recordType]];
+      } else if (UserSettings.RecordSet.toggleAllRecordColumns.match(action)) {
+        const { recordType, hide } = action.payload;
+        draftState.tableColumns[recordType] = draftState.tableColumns[recordType].map((row) => {
+          row.hide = hide;
+          return row;
+        });
       } else if (UserSettings.toggleLayerPickerAccordion.match(action)) {
         draftState.layerPickerIsAccordion = !draftState.layerPickerIsAccordion;
       } else if (WhatsHere.toggle.match(action)) {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

> [!IMPORTANT]
> Abandoned switching to MUI Data grids, they do not auto resize and rely on hovering to see the full text. This is not beneficial to Mobile. This [DataGrid] feature is locked to the premium version.

- Record Table Columns
    - Add a `hide` key to all Record Table columns
    - Move to Redux State using RecordSetType as accessor
    - Alphabetize columns 
- Add Popover to Toggle visibility of Columns in the table
    - Add Redux Actions to modify the popover  
- Remove several ternary map conditions out of `RecordTable.tsx` determining the appropriate values before the JSX
- Closes  #3862 
## Screenshots

![image](https://github.com/user-attachments/assets/d10f6559-b1d7-426d-b7d8-8d0699e4fc41)

![image](https://github.com/user-attachments/assets/5b17d84f-e6de-4d0a-ab54-dbe0e9679f05)
