### PR TITLE
[N/A] Bugfix** Change Progress Callback from being % based to n based

### DIFF
--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -228,11 +228,11 @@ abstract class RecordCacheService extends BaseCacheService<
       // trigger a callback on the first run, on the last run, every 3%
       if (
         lastProgressCallback == null ||
-        currentProgress - lastProgressCallback > 0.003 ||
+        processedCaches - lastProgressCallback > 400 ||
         processedCaches == totalRecordsToCache
       ) {
         pauseOrAbort = await this.checkPauseOrAbort(spec.setId);
-        lastProgressCallback = currentProgress;
+        lastProgressCallback = processedCaches;
         if (progressCallback) {
           progressCallback({
             setId: spec.setId,
@@ -290,11 +290,11 @@ abstract class RecordCacheService extends BaseCacheService<
       // trigger a callback on the first run, on the last run, every 3%
       if (
         lastProgressCallback == null ||
-        currentProgress - lastProgressCallback > 0.005 ||
+        processedCaches - lastProgressCallback > 450 ||
         processedCaches === totalRecordsToCache
       ) {
         pauseOrAbort = await this.checkPauseOrAbort(spec.setId);
-        lastProgressCallback = currentProgress;
+        lastProgressCallback = processedCaches;
         const normalizedProgress = currentProgress;
         const progressLabel = `${processedCaches.toLocaleString()}/${totalRecordsToCache.toLocaleString()} Records`;
 


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

With progress callbacks being affected by a percentage, smaller recordsets are more likely to trigger a crash from constant rerendering. 

This PR moves the checks from being % of records to based on a minimum number of records cached. Ensuring consistent level of rerenders in the progress section, regardless of recordset size.

Iapp gets a little more frequency than activities as it is double the records being processed per count (Table and Full records are separate and included in one PR.)