### PR TITLE
[INV-3883] Fix Crashes when Caching large recordsets

### DIFF
--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -83,7 +83,7 @@ abstract class RecordCacheService extends BaseCacheService<
   UserRecordCacheStatus
 > {
   private readonly CONCURRENCY_LIMIT = 3;
-  private readonly BATCH_AMOUNT = 19; // Use odd number increments so more digits update, appearing faster.
+  private readonly BATCH_AMOUNT = 20;
   protected constructor() {
     super();
   }
@@ -100,7 +100,7 @@ abstract class RecordCacheService extends BaseCacheService<
 
   public abstract loadIapp(id: string, type: IappRecordMode): Promise<IappRecord | IappTableRow>;
 
-  protected abstract saveActivity(id: string, data: unknown): Promise<void>;
+  protected abstract saveActivity(data: unknown): Promise<void>;
 
   protected abstract dateOfMostRecentRecord();
 
@@ -201,7 +201,7 @@ abstract class RecordCacheService extends BaseCacheService<
     const uncachedRecords = await this.filterIds('exclusive', spec.idsToCache);
     let pauseOrAbort: CacheDownloadMode = CacheDownloadMode.DEFAULT;
     let processedCaches = spec.idsToCache.length - uncachedRecords.length;
-    const lastProgressCallback: null | number = null;
+    let lastProgressCallback: null | number = null;
     const totalRecordsToCache = spec.idsToCache.length;
 
     for (let i = 0; i < uncachedRecords.length && pauseOrAbort === CacheDownloadMode.DEFAULT; i += this.BATCH_AMOUNT) {
@@ -230,11 +230,11 @@ abstract class RecordCacheService extends BaseCacheService<
       // trigger a callback on the first run, on the last run, every 3%
       if (
         lastProgressCallback == null ||
-        currentProgress - lastProgressCallback > 0.03 ||
+        currentProgress - lastProgressCallback > 0.005 ||
         processedCaches == totalRecordsToCache
       ) {
         pauseOrAbort = await this.checkPauseOrAbort(spec.setId);
-
+        lastProgressCallback = currentProgress;
         if (progressCallback) {
           progressCallback({
             setId: spec.setId,
@@ -266,7 +266,7 @@ abstract class RecordCacheService extends BaseCacheService<
     const uncachedRecords = await this.filterIds('exclusive', spec.idsToCache);
     let pauseOrAbort: CacheDownloadMode = CacheDownloadMode.DEFAULT;
     let processedCaches = spec.idsToCache.length - uncachedRecords.length;
-    const lastProgressCallback: null | number = null;
+    let lastProgressCallback: null | number = null;
     const totalRecordsToCache = spec.idsToCache.length;
 
     for (let i = 0; i < uncachedRecords.length && pauseOrAbort === CacheDownloadMode.DEFAULT; i += this.BATCH_AMOUNT) {
@@ -281,10 +281,7 @@ abstract class RecordCacheService extends BaseCacheService<
           headers: { Authorization: await getCurrentJWT(), 'Content-Type': 'application/json' }
         });
         if (rez.ok) {
-          const response = await rez.json();
-          Object.keys(response).forEach(async (key) => {
-            await this.saveActivity(key, response[key]);
-          });
+          this.saveActivity(await rez.json());
         }
       });
 
@@ -294,11 +291,11 @@ abstract class RecordCacheService extends BaseCacheService<
       // trigger a callback on the first run, on the last run, every 3%
       if (
         lastProgressCallback == null ||
-        currentProgress - lastProgressCallback > 0.03 ||
+        currentProgress - lastProgressCallback > 0.005 ||
         processedCaches === totalRecordsToCache
       ) {
         pauseOrAbort = await this.checkPauseOrAbort(spec.setId);
-
+        lastProgressCallback = currentProgress;
         const normalizedProgress = currentProgress;
         const progressLabel = `${processedCaches.toLocaleString()}/${totalRecordsToCache.toLocaleString()} Records`;
 
@@ -414,9 +411,7 @@ abstract class RecordCacheService extends BaseCacheService<
             headers: { Authorization: await getCurrentJWT(), 'Content-Type': 'application/json' }
           });
           const newRecords = (await rez.json()) ?? {};
-          Object.keys(newRecords).forEach(async (key) => {
-            await this.saveActivity(key, newRecords[key]);
-          });
+          await this.saveActivity(newRecords);
         }
         const updatedShapes = await this.createActivityRecordsetSourceMetadata([...r.cachedIds, ...newIds]);
         this.addOrUpdateRepository({

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -104,7 +104,7 @@ abstract class RecordCacheService extends BaseCacheService<
 
   protected abstract dateOfMostRecentRecord();
 
-  protected abstract saveIapp(id: string, iappRecord: unknown, iappTableRow: unknown): Promise<void>;
+  protected abstract saveIapp(data: Record<PropertyKey, IappRecord | IappTableRow>): Promise<void>;
 
   public abstract getPaginatedCachedActivityRecords(
     recordSetIdList: string[],
@@ -218,9 +218,7 @@ abstract class RecordCacheService extends BaseCacheService<
         });
         if (rez.ok) {
           const response = await rez.json();
-          Object.keys(response).forEach(async (key) => {
-            await this.saveIapp(key.toString(), response[key].record, response[key].row);
-          });
+          await this.saveIapp(response);
         }
       });
 
@@ -230,7 +228,7 @@ abstract class RecordCacheService extends BaseCacheService<
       // trigger a callback on the first run, on the last run, every 3%
       if (
         lastProgressCallback == null ||
-        currentProgress - lastProgressCallback > 0.005 ||
+        currentProgress - lastProgressCallback > 0.003 ||
         processedCaches == totalRecordsToCache
       ) {
         pauseOrAbort = await this.checkPauseOrAbort(spec.setId);
@@ -281,7 +279,8 @@ abstract class RecordCacheService extends BaseCacheService<
           headers: { Authorization: await getCurrentJWT(), 'Content-Type': 'application/json' }
         });
         if (rez.ok) {
-          this.saveActivity(await rez.json());
+          const response = await rez.json();
+          await this.saveActivity(response);
         }
       });
 

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -53,12 +53,11 @@ class LocalForageRecordCacheService extends RecordCacheService {
     return (await this.getRepository(repositoryId)).cachedIds ?? [];
   }
 
-  async saveActivity(id: string, data: unknown): Promise<void> {
+  async saveActivity(data: Record<PropertyKey, UserRecord>): Promise<void> {
     if (this.store == null) {
       throw new Error('cache not available');
     }
-
-    await this.store.setItem(id, data);
+    await Promise.all(Object.keys(data).map((key) => this.store?.setItem(key, data[key])));
   }
 
   async setRepositoryStatus(cacheId: string, status: UserRecordCacheStatus) {

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -82,12 +82,11 @@ class LocalForageRecordCacheService extends RecordCacheService {
     return CacheDownloadMode.DEFAULT;
   }
 
-  async saveIapp(id: string, iappRecord: IappRecord, iappTableRow: IappTableRow): Promise<void> {
+  async saveIapp(data: Record<PropertyKey, IappRecord | IappTableRow>): Promise<void> {
     if (this.store == null) {
       throw new Error('cache not available');
     }
-    const data = { record: iappRecord, row: iappTableRow };
-    await this.store.setItem(id.toString(), data);
+    await Promise.all(Object.keys(data).map((id) => this.store?.setItem(id.toString(), data[id])));
   }
 
   async loadIapp(id: string, type: IappRecordMode): Promise<IappRecord | IappTableRow> {

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -1,4 +1,4 @@
-import { SQLiteConnection, SQLiteDBConnection } from '@capacitor-community/sqlite';
+import { DBSQLiteValues, SQLiteConnection, SQLiteDBConnection } from '@capacitor-community/sqlite';
 import centroid from '@turf/centroid';
 import { Feature } from '@turf/helpers';
 import { GeoJSONSourceSpecification } from 'maplibre-gl';
@@ -19,9 +19,15 @@ import MIGRATIONS from './migrations';
 const CACHE_DB_NAME = 'record_cache.db';
 const CACHE_UNAVAILABLE = 'cache not available';
 
+/*
+  To avoid hitting SQLite variable limits (That crashes the DB)
+  SQLiteRecordCacheService uses the class member QUERY_LIMIT to break up larger queries.
+  These errors can become noticeable when dealing with recordsets in the hundred thousands.
+  Example Error: "Query: Failed in selectSQL : Error: querySQL prepare failed rc: 1 message: too many SQL variables"
+*/
 class SQLiteRecordCacheService extends RecordCacheService {
   private static _instance: SQLiteRecordCacheService;
-
+  private QUERY_LIMIT: number = 50000;
   private cacheDB: SQLiteDBConnection | null = null;
   protected constructor() {
     super();
@@ -222,13 +228,13 @@ class SQLiteRecordCacheService extends RecordCacheService {
     }
 
     const startPos = page * limit;
+    const subset = recordSetIdList.slice(startPos, startPos + limit);
     const results = await this.cacheDB?.query(
       // language=SQLite
       `SELECT DATA
        FROM CACHED_RECORDS
-       WHERE ID IN (${recordSetIdList.map(() => '?').join(', ')})
-       LIMIT ?, ?`,
-      [...recordSetIdList, startPos, limit]
+       WHERE ID IN (${subset.map(() => '?').join(', ')})`,
+      [...subset]
     );
 
     if (!results?.values || results.values?.length === 0) {
@@ -303,12 +309,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
 
     return JSON.parse(result.values[0]['DATA']);
   }
-
-  async saveActivity(id: string, data: unknown): Promise<void> {
-    if (this.cacheDB == null) {
-      throw new Error(CACHE_UNAVAILABLE);
-    }
-
+  private transformActivity(id: string, data: UserRecord): Array<any> {
     const stringified = JSON.stringify(data);
     const short_id = (data as Record<PropertyKey, Feature[]>)?.short_id;
     const geometry = (data as Record<PropertyKey, Feature[]>)?.geometry;
@@ -321,17 +322,26 @@ class SQLiteRecordCacheService extends RecordCacheService {
       };
     });
     const geojson = JSON.stringify(geometry) ?? null;
-    await this.cacheDB.query(
-      //language=SQLite
-      `INSERT INTO CACHED_RECORDS(ID, DATA, GEOJSON, SHORT_ID, DATE_CREATED)
-        VALUES (?, ?, ?, ?, ?)
-        ON CONFLICT (ID)
-        DO UPDATE SET
-        DATA = excluded.DATA,
-        DATE_CREATED = excluded.DATE_CREATED,
-        GEOJSON = excluded.GEOJSON`,
-      [id, stringified, geojson, short_id, activityDate]
-    );
+    return [id, stringified, geojson, short_id, activityDate];
+  }
+
+  async saveActivity(data: Record<PropertyKey, UserRecord>): Promise<void> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const entry = `( ?, ?, ?, ?, ? )`;
+    const values: Array<any> = [];
+    Object.keys(data).forEach((key) => values.push(this.transformActivity(key, data[key])));
+    let query = 'INSERT INTO CACHED_RECORDS(ID, DATA, GEOJSON, SHORT_ID, DATE_CREATED) VALUES ';
+    query += values.map(() => entry).join(', ');
+    query += `
+      ON CONFLICT (ID)
+      DO UPDATE SET
+      DATA = excluded.DATA,
+      DATE_CREATED = excluded.DATE_CREATED,
+      GEOJSON = excluded.GEOJSON`;
+
+    await this.cacheDB.run(query, values.flat(), false);
   }
   protected async dateOfMostRecentRecord() {
     if (this.cacheDB == null) {
@@ -424,25 +434,31 @@ class SQLiteRecordCacheService extends RecordCacheService {
     }
     const centroidArr: any[] = [];
     const geoJsonArr: any[] = [];
-    const results = await this.cacheDB?.query(
-      // language=SQLite
-      `SELECT GEOJSON, SHORT_ID
-       FROM CACHED_RECORDS
-       WHERE ID IN (${ids.map(() => '?').join(', ')})
-       AND GEOJSON NOT NULL`,
-      [...ids]
-    );
 
-    results?.values?.forEach((item) => {
-      try {
-        JSON.parse(item['GEOJSON'])?.forEach((feature: Feature) => {
-          centroidArr.push(centroid(feature));
-          geoJsonArr.push(feature);
-        });
-      } catch (e) {
-        console.error('Error parsing record:', e);
-      }
-    });
+    let results: DBSQLiteValues;
+
+    for (let i = 0; i < ids.length; i += this.QUERY_LIMIT) {
+      const slice = ids.slice(i, i + this.QUERY_LIMIT);
+      results = await this.cacheDB?.query(
+        // language=SQLite
+        `SELECT GEOJSON, SHORT_ID
+       FROM CACHED_RECORDS
+       WHERE ID IN (${slice.map(() => '?').join(', ')})
+       AND GEOJSON NOT NULL`,
+        [...slice]
+      );
+
+      results?.values?.forEach((item) => {
+        try {
+          JSON.parse(item['GEOJSON'])?.forEach((feature: Feature) => {
+            centroidArr.push(centroid(feature));
+            geoJsonArr.push(feature);
+          });
+        } catch (e) {
+          console.error('Error parsing record:', e);
+        }
+      });
+    }
 
     const cachedCentroid: GeoJSONSourceSpecification = {
       type: 'geojson',
@@ -495,23 +511,42 @@ class SQLiteRecordCacheService extends RecordCacheService {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
-    const [act, iapp] = await Promise.all([
-      (
-        await this.cacheDB.query(
-          //language=SQLite
-          `SELECT ID
-           FROM CACHED_RECORDS`
-        )
-      )?.values ?? [],
-      (
-        await this.cacheDB.query(
-          //language=SQLite
-          `SELECT ID
-           FROM CACHED_IAPP_RECORDS`
-        )
-      )?.values ?? []
-    ]);
-    return act.concat(iapp).map((set) => set['ID']);
+    const idList: string[] = [];
+    let moreRows = true;
+    let offsetMultiplier = 0;
+    do {
+      const act =
+        (
+          await this.cacheDB.query(
+            //language=SQLite
+            `SELECT ID
+           FROM CACHED_RECORDS
+           ORDER BY ID ASC
+           LIMIT ?
+           OFFSET ?`,
+            [this.QUERY_LIMIT, this.QUERY_LIMIT * offsetMultiplier]
+          )
+        )?.values ?? [];
+      const iapp =
+        (
+          await this.cacheDB.query(
+            //language=SQLite
+            `SELECT ID
+           FROM CACHED_IAPP_RECORDS
+           ORDER BY ID ASC
+           LIMIT ?
+           OFFSET ?`,
+            [this.QUERY_LIMIT, this.QUERY_LIMIT * offsetMultiplier]
+          )
+        )?.values ?? [];
+
+      offsetMultiplier++;
+      moreRows = act.length + iapp.length !== 0;
+      act.forEach((set) => idList.push(set['ID']));
+      iapp.forEach((set) => idList.push(set['ID']));
+    } while (moreRows);
+
+    return idList;
   }
 
   private async initializeRecordCache(sqlite: SQLiteConnection) {

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -27,7 +27,7 @@ const CACHE_UNAVAILABLE = 'cache not available';
 */
 class SQLiteRecordCacheService extends RecordCacheService {
   private static _instance: SQLiteRecordCacheService;
-  private QUERY_LIMIT: number = 50000;
+  private readonly QUERY_LIMIT: number = 50000;
   private cacheDB: SQLiteDBConnection | null = null;
   protected constructor() {
     super();
@@ -360,30 +360,31 @@ class SQLiteRecordCacheService extends RecordCacheService {
       console.error(e);
     }
   }
-  async saveIapp(id: string, iappRecord: IappRecord, iappTableRow: IappTableRow): Promise<void> {
+
+  private transformIapp(id: string, iappRecord: IappRecord, iappRow: IappTableRow): Array<any> {
+    const geojson = iappRow.geojson;
+    const map_symbol = geojson?.properties?.map_symbol;
+    geojson.properties = {
+      name: id + (map_symbol ? '\n' + map_symbol : ''),
+      description: id
+    };
+    const stringRecord = JSON.stringify(iappRecord);
+    const stringRow = JSON.stringify(iappRow);
+    const stringGeo = JSON.stringify(geojson);
+    return [id.toString(), stringRecord, stringRow, stringGeo];
+  }
+
+  async saveIapp(data: Record<PropertyKey, { record: IappRecord; row: IappTableRow }>): Promise<void> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
-    try {
-      const geojson = iappTableRow.geojson;
-      const map_symbol = geojson?.properties?.map_symbol;
-      geojson.properties = {
-        name: id + (map_symbol ? '\n' + map_symbol : ''),
-        description: id
-      };
-      const stringRecord = JSON.stringify(iappRecord);
-      const stringRow = JSON.stringify(iappTableRow);
-      const stringGeo = JSON.stringify(geojson);
-      await this.cacheDB.query(
-        //language=SQLite
-        `INSERT INTO CACHED_IAPP_RECORDS(ID, RECORD_DATA, TABLE_DATA, GEOJSON)
-         VALUES ( ?, ?, ?, ? )
-         ON CONFLICT (ID) DO NOTHING;`, // IAPP is static, no update needed.
-        [id.toString(), stringRecord, stringRow, stringGeo]
-      );
-    } catch (e) {
-      console.error(e);
-    }
+    const entry = ` ( ?, ?, ?, ? ) `;
+    const values: Array<any> = [];
+    Object.keys(data).forEach((id) => values.push(this.transformIapp(id, data[id].record, data[id].row)));
+    let query = 'INSERT INTO CACHED_IAPP_RECORDS(ID, RECORD_DATA, TABLE_DATA, GEOJSON) VALUES ';
+    query += values.map(() => entry).join(', ');
+    query += 'ON CONFLICT (ID) DO NOTHING';
+    await this.cacheDB.run(query, values.flat(), false);
   }
 
   async loadIapp(id: string, type: IappRecordMode): Promise<IappRecord | IappTableRow> {
@@ -409,15 +410,20 @@ class SQLiteRecordCacheService extends RecordCacheService {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
-    const results = await this.cacheDB?.query(
-      // language SQLite
-      `SELECT GEOJSON
-      FROM CACHED_IAPP_RECORDS
-      WHERE ID IN (${ids.map(() => '?').join(', ')})
-      AND GEOJSON NOT NULL`,
-      [...ids]
-    );
-    const geojson = results?.values?.map((item) => JSON.parse(item['GEOJSON']));
+    const geojson: Array<Feature> = [];
+    for (let i = 0; i < ids.length; i += this.QUERY_LIMIT) {
+      const slice = ids.slice(i, i + this.QUERY_LIMIT);
+      const results = await this.cacheDB.query(
+        //language SQLite
+        `SELECT GEOJSON
+         FROM CACHED_IAPP_RECORDS
+         WHERE ID IN (${slice.map(() => '?').join(', ')})
+         AND GEOJSON NOT NULL`,
+        [...slice]
+      );
+      results?.values?.forEach((item) => geojson.push(JSON.parse(item['GEOJSON'])));
+    }
+
     const cachedGeoJson: GeoJSONSourceSpecification = {
       type: 'geojson',
       data: {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Fixed rerendering issue caused from the progressCallback conditions always being true.
    - Constant (concurrent) rerenders of state caused indexdb to fail for Redux, creating crashes
    - Fixing this issue revealed underlying issues with SQLite upper limits 
- Rewrote all the caching SQL to cache the entire batch per statement instead of one statement per record in result.
    - Made these queries non transactional as the local device database only uses upsert operations, and has no relationships. 
        - To keep this we would either need to have one very large transaction, or remove concurrency, slowing down our downloads.  
- Rewrote the SQL queries to use a batch limit of 50,000 records and consolidate results for the return to circumvent SQLite errors when dealing with massive recordsets.
