### PR TITLE
[INV-3925] Whats here text

### DIFF
--- a/app/src/UI/LegacyMap/LayerPicker/LpRecordSet/LpRecordSetOption.tsx
+++ b/app/src/UI/LegacyMap/LayerPicker/LpRecordSet/LpRecordSetOption.tsx
@@ -1,4 +1,4 @@
-import { Label, LabelOff, Palette, Visibility, VisibilityOff } from '@mui/icons-material';
+import { Label, LabelOff, Layers, LayersClear, Palette } from '@mui/icons-material';
 import { Tooltip } from '@mui/material';
 import { UserRecordSet } from 'interfaces/UserRecordSet';
 
@@ -37,7 +37,7 @@ const LpRecordSetOption = ({
             title="Toggle viewing the layer on the map, and including these records in the Whats Here search results."
           >
             <button onClick={() => toggleVisibility(recordSet.id!)}>
-              {recordSet?.mapToggle ? <Visibility /> : <VisibilityOff />}
+              {recordSet?.mapToggle ? <Layers /> : <LayersClear />}
             </button>
           </Tooltip>
           {canColour && (

--- a/app/src/UI/Overlay/WhatsHere/Subcomponents/NoRowsInSearch.tsx
+++ b/app/src/UI/Overlay/WhatsHere/Subcomponents/NoRowsInSearch.tsx
@@ -1,11 +1,26 @@
+import { LayersClear } from '@mui/icons-material';
 import { Link } from 'react-router-dom';
+import { useSelector } from 'utils/use_selector';
 
-const NoRowsInSearch = () => (
-  <div style={{ color: 'black' }}>
-    <p>It seems there are no records to display based on your current settings.</p>
-    <p>Verify that the correct record layers are active on your map.</p>
-    <Link to="/Records">Go to Records</Link>
-  </div>
-);
+const NoRowsInSearch = () => {
+  const recordSets = useSelector((state) => state.UserSettings.recordSets);
+  const noRecordsetsDisplayed = !Object.values(recordSets).some((recordset) => recordset.mapToggle);
+  return (
+    <div style={{ color: 'black' }}>
+      {noRecordsetsDisplayed ? (
+        <>
+          <p>There are no Recordsets currently visible on the map.</p>
+        </>
+      ) : (
+        <p>There are no points of interest in the selected area.</p>
+      )}
+      <p>
+        To select points of interest on the map, please turn on the visibility of one or more Recordsets by clicking the{' '}
+        {<LayersClear />} button.
+      </p>
+      <Link to="/Records">Go to Records</Link>
+    </div>
+  );
+};
 
 export default NoRowsInSearch;


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Add a better call to action on `zero result` Whats Here text.
- Change icons on LayerPicker Recordset tab to be consistent with those in `/Records` (originally mimicked what was used for the WMS layers in the original layerpicker

- Closes #3925  

![image](https://github.com/user-attachments/assets/fa2afafc-9c3a-4754-aa70-72c03b9b8fa3)
