### PR TITLE
[Req.] Use original column order for Record tables

### DIFF
--- a/app/src/UI/Overlay/Records/RecordSet/RecordTableHelpers.tsx
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordTableHelpers.tsx
@@ -116,7 +116,7 @@ export const activityColumnsToDisplay = [
   { key: 'biogeoclimatic_zones', name: 'Bio Geo Climatic Zones', hide: false },
   { key: 'elevation', name: 'Elevation', hide: false },
   { key: 'batch_id', name: 'Batch ID', hide: false }
-].sort((a, b) => a.name.localeCompare(b.name));
+];
 
 export const iappColumnsToDisplay = [
   { key: 'site_id', name: 'Site ID', hide: false },
@@ -135,4 +135,4 @@ export const iappColumnsToDisplay = [
   { key: 'regional_district', name: 'Regional District', hide: false },
   { key: 'regional_invasive_species_organization', name: 'Regional Invasive Species Organization', hide: false },
   { key: 'invasive_plant_management_area', name: 'Invasive Plant Management Area', hide: false }
-].sort((a, b) => a.name.localeCompare(b.name));
+];

--- a/app/src/constants/offline_state_version.ts
+++ b/app/src/constants/offline_state_version.ts
@@ -1,5 +1,5 @@
 /*
 handle purging the offline storage on app version upgrade
  */
-export const CURRENT_MIGRATION_VERSION = 20250303;
+export const CURRENT_MIGRATION_VERSION = 20250304;
 export const MIGRATION_VERSION_KEY = '_persistedMigrationVersion';


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

Requested by @brennanwebster 

- Bump migration key to tomorrow (because today is taken).
- Remove sorting of Columns in ColumnSelect and Record tables
