### PR TITLE
[BugFix] Fix error left behind in refactor, lower concurrency by 1

### DIFF
--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -79,7 +79,7 @@ abstract class RecordCacheService extends BaseCacheService<
   RecordCacheProgressCallbackParameters,
   UserRecordCacheStatus
 > {
-  private readonly CONCURRENCY_LIMIT = 4;
+  private readonly CONCURRENCY_LIMIT = 3;
   protected constructor() {
     super();
   }

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -376,7 +376,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
       throw new Error(CACHE_UNAVAILABLE);
     }
     try {
-      const geojson = iappTableRow.result[0].geojson;
+      const geojson = iappTableRow.geojson;
       const map_symbol = geojson?.properties?.map_symbol;
       geojson.properties = {
         name: id + (map_symbol ? '\n' + map_symbol : ''),

--- a/app/src/utils/tile-cache/index.ts
+++ b/app/src/utils/tile-cache/index.ts
@@ -1,4 +1,3 @@
-import { DEBUG } from 'state/build-time-config';
 import BaseCacheService from 'utils/base-classes/BaseCacheService';
 import { base64toBuffer, lat2tile, long2tile } from 'utils/tile-cache/helpers';
 
@@ -74,7 +73,7 @@ abstract class TileCacheService extends BaseCacheService<
   TileCacheProgressCallbackParameters,
   RepositoryStatus
 > {
-  CONCURRENCY_LIMIT = DEBUG ? 10 : 6; // Throttle for Mobile launches, boost for development.
+  CONCURRENCY_LIMIT = 5; // Throttle for Mobile launches, boost for development.
   protected constructor() {
     super();
   }


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Noticed app would reboot while caching, but typically not crash. caching now takes in a lot more records per request than it did before, so dropped concurrency by one to reduce load.
- Fix bug leftover from Refactor where IAPP records would not save on iOS. 