### PR TITLE
[INV-3957] Backup cached recordsets on Redux cache clear

### DIFF
--- a/app/src/interfaces/UserRecordSet.ts
+++ b/app/src/interfaces/UserRecordSet.ts
@@ -27,7 +27,21 @@ export enum UserRecordCacheStatus {
 export interface UserRecordSet {
   tableFilters: IFilter[];
   id?: string;
-  color: string;
+  colorScheme?: {
+    Activity_Biocontrol_Collection: string;
+    Activity_Biocontrol_Release: string;
+    Activity_Monitoring_BiocontrolDispersal_TerrestrialPlant: string;
+    Activity_Monitoring_BiocontrolRelease_TerrestrialPlant: string;
+    Activity_Monitoring_ChemicalTerrestrialAquaticPlant: string;
+    Activity_Monitoring_MechanicalTerrestrialAquaticPlant: string;
+    Activity_Observation_PlantAquatic: string;
+    Activity_Observation_PlantTerrestrial: string;
+    Activity_Treatment_ChemicalPlantAquatic: string;
+    Activity_Treatment_ChemicalPlantTerrestrial: string;
+    Activity_Treatment_MechanicalPlantAquatic: string;
+    Activity_Treatment_MechanicalPlantTerrestrial: string;
+  };
+  color?: string;
   drawOrder: number;
   expanded: boolean;
   isSelected: boolean;

--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -72,6 +72,7 @@ class RecordCache {
           API_BASE: state.Configuration.current.API_BASE,
           bbox,
           idsToCache,
+          setName: recordSet.recordSetName,
           recordSetType: recordSet.recordSetType,
           recordSetCacheStatus: recordSet.cacheMetadataStatus,
           setId: spec.setId,

--- a/app/src/state/actions/userSettings/RecordSet.ts
+++ b/app/src/state/actions/userSettings/RecordSet.ts
@@ -100,7 +100,7 @@ class RecordSet {
   static readonly removeFilter = createAction<IRemoveFilter>(`${this.PREFIX}/removeFilter`);
   static readonly hideFilters = createAction(`${this.PREFIX}/hideFilters`);
 
-  private static readonly createDefaultRecordset = (type: RecordSetType): UserRecordSet => ({
+  public static readonly createDefaultRecordset = (type: RecordSetType): UserRecordSet => ({
     tableFilters: [],
     id: nanoid(),
     color: RECORD_COLOURS[0],

--- a/app/src/state/sagas/userSettings.ts
+++ b/app/src/state/sagas/userSettings.ts
@@ -3,12 +3,14 @@ import { ActivityStatus } from 'sharedAPI';
 import { InvasivesAPI_Call } from 'hooks/useInvasivesApi';
 import { selectUserSettings } from 'state/reducers/userSettings';
 import UserSettings from 'state/actions/userSettings/UserSettings';
-import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
+import { RecordSetType, UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
 import Activity from 'state/actions/activity/Activity';
 import { AuthActions } from 'state/actions/auth/Auth';
 import { APIDocs } from 'state/actions/userSettings/APIDocs';
 import { selectAuth } from 'state/reducers/auth';
 import { MOBILE } from 'state/build-time-config';
+import { RecordCacheServiceFactory } from 'utils/record-cache/context';
+import { RepositoryMetadata } from 'utils/record-cache';
 
 function* handle_USER_SETTINGS_TOGGLE_RECORDS_EXPANDED_REQUEST() {
   yield put(UserSettings.toggleRecordExpandSuccess());
@@ -80,8 +82,7 @@ function* handle_USER_SETTINGS_GET_INITIAL_STATE_REQUEST(action) {
   if (!UserSettings.InitState.get.match(action)) {
     return;
   }
-
-  const defaultRecordSet = {
+  const defaultRecordSet: Record<PropertyKey, Partial<UserRecordSet>> = {
     '1': {
       recordSetType: RecordSetType.Activity,
       recordSetName: 'My Drafts',
@@ -151,6 +152,22 @@ function* handle_USER_SETTINGS_GET_INITIAL_STATE_REQUEST(action) {
       drawOrder: 4,
       mapToggle: true // by default
     };
+
+    if (!recordSets || Object.keys(recordSets).length === 0) {
+      // RecordSets are empty, try to recover whats in the local database
+      const service = yield RecordCacheServiceFactory.getPlatformInstance();
+      const repos = yield service.listRepositories();
+      repos.forEach((repo: RepositoryMetadata) => {
+        // recordSet is immutable, so append it to defaultRecordSet
+        if (!defaultRecordSet[repo.setId]) {
+          const backedUpRecordSet = UserSettings.RecordSet.createDefaultRecordset(repo.recordSetType);
+          backedUpRecordSet.tableFilters = repo.filterObjects.tableFilters;
+          backedUpRecordSet.cacheMetadataStatus = repo.status;
+          backedUpRecordSet.recordSetName = repo.setName ?? '';
+          defaultRecordSet[repo.setId] = backedUpRecordSet;
+        }
+      });
+    }
   }
 
   if (action.payload && action.payload.offlineAPIDocsDisplayName) {

--- a/app/src/state/sagas/userSettings.ts
+++ b/app/src/state/sagas/userSettings.ts
@@ -159,7 +159,7 @@ function* handle_USER_SETTINGS_GET_INITIAL_STATE_REQUEST(action) {
       const repos = yield service.listRepositories();
       repos.forEach((repo: RepositoryMetadata) => {
         // recordSet is immutable, so append it to defaultRecordSet
-        if (!defaultRecordSet[repo.setId]) {
+        if (repo.status === UserRecordCacheStatus.CACHED && !defaultRecordSet[repo.setId]) {
           const backedUpRecordSet = UserSettings.RecordSet.createDefaultRecordset(repo.recordSetType);
           backedUpRecordSet.tableFilters = repo.filterObjects.tableFilters;
           backedUpRecordSet.cacheMetadataStatus = repo.status;

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -39,6 +39,7 @@ export interface RecordCacheDownloadRequestSpec {
  */
 export interface RepositoryMetadata {
   setId: string;
+  setName?: string;
   cacheTime: Date;
   cachedIds: string[];
   recordSetType: RecordSetType;
@@ -68,6 +69,7 @@ export interface CacheDownloadSpec {
   bbox: RepositoryBoundingBoxSpec;
   idsToCache: string[];
   setId: string;
+  setName: string;
   API_BASE: string;
   recordSetType: RecordSetType;
   recordSetCacheStatus: UserRecordCacheStatus;
@@ -175,6 +177,7 @@ abstract class RecordCacheService extends BaseCacheService<
       await this.addOrUpdateRepository({
         setId: spec.setId,
         cacheTime: new Date(),
+        setName: spec.setName,
         cachedIds: spec.idsToCache,
         recordSetType: spec.recordSetType,
         status: UserRecordCacheStatus.CACHED,


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

>[!NOTE]
> This is is a Failover function, and is not fired unless the redux state was compromised. This allows an the cached records to be accessible if the redux state fails, is cleared, or a migration key breaks the state.

- Add workflow for if a redux cache is cleared, the SQL/localforage db is checked for existing recordsets and recreated
- Added the colorScheme type to the UserRecordSet interface
- Cache the name of a recordset at the time of creating the recordset
- Closes #3957

To manually trigger this, do the following:

1. Name and Make two recordsets, cache only one of them

![image](https://github.com/user-attachments/assets/f214aeef-78ae-4658-af14-f50e6f7d9c36)

2. Delete your Redux data, seen here in the Developer tools

![image](https://github.com/user-attachments/assets/c3cb727a-53b7-4077-a478-b831effa33b2)

3. Refresh the page. The cached record was backed up

![image](https://github.com/user-attachments/assets/113b8223-9438-4031-afc6-f0ad120e3e42)
