### PR TITLE
[INV-3954] No editing records pulled from cache

### DIFF
--- a/app/src/UI/Overlay/Records/Activity/form/FormContainer.tsx
+++ b/app/src/UI/Overlay/Records/Activity/form/FormContainer.tsx
@@ -23,6 +23,8 @@ import AgentSelectAutoComplete from 'rjsf/widgets/AgentSelectAutoComplete';
 import LinkedIdSelectAutoComplete from 'rjsf/widgets/LinkedIdSelectAutoComplete';
 import ErrorListTemplate from './ErrorListTemplate';
 import Activity from 'state/actions/activity/Activity';
+import { selectNetworkState } from 'state/reducers/network';
+import { selectOfflineActivity } from 'state/reducers/offlineActivity';
 
 const FormContainer = () => {
   const ref = useRef(0);
@@ -54,13 +56,15 @@ const FormContainer = () => {
   const activitySchema = useSelector((state) => state.ActivityPage.schema);
   const activityUISchema = useSelector((state) => state.ActivityPage.uiSchema);
 
+  const { connected } = useSelector(selectNetworkState);
   const created_by = useSelector((state) => state.ActivityPage.activity.created_by);
   const pasteCount = useSelector((state) => state.ActivityPage.pasteCount);
   const reported_area = useSelector((state) => state.ActivityPage.activity.form_data.activity_data?.reported_area);
+  const { serializedActivities } = useSelector(selectOfflineActivity);
   const username = useSelector((state) => state.Auth.username);
-
   const [isCreatedByUser, setIsCreatedByUser] = useState<boolean>(username === created_by);
-  const [isDisabled, setIsDisabled] = useState<boolean>(!isCreatedByUser);
+  const [isCachedRecord, setIsCachedRecord] = useState<boolean>(!serializedActivities?.[activity_ID] && !connected);
+  const [isDisabled, setIsDisabled] = useState<boolean>(!isCreatedByUser || isCachedRecord);
   const [userIsAdmin] = useState<boolean>(accessRoles?.some((role) => role.role_id === 18));
 
   const debouncedFormChange = useCallback(
@@ -85,9 +89,13 @@ const FormContainer = () => {
   }, [formDataState]);
 
   useEffect(() => {
+    setIsCachedRecord(!connected && !serializedActivities?.[activity_ID]);
+  }, [activity_ID, connected, serializedActivities]);
+
+  useEffect(() => {
     setIsCreatedByUser(username === created_by);
-    setIsDisabled(username !== created_by);
-  }, [username, created_by]);
+    setIsDisabled(username !== created_by || isCachedRecord);
+  }, [username, created_by, isCachedRecord]);
 
   const isActivityChemTreatment = (): boolean =>
     activity_subtype === 'Activity_Treatment_ChemicalPlantTerrestrial' ||
@@ -100,7 +108,7 @@ const FormContainer = () => {
     <Box sx={{ px: '15%' }}>
       <ThemeProvider theme={theme}>
         <SelectAutoCompleteContextProvider>
-          {!isCreatedByUser && userIsAdmin && (
+          {userIsAdmin && !isCreatedByUser && !isCachedRecord && (
             <div className="editFormButtonCont">
               <Button variant="contained" color="warning" onClick={() => setIsDisabled((prev) => !prev)}>
                 {isDisabled ? 'Enable Editing' : 'Disable Editing'}

--- a/app/src/UI/Overlay/Records/FormMenuButtons/FormMenuButtons.tsx
+++ b/app/src/UI/Overlay/Records/FormMenuButtons/FormMenuButtons.tsx
@@ -12,17 +12,18 @@ const FormMenuButtons = () => {
   const dispatch = useDispatch();
   const history = useHistory();
 
-  const [saveDisabled, setSaveDisabled] = useState(false);
-  const [draftDisabled, setDraftDisabled] = useState(false);
-
   const accessRoles = useSelector((state) => state.Auth?.accessRoles);
   const activityCreatedBy = useSelector((state) => state.ActivityPage?.activity?.created_by);
   const activityErrors = useSelector((state) => state.ActivityPage?.activityErrors);
   const activity_id = useSelector((state) => state.ActivityPage?.activity?.activity_id);
   const { connected } = useSelector((state) => state.Network);
-  const status = useSelector((state) => state.ActivityPage?.activity?.form_status);
   const { serializedActivities } = useSelector(selectOfflineActivity);
+  const status = useSelector((state) => state.ActivityPage?.activity?.form_status);
   const username = useSelector((state) => state.Auth?.username);
+
+  const [saveDisabled, setSaveDisabled] = useState<boolean>(false);
+  const [draftDisabled, setDraftDisabled] = useState<boolean>(false);
+  const [isCachedRecord, setIsCachedRecord] = useState<boolean>(!serializedActivities?.[activity_id] && !connected);
 
   const recordIsSerializedActivity = !!serializedActivities[activity_id];
   // Users must have write permission and be online to delete, or record is users offline record
@@ -32,15 +33,10 @@ const FormMenuButtons = () => {
     if (!activityCreatedBy || !username || !accessRoles) return;
     const createdByUser = username === activityCreatedBy;
     const isAdmin = accessRoles.some((role: Record<string, any>) => role.role_id === 18);
-    if (isAdmin || createdByUser) {
-      setSaveDisabled(false);
-    } else {
-      setSaveDisabled(true);
-    }
-    if (status === 'Submitted') {
-      setDraftDisabled(true);
-    }
-  }, [accessRoles, username, activityCreatedBy]);
+    setIsCachedRecord(!serializedActivities?.[activity_id] && !connected);
+    setSaveDisabled(!((isAdmin || createdByUser) && !isCachedRecord));
+    setDraftDisabled(status === 'Submitted' || isCachedRecord);
+  }, [accessRoles, activityCreatedBy, activity_id, username, connected]);
 
   const handleSaveDraft = () => {
     dispatch(Activity.save());


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

When a user is offline, and a record is not in their `serializedActivities` prevent edits from occurring.
Admin users viewing another users records will not have an `Edit` button available to them when record is from cache

From cache is defined as Record accessed while offline, and record is not part of `serializedActivities`

Cases where users were able to 'edit' cached records.
    - User has cached one of their own records and is viewing it offline (this would trigger edit mode immediately)
    - User is an admin and viewing a record offline (This would trigger an edit button to be available)

- Closes #3954

Edit button (For reference)
![image](https://github.com/user-attachments/assets/7ed0b6cf-d423-4022-bc8e-300139c4b590)

