### PR TITLE
[INV-3955] Make in-form delete button delete offline records

### DIFF
--- a/app/src/UI/Overlay/Records/FormMenuButtons/FormMenuButtons.tsx
+++ b/app/src/UI/Overlay/Records/FormMenuButtons/FormMenuButtons.tsx
@@ -79,7 +79,7 @@ const FormMenuButtons = () => {
         PASTE FORM
       </Button>
       <Button disabled={blockUserFromDeletingRecord} onClick={handleDelete} variant="contained">
-        DELETE
+        DELETE {recordIsSerializedActivity && 'FROM LOCAL DEVICE'}
       </Button>
     </div>
   );

--- a/app/src/UI/Overlay/Records/FormMenuButtons/FormMenuButtons.tsx
+++ b/app/src/UI/Overlay/Records/FormMenuButtons/FormMenuButtons.tsx
@@ -6,9 +6,11 @@ import Activity from 'state/actions/activity/Activity';
 import './FormMenuButtons.css';
 import { selectOfflineActivity } from 'state/reducers/offlineActivity';
 import { ACTIVITY_OFFLINE_DELETE_ITEM } from 'state/actions';
+import { useHistory } from 'react-router';
 
 const FormMenuButtons = () => {
   const dispatch = useDispatch();
+  const history = useHistory();
 
   const [saveDisabled, setSaveDisabled] = useState(false);
   const [draftDisabled, setDraftDisabled] = useState(false);
@@ -54,12 +56,12 @@ const FormMenuButtons = () => {
   };
 
   const handleDelete = () => {
-    if (!connected && recordIsSerializedActivity) {
+    if (recordIsSerializedActivity) {
       dispatch({ type: ACTIVITY_OFFLINE_DELETE_ITEM, payload: { id: activity_id } });
     } else {
       dispatch(Activity.deleteReq());
     }
-    setTimeout(() => history.back(), 3000);
+    setTimeout(() => history.push('/Records'), 500);
   };
 
   return (

--- a/app/src/UI/Overlay/Records/FormMenuButtons/FormMenuButtons.tsx
+++ b/app/src/UI/Overlay/Records/FormMenuButtons/FormMenuButtons.tsx
@@ -18,7 +18,7 @@ const FormMenuButtons = () => {
   const accessRoles = useSelector((state) => state.Auth?.accessRoles);
   const activityCreatedBy = useSelector((state) => state.ActivityPage?.activity?.created_by);
   const activityErrors = useSelector((state) => state.ActivityPage?.activityErrors);
-  const activity_id = useSelector((state) => state.ActivityPage.activity.activity_id);
+  const activity_id = useSelector((state) => state.ActivityPage?.activity?.activity_id);
   const { connected } = useSelector((state) => state.Network);
   const status = useSelector((state) => state.ActivityPage?.activity?.form_status);
   const { serializedActivities } = useSelector(selectOfflineActivity);

--- a/app/src/UI/Overlay/Records/FormMenuButtons/FormMenuButtons.tsx
+++ b/app/src/UI/Overlay/Records/FormMenuButtons/FormMenuButtons.tsx
@@ -4,6 +4,8 @@ import { useDispatch } from 'react-redux';
 import { useSelector } from 'utils/use_selector';
 import Activity from 'state/actions/activity/Activity';
 import './FormMenuButtons.css';
+import { selectOfflineActivity } from 'state/reducers/offlineActivity';
+import { ACTIVITY_OFFLINE_DELETE_ITEM } from 'state/actions';
 
 const FormMenuButtons = () => {
   const dispatch = useDispatch();
@@ -11,12 +13,18 @@ const FormMenuButtons = () => {
   const [saveDisabled, setSaveDisabled] = useState(false);
   const [draftDisabled, setDraftDisabled] = useState(false);
 
-  const { connected } = useSelector((state) => state.Network);
+  const accessRoles = useSelector((state) => state.Auth?.accessRoles);
   const activityCreatedBy = useSelector((state) => state.ActivityPage?.activity?.created_by);
   const activityErrors = useSelector((state) => state.ActivityPage?.activityErrors);
+  const activity_id = useSelector((state) => state.ActivityPage.activity.activity_id);
+  const { connected } = useSelector((state) => state.Network);
   const status = useSelector((state) => state.ActivityPage?.activity?.form_status);
+  const { serializedActivities } = useSelector(selectOfflineActivity);
   const username = useSelector((state) => state.Auth?.username);
-  const accessRoles = useSelector((state) => state.Auth?.accessRoles);
+
+  const recordIsSerializedActivity = !!serializedActivities[activity_id];
+  // Users must have write permission and be online to delete, or record is users offline record
+  const blockUserFromDeletingRecord = (saveDisabled || !connected) && !recordIsSerializedActivity;
 
   useEffect(() => {
     if (!activityCreatedBy || !username || !accessRoles) return;
@@ -44,9 +52,14 @@ const FormMenuButtons = () => {
   const handlePaste = () => {
     dispatch(Activity.paste());
   };
+
   const handleDelete = () => {
-    dispatch(Activity.deleteReq());
-    setTimeout(() => history.back(), 5000);
+    if (!connected && recordIsSerializedActivity) {
+      dispatch({ type: ACTIVITY_OFFLINE_DELETE_ITEM, payload: { id: activity_id } });
+    } else {
+      dispatch(Activity.deleteReq());
+    }
+    setTimeout(() => history.back(), 3000);
   };
 
   return (
@@ -63,7 +76,7 @@ const FormMenuButtons = () => {
       <Button disabled={saveDisabled} onClick={handlePaste} variant="contained">
         PASTE FORM
       </Button>
-      <Button disabled={saveDisabled || !connected} onClick={handleDelete} variant="contained">
+      <Button disabled={blockUserFromDeletingRecord} onClick={handleDelete} variant="contained">
         DELETE
       </Button>
     </div>

--- a/app/src/state/sagas/activity/offline.ts
+++ b/app/src/state/sagas/activity/offline.ts
@@ -3,6 +3,7 @@ import { ActivityStatus, ActivitySyncStatus } from 'sharedAPI';
 import { PayloadAction } from '@reduxjs/toolkit';
 import {
   ACTIVITIES_GET_IDS_FOR_RECORDSET_REQUEST,
+  ACTIVITY_OFFLINE_DELETE_ITEM,
   ACTIVITY_RUN_OFFLINE_SYNC,
   ACTIVITY_RUN_OFFLINE_SYNC_COMPLETE,
   ACTIVITY_SAVE_OFFLINE,
@@ -169,9 +170,33 @@ export function* handle_ACTIVITY_RUN_OFFLINE_SYNC() {
   yield put({ type: ACTIVITY_RUN_OFFLINE_SYNC_COMPLETE });
 }
 
+function* handle_ACTIVITY_OFFLINE_DELETE_ITEM(action: PayloadAction<{ id: string }>) {
+  const { serializedActivities } = yield select(selectOfflineActivity);
+  if (!serializedActivities[action.payload.id]) {
+    yield put(
+      Alerts.create({
+        content: 'Offline activity deleted from device',
+        subject: AlertSubjects.Form,
+        severity: AlertSeverity.Success,
+        autoClose: 4
+      })
+    );
+  } else {
+    yield put(
+      Alerts.create({
+        content: 'Failed to delete offline activity',
+        subject: AlertSubjects.Form,
+        severity: AlertSeverity.Error,
+        autoClose: 4
+      })
+    );
+  }
+}
+
 export function* handle_ACTIVITY_RESTORE_OFFLINE() {}
 
 export const OFFLINE_ACTIVITY_SAGA_HANDLERS = [
+  takeEvery(ACTIVITY_OFFLINE_DELETE_ITEM, handle_ACTIVITY_OFFLINE_DELETE_ITEM),
   takeEvery(Activity.getLocal, handle_ACTIVITY_GET_LOCAL_REQUEST),
   takeEvery(ACTIVITY_SAVE_OFFLINE, handle_ACTIVITY_SAVE_OFFLINE),
   takeEvery(Activity.createLocal, handle_ACTIVITY_CREATE_LOCAL),


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Refactors the in-form delete button to include deletion of users offline records. Previously this functionality was only in `OfflineDataSyncTable.tsx` and the form delete button was disabled
- Sort useSelectors
- Closes #3955