### PR TITLE
Prevent spatial autofill on intersection & fix Line tool behaviour during record creation

### DIFF
--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -169,6 +169,7 @@ export function* handle_ACTIVITY_UPDATE_GEO_REQUEST(action: Record<string, any>)
       const hasSelfIntersections = kinks(sanitizedGeo.geometry).features.length > 0;
       if (hasSelfIntersections) {
         yield put(Alerts.create(mappingAlertMessages.containsIntersections));
+        return;
       }
     }
 

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -167,7 +167,9 @@ export function* handle_ACTIVITY_UPDATE_GEO_REQUEST(action: Record<string, any>)
 
     if (!isPointGeometry) {
       const hasSelfIntersections = kinks(sanitizedGeo.geometry).features.length > 0;
-      if (hasSelfIntersections) {
+      const hasHoles = sanitizedGeo.geometry.coordinates.length > 1; // check for intersections after LineStrings are converted to Polygons
+
+      if (hasSelfIntersections || hasHoles) {
         yield put(Alerts.create(mappingAlertMessages.containsIntersections));
         return;
       }

--- a/app/src/state/sagas/map.ts
+++ b/app/src/state/sagas/map.ts
@@ -85,6 +85,7 @@ import {
   handle_ACTIVITIES_TABLE_ROWS_GET_OFFLINE
 } from './map/offline';
 import MapActions from 'state/actions/map';
+import GeoShapes from 'constants/geoShapes';
 
 function* handle_USER_SETTINGS_GET_INITIAL_STATE_SUCCESS() {
   yield put(MapActions.initRequest());
@@ -737,7 +738,7 @@ function* handle_MAP_ON_SHAPE_CREATE(action) {
   };
   const appModeUrl = yield select((state: any) => state.AppMode.url);
   const whatsHereToggle = yield select((state: any) => state.Map.whatsHere.toggle);
-  if (action?.payload?.geometry?.type === 'LineString') {
+  if (action?.payload?.geometry?.type === GeoShapes.LineString) {
     yield put(
       Prompt.number({
         title: 'Buffer needed',
@@ -758,6 +759,7 @@ function* handle_MAP_ON_SHAPE_UPDATE(action) {
   if (drawingCustomLayer) {
     yield put({ type: CUSTOM_LAYER_DRAWN, payload: action.payload });
   } else if (url && /Activity/.test(url) && !whatsHere.toggle) {
+    if (action.payload.geometry.type === GeoShapes.LineString) return; // prevent updating LineString on outside click
     yield put({ type: ACTIVITY_UPDATE_GEO_REQUEST, payload: { geometry: [action.payload] } });
   } else if (tileCacheMode) {
     yield put(TileCache.setTileCacheShape({ geometry: action.payload.geometry }));


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Prevents spatial autofill for LineString and Polygon when shape intersections occur during new record creation. Fixes #3784.
- Fixes Line tool behaviour during record creation: clicking outside no longer updates the area or shape. Fixes #3922 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
