### PR TITLE
[INV-3885] Remove % Download from Cache Progress

### DIFF
--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -293,10 +293,7 @@ abstract class RecordCacheService extends BaseCacheService<
         pauseOrAbort = await this.checkPauseOrAbort(spec.setId);
 
         const normalizedProgress = currentProgress;
-        const progressLabel =
-          normalizedProgress * 100 < 1
-            ? `${processedCaches.toLocaleString()}/${totalRecordsToCache.toLocaleString()} Records`
-            : `${Math.round(normalizedProgress * 100)}% completed`;
+        const progressLabel = `${processedCaches.toLocaleString()}/${totalRecordsToCache.toLocaleString()} Records`;
 
         if (progressCallback) {
           progressCallback({


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Show downloaded records over total records **always**, remove change to percentage after `n` records downloaded.
- Closes #3885 

![image](https://github.com/user-attachments/assets/76e81ce9-6f2e-4abb-aa4f-dcff45a43852)
