### PR TITLE
[INV-3976] Update ConnectivityErrorHandler

### DIFF
--- a/app/src/UI/ErrorHandler/ConnectivityErrorHandler.tsx
+++ b/app/src/UI/ErrorHandler/ConnectivityErrorHandler.tsx
@@ -1,15 +1,44 @@
-import React from 'react';
 import './ErrorHandler.css';
+import { useDispatch } from 'react-redux';
+import { AuthActions } from 'state/actions/auth/Auth';
+import { Button } from '@mui/material';
+import { useEffect, useState } from 'react';
 
 export const ConnectivityErrorHandler = () => {
+  const dispatch = useDispatch();
+  const handleRefresh = () => location.reload();
+  const handleOffline = () => {
+    dispatch(AuthActions.signoutRequest());
+  };
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setTimeSinceCrash(Math.floor((new Date().getTime() - time.getTime()) / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  });
+  const [time] = useState<Date>(new Date());
+  const [timeSinceCrash, setTimeSinceCrash] = useState<number>();
   return (
-    <div className={'connectivityError'}>
-      <h2>An temporary connectivity error has occurred</h2>
-
-      <p>
-        The application will attempt to recover. Please wait while connectivity is restored. If this message persists
-        for more than 1 minute, try refreshing your browser.
-      </p>
+    <div id="connectivity-error-handler" className="errorHandler">
+      <div>
+        <h1>Having Trouble Connecting?</h1>
+        <p>
+          It looks like there's an issue connecting to the authentication server. The app will try to fix it on its own.
+          Please be patient while it reconnects. If this message stays for more than a minute, try refreshing your
+          browser.
+        </p>
+        <p>
+          Elapsed time: <b>{timeSinceCrash?.toLocaleString()}</b> seconds
+        </p>
+        <div className="controls">
+          <Button variant="contained" color="primary" onClick={handleRefresh}>
+            Refresh
+          </Button>
+          <Button variant="contained" color="secondary" onClick={handleOffline} sx={{ margin: '0.5rem' }}>
+            Sign out
+          </Button>
+        </div>
+      </div>
     </div>
   );
 };

--- a/app/src/UI/ErrorHandler/ErrorHandler.css
+++ b/app/src/UI/ErrorHandler/ErrorHandler.css
@@ -1,6 +1,8 @@
-div.connectivityError {
-  font-size: 1.5rem;
-  margin: 4rem 2em;
+#connectivity-error-handler {
+  border-radius: 8pt;
+  margin: 3rem 2rem;
+  max-width: 900px;
+  box-sizing: border-box;
 }
 
 div.errorHandler {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Refactor `ConnectivityErrorHandler`
    - Text is more readable
    - Add Refresh / Signout buttons
    - Show elapsed time since crash, adding insight to if user wants to be there  
    - Closes #3976 

This is only displayed when Keycloak tokens fail to refresh, It's not very common.

in `app/src/UI/App.tsx:33` change `disrupted` => `!disrupted` and it will render

## Screenshots

### New
![image](https://github.com/user-attachments/assets/f0793f74-a909-4ded-a1c1-56a271b65996)

### Previous

![Image](https://github.com/user-attachments/assets/3985a9e0-9964-4fc8-8ebe-3b4c2085aeb5)
