### PR TITLE
[INV-3921][INV-3926] DrawTools** Make inactive shapes Solid line, Get Delete button working

### DIFF
--- a/app/src/UI/LegacyMap/helpers/components/DrawControls.tsx
+++ b/app/src/UI/LegacyMap/helpers/components/DrawControls.tsx
@@ -87,6 +87,8 @@ const DrawControls = () => {
     } else {
       if (mode === TargetMode.TILE_CACHE) {
         dispatch(TileCache.clearTileCacheShape());
+      } else if (mode === TargetMode.WHATS_HERE) {
+        dispatch(WhatsHere.clear_whats_here());
       }
       drawInstance.current.deleteAll();
     }

--- a/app/src/UI/LegacyMap/helpers/components/DrawControls.tsx
+++ b/app/src/UI/LegacyMap/helpers/components/DrawControls.tsx
@@ -85,6 +85,9 @@ const DrawControls = () => {
         })
       );
     } else {
+      if (mode === TargetMode.TILE_CACHE) {
+        dispatch(TileCache.clearTileCacheShape());
+      }
       drawInstance.current.deleteAll();
     }
   };

--- a/app/src/UI/LegacyMap/helpers/components/DrawControls.tsx
+++ b/app/src/UI/LegacyMap/helpers/components/DrawControls.tsx
@@ -3,7 +3,7 @@ import { MapContext } from 'UI/LegacyMap/helpers/components/MapContext';
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
 import DrawRectangle from 'mapbox-gl-draw-rectangle-mode';
 import { useDispatch, useSelector } from 'utils/use_selector';
-import { MAP_ON_SHAPE_CREATE, MAP_ON_SHAPE_UPDATE } from 'state/actions';
+import { ACTIVITY_UPDATE_GEO_SUCCESS, MAP_ON_SHAPE_CREATE, MAP_ON_SHAPE_UPDATE } from 'state/actions';
 import TileCache from 'state/actions/cache/TileCache';
 import WhatsHere from 'state/actions/whatsHere/WhatsHere';
 import { useHistory } from 'react-router-dom';
@@ -13,6 +13,7 @@ import { createRoot, Root } from 'react-dom/client';
 
 import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css';
 import { InvasivesMap } from 'UI/LegacyMap/InvasivesMap';
+import Prompt from 'state/actions/prompts/Prompt';
 
 // @ts-expect-error mapboxdraw compatibility with maplibre-gl issue
 MapboxDraw.constants.classes.CONTROL_BASE = 'maplibregl-ctrl';
@@ -52,6 +53,41 @@ const DrawControls = () => {
   useEffect(() => {
     modeRef.current = mode;
   }, [mode]);
+
+  /**
+   * @desc Override the delete button to clear all shapes from drawn tools and to update the Form activity with null shape.
+   */
+  MapboxDraw.modes.simple_select.onTrash = () => {
+    const callback = (confirmation: boolean) => {
+      if (confirmation) {
+        drawInstance.current?.deleteAll();
+        dispatch({
+          type: ACTIVITY_UPDATE_GEO_SUCCESS,
+          payload: {
+            geometry: undefined,
+            utm: undefined,
+            lat: undefined,
+            long: undefined,
+            reported_area: undefined,
+            Well_Information: undefined
+          }
+        });
+      }
+    };
+    if (!drawInstance.current) return;
+    if (mode === TargetMode.ACTIVITY) {
+      dispatch(
+        Prompt.confirmation({
+          callback,
+          title: 'Delete Geometry',
+          prompt: 'Do you want to delete the geometry from the activity? This action cannot be undone.',
+          confirmText: 'Delete Geometry'
+        })
+      );
+    } else {
+      drawInstance.current.deleteAll();
+    }
+  };
 
   const drawCreate = useCallback((event) => {
     if (!drawInstance.current) return;
@@ -184,15 +220,29 @@ const DrawControls = () => {
       },
       styles: [
         {
-          id: 'gl-draw-line',
+          id: 'gl-edited-line',
           type: 'line',
           layout: {
             'line-cap': 'round',
             'line-join': 'round'
           },
+          filter: ['all', ['==', 'active', 'true']],
           paint: {
             'line-color': '#D20C0C',
             'line-dasharray': [0.2, 2],
+            'line-width': 3
+          }
+        },
+        {
+          id: 'gl-drawn-line',
+          type: 'line',
+          layout: {
+            'line-cap': 'round',
+            'line-join': 'round'
+          },
+          filter: ['all', ['==', 'active', 'false']],
+          paint: {
+            'line-color': '#D20C0C',
             'line-width': 3
           }
         },
@@ -208,7 +258,6 @@ const DrawControls = () => {
         }
       ]
     });
-
     drawModeDisplay.current = new DrawModeDisplay(mode);
 
     map.on('draw.create', drawCreate);

--- a/app/src/UI/LegacyMap/helpers/components/DrawControls.tsx
+++ b/app/src/UI/LegacyMap/helpers/components/DrawControls.tsx
@@ -191,8 +191,6 @@ const DrawControls = () => {
           drawInstance.current.changeMode('whats_here_box_mode');
           break;
         case TargetMode.DISABLED:
-          drawInstance.current.changeMode('do_nothing');
-          break;
         case TargetMode.ACTIVITY:
           drawInstance.current.changeMode('do_nothing');
           break;
@@ -231,7 +229,7 @@ const DrawControls = () => {
           },
           filter: ['all', ['==', 'active', 'true']],
           paint: {
-            'line-color': '#D20C0C',
+            'line-color': '#FCBA19',
             'line-dasharray': [0.2, 2],
             'line-width': 3
           }
@@ -245,7 +243,7 @@ const DrawControls = () => {
           },
           filter: ['all', ['==', 'active', 'false']],
           paint: {
-            'line-color': '#D20C0C',
+            'line-color': '#FCBA19',
             'line-width': 3
           }
         },
@@ -254,7 +252,7 @@ const DrawControls = () => {
           type: 'circle',
           paint: {
             'circle-radius': 3,
-            'circle-color': '#f00',
+            'circle-color': '#FCBA19',
             'circle-stroke-width': 1,
             'circle-stroke-color': '#fff'
           }

--- a/app/src/state/actions/cache/TileCache.ts
+++ b/app/src/state/actions/cache/TileCache.ts
@@ -9,25 +9,25 @@ class TileCache {
   static readonly PREFIX = 'TileCache';
 
   // used to tell the map we are on a page where we might want to draw a rectangle
-  static readonly setMapTileCacheMode = createAction<boolean>(`${this.PREFIX}/setDrawMode`);
+  static readonly setMapTileCacheMode = createAction<boolean>(`${this.PREFIX}/setMapTileCacheMode`);
 
-  static readonly setTileCacheShape = createAction<{ geometry: GeoJSON }>(`${this.PREFIX}/setShape`);
-  static readonly clearTileCacheShape = createAction(`${this.PREFIX}/clearShape`);
+  static readonly setTileCacheShape = createAction<{ geometry: GeoJSON }>(`${this.PREFIX}/setTileCacheShape`);
+  static readonly clearTileCacheShape = createAction(`${this.PREFIX}/clearTileCacheShape`);
 
   static readonly downloadProgressEvent = createAction<TileCacheProgressCallbackParameters>(
     `${this.PREFIX}/downloadProgressEvent`
   );
 
-  static readonly repositoryList = createAsyncThunk(`${this.PREFIX}/repoList`, async () => {
+  static readonly repositoryList = createAsyncThunk(`${this.PREFIX}/repositoryList`, async () => {
     return await (await TileCacheServiceFactory.getPlatformInstance()).listRepositories();
   });
-  static readonly deleteRepository = createAsyncThunk(`${this.PREFIX}/repoDelete`, async (repository: string) => {
+  static readonly deleteRepository = createAsyncThunk(`${this.PREFIX}/deleteRepository`, async (repository: string) => {
     const service = await TileCacheServiceFactory.getPlatformInstance();
     await service.deleteRepository(repository);
     return await service.listRepositories();
   });
   static readonly updateDescription = createAsyncThunk(
-    `${this.PREFIX}/repoUpdateDescription`,
+    `${this.PREFIX}/updateDescription`,
     async (spec: { repository: string; newDescription: string }) => {
       const service = await TileCacheServiceFactory.getPlatformInstance();
       await service.updateDescription(spec.repository, spec.newDescription);

--- a/app/src/state/actions/whatsHere/WhatsHere.ts
+++ b/app/src/state/actions/whatsHere/WhatsHere.ts
@@ -33,6 +33,7 @@ class WhatsHere {
       payload: { activities, iapp }
     })
   );
+  static readonly clear_whats_here = createAction(`${this.PREFIX}/clear_whats_here`);
   static readonly set_highlighted_iapp = createAction<string>(`${this.PREFIX}/set_highlighted_iapp`);
   static readonly set_highlighted_activity = createAction(
     `${this.PREFIX}/set_highlighted_activity`,

--- a/app/src/state/reducers/map.ts
+++ b/app/src/state/reducers/map.ts
@@ -512,6 +512,26 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           limit: 5,
           page: 0
         });
+      } else if (WhatsHere.clear_whats_here.match(action)) {
+        Object.assign(draftState.whatsHere, {
+          clickedActivity: null,
+          clickedActivityDescription: null,
+          clickedIAPP: null,
+          clickedIAPPDescription: null,
+          loadingActivities: false,
+          loadingIAPP: false,
+          feature: null,
+          limit: 5,
+          page: 0,
+          ActivityIDs: [],
+          activityRows: [],
+          ActivityPage: 0,
+          ActivityLimit: 15,
+          IAPPIDs: [],
+          iappRows: [],
+          IAPPPage: 0,
+          IAPPLimit: 15
+        });
       } else if (WhatsHere.server_filtered_ids_fetched.match(action)) {
         const { iapp, activities } = action.payload;
         draftState.whatsHere.serverActivityIDs = activities;


### PR DESCRIPTION
# Overview

- When shape is inactive, make solid line instead of dotted
    - Color changed to [BC Gold Color](https://www2.gov.bc.ca/gov/content/digital/design-system/foundations/colour)
        - More neutral than red, and still visible on all maps 
- Simplify the delete button to clear all shape off the map (we only keep one at a time)
    - Delete Shape from Activity (Prompt for confirmation)
- Change the strings in some MapTile actions to match their function name. (Making cross referencing easier and faster)

- Closes #3921
- Closes #3926