### PR TITLE
Fix for Geo-tracking 

### DIFF
--- a/app/src/UI/LegacyMap/Controls/GeoTrackingButton.tsx
+++ b/app/src/UI/LegacyMap/Controls/GeoTrackingButton.tsx
@@ -2,7 +2,7 @@ import { IconButton, Tooltip } from '@mui/material';
 import PolylineIcon from '@mui/icons-material/Polyline';
 import DirectionsWalkIcon from '@mui/icons-material/DirectionsWalk';
 import GeoShapes from 'constants/geoShapes';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useSelector } from 'utils/use_selector';
 import GeoTracking from 'state/actions/geotracking/GeoTracking';
@@ -13,15 +13,25 @@ import Prompt from 'state/actions/prompts/Prompt';
  * @description Component to handle the functionality of the find me button
  * @returns {void}
  */
-export const GeoTrackingButton = (props) => {
+export const GeoTrackingButton = () => {
   const { isTracking } = useSelector((state) => state.Map.track_me_draw_geo);
+
   const dispatch = useDispatch();
   const [show, setShow] = useState(false);
   const divRef = useRef();
 
+  const activityGeo = (useSelector((state) => state.ActivityPage.activity?.geometry) ?? [])[0] ?? {};
+
   const promptHandler = (input: string | number) => {
     dispatch(GeoTracking.start(input as GeoShapes));
   };
+
+  useEffect(() => {
+    if (activityGeo && activityGeo?.properties?.error == 'true') {
+      dispatch(GeoTracking.stop());
+    }
+  }, [activityGeo?.properties]);
+
   const clickHandler = () => {
     setShow(false);
     if (isTracking) {

--- a/app/src/UI/LegacyMap/helpers/components/DrawControls.tsx
+++ b/app/src/UI/LegacyMap/helpers/components/DrawControls.tsx
@@ -40,7 +40,7 @@ const DrawControls = () => {
   const appModeURL = useSelector((state) => state.AppMode.url);
 
   const EMPTY_OBJECT = {}; //  a stable reference for the default value to avoid unnecessary re-renders
-  const activityGeo = useSelector((state) => state.ActivityPage.activity?.geometry ?? EMPTY_OBJECT);
+  const activityGeo = (useSelector((state) => state.ActivityPage.activity?.geometry) ?? [])[0] ?? EMPTY_OBJECT;
 
   const dispatch = useDispatch();
   const drawInstance = useRef<MapboxDraw>();

--- a/app/src/constants/alerts/mappingAlerts.ts
+++ b/app/src/constants/alerts/mappingAlerts.ts
@@ -28,7 +28,7 @@ const mappingAlertMessages: Record<string, AlertMessage> = {
     severity: AlertSeverity.Error,
     subject: AlertSubjects.Map,
     content: 'Activity geometry intersects itself',
-    autoClose: 5
+    autoClose: 10
   },
   cannotValidateRegion: {
     severity: AlertSeverity.Error,

--- a/app/src/state/sagas/activity.ts
+++ b/app/src/state/sagas/activity.ts
@@ -260,7 +260,11 @@ function* handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_STOP() {
     console.error(err);
   }
   if (geographyWillContainIntersections) {
-    validationErrors.push(mappingAlertMessages.willContainIntersections);
+    // validationErrors.push(mappingAlertMessages.willContainIntersections);
+    yield put(GeoTracking.earlyExit());
+    yield put({ type: ACTIVITY_UPDATE_GEO_REQUEST, payload: { geometry: [] } });
+    yield put(Alerts.create(mappingAlertMessages.trackMyPathStoppedEarly));
+    return;
   }
   if (!geometryHasPositiveArea) {
     validationErrors.push(mappingAlertMessages.noAreaCalculated);
@@ -297,7 +301,7 @@ function* handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_STOP() {
     }
   } else {
     yield put(GeoTracking.pause());
-    yield put(Alerts.create(mappingAlertMessages.canEditInfo));
+    // yield put(Alerts.create(mappingAlertMessages.canEditInfo)); // WIP
     for (const error of validationErrors) {
       yield put(Alerts.create(error));
     }

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -167,7 +167,7 @@ export function* handle_ACTIVITY_UPDATE_GEO_REQUEST(action: Record<string, any>)
 
     if (!isPointGeometry) {
       const hasSelfIntersections = kinks(sanitizedGeo.geometry).features.length > 0;
-      const hasHoles = sanitizedGeo.geometry.coordinates.length > 1; // check for intersections after LineStrings are converted to Polygons
+      const hasHoles = sanitizedGeo.geometry.coordinates.length > 1 && sanitizedGeo.geometry.type === 'Polygon'; // check for intersections after LineStrings are converted to Polygons
 
       if (hasSelfIntersections || hasHoles) {
         yield put(Activity.updateGeoFailure({ geometry: { ...sanitizedGeo, properties: { error: 'true' } } }));

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -170,7 +170,7 @@ export function* handle_ACTIVITY_UPDATE_GEO_REQUEST(action: Record<string, any>)
       const hasHoles = sanitizedGeo.geometry.coordinates.length > 1 && sanitizedGeo.geometry.type === 'Polygon'; // check for intersections after LineStrings are converted to Polygons
 
       if (hasSelfIntersections || hasHoles) {
-        yield put(Activity.updateGeoFailure({ geometry: { ...sanitizedGeo, properties: { error: 'true' } } }));
+        yield put(Activity.updateGeoFailure({ geometry: [{ ...sanitizedGeo, properties: { error: 'true' } }] }));
         yield put(Alerts.create(mappingAlertMessages.containsIntersections));
         return;
       }


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Closes https://github.com/bcgov/invasivesbc/issues/3941
- Fixed basic functionality - drawing `LineString`, drawing `Polygon`, pause/resume drawing, early exit on errors
- When a shape intersection occurs, drawing is halted and tracking is stopped. 
- This establishes the core feature for launch. The next iteration will be more in sync with the draw tools

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
