### PR TITLE
Hide Offline activities layer and custom layers on logout

### DIFF
--- a/app/src/UI/LegacyMap/Map.tsx
+++ b/app/src/UI/LegacyMap/Map.tsx
@@ -20,11 +20,7 @@ import {
   removeOfflineActivitiesLayer,
   toggleOfflineActivityLabels
 } from 'UI/LegacyMap/helpers/functional/recordset-layers';
-import {
-  addWMSLayersIfNotExist,
-  hideWMSIfUnauthorized,
-  refreshWMSOnToggle
-} from 'UI/LegacyMap/helpers/functional/wms-layers';
+import { addWMSLayersIfNotExist, refreshWMSOnToggle } from 'UI/LegacyMap/helpers/functional/wms-layers';
 import {
   addServerBoundariesIfNotExists,
   refreshServerBoundariesOnToggle
@@ -44,7 +40,7 @@ import { TileCacheService } from 'utils/tile-cache';
 import { ReactiveLayers } from 'UI/LegacyMap/helpers/components/ReactiveLayers';
 import { CurrentActivityLayer } from 'UI/LegacyMap/helpers/components/CurrentActivityLayer';
 import { DrawControls } from 'UI/LegacyMap/helpers/components/DrawControls';
-import { toggleLayerOnBool } from 'UI/LegacyMap/helpers/functional/utility-functions';
+import { toggleLayerOnBool, removeLayerIfUnauthorized } from 'UI/LegacyMap/helpers/functional/utility-functions';
 import { OfflineActivityRecord, OfflineActivitySyncState } from 'state/reducers/offlineActivity';
 import DisplayComposite from './helpers/components/DisplayComposite/DisplayComposite';
 /*
@@ -272,7 +268,7 @@ export const Map = ({ children }) => {
   useEffect(() => {
     if (!map || !mapReady || !MOBILE) return;
 
-    if (!mapToggle) {
+    if (!mapToggle || !loggedInOrWorkingOffline) {
       removeOfflineActivitiesLayer(map);
     } else {
       const unsyncedOfflineActivities = Object.fromEntries(
@@ -301,8 +297,8 @@ export const Map = ({ children }) => {
     if (!mapReady) return;
     if (!map) return;
     const layers = connectedToNetwork ? simplePickerLayers2 : DEFAULT_LOCAL_LAYERS;
-    if (!authenticated || !rolesInitialized) {
-      hideWMSIfUnauthorized(layers, map);
+    if (!loggedInOrWorkingOffline) {
+      removeLayerIfUnauthorized(layers, map);
       return;
     }
 
@@ -318,8 +314,15 @@ export const Map = ({ children }) => {
     }
   }, [serverBoundaries, authenticated, map, mapReady]);
 
+  // Custom Layers:
   useEffect(() => {
     if (!mapReady) return;
+
+    if (!loggedInOrWorkingOffline) {
+      removeLayerIfUnauthorized(clientBoundaries, map);
+      return;
+    }
+
     addClientBoundariesIfNotExists(clientBoundaries, map);
     refreshClientBoundariesOnToggle(clientBoundaries, map);
   }, [clientBoundaries, map, mapReady]);

--- a/app/src/UI/LegacyMap/Map.tsx
+++ b/app/src/UI/LegacyMap/Map.tsx
@@ -20,14 +20,19 @@ import {
   removeOfflineActivitiesLayer,
   toggleOfflineActivityLabels
 } from 'UI/LegacyMap/helpers/functional/recordset-layers';
-import { addWMSLayersIfNotExist, refreshWMSOnToggle } from 'UI/LegacyMap/helpers/functional/wms-layers';
+import {
+  addWMSLayersIfNotExist,
+  refreshWMSOnToggle,
+  removeWMSLayers
+} from 'UI/LegacyMap/helpers/functional/wms-layers';
 import {
   addServerBoundariesIfNotExists,
   refreshServerBoundariesOnToggle
 } from 'UI/LegacyMap/helpers/functional/server-boundaries';
 import {
   addClientBoundariesIfNotExists,
-  refreshClientBoundariesOnToggle
+  refreshClientBoundariesOnToggle,
+  removeClientBoundaries
 } from 'UI/LegacyMap/helpers/functional/client-boundaries';
 import { DEFAULT_LOCAL_LAYERS } from 'state/reducers/map';
 import { MapContext } from 'UI/LegacyMap/helpers/components/MapContext';
@@ -40,7 +45,7 @@ import { TileCacheService } from 'utils/tile-cache';
 import { ReactiveLayers } from 'UI/LegacyMap/helpers/components/ReactiveLayers';
 import { CurrentActivityLayer } from 'UI/LegacyMap/helpers/components/CurrentActivityLayer';
 import { DrawControls } from 'UI/LegacyMap/helpers/components/DrawControls';
-import { toggleLayerOnBool, removeLayerIfUnauthorized } from 'UI/LegacyMap/helpers/functional/utility-functions';
+import { toggleLayerOnBool } from 'UI/LegacyMap/helpers/functional/utility-functions';
 import { OfflineActivityRecord, OfflineActivitySyncState } from 'state/reducers/offlineActivity';
 import DisplayComposite from './helpers/components/DisplayComposite/DisplayComposite';
 /*
@@ -298,7 +303,7 @@ export const Map = ({ children }) => {
     if (!map) return;
     const layers = connectedToNetwork ? simplePickerLayers2 : DEFAULT_LOCAL_LAYERS;
     if (!loggedInOrWorkingOffline) {
-      removeLayerIfUnauthorized(layers, map);
+      removeWMSLayers(layers, map);
       return;
     }
 
@@ -316,10 +321,10 @@ export const Map = ({ children }) => {
 
   // Custom Layers:
   useEffect(() => {
-    if (!mapReady) return;
+    if (!mapReady || !map) return;
 
     if (!loggedInOrWorkingOffline) {
-      removeLayerIfUnauthorized(clientBoundaries, map);
+      removeClientBoundaries(clientBoundaries, map);
       return;
     }
 

--- a/app/src/UI/LegacyMap/Map.tsx
+++ b/app/src/UI/LegacyMap/Map.tsx
@@ -330,7 +330,7 @@ export const Map = ({ children }) => {
 
     addClientBoundariesIfNotExists(clientBoundaries, map);
     refreshClientBoundariesOnToggle(clientBoundaries, map);
-  }, [clientBoundaries, map, mapReady]);
+  }, [clientBoundaries, map, mapReady, loggedInOrWorkingOffline]);
 
   // Jump Nav
   useEffect(() => {

--- a/app/src/UI/LegacyMap/helpers/functional/client-boundaries.ts
+++ b/app/src/UI/LegacyMap/helpers/functional/client-boundaries.ts
@@ -48,3 +48,13 @@ export const refreshClientBoundariesOnToggle = (clientBoundaries, map) => {
     });
   }
 };
+
+export const removeClientBoundaries = (clientBoundaries, map) => {
+  clientBoundaries.map((layer) => {
+    const layerID = 'clientBoundaries' + layer.id;
+    if (map.getSource(layerID) && map.getLayer(layerID)) {
+      map.removeLayer(layerID);
+      map.removeSource(layerID);
+    }
+  });
+};

--- a/app/src/UI/LegacyMap/helpers/functional/utility-functions.ts
+++ b/app/src/UI/LegacyMap/helpers/functional/utility-functions.ts
@@ -24,12 +24,3 @@ export function safelySetPaintProperty(map: maplibregl.Map, mapLayer: string, pr
     console.error(e);
   }
 }
-
-export const removeLayerIfUnauthorized = (curr_layer, map) => {
-  curr_layer.map((layer) => {
-    if (map.getLayer(layer.url)) {
-      map.removeLayer(layer.url);
-      map.removeSource(layer.url);
-    }
-  });
-};

--- a/app/src/UI/LegacyMap/helpers/functional/utility-functions.ts
+++ b/app/src/UI/LegacyMap/helpers/functional/utility-functions.ts
@@ -24,3 +24,12 @@ export function safelySetPaintProperty(map: maplibregl.Map, mapLayer: string, pr
     console.error(e);
   }
 }
+
+export const removeLayerIfUnauthorized = (curr_layer, map) => {
+  curr_layer.map((layer) => {
+    if (map.getLayer(layer.url)) {
+      map.removeLayer(layer.url);
+      map.removeSource(layer.url);
+    }
+  });
+};

--- a/app/src/UI/LegacyMap/helpers/functional/wms-layers.ts
+++ b/app/src/UI/LegacyMap/helpers/functional/wms-layers.ts
@@ -51,3 +51,12 @@ export const refreshWMSOnToggle = (simplePickerLayers2, map) => {
     }
   });
 };
+
+export const removeWMSLayers = (simplePickerLayers2, map) => {
+  simplePickerLayers2.map((layer) => {
+    if (map.getLayer(layer.url)) {
+      map.removeLayer(layer.url);
+      map.removeSource(layer.url);
+    }
+  });
+};

--- a/app/src/UI/LegacyMap/helpers/functional/wms-layers.ts
+++ b/app/src/UI/LegacyMap/helpers/functional/wms-layers.ts
@@ -51,12 +51,3 @@ export const refreshWMSOnToggle = (simplePickerLayers2, map) => {
     }
   });
 };
-
-export const hideWMSIfUnauthorized = (simplePickerLayers2, map) => {
-  simplePickerLayers2.map((layer) => {
-    if (map.getLayer(layer.url)) {
-      map.removeLayer(layer.url);
-      map.removeSource(layer.url);
-    }
-  });
-};


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Hide authenticated layers when logged out. 
- Closes #3943 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
