### PR TITLE
[INV-3928] Fix time interval between heartbeats

### DIFF
--- a/app/src/constants/alerts/networkAlerts.ts
+++ b/app/src/constants/alerts/networkAlerts.ts
@@ -47,7 +47,7 @@ const networkAlertMessages: Record<string, AlertMessage> = {
     content: 'An error occured while attempting to fetch resources. Please try again later.',
     severity: AlertSeverity.Error,
     subject: AlertSubjects.Network,
-    autoClose: 5
+    autoClose: 10
   }
 };
 

--- a/app/src/state/sagas/map/dataAccess.ts
+++ b/app/src/state/sagas/map/dataAccess.ts
@@ -25,7 +25,7 @@ import { selectUserSettings } from 'state/reducers/userSettings';
 import getSelectColumnsByRecordSetType from 'sharedAPI/src/getSelectColumnsByRecordSetType';
 import { PayloadAction } from '@reduxjs/toolkit';
 import IappActions, { IappTableRowRequest } from 'state/actions/activity/Iapp';
-import Activity from 'state/actions/activity/Activity';
+import Activity, { ActivityTableRowGetRequest } from 'state/actions/activity/Activity';
 
 export function* handle_ACTIVITIES_GEOJSON_GET_REQUEST(action) {
   try {
@@ -224,7 +224,7 @@ export const getRecordFilterObjectFromStateForAPI = (recordSetID, recordSetsStat
   } as any;
 };
 
-export function* handle_ACTIVITIES_TABLE_GET_ROWS(action) {
+export function* handle_ACTIVITIES_TABLE_GET_ROWS(action: PayloadAction<ActivityTableRowGetRequest>) {
   try {
     const currentState = yield select(selectUserSettings);
     const connected = yield select(selectNetworkConnected);
@@ -261,22 +261,31 @@ export function* handle_ACTIVITIES_TABLE_GET_ROWS(action) {
       );
     } else {
       // user offline: fetch from cache
-      const service = yield RecordCacheServiceFactory.getPlatformInstance();
-      const recordSetIdList = yield service.getIdList(recordSetID);
-      const records = yield service.getPaginatedCachedActivityRecords(recordSetIdList, page, limit);
-
-      yield put(
-        Activity.getRowsSuccess({
-          recordSetID: recordSetID,
-          rows: records,
-          tableFiltersHash: tableFiltersHash,
-          page: page,
-          limit: limit
-        })
-      );
+      yield getRowsFromCachedRecordset(action.payload);
     }
   } catch (e) {
     console.error(e);
+  }
+}
+
+export function* getRowsFromCachedRecordset(req: ActivityTableRowGetRequest) {
+  try {
+    const { recordSetID, page, limit, tableFiltersHash } = req;
+    const service = yield RecordCacheServiceFactory.getPlatformInstance();
+    const recordSetIdList = yield service.getIdList(recordSetID);
+    const records = yield service.getPaginatedCachedActivityRecords(recordSetIdList, page, limit);
+
+    yield put(
+      Activity.getRowsSuccess({
+        recordSetID: recordSetID,
+        rows: records,
+        tableFiltersHash: tableFiltersHash,
+        page: page,
+        limit: limit
+      })
+    );
+  } catch {
+    // do nothing. An expected error here is 'repository n not found' if the recordset contains no cache.
   }
 }
 

--- a/app/src/state/sagas/map/dataAccess.ts
+++ b/app/src/state/sagas/map/dataAccess.ts
@@ -284,8 +284,8 @@ export function* getRowsFromCachedRecordset(req: ActivityTableRowGetRequest) {
         limit: limit
       })
     );
-  } catch {
-    // do nothing. An expected error here is 'repository n not found' if the recordset contains no cache.
+  } catch (ex) {
+    console.error(ex);
   }
 }
 

--- a/app/src/state/sagas/map/online.ts
+++ b/app/src/state/sagas/map/online.ts
@@ -15,8 +15,10 @@ import {
 import { selectConfiguration, selectRootConfiguration } from 'state/reducers/configuration';
 import { PayloadAction } from '@reduxjs/toolkit';
 import IappActions, { IappTableRowGetRequest } from 'state/actions/activity/Iapp';
-import Activity from 'state/actions/activity/Activity';
+import Activity, { ActivityTableRowGetRequest } from 'state/actions/activity/Activity';
 import UserRecord from 'interfaces/UserRecord';
+import { getRowsFromCachedRecordset } from './dataAccess';
+import { MOBILE } from 'state/build-time-config';
 
 function* refreshExportConfigIfRequired(action?: AnyAction) {
   const config = yield select(selectRootConfiguration);
@@ -129,7 +131,7 @@ export function* handle_IAPP_GEOJSON_GET_ONLINE(action) {
   });
 }
 
-export function* handle_ACTIVITIES_TABLE_ROWS_GET_ONLINE(action) {
+export function* handle_ACTIVITIES_TABLE_ROWS_GET_ONLINE(action: PayloadAction<ActivityTableRowGetRequest>) {
   let mapState = yield select((state) => state.Map);
   let tableFiltersHash = mapState?.recordTables[action.payload.recordSetID]?.tableFiltersHash;
 
@@ -153,6 +155,9 @@ export function* handle_ACTIVITIES_TABLE_ROWS_GET_ONLINE(action) {
         limit: action.payload.limit
       })
     );
+  } else if (MOBILE) {
+    // API Request Failed, see if we can rows from a cache
+    yield getRowsFromCachedRecordset(action.payload);
   }
 }
 

--- a/app/src/state/sagas/network.ts
+++ b/app/src/state/sagas/network.ts
@@ -25,15 +25,18 @@ const canConnectToNetwork = async (url: string): Promise<boolean> => {
 
 /**
  * @desc Get the time between ticks for polling the heartbeat
- * @param heartbeatFailures Current number of failed network attempts
- * @returns { number } Greater of two delay values
+ * @param heartbeatFailures Current number of sequential failed network attempts
+ * @returns { number } delay between heartbeat checks
  */
 const getTimeBetweenTicks = (heartbeatFailures: number): number => {
-  const BASE_SECONDS_BETWEEN_FAILURE = 20;
-  const BASE_SECONDS_BETWEEN_SUCCESS = 60;
-  return heartbeatFailures === 0
-    ? BASE_SECONDS_BETWEEN_SUCCESS * 1000
-    : BASE_SECONDS_BETWEEN_FAILURE * 1000 * Math.floor(Math.pow(1.1, heartbeatFailures));
+  const BASE_SECONDS_BETWEEN_FAILURE = 20 * 1000;
+  const BASE_SECONDS_BETWEEN_SUCCESS = 60 * 1000;
+  if (heartbeatFailures === 0) {
+    // We are online and working as intended
+    return BASE_SECONDS_BETWEEN_SUCCESS;
+  }
+  // Poll more frequently if there are failed heartbeats, gradually increasing the time between ticks.
+  return BASE_SECONDS_BETWEEN_FAILURE * Math.floor(Math.pow(1.1, heartbeatFailures));
 };
 
 /* Sagas */

--- a/app/src/state/sagas/network.ts
+++ b/app/src/state/sagas/network.ts
@@ -31,10 +31,9 @@ const canConnectToNetwork = async (url: string): Promise<boolean> => {
 const getTimeBetweenTicks = (heartbeatFailures: number): number => {
   const BASE_SECONDS_BETWEEN_FAILURE = 20;
   const BASE_SECONDS_BETWEEN_SUCCESS = 60;
-  return Math.max(
-    BASE_SECONDS_BETWEEN_FAILURE * 1000 * Math.pow(1.1, heartbeatFailures),
-    BASE_SECONDS_BETWEEN_SUCCESS * 1000
-  );
+  return heartbeatFailures === 0
+    ? BASE_SECONDS_BETWEEN_SUCCESS * 1000
+    : BASE_SECONDS_BETWEEN_FAILURE * 1000 * Math.floor(Math.pow(1.1, heartbeatFailures));
 };
 
 /* Sagas */


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Fix issue where time was not being reduced properly between failed heartbeats causing each check to last a full minute or longer,
- Heartbeats now go 60 seconds per beat, or 20 seconds per beat if there is a currently failing beat on the number (original intention)

- If attempting to fetch table rows from a recordset but the user has spotty internet, attempt to grab records from the cache (if exists).

Possible Fix for #3928, pending additional details 