### PR TITLE
[INV-3796] Add GET request for getting new/updated cached record Id's

### DIFF
--- a/api/src/paths/v2/activities/batch-request.ts
+++ b/api/src/paths/v2/activities/batch-request.ts
@@ -9,13 +9,11 @@ import { getLogger } from 'utils/logger';
 import { getMediaItemsList } from 'paths/media';
 import { PoolClient } from 'pg';
 import { InvasivesRequest } from 'utils/auth-utils';
-import { getActivitiesSQLv2, sanitizeActivityFilterObject } from 'queries/activities-v2-queries';
 
 const NAMESPACE = '/v2/activities/batch-request';
 const defaultLog = getLogger(NAMESPACE);
 
 const GET: Operation = [getActivity()];
-const POST: Operation = [getUpdatedActivities()];
 
 GET.apiDoc = {
   description: 'Returns multiple Activity Records for device caching',
@@ -121,99 +119,4 @@ function getActivity(): RequestHandler {
   };
 }
 
-POST.apiDoc = {
-  description: 'Returns activity records that have received updates since time of caching',
-  tags: ['activity'],
-  security: SECURITY_ON
-    ? [
-        {
-          Bearer: ALL_ROLES
-        }
-      ]
-    : [],
-  requestBody: {
-    description: 'Request parameters',
-    content: {
-      'application/json': {
-        schema: {
-          properties: {
-            lastUpdated: {
-              type: 'string',
-              description: 'Date of last cache',
-              example: '2025-03-04T15:20:22.765Z',
-              pattern: '^[\\d]{4}-[\\d]{2}-[\\d]{2}T[\\d]{2}:[\\d]{2}:[\\d]{2}\\.[\\d]{3}Z$'
-            },
-            filterObjects: {
-              type: 'array',
-              items: {
-                type: 'object',
-                properties: {}
-              }
-            }
-          },
-          required: ['lastUpdated', 'filterObjects']
-        }
-      }
-    }
-  },
-  responses: {
-    200: {
-      description: 'Activity Ids with records more recent than cached.',
-      content: {
-        'application/json': {
-          schema: {
-            type: 'array',
-            items: {
-              type: 'string',
-              description: 'activity_id',
-              example: 'a1b2a1b2-c3d4-e5f6-g7h8g7h8g7h8',
-              pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
-            }
-          }
-        }
-      }
-    },
-    400: {
-      $ref: '#/components/responses/400'
-    },
-    401: {
-      $ref: '#/components/responses/401'
-    },
-    default: {
-      $ref: '#/components/responses/default'
-    }
-  }
-};
-
-function getUpdatedActivities(): RequestHandler {
-  return async (req: InvasivesRequest, res) => {
-    if (req.authContext.roles.length === 0) return res.status(401).json({ message: 'No Role for user' });
-
-    let connection: PoolClient;
-    try {
-      connection = await getDBConnection();
-      const { filterObjects, lastUpdated } = req.body;
-      const sanitizedFilters = sanitizeActivityFilterObject(filterObjects?.[0], req);
-      sanitizedFilters.timestamp = lastUpdated;
-      sanitizedFilters.updateCache = true;
-
-      const { text, values } = getActivitiesSQLv2(sanitizedFilters);
-      const response = (await connection.query(text, values)).rows[0].ids ?? [];
-
-      return res.status(200).json(response);
-    } catch (error) {
-      defaultLog.debug({ label: NAMESPACE, error: error, body: req.body, method: 'POST' });
-      return res.sendStatus(500).json({
-        message: 'Unable to provide list of ids.',
-        request: req.body,
-        error: JSON.stringify(error),
-        namespace: NAMESPACE,
-        code: 500
-      });
-    } finally {
-      connection?.release();
-    }
-  };
-}
-
-export { GET, POST };
+export { GET };

--- a/api/src/paths/v2/activities/batch-request.ts
+++ b/api/src/paths/v2/activities/batch-request.ts
@@ -9,11 +9,13 @@ import { getLogger } from 'utils/logger';
 import { getMediaItemsList } from 'paths/media';
 import { PoolClient } from 'pg';
 import { InvasivesRequest } from 'utils/auth-utils';
+import { getActivitiesSQLv2, sanitizeActivityFilterObject } from 'queries/activities-v2-queries';
 
 const NAMESPACE = '/v2/activities/batch-request';
 const defaultLog = getLogger(NAMESPACE);
 
 const GET: Operation = [getActivity()];
+const POST: Operation = [getUpdatedActivities()];
 
 GET.apiDoc = {
   description: 'Returns multiple Activity Records for device caching',
@@ -105,7 +107,7 @@ function getActivity(): RequestHandler {
       }
       return res.status(200).json(resObj);
     } catch (error) {
-      defaultLog.debug({ label: NAMESPACE, error: error, body: req.body });
+      defaultLog.debug({ label: NAMESPACE, error: error, body: req.body, method: 'GET' });
       return res.status(500).json({
         message: 'Unable to fetch ids in list.',
         request: req.query,
@@ -119,4 +121,99 @@ function getActivity(): RequestHandler {
   };
 }
 
-export { GET };
+POST.apiDoc = {
+  description: 'Returns activity records that have received updates since time of caching',
+  tags: ['activity'],
+  security: SECURITY_ON
+    ? [
+        {
+          Bearer: ALL_ROLES
+        }
+      ]
+    : [],
+  requestBody: {
+    description: 'Request parameters',
+    content: {
+      'application/json': {
+        schema: {
+          properties: {
+            lastUpdated: {
+              type: 'string',
+              description: 'Date of last cache',
+              example: '2025-03-04T15:20:22.765Z',
+              pattern: '^[\\d]{4}-[\\d]{2}-[\\d]{2}T[\\d]{2}:[\\d]{2}:[\\d]{2}\\.[\\d]{3}Z$'
+            },
+            filterObjects: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {}
+              }
+            }
+          },
+          required: ['lastUpdated', 'filterObjects']
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Activity Ids with records more recent than cached.',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'array',
+            items: {
+              type: 'string',
+              description: 'activity_id',
+              example: 'a1b2a1b2-c3d4-e5f6-g7h8g7h8g7h8',
+              pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+            }
+          }
+        }
+      }
+    },
+    400: {
+      $ref: '#/components/responses/400'
+    },
+    401: {
+      $ref: '#/components/responses/401'
+    },
+    default: {
+      $ref: '#/components/responses/default'
+    }
+  }
+};
+
+function getUpdatedActivities(): RequestHandler {
+  return async (req: InvasivesRequest, res) => {
+    if (req.authContext.roles.length === 0) return res.status(401).json({ message: 'No Role for user' });
+
+    let connection: PoolClient;
+    try {
+      connection = await getDBConnection();
+      const { filterObjects, lastUpdated } = req.body;
+      const sanitizedFilters = sanitizeActivityFilterObject(filterObjects?.[0], req);
+      sanitizedFilters.timestamp = lastUpdated;
+      sanitizedFilters.updateCache = true;
+
+      const { text, values } = getActivitiesSQLv2(sanitizedFilters);
+      const response = (await connection.query(text, values)).rows[0].ids ?? [];
+
+      return res.status(200).json(response);
+    } catch (error) {
+      defaultLog.debug({ label: NAMESPACE, error: error, body: req.body, method: 'POST' });
+      return res.sendStatus(500).json({
+        message: 'Unable to provide list of ids.',
+        request: req.body,
+        error: JSON.stringify(error),
+        namespace: NAMESPACE,
+        code: 500
+      });
+    } finally {
+      connection?.release();
+    }
+  };
+}
+
+export { GET, POST };

--- a/api/src/paths/v2/activities/batch-request.ts
+++ b/api/src/paths/v2/activities/batch-request.ts
@@ -105,7 +105,7 @@ function getActivity(): RequestHandler {
       }
       return res.status(200).json(resObj);
     } catch (error) {
-      defaultLog.debug({ label: NAMESPACE, error: error, body: req.body, method: 'GET' });
+      defaultLog.debug({ label: NAMESPACE, error: error, body: req.body });
       return res.status(500).json({
         message: 'Unable to fetch ids in list.',
         request: req.query,

--- a/api/src/paths/v2/activities/cache-update-ids.ts
+++ b/api/src/paths/v2/activities/cache-update-ids.ts
@@ -1,0 +1,104 @@
+import { ALL_ROLES, SECURITY_ON } from 'constants/misc';
+import { getDBConnection } from 'database/db';
+import { RequestHandler } from 'express';
+import { Operation } from 'express-openapi';
+import { PoolClient } from 'pg';
+import { getActivitiesSQLv2, sanitizeActivityFilterObject } from 'queries/activities-v2-queries';
+import { InvasivesRequest } from 'utils/auth-utils';
+import { getLogger } from 'utils/logger';
+
+const NAMESPACE = '/v2/activities/cache-update-ids';
+const defaultLog = getLogger(NAMESPACE);
+
+const GET: Operation = [getUpdatedActivities()];
+
+GET.apiDoc = {
+  description: 'Returns list of Ids matching FilterObjects where date more recent than one supplied.',
+  tags: ['activity'],
+  security: SECURITY_ON
+    ? [
+        {
+          Bearer: ALL_ROLES
+        }
+      ]
+    : [],
+  parameters: [
+    {
+      description: 'Date of last cache',
+      example: '2025-03-04T15:20:22.765Z',
+      in: 'query',
+      name: 'lastUpdated',
+      required: true,
+      type: 'string'
+    },
+    {
+      description: 'Recordset filter objects',
+      in: 'query',
+      name: 'filterObjects',
+      required: true,
+      type: 'string'
+    }
+  ],
+  responses: {
+    200: {
+      description: 'Activity Ids with records more recent than cached.',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'array',
+            items: {
+              type: 'string',
+              description: 'activity_id',
+              example: 'a1b2a1b2-c3d4-e5f6-g7h8g7h8g7h8',
+              pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+            }
+          }
+        }
+      }
+    },
+    400: {
+      $ref: '#/components/responses/400'
+    },
+    401: {
+      $ref: '#/components/responses/401'
+    },
+    default: {
+      $ref: '#/components/responses/default'
+    }
+  }
+};
+
+function getUpdatedActivities(): RequestHandler {
+  return async (req: InvasivesRequest, res) => {
+    if (req.authContext.roles.length === 0) return res.status(401).json({ message: 'No Role for user' });
+
+    let connection: PoolClient;
+    try {
+      connection = await getDBConnection();
+      const filterObjects = JSON.parse(req.query.filterObjects as string);
+      const { lastUpdated } = req.query;
+      const sanitizedFilters = sanitizeActivityFilterObject(filterObjects?.[0], req);
+      sanitizedFilters.timestamp = lastUpdated;
+      sanitizedFilters.updateCache = true;
+
+      const { text, values } = getActivitiesSQLv2(sanitizedFilters);
+      const response = (await connection.query(text, values)).rows[0].ids ?? [];
+
+      return res.status(200).json(response);
+    } catch (error) {
+      console.log(error);
+      defaultLog.debug({ label: NAMESPACE, error: error, body: req.body, method: 'POST' });
+      return res.sendStatus(500).json({
+        message: 'Unable to provide list of ids.',
+        request: req.query,
+        error: JSON.stringify(error),
+        namespace: NAMESPACE,
+        code: 500
+      });
+    } finally {
+      connection?.release();
+    }
+  };
+}
+
+export default { GET };

--- a/api/src/paths/v2/activities/cache-update-ids.ts
+++ b/api/src/paths/v2/activities/cache-update-ids.ts
@@ -87,7 +87,7 @@ function getUpdatedActivities(): RequestHandler {
       return res.status(200).json(response);
     } catch (error) {
       console.log(error);
-      defaultLog.debug({ label: NAMESPACE, error: error, body: req.body, method: 'POST' });
+      defaultLog.debug({ label: NAMESPACE, error: error, body: req.body });
       return res.sendStatus(500).json({
         message: 'Unable to provide list of ids.',
         request: req.query,

--- a/api/src/queries/activities-v2-queries.ts
+++ b/api/src/queries/activities-v2-queries.ts
@@ -242,6 +242,7 @@ function sanitizeActivityFilterObject(filterObject: any, req: any) {
 
   // may be explicitly set to true by calling function
   sanitizedSearchCriteria.boundingBoxOnly = false;
+  sanitizedSearchCriteria.cacheUpdate = false;
 
   defaultLog.debug({
     label: 'getActivitiesBySearchFilterCriteria',
@@ -268,7 +269,7 @@ function getActivitiesSQLv2(filterObject: any) {
     sqlStatement = groupByStatement(sqlStatement, filterObject);
     if (filterObject.vt_request) {
       sqlStatement.append(` ) SELECT ST_AsMVT(mvtgeom.*, 'data', 4096, 'geom', 'feature_id') as data from mvtgeom`);
-    } else if (!filterObject.boundingBoxOnly) {
+    } else if (!filterObject.boundingBoxOnly && !filterObject.updateCache) {
       // we don't want limits or offsets when computing the bounding box
       sqlStatement = orderByStatement(sqlStatement, filterObject);
       sqlStatement = limitStatement(sqlStatement, filterObject);
@@ -286,6 +287,17 @@ function getActivitiesSQLv2(filterObject: any) {
 
       defaultLog.debug({ label: 'getActivitiesBySearchFilterCriteria', message: 'sql', body: wrappedStatement });
 
+      return wrappedStatement;
+    } else if (filterObject.updateCache) {
+      const wrappedStatement = SQL` WITH userQuery AS ( `.append(sqlStatement.text).append(` ) 
+        SELECT array_agg(activity_id::text) as ids
+        FROM invasivesbc.activity_incoming_data
+        WHERE iscurrent = true
+          AND form_status = 'Submitted'
+          AND created_timestamp >= '${filterObject.timestamp}'::date
+          AND activity_id in (SELECT activity_id FROM userQuery)
+      `);
+      defaultLog.debug({ label: 'getActivitiesBySearchFilterCriteria', message: 'sql', body: wrappedStatement });
       return wrappedStatement;
     } else {
       defaultLog.debug({ label: 'getActivitiesBySearchFilterCriteria', message: 'sql', body: sqlStatement });

--- a/api/src/queries/activity-queries.ts
+++ b/api/src/queries/activity-queries.ts
@@ -779,8 +779,9 @@ export const getActivitySQL = (activityId: string): SQLStatement => {
 export const getActivitiesByIdsSQL = (recordIds: string[]): SQLStatement => SQL`
   SELECT a.*
   FROM activity_incoming_data a
-  WHERE a.iscurrent = true 
-    and a.activity_id = ANY(${recordIds});
+  WHERE a.iscurrent = true
+    AND a.form_status = 'Submitted'
+    AND a.activity_id = ANY(${recordIds});
 `;
 
 export const getActivityHistorySQL = (activityId: string): SQLStatement => {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

> [!NOTE]
> Frontend is separate ticket.

- Add `GET` method to `/v2/activities/cache-update-ids` to get list of IDs that have updated since last [provided] time
    - leverages existing filter objects
- Modify `getActivitiesSQLv2()` to use CTE to wrap the general main query, as we do with `/bbox`
- Optimize the SQL for `getActivitiesByIdsSQL`, eliminating Draft records from consideration.
- Closes #3796

Testing

URL to ping on your local. that parameterize the previous POST example

```
localhost:3002/api/v2/activities/cache-update-ids?filterObjects=[ { "limit": 200000, "recordSetType": "Activity", "selectColumns": [ "activity_id" ], "tableFilters": [ { "field": "created_by", "filter": "mat", "filterType": "tableFilter", "id": "3wtGf-QbPTO22L_TERr7l", "operator": "CONTAINS", "operator2": "AND" } ] } ]&lastUpdated="2024-12-10T07:00:00.000Z"
```