### PR TITLE
Mobile Auth Enhancements

### DIFF
--- a/app/ios/App/App/AuthBridge.swift
+++ b/app/ios/App/App/AuthBridge.swift
@@ -212,13 +212,19 @@ public class AuthBridge: CAPPlugin, CAPBridgedPlugin {
                                                     tokenEndpoint: tokenEndpoint)
         let redirectURI = URL(string:"invasivesbc://callback")!
         let clientID = "\(SSO_CLIENT_ID)"
+                
+        
+        var authorizationParameters = ["prompt": "login"]
+        if let idpHint = call.options["idpHint"] {
+            authorizationParameters["kc_idp_hint"] = "\(idpHint)";
+        }
         
         let request = OIDAuthorizationRequest(configuration: configuration,
                                               clientId: clientID,
                                               scopes: [OIDScopeOpenID, OIDScopeProfile],
                                               redirectURL: redirectURI,
                                               responseType: OIDResponseTypeCode,
-                                              additionalParameters: ["prompt": "login"])
+                                              additionalParameters: authorizationParameters)
 
         DispatchQueue.main.sync {
             

--- a/app/src/UI/Header/Header.tsx
+++ b/app/src/UI/Header/Header.tsx
@@ -163,14 +163,14 @@ const ButtonWrapper = ({ children }) => {
   );
 };
 
-const LoginButton = ({ labelText = 'Login' }) => {
+const LoginButton = ({ labelText = 'Login', idpHint }) => {
   const dispatch = useDispatch();
   const loginInProgress = useSelector((state) => state.Auth.loginInProgress);
   return (
     <MenuItem
       disabled={loginInProgress}
       onClick={() => {
-        dispatch(AuthActions.signinRequest());
+        dispatch(AuthActions.signinRequest({ idpHint }));
       }}
     >
       <ListItemIcon>
@@ -317,7 +317,7 @@ const LoginOrOutMemo = React.memo(() => {
 
   const requestAccess = async () => {
     if (!authenticated) {
-      dispatch(AuthActions.signinRequest());
+      dispatch(AuthActions.signinRequest({}));
     } else {
       history.push('/AccessRequest');
       dispatch({
@@ -380,8 +380,18 @@ const LoginOrOutMemo = React.memo(() => {
             Choose Offline User
           </MenuItem>
         )}
-        {workingOffline && <LoginButton labelText={'Go Online'} />}
-        {loggedInOrWorkingOffline ? <LogoutButton /> : <LoginButton />}
+        {workingOffline && [
+          <LoginButton labelText={'Go Online (IDIR)'} idpHint={'idir'} key={'idir-go'} />,
+          <LoginButton labelText={'Login (BCEID Business)'} idpHint={'bceidbusiness'} key={'bceidbusiness-go'} />
+        ]}
+        {loggedInOrWorkingOffline ? (
+          <LogoutButton />
+        ) : (
+          [
+            <LoginButton labelText={'Login (IDIR)'} idpHint={'idir'} key={'idir'} />,
+            <LoginButton labelText={'Login (BCEID Business)'} idpHint={'bceidbusiness'} key={'bceidbusiness'} />
+          ]
+        )}
       </Menu>
     </div>
   );

--- a/app/src/UI/Overlay/Landing/Landing.tsx
+++ b/app/src/UI/Overlay/Landing/Landing.tsx
@@ -29,14 +29,14 @@ const InformationalLinkBox = () => {
   );
 };
 
-export const LandingComponent = (props) => {
+export const LandingComponent = () => {
   const connected = useSelector(selectNetworkConnected);
   const dispatch = useDispatch();
   const history = useHistory();
 
   const requestAccess = async () => {
     if (connected && !authenticated) {
-      dispatch(AuthActions.signinRequest());
+      dispatch(AuthActions.signinRequest({}));
     } else {
       history.push('/AccessRequest');
       dispatch({
@@ -106,8 +106,8 @@ export const LandingComponent = (props) => {
                       <p>
                         <strong>Roles:</strong>
                       </p>
-                      {roles.map((role: any) => {
-                        return <span key={role.role_id}>{role.role_description + '\n'}</span>;
+                      {roles.map((role) => {
+                        return <span key={role.role_id}>{role.role_name + '\n'}</span>;
                       })}
                     </Box>
                   </Grid>

--- a/app/src/state/actions/auth/Auth.ts
+++ b/app/src/state/actions/auth/Auth.ts
@@ -19,7 +19,7 @@ class AuthActions {
 
   static readonly tokenValidationRequest = createAction(`${this.PREFIX}/tokenValidationRequest`);
 
-  static readonly signinRequest = createAction(`${this.PREFIX}/signinRequest`);
+  static readonly signinRequest = createAction<{ idpHint?: string }>(`${this.PREFIX}/signinRequest`);
   static readonly signoutRequest = createAction(`${this.PREFIX}/signoutRequest`);
   static readonly signoutComplete = createAction(`${this.PREFIX}/signoutComplete`);
   static readonly updateTokenState = createAction<{ idToken: string }>(`${this.PREFIX}/updateTokenState`);

--- a/app/src/state/actions/events/EventActions.ts
+++ b/app/src/state/actions/events/EventActions.ts
@@ -1,0 +1,10 @@
+import { createAction } from '@reduxjs/toolkit';
+
+class EventActions {
+  public static readonly PREFIX = 'EventActions';
+
+  /* fired for window.onfocus and window.visibilitychange (with document.hidden == false). for detecting wakeups on mobile. */
+  static readonly wakeup = createAction(`${this.PREFIX}/wakeup`);
+}
+
+export default EventActions;

--- a/app/src/state/sagas/auth/keycloak.ts
+++ b/app/src/state/sagas/auth/keycloak.ts
@@ -12,15 +12,20 @@ let keycloakInstance: Keycloak | null = null;
 const MIN_TOKEN_FRESHNESS = 20; //want our token to be good for at least this long at all times
 const TOKEN_REFRESH_INTERVAL = 5 * 1000;
 
-function* handleSigninRequest() {
+function* handleSigninRequest(action) {
   const config: AppConfig = yield select(selectConfiguration);
   if (!keycloakInstance) {
     return;
   }
 
+  if (!AuthActions.signinRequest.match(action)) {
+    return;
+  }
+
   try {
     yield call(keycloakInstance.login, {
-      redirectUri: config.REDIRECT_URI
+      redirectUri: config.REDIRECT_URI,
+      ...action.payload
     });
 
     yield put(AuthActions.requestComplete({ idToken: keycloakInstance.idToken }));

--- a/app/src/state/sagas/auth/native.ts
+++ b/app/src/state/sagas/auth/native.ts
@@ -1,4 +1,4 @@
-import { all, put, takeLatest } from 'redux-saga/effects';
+import { all, put, select, takeLatest } from 'redux-saga/effects';
 import { nanoid } from '@reduxjs/toolkit';
 import { USERINFO_CLEAR_REQUEST } from 'state/actions';
 import AuthBridge from 'utils/auth/authBridge';
@@ -6,9 +6,14 @@ import { AuthActions } from 'state/actions/auth/Auth';
 import NetworkActions from 'state/actions/network/NetworkActions';
 import { AlertSeverity, AlertSubjects } from 'constants/alertEnums';
 import Alerts from 'state/actions/alerts/Alerts';
+import EventActions from 'state/actions/events/EventActions';
 
-function* handleSigninRequest() {
-  const authResult = yield AuthBridge.authStart({});
+function* handleSigninRequest(action) {
+  if (!AuthActions.signinRequest.match(action)) {
+    return;
+  }
+
+  const authResult = yield AuthBridge.authStart({ ...action.payload });
 
   if (authResult.error) {
     yield put(AuthActions.requestError());
@@ -55,6 +60,13 @@ function* initializeAuthentication() {
 }
 
 function* checkTokenValidity() {
+  const { authenticated } = yield select((state) => state.Auth);
+
+  if (!authenticated) {
+    // if we don't think we're logged in, we have no opinion here
+    return;
+  }
+
   // verify that we can recover our auth session, sign out if we can't.
   const { error } = yield AuthBridge.token({});
   if (error) {
@@ -79,7 +91,10 @@ const nativeAuthEffects = [
   takeLatest(AuthActions.signinRequest.type, handleSigninRequest),
   takeLatest(AuthActions.signoutRequest.type, handleSignoutRequest),
   takeLatest(AuthActions.initializeRequest.type, initializeAuthentication),
-  takeLatest([NetworkActions.online.type, AuthActions.tokenValidationRequest.type], checkTokenValidity)
+  takeLatest(
+    [NetworkActions.online.type, AuthActions.tokenValidationRequest.type, EventActions.wakeup.type],
+    checkTokenValidity
+  )
 ];
 
 export { nativeAuthEffects };

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -21,6 +21,7 @@ import { AppConfig } from './config';
 import { DEBUG } from './build-time-config';
 import NetworkActions from './actions/network/NetworkActions';
 import { AuthActions } from 'state/actions/auth/Auth';
+import EventActions from 'state/actions/events/EventActions';
 
 const historySingleton = createBrowserHistory();
 
@@ -94,6 +95,14 @@ export function setupStore(configuration: AppConfig) {
   });
 
   storeRef.store = store;
+  document.addEventListener('visibilitychange', () => {
+    if (!document.hidden) {
+      store.dispatch(EventActions.wakeup());
+    }
+  });
+  document.addEventListener('focus', () => {
+    store.dispatch(EventActions.wakeup());
+  });
 
   return { store, persistor: persistStore(store) };
 }

--- a/app/src/utils/auth/authBridge.ts
+++ b/app/src/utils/auth/authBridge.ts
@@ -1,13 +1,18 @@
 import { registerPlugin } from '@capacitor/core';
 
 interface AuthBridgePlugin {
-  authStart(options: {}): Promise<{ error?: string; idToken?: string; accessToken?: string; authorized?: boolean }>;
+  authStart(options: { idpHint?: string }): Promise<{
+    error?: string;
+    idToken?: string;
+    accessToken?: string;
+    authorized?: boolean;
+  }>;
 
-  logout(options: {}): Promise<{ error?: string }>;
+  logout(options: Record<string, never>): Promise<{ error?: string }>;
 
-  token(options: {}): Promise<{ error?: string; idToken?: string; accessToken?: string }>;
+  token(options: Record<string, never>): Promise<{ error?: string; idToken?: string; accessToken?: string }>;
 
-  authStatus(options: {}): Promise<{ error?: string; authorized?: boolean }>;
+  authStatus(options: Record<string, never>): Promise<{ error?: string; authorized?: boolean }>;
 }
 
 const AuthBridge = registerPlugin<AuthBridgePlugin>('AuthBridge');


### PR DESCRIPTION
- recheck token on `onfocus` and `visibilitychange` events (wake up)
- add `kc_idp_hint` and split Login function (test for keycloak workaround).
- just omit `idpHint` on `Auth.signinRequest()` to revert to old behaviour

# Overview

This PR includes the following proposed change(s):

- {List all the changes, if possible add the linked issue/ticket #}

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
