### PR TITLE
[INV-3937] Corrections to LayerPicker

### DIFF
--- a/app/src/UI/LegacyMap/LayerPicker/LayerPicker.css
+++ b/app/src/UI/LegacyMap/LayerPicker/LayerPicker.css
@@ -17,6 +17,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  color: black;
   svg {
     height: 20pt;
     width: 20pt;
@@ -54,6 +55,9 @@ li > hr {
   .lp-content {
     height: 100%;
     overflow-y: auto;
+  }
+  * > button {
+    color: black;
   }
 }
 

--- a/app/src/UI/LegacyMap/LayerPicker/LayerPicker.tsx
+++ b/app/src/UI/LegacyMap/LayerPicker/LayerPicker.tsx
@@ -23,7 +23,7 @@ export const LayerPicker = () => {
   const toggleLayerPickerAccordion = () => dispatch(UserSettings.toggleLayerPickerAccordion());
   const [pickerPath, setPickerPath] = useState<LpModules>(LpModules.Init);
   const [showLayerPicker, setShowLayerPicker] = useState<boolean>(false);
-  const isAuth = useSelector((state) => state.Auth.authenticated);
+  const isAuth = useSelector((state) => state.Auth.loggedInOrWorkingOffline);
   const accordionMode = useSelector((state) => state.UserSettings.layerPickerIsAccordion);
   const dispatch = useDispatch();
 


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):
- Fix rendering issue that locks out pure offline users from the layerPicker
    - `authorized` is a boolean of having a keycloak token, we cannot hit 97% of the API without one.
    -  loggedInOrOffline just grants permission to places in the app that don't require the API. (Presently its just used for map related things)
- Add `color` styling to Layer Picker buttons that were being overridden by Safari Browsers blue color.
- Closes #3937 