### PR TITLE
[Related: INV-3987] Add transformer to reset working state of offline sync

### DIFF
--- a/app/src/state/reducers/rootReducer.ts
+++ b/app/src/state/reducers/rootReducer.ts
@@ -80,6 +80,12 @@ const handleActiveDownloadsOnRehydration = createTransform(
   { whitelist: ['recordSets'] }
 );
 
+// Sets the working state to false on app reload
+const handleSyncTermination = createTransform(
+  (inboundState) => inboundState,
+  () => false,
+  { whitelist: ['working'] }
+);
 function createRootReducer(config: AppConfig) {
   return combineReducers({
     AppMode: appMode,
@@ -170,7 +176,8 @@ function createRootReducer(config: AppConfig) {
           key: 'offline-activity',
           storage: durableStorage,
           migrate: preserveStateOnVersionUpgrade,
-          stateReconciler: autoMergeLevel1
+          stateReconciler: autoMergeLevel1,
+          transforms: [handleSyncTermination]
         },
         createOfflineActivityReducer(config)
       );


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

If the app resets or crashes during a sync, the `working` state is being persisted due to the caching functionality.
The working state causes many spinners to persist, and doesn't go away unless the user manually triggers sync again by opening a single record and submitted it while offline.
When the working state is true, the `sync all` button is disabled.

References Issue #3987

Replication steps
- Create 3-4 local records
- Hit Sync
- Close the browser before the sync completes