### PR TITLE
[INV-3748] Fix issue with some Vector tile filters

### DIFF
--- a/api/src/paths/vectors/{source}/{z}/{x}/{y}.ts
+++ b/api/src/paths/vectors/{source}/{z}/{x}/{y}.ts
@@ -29,7 +29,7 @@ function tile(): RequestHandler {
     if (req.authContext.roles.length === 0) {
       res.status(401).json({ message: 'No Role for user' });
     }
-    const rawBodyCriteria = JSON.parse(decodeURI(req.query.filterObject as string));
+    const rawBodyCriteria = JSON.parse(req.query.filterObject as string);
     const { source } = req.params;
     let filterObj = null;
     if (source === 'activities') {
@@ -37,10 +37,8 @@ function tile(): RequestHandler {
     } else {
       filterObj = sanitizeIAPPFilterObject(rawBodyCriteria, req);
     }
-
     //@todo validate source, tile bounds
     const tileData = await PostgresTileService.tile(source, filterObj);
-
     res.setHeader('content-type', 'application/vnd.mapbox-vector-tile');
     res.status(200).send(tileData);
   };


### PR DESCRIPTION
# Overview

## This PR includes the following proposed change(s):

Fixing the Vector endpoint.

**Problem**:
Using certain special characters would cause the vector endpoint to fail, making tiles not render.

**Solution**:
remove the DecodeURI call that was failing on special characters

**Testing**:
Use a parenthesis in the Jurisdiction value `CN Rail (80%)` or some equivalent. The vector tiles will not appear on the map. In this branch, they will. 

Closes #3748