### PR TITLE
3872 show queued tile cache downloads

### DIFF
--- a/app/src/UI/Overlay/TileCache/TileCacheDownloadProgress.tsx
+++ b/app/src/UI/Overlay/TileCache/TileCacheDownloadProgress.tsx
@@ -19,7 +19,6 @@ const TileCacheDownloadProgress = () => {
       </section>
     );
   }
-
   return (
     <section>
       <table>
@@ -34,7 +33,7 @@ const TileCacheDownloadProgress = () => {
         <tbody>
           {Object.keys(downloadProgress).map((k) => (
             <tr key={k}>
-              <td>{downloadProgress[k].repository}</td>
+              <td>{downloadProgress[k].description ?? downloadProgress[k].repository}</td>
               <td>{downloadProgress[k].message}</td>
               <td>
                 <LinearProgress variant={'determinate'} value={downloadProgress[k].normalizedProgress * 100} />

--- a/app/src/UI/Overlay/TileCache/tileCache.css
+++ b/app/src/UI/Overlay/TileCache/tileCache.css
@@ -51,7 +51,6 @@
     border-collapse: collapse;
     border: 1pt solid lightgray;
     border-radius: 5pt;
-    table-layout: fixed;
     word-wrap: break-word;
 
     tbody tr:nth-child(odd) {

--- a/app/src/state/actions/cache/TileCache.ts
+++ b/app/src/state/actions/cache/TileCache.ts
@@ -2,7 +2,8 @@ import { createAction, createAsyncThunk, nanoid } from '@reduxjs/toolkit';
 import { GeoJSON } from 'geojson';
 import DownloadActions from '../downloads/DownloadActions';
 import { TileCacheServiceFactory } from 'utils/tile-cache/context';
-import { TileCacheProgressCallbackParameters, RepositoryBoundingBoxSpec } from 'utils/tile-cache';
+import { TileCacheProgressCallbackParameters, RepositoryBoundingBoxSpec, RepositoryStatus } from 'utils/tile-cache';
+import { RootState } from 'state/reducers/rootReducer';
 
 class TileCache {
   static readonly PREFIX = 'TileCache';
@@ -42,25 +43,38 @@ class TileCache {
         bounds: RepositoryBoundingBoxSpec;
         id?: string;
       },
-      { dispatch }
+      { dispatch, getState }
     ) => {
-      await dispatch(DownloadActions.request());
-      const service = await TileCacheServiceFactory.getPlatformInstance();
       const id = spec.id ?? `tile-cache-${nanoid()}`;
-      await service.download(
-        {
-          id: id,
-          maxZoom: spec.maxZoom,
-          bounds: spec.bounds,
+      dispatch(
+        TileCache.downloadProgressEvent({
+          repository: id,
           description: spec.description,
-          tileURL: (x, y, z) =>
-            `https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/${z}/${y}/${x}`
-        },
-        (p) => {
-          dispatch(TileCache.downloadProgressEvent(p));
-        }
+          message: RepositoryStatus.QUEUED,
+          aborted: false,
+          normalizedProgress: 0,
+          totalTiles: 0,
+          processedTiles: 0
+        })
       );
-
+      await dispatch(DownloadActions.request());
+      const downloadInQueue = !!(getState() as RootState)?.TileCache?.downloadProgress?.[id];
+      const service = await TileCacheServiceFactory.getPlatformInstance();
+      if (downloadInQueue) {
+        await service.download(
+          {
+            id: id,
+            maxZoom: spec.maxZoom,
+            bounds: spec.bounds,
+            description: spec.description,
+            tileURL: (x, y, z) =>
+              `https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/${z}/${y}/${x}`
+          },
+          (p) => {
+            dispatch(TileCache.downloadProgressEvent(p));
+          }
+        );
+      }
       return await service.listRepositories();
     }
   );

--- a/app/src/state/reducers/tile_cache.ts
+++ b/app/src/state/reducers/tile_cache.ts
@@ -153,6 +153,9 @@ function createTileCacheReducer() {
 
       if (TileCache.deleteRepository.pending.match(action)) {
         draft.loading = true;
+        if (Object.prototype.hasOwnProperty.call(draft.downloadProgress, action.meta.arg)) {
+          delete draft.downloadProgress[action.meta.arg];
+        }
       } else if (TileCache.deleteRepository.fulfilled.match(action)) {
         draft.loading = false;
         draft.repositories = action.payload;

--- a/app/src/utils/tile-cache/index.ts
+++ b/app/src/utils/tile-cache/index.ts
@@ -40,8 +40,9 @@ export interface RepositoryMetadata {
 enum RepositoryStatus {
   DOWNLOADING = 'DOWNLOADING',
   DELETING = 'DELETING',
-  READY = 'READY',
   FAILED = 'FAILED',
+  READY = 'READY',
+  QUEUED = 'QUEUED',
   UNKNOWN = 'UNKNOWN'
 }
 interface TilePromise {
@@ -53,12 +54,13 @@ interface TilePromise {
 }
 
 export interface TileCacheProgressCallbackParameters {
-  repository: string;
-  message: string;
   aborted: boolean;
+  description?: string;
+  message: string;
   normalizedProgress: number;
-  totalTiles: number;
   processedTiles: number;
+  repository: string;
+  totalTiles: number;
 }
 
 export interface RepositoryStatistics {
@@ -189,6 +191,7 @@ abstract class TileCacheService extends BaseCacheService<
           if (progressCallback) {
             progressCallback({
               repository: spec.id,
+              description: spec.description,
               message: abort ? `Aborting` : `${processedTiles.toLocaleString()}/${totalTiles.toLocaleString()} Tiles`,
               aborted: abort,
               normalizedProgress: processedTiles / totalTiles,


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):
- Closes #3871
- Closes #3872
    - Fires Progress Callback at start so queued results render in list
    - Cancelling a download/queue removes the item from the download progress object
 

![image](https://github.com/user-attachments/assets/8bd99819-ebab-43b2-b02e-ca3b22b500f7)
