### PR TITLE
[INV-3867] Handle bad record requests

### DIFF
--- a/api/src/paths/v2/iapp.ts
+++ b/api/src/paths/v2/iapp.ts
@@ -8,6 +8,7 @@ import { streamIAPPResult } from 'utils/iapp-json-utils';
 import { getDBConnection } from 'database/db';
 import { ALL_ROLES, SECURITY_ON } from 'constants/misc';
 import { InvasivesRequest } from 'utils/auth-utils';
+import { PoolClient } from 'pg';
 
 const defaultLog = getLogger('IAPP');
 
@@ -92,11 +93,9 @@ export function sanitizeIAPPFilterObject(filterObject: any, req: any) {
     sanitizedSearchCriteria.z = req.params.z;
   }
 
-  const roleName = (req as any).authContext.roles[0]?.role_name;
-  //const sanitizedSearchCriteria = new ActivitySearchCriteria(criteria);
-  // sanitizedSearchCriteria.created_by = [req.authContext.user['preferred_username']];
-  const isAuth = req.authContext?.user !== null ? true : false;
-  const user_role = (req as any).authContext?.roles?.[0]?.role_id;
+  const roleName = req.authContext.roles?.[0]?.role_name;
+  const isAuth = req.authContext?.user !== null;
+  const user_role = req.authContext?.roles?.[0]?.role_id;
   if (user_role) {
     const user_roles = Array.from({ length: user_role }, (_, i) => i + 1);
     sanitizedSearchCriteria.user_roles = user_roles;
@@ -138,12 +137,8 @@ export function sanitizeIAPPFilterObject(filterObject: any, req: any) {
     filterObject.selectColumns.forEach((column) => {
       if (acceptableColumns.includes(column)) {
         switch (column) {
-          case 'created_by':
-            if (!sanitizedSearchCriteria.serverSideNamedFilters.hideEditedByFields) {
-              selectColumns.push(column);
-            }
-            break;
           case 'updated_by':
+          case 'created_by':
             if (!sanitizedSearchCriteria.serverSideNamedFilters.hideEditedByFields) {
               selectColumns.push(column);
             }
@@ -191,10 +186,6 @@ export function sanitizeIAPPFilterObject(filterObject: any, req: any) {
         case 'tableFilter':
           switch (filter.field) {
             case 'created_by':
-              if (!sanitizedSearchCriteria.serverSideNamedFilters.hideEditedByFields) {
-                sanitizedTableFilters.push(filter);
-              }
-              break;
             case 'updated_by':
               if (!sanitizedSearchCriteria.serverSideNamedFilters.hideEditedByFields) {
                 sanitizedTableFilters.push(filter);
@@ -278,8 +269,8 @@ function getIAPPSitesBySearchFilterCriteria(): RequestHandler {
     const filterObject = sanitizeIAPPFilterObject(rawBodyCriteria?.[0], req);
     defaultLog.debug({ label: 'v2/IAPP', message: 'getIAPPBySearchFilterCriteria v2', body: '' });
 
-    let connection;
-    let sql;
+    let connection: PoolClient;
+    let sql: SQLStatement;
 
     try {
       connection = await getDBConnection();
@@ -456,18 +447,6 @@ sites as (
   b.geog as geog
 
   `);
-
-  /*if (filterObject?.serverFilterGeometries?.length > 0) {
-    sqlStatement.append(`
-    ,case when ServerBoundariesToIntersect.geog is null then false else true end as intersects_server_boundary
-    `);
-  }
-  if (filterObject?.clientFilterGeometries?.length > 0) {
-    sqlStatement.append(`
-    ,case when ClientBoundariesToIntersect.geog is null then false else true end as intersects_client_boundary
-    `);
-  }
-  */
 
   sqlStatement.append(`
     from iapp_site_summary_and_geojson b

--- a/app/src/constants/alerts/networkAlerts.ts
+++ b/app/src/constants/alerts/networkAlerts.ts
@@ -42,6 +42,12 @@ const networkAlertMessages: Record<string, AlertMessage> = {
     severity: AlertSeverity.Warning,
     subject: AlertSubjects.Network,
     autoClose: 8
+  },
+  fetchFailed: {
+    content: 'An error occured while attempting to fetch resources. Please try again later.',
+    severity: AlertSeverity.Error,
+    subject: AlertSubjects.Network,
+    autoClose: 5
   }
 };
 

--- a/app/src/hooks/useInvasivesApi.ts
+++ b/app/src/hooks/useInvasivesApi.ts
@@ -257,27 +257,22 @@ export function* InvasivesAPI_Call(method, endpoint, payloadData?, additionalHea
     }
   }
 
-  let res;
+  let res: Response;
   try {
     if (method === 'GET') {
       if (payloadData) {
         url.searchParams.set('query', JSON.stringify(payloadData));
       }
-
       res = yield fetch(url, {
         method: method,
         headers: { Authorization: yield getCurrentJWT(), ...additionalHeaders }
       });
-      const data = yield response_data(res);
-      return { data, status: res.status, url, ok: res.ok };
     } else if (['PUT', 'POST'].includes(method)) {
       res = yield fetch(url, {
         method: method,
         headers: { Authorization: yield getCurrentJWT(), 'Content-Type': 'application/json' },
         body: JSON.stringify(payloadData)
       });
-      const data = yield response_data(res);
-      return { data, status: res.status, url, ok: res.ok };
     } else if (method === 'DELETE') {
       const payloadOptions: { body?: string } = {};
       if (payloadData) {
@@ -288,19 +283,16 @@ export function* InvasivesAPI_Call(method, endpoint, payloadData?, additionalHea
         headers: { Authorization: yield getCurrentJWT(), 'Content-Type': 'application/json' },
         ...payloadOptions
       });
-      const data = yield response_data(res);
-      return { data, status: res.status, url, ok: res.ok };
     } else {
       res = yield fetch(url, {
         method: method,
         headers: { Authorization: yield getCurrentJWT() }
       });
-      const data = yield response_data(res);
-      return { data, status: res.status, url, ok: res.ok };
     }
+    const data = yield response_data(res);
+    return { data, status: res.status, url, ok: res.ok };
   } catch (ex) {
     yield put(Alerts.create(networkAlertMessages.fetchFailed));
-    return res;
   }
 }
 

--- a/app/src/hooks/useInvasivesApi.ts
+++ b/app/src/hooks/useInvasivesApi.ts
@@ -1,7 +1,9 @@
-import { select } from 'redux-saga/effects';
+import { put, select } from 'redux-saga/effects';
 import { selectConfiguration } from 'state/reducers/configuration';
 import { useSelector } from 'utils/use_selector';
 import { getCurrentJWT } from 'state/sagas/auth/auth';
+import networkAlertMessages from 'constants/alerts/networkAlerts';
+import Alerts from 'state/actions/alerts/Alerts';
 
 export const useInvasivesApi = () => {
   const { API_BASE } = useSelector(selectConfiguration);
@@ -255,48 +257,50 @@ export function* InvasivesAPI_Call(method, endpoint, payloadData?, additionalHea
     }
   }
 
-  if (method === 'GET') {
-    if (payloadData) {
-      url.searchParams.set('query', JSON.stringify(payloadData));
-    }
+  let res;
+  try {
+    if (method === 'GET') {
+      if (payloadData) {
+        url.searchParams.set('query', JSON.stringify(payloadData));
+      }
 
-    const res = yield fetch(url, {
-      method: method,
-      headers: { Authorization: yield getCurrentJWT(), ...additionalHeaders }
-    });
-    const data = yield response_data(res);
-    const status = res.status;
-    return { data, status, url };
-  } else if (['PUT', 'POST'].includes(method)) {
-    const res = yield fetch(url, {
-      method: method,
-      headers: { Authorization: yield getCurrentJWT(), 'Content-Type': 'application/json' },
-      body: JSON.stringify(payloadData)
-    });
-    const data = yield response_data(res);
-    const status = res.status;
-    return { data, status, url };
-  } else if (method === 'DELETE') {
-    const payloadOptions: { body?: string } = {};
-    if (payloadData) {
-      payloadOptions.body = JSON.stringify(payloadData);
+      res = yield fetch(url, {
+        method: method,
+        headers: { Authorization: yield getCurrentJWT(), ...additionalHeaders }
+      });
+      const data = yield response_data(res);
+      return { data, status: res.status, url, ok: res.ok };
+    } else if (['PUT', 'POST'].includes(method)) {
+      res = yield fetch(url, {
+        method: method,
+        headers: { Authorization: yield getCurrentJWT(), 'Content-Type': 'application/json' },
+        body: JSON.stringify(payloadData)
+      });
+      const data = yield response_data(res);
+      return { data, status: res.status, url, ok: res.ok };
+    } else if (method === 'DELETE') {
+      const payloadOptions: { body?: string } = {};
+      if (payloadData) {
+        payloadOptions.body = JSON.stringify(payloadData);
+      }
+      res = yield fetch(url, {
+        method: method,
+        headers: { Authorization: yield getCurrentJWT(), 'Content-Type': 'application/json' },
+        ...payloadOptions
+      });
+      const data = yield response_data(res);
+      return { data, status: res.status, url, ok: res.ok };
+    } else {
+      res = yield fetch(url, {
+        method: method,
+        headers: { Authorization: yield getCurrentJWT() }
+      });
+      const data = yield response_data(res);
+      return { data, status: res.status, url, ok: res.ok };
     }
-    const res = yield fetch(url, {
-      method: method,
-      headers: { Authorization: yield getCurrentJWT(), 'Content-Type': 'application/json' },
-      ...payloadOptions
-    });
-    const data = yield response_data(res);
-    const status = res.status;
-    return { data, status, url };
-  } else {
-    const res = yield fetch(url, {
-      method: method,
-      headers: { Authorization: yield getCurrentJWT() }
-    });
-    const data = yield response_data(res);
-    const status = res.status;
-    return { data, status, url };
+  } catch (ex) {
+    yield put(Alerts.create(networkAlertMessages.fetchFailed));
+    return res;
   }
 }
 

--- a/app/src/state/sagas/map/online.ts
+++ b/app/src/state/sagas/map/online.ts
@@ -16,6 +16,7 @@ import { selectConfiguration, selectRootConfiguration } from 'state/reducers/con
 import { PayloadAction } from '@reduxjs/toolkit';
 import IappActions, { IappTableRowGetRequest } from 'state/actions/activity/Iapp';
 import Activity from 'state/actions/activity/Activity';
+import UserRecord from 'interfaces/UserRecord';
 
 function* refreshExportConfigIfRequired(action?: AnyAction) {
   const config = yield select(selectRootConfiguration);
@@ -142,7 +143,7 @@ export function* handle_ACTIVITIES_TABLE_ROWS_GET_ONLINE(action) {
     return;
   }
 
-  if (networkReturn.data.result) {
+  if (networkReturn?.ok && networkReturn.data.result) {
     yield put(
       Activity.getRowsSuccess({
         recordSetID: action.payload.recordSetID,
@@ -167,7 +168,7 @@ export function* handle_IAPP_TABLE_ROWS_GET_ONLINE(action: PayloadAction<IappTab
     return;
   }
 
-  if (networkReturn.data.result) {
+  if (networkReturn?.ok && networkReturn?.data?.result) {
     yield put(
       IappActions.getRowsSuccess({
         recordSetID: action.payload.recordSetID,
@@ -181,7 +182,7 @@ export function* handle_IAPP_TABLE_ROWS_GET_ONLINE(action: PayloadAction<IappTab
     put(
       IappActions.getRowsFailure({
         recordSetID: action.payload.recordSetID,
-        error: networkReturn.data,
+        error: networkReturn?.data,
         tableFiltersHash: action.payload.tableFiltersHash,
         page: action.payload.page,
         limit: action.payload.limit
@@ -203,21 +204,16 @@ export function* handle_ACTIVITIES_GET_IDS_FOR_RECORDSET_ONLINE(action) {
     return;
   }
 
-  if (networkReturn.data.result || networkReturn.data?.data?.result) {
-    const list = networkReturn.data?.data?.result ? networkReturn.data?.data?.result : networkReturn.data?.result;
-    const IDList = list.map((row) => {
-      return row.activity_id;
-    });
+  if (networkReturn?.ok && (networkReturn?.data?.result || networkReturn.data?.data?.result)) {
+    const list = networkReturn.data?.data?.result ?? networkReturn.data?.result;
+    const IDList = list.map((row: UserRecord) => row.activity_id);
 
     // check again after the network call
     const mapState = yield select((state) => state.Map);
-    const tableFiltersHash = mapState?.layers?.filter((layer) => {
-      return layer?.recordSetID === action.payload.recordSetID;
-    })?.[0]?.tableFiltersHash;
+    const tableFiltersHash = mapState?.layers?.filter((layer) => layer?.recordSetID === action.payload.recordSetID)?.[0]
+      ?.tableFiltersHash;
 
-    if (!tableFiltersHash === action.payload.tableFiltersHash) {
-      return;
-    }
+    if (tableFiltersHash !== action.payload.tableFiltersHash) return;
 
     yield put({
       type: ACTIVITIES_GET_IDS_FOR_RECORDSET_SUCCESS,
@@ -241,7 +237,7 @@ export function* handle_IAPP_GET_IDS_FOR_RECORDSET_ONLINE(action) {
     return;
   }
 
-  if (networkReturn.data.result || networkReturn.data?.data?.result) {
+  if (networkReturn?.ok && (networkReturn.data.result || networkReturn.data?.data?.result)) {
     const list = networkReturn.data?.data?.result ? networkReturn.data?.data?.result : networkReturn.data?.result;
     const IDList = list?.map((row) => {
       return row.site_id;

--- a/app/src/state/sagas/userSettings.ts
+++ b/app/src/state/sagas/userSettings.ts
@@ -66,7 +66,7 @@ function* handle_USER_SETTINGS_DELETE_KML_REQUEST(action) {
       server_id: action.payload
     });
 
-    if (networkReturn) {
+    if (networkReturn.ok) {
       yield put(UserSettings.KML.deleteSuccess(action.payload));
     }
   } catch (e) {

--- a/app/src/state/sagas/userSettings.ts
+++ b/app/src/state/sagas/userSettings.ts
@@ -66,7 +66,7 @@ function* handle_USER_SETTINGS_DELETE_KML_REQUEST(action) {
       server_id: action.payload
     });
 
-    if (networkReturn.ok) {
+    if (networkReturn?.ok) {
       yield put(UserSettings.KML.deleteSuccess(action.payload));
     }
   } catch (e) {
@@ -187,17 +187,19 @@ function* handle_GET_API_DOC_REQUEST() {
     { filterForSelectable: 'true' }
   );
   const apiDocsWithViewOptionsResponse = yield InvasivesAPI_Call('GET', '/api/api-docs/');
-  const apiDocsWithViewOptions = apiDocsWithViewOptionsResponse.data;
-  const apiDocsWithSelectOptions = apiDocsWithSelectOptionsResponse.data;
+  if (apiDocsWithViewOptionsResponse?.ok) {
+    const apiDocsWithViewOptions = apiDocsWithViewOptionsResponse.data;
+    const apiDocsWithSelectOptions = apiDocsWithSelectOptionsResponse.data;
 
-  yield put(
-    APIDocs.set({
-      apiDocsWithViewOptions: apiDocsWithViewOptions,
-      apiDocsWithSelectOptions: apiDocsWithSelectOptions
-    })
-  );
-  if (displayName) {
-    yield put(APIDocs.save({ displayName }));
+    yield put(
+      APIDocs.set({
+        apiDocsWithViewOptions: apiDocsWithViewOptions,
+        apiDocsWithSelectOptions: apiDocsWithSelectOptions
+      })
+    );
+    if (displayName) {
+      yield put(APIDocs.save({ displayName }));
+    }
   }
 }
 


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

Since we're parsing out the responses in the `InvasivesAPI_Call` function, I've passed along the pre parse `ok` flag, so we can make sure our requests are actually passing beforehand. We did have `status` passed before, but `ok` is simpler than making sure its not a 200, 201, 202, ...etc

- Modify the `InvasivesAPI_Call` functions to
    - return `ok` status from response
    - Catch failed requests and send an alert to user
- Implement checks with `response?.ok` before handling response data for Recordsets + apiDocs
- Cleanup code smells
- Closes #3867  
