### PR TITLE
[INV-4004][INV-4001] Whats here Popover, State Cleanup, Fix WhatsHere stopping randomly

### DIFF
--- a/app/src/UI/LegacyMap/helpers/components/DrawControls.tsx
+++ b/app/src/UI/LegacyMap/helpers/components/DrawControls.tsx
@@ -128,7 +128,9 @@ const DrawControls = () => {
     switch (currentMode) {
       case TargetMode.WHATS_HERE: {
         dispatch(WhatsHere.map_feature({ type: 'Feature', geometry: feature.geometry }));
-        uHistory.push('/WhatsHere');
+        if (uHistory.location.pathname !== '/WhatsHere') {
+          uHistory.push('/WhatsHere');
+        }
         break;
       }
       case TargetMode.ACTIVITY: {

--- a/app/src/UI/Overlay/WhatsHere/Subcomponents/RenderTableActivity.tsx
+++ b/app/src/UI/Overlay/WhatsHere/Subcomponents/RenderTableActivity.tsx
@@ -1,12 +1,17 @@
-import { DataGrid, GridRowParams, MuiEvent } from '@mui/x-data-grid';
+import { DataGrid, MuiEvent } from '@mui/x-data-grid';
 import WhatsHerePagination from './WhatsHerePagination';
 import { useSelector } from 'utils/use_selector';
 import { useDispatch } from 'react-redux';
 import NoRowsInSearch from './NoRowsInSearch';
 import WhatsHere from 'state/actions/whatsHere/WhatsHere';
 import { RecordSetType } from 'interfaces/UserRecordSet';
+import { MouseEvent } from 'react';
 
-const RenderTableActivity = () => {
+type PropTypes = {
+  setAnchorEl: (anchorEl: HTMLElement | null) => void;
+};
+
+const RenderTableActivity = ({ setAnchorEl }: PropTypes) => {
   const dispatch = useDispatch();
   const { authenticated, roles } = useSelector((state) => state.Auth);
   const whatsHere = useSelector((state) => state.Map?.whatsHere);
@@ -36,14 +41,12 @@ const RenderTableActivity = () => {
       headerName: 'Reported Area',
       flex: 0.2,
       sortable: false,
-      renderCell: (params) => {
-        return (
-          <div onMouseEnter={dispatchUpdatedID.bind(this, params)}>
-            {params.value}
-            {'m\u00B2'}
-          </div>
-        );
-      }
+      renderCell: (params) => (
+        <div onMouseEnter={dispatchUpdatedID.bind(this, params)}>
+          {params.value}
+          {'m\u00B2'}
+        </div>
+      )
     },
     {
       field: 'created',
@@ -70,7 +73,7 @@ const RenderTableActivity = () => {
 
   const highlightActivity = async (params) => {
     const { id, short_id } = params.row;
-    dispatch(WhatsHere.id_clicked({ type: RecordSetType.Activity, description: 'Activity-' + short_id, id }));
+    dispatch(WhatsHere.id_clicked({ type: RecordSetType.Activity, description: short_id, id }));
     dispatch(WhatsHere.set_highlighted_activity(id, short_id));
   };
 
@@ -89,8 +92,9 @@ const RenderTableActivity = () => {
             onColumnHeaderClick={(c) => {
               dispatch(WhatsHere.sort_filter_update(RecordSetType.Activity, c.field));
             }}
-            onRowClick={(params: GridRowParams, _event: MuiEvent<React.MouseEvent>) => {
+            onCellClick={(params, evt: MuiEvent<MouseEvent>) => {
               if (authenticated && roles.length > 0) {
+                setAnchorEl(evt.currentTarget as HTMLElement);
                 highlightActivity(params);
               }
             }}

--- a/app/src/UI/Overlay/WhatsHere/Subcomponents/RenderTablePOI.tsx
+++ b/app/src/UI/Overlay/WhatsHere/Subcomponents/RenderTablePOI.tsx
@@ -6,7 +6,10 @@ import NoRowsInSearch from './NoRowsInSearch';
 import WhatsHere from 'state/actions/whatsHere/WhatsHere';
 import { RecordSetType } from 'interfaces/UserRecordSet';
 
-const RenderTablePOI = (props: any) => {
+type PropTypes = {
+  setAnchorEl: (anchorEl: HTMLElement | null) => void;
+};
+const RenderTablePOI = ({ setAnchorEl }: PropTypes) => {
   const dispatch = useDispatch();
   const { authenticated, roles } = useSelector((state: any) => state.Auth);
   const whatsHere = useSelector((state: any) => state.Map?.whatsHere);
@@ -74,8 +77,9 @@ const RenderTablePOI = (props: any) => {
             onColumnHeaderClick={(c) => {
               dispatch(WhatsHere.sort_filter_update(RecordSetType.IAPP, c.field));
             }}
-            onCellClick={(params: GridCellParams, _event: MuiEvent<React.MouseEvent>) => {
+            onCellClick={(params: GridCellParams, event: MuiEvent<React.MouseEvent>) => {
               if (authenticated && roles.length > 0) {
+                setAnchorEl(event.currentTarget as HTMLElement);
                 highlightPOI(params);
               }
             }}

--- a/app/src/UI/Overlay/WhatsHere/WhatsHereTable.tsx
+++ b/app/src/UI/Overlay/WhatsHere/WhatsHereTable.tsx
@@ -1,11 +1,10 @@
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import center from '@turf/center';
 import { Button, Grid, Tab, TableContainer, Tabs } from '@mui/material';
 import AdjustIcon from '@mui/icons-material/Adjust';
 import FolderIcon from '@mui/icons-material/Folder';
 import { useHistory } from 'react-router';
-
 import RenderTableActivity from './Subcomponents/RenderTableActivity';
 import RenderTablePOI from './Subcomponents/RenderTablePOI';
 import { useSelector } from 'utils/use_selector';
@@ -14,18 +13,35 @@ import './WhatsHereTable.css';
 import { ArrowLeftIcon } from '@mui/x-date-pickers/icons';
 import WhatsHere from 'state/actions/whatsHere/WhatsHere';
 import Spinner from 'UI/Spinner/Spinner';
-
-export const createDataUTM = (name: string, value: any) => {
-  return { name, value };
-};
+import { RecordSetType } from 'interfaces/UserRecordSet';
+import CustomPopover from 'UI/CustomPopover/CustomPopover';
+import RecordTablePopoverContent from '../Records/RecordSet/RecordTablePopoverContent/RecordTablePopoverContent';
 
 export const WhatsHereTable = () => {
-  const dispatch = useDispatch();
+  const createDataUTM = (name: string, value: any) => ({ name, value });
+  const handleChange = (_event: ChangeEvent<{}>, newSection: string) => {
+    setRecordTab(newSection as RecordSetType);
+    dispatch(WhatsHere.map_change_tab());
+  };
 
-  const whatsHere = useSelector((state) => state.Map?.whatsHere);
+  const dispatch = useDispatch();
   const history = useHistory();
+  const whatsHere = useSelector((state) => state.Map?.whatsHere);
+
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [recordTab, setRecordTab] = useState<RecordSetType>(RecordSetType.Activity);
+  const loadingInProgress = whatsHere.loadingActivities || whatsHere.loadingIAPP;
 
   const position = whatsHere?.feature?.geometry ? center(whatsHere?.feature?.geometry)?.geometry.coordinates : [0, 0];
+  const recordDisplayId = {
+    [RecordSetType.Activity]: whatsHere?.clickedActivityDescription,
+    [RecordSetType.IAPP]: whatsHere?.clickedIAPP
+  };
+  const recordLookupId = {
+    [RecordSetType.Activity]: whatsHere?.clickedActivity,
+    [RecordSetType.IAPP]: whatsHere?.clickedIAPP
+  };
+
   const utmResult = calc_utm(position[0], position[1]);
   const utmRows = [
     createDataUTM('Zone', utmResult[0]),
@@ -33,66 +49,43 @@ export const WhatsHereTable = () => {
     createDataUTM('Northing', utmResult[2])
   ];
 
-  const handleChange = (_event: ChangeEvent<{}>, newSection: string) => {
-    dispatch(WhatsHere.map_set_section(newSection));
-  };
-
-  const goToRecord = () => {
-    const id = whatsHere.section === 'invasivesbc' ? whatsHere?.clickedActivity : whatsHere?.clickedIAPP;
-    if (whatsHere?.section === 'invasivesbc') {
-      history.push(`/Records/Activity:${id}/form`);
-    } else if (whatsHere?.highlightedType === 'IAPP') {
-      history.push(`/Records/IAPP/${id}/summary`);
-    }
-  };
-
-  const getActivityDescriptionForOpenButton = () => `Open InvasivesBC record: ${whatsHere?.clickedActivityDescription}`;
-  const getIAPPDescriptionForOpenButton = () => `Open IAPP record: ${whatsHere?.clickedIAPPDescription}`;
-
-  const loadingInProgress = whatsHere.loadingActivities || whatsHere.loadingIAPP;
-
   return (
     <div className="whatshere-container">
-      {whatsHere?.section && (
-        <div className="whatshere-table-container">
-          <div className="whatshere_back_button">
-            <Button onClick={history.goBack} color="info" variant="contained">
-              <ArrowLeftIcon />
-              Back
-            </Button>
-          </div>
-          <div id="whatsherepopup" className="whatshere-table">
-            <Grid className="whatshere-header" container justifyContent="center" sx={{ mb: 2 }}>
-              <div className="whatshere-title">
-                What's Here: <br /> {`UTM: Z-${utmRows[0]?.value} E-${utmRows[1]?.value} N-${utmRows[2]?.value}`}
-              </div>
-              <Tabs value={whatsHere?.section} onChange={handleChange} centered>
-                <Tab value="invasivesbc" label="InvasivesBC Records" icon={<FolderIcon />} />
-                <Tab value="iapp" label="IAPP Records" icon={<AdjustIcon />} />
-              </Tabs>
-            </Grid>
-            <Grid container spacing={2} justifyContent="center">
-              <Grid item sx={{ mb: 1 }}>
-                {whatsHere?.section === 'invasivesbc' && whatsHere?.clickedActivity && (
-                  <Button variant="contained" color="info" onClick={goToRecord}>
-                    {getActivityDescriptionForOpenButton()}
-                  </Button>
-                )}
-                {whatsHere?.section === 'iapp' && whatsHere?.clickedIAPP && (
-                  <Button variant="contained" color="info" onClick={goToRecord}>
-                    {getIAPPDescriptionForOpenButton()}
-                  </Button>
-                )}
-              </Grid>
-            </Grid>
-            {loadingInProgress && <Spinner />}
-            <TableContainer className="whatshere-position">
-              {whatsHere?.section === 'invasivesbc' && <RenderTableActivity />}
-              {whatsHere?.section === 'iapp' && <RenderTablePOI />}
-            </TableContainer>
-          </div>
+      <CustomPopover buttonOverrideOptions={{ anchorEl, setAnchorEl }}>
+        <RecordTablePopoverContent
+          recordDisplayId={recordDisplayId[recordTab]}
+          recordType={recordTab}
+          recordLookupId={recordLookupId[recordTab]}
+        />
+      </CustomPopover>
+      <div className="whatshere-table-container">
+        <div className="whatshere_back_button">
+          <Button onClick={history.goBack} color="info" variant="contained">
+            <ArrowLeftIcon />
+            Back
+          </Button>
         </div>
-      )}
+        <div id="whatsherepopup" className="whatshere-table">
+          <Grid className="whatshere-header" container justifyContent="center" sx={{ mb: 2 }}>
+            <div className="whatshere-title">
+              What's Here: <br /> {`UTM: Z-${utmRows[0]?.value} E-${utmRows[1]?.value} N-${utmRows[2]?.value}`}
+            </div>
+            <Tabs value={recordTab} onChange={handleChange} centered>
+              <Tab value={RecordSetType.Activity} label="InvasivesBC Records" icon={<FolderIcon />} />
+              <Tab value={RecordSetType.IAPP} label="IAPP Records" icon={<AdjustIcon />} />
+            </Tabs>
+          </Grid>
+          {loadingInProgress && <Spinner />}
+          <TableContainer className="whatshere-position">
+            {
+              {
+                [RecordSetType.Activity]: <RenderTableActivity setAnchorEl={setAnchorEl} />,
+                [RecordSetType.IAPP]: <RenderTablePOI setAnchorEl={setAnchorEl} />
+              }[recordTab]
+            }
+          </TableContainer>
+        </div>
+      </div>
     </div>
   );
 };

--- a/app/src/state/actions/whatsHere/WhatsHere.ts
+++ b/app/src/state/actions/whatsHere/WhatsHere.ts
@@ -23,7 +23,7 @@ class WhatsHere {
   static readonly map_init_get_poi = createAction(`${this.PREFIX}/map_init_get_poi`);
   static readonly map_init_get_poi_ids_fetched = createAction<string[]>(`${this.PREFIX}/map_init_get_poi_ids_fetched`);
   static readonly map_page_limit = createAction<{ page: number; limit: number }>(`${this.PREFIX}/map_page_limit`);
-  static readonly map_set_section = createAction<string>(`${this.PREFIX}/map_set_section`);
+  static readonly map_change_tab = createAction(`${this.PREFIX}/map_change_section`);
   static readonly map_feature = createAction<Record<string, any>>(`${this.PREFIX}/map_feature`);
   static readonly page_poi = createAction<{ page: number; limit: number }>(`${this.PREFIX}/page_poi`);
   static readonly page_activity = createAction<{ page: number; limit: number }>(`${this.PREFIX}/page_activity`);

--- a/app/src/state/reducers/map.ts
+++ b/app/src/state/reducers/map.ts
@@ -207,7 +207,7 @@ export interface MapState {
   activity_center: [number, number];
   activity_zoom: number;
   clientBoundaries: any[];
-  currentOpenSet: string;
+  currentOpenSet: string | null;
   customizeLayersToggle: boolean;
   drawingCustomLayer: boolean;
   error: boolean;
@@ -215,7 +215,7 @@ export interface MapState {
   labelBoundsPolygon: any;
   layers: any[];
   legendsPopup: any;
-  linkToCSV: string;
+  linkToCSV: string | null;
   map_center: [number, number];
   map_zoom: number;
   panned: boolean;
@@ -226,7 +226,7 @@ export interface MapState {
     drawingShape: boolean;
   };
   quickPanToRecord: boolean;
-  recordSetForCSV: number;
+  recordSetForCSV: number | null;
   recordTables: object;
   serverBoundaries: any[];
   simplePickerLayers2: any[];
@@ -242,21 +242,13 @@ export interface MapState {
     feature: any | null;
     limit: number;
     page: number;
-    section: string;
 
     clickedActivity: any | null;
     clickedActivityDescription: string | null;
     clickedIAPP: any | null;
-    clickedIAPPDescription: string | null;
 
     loadingActivities: boolean;
     loadingIAPP: boolean;
-
-    highlightedType: 'IAPP' | 'Activity' | null;
-    highlightedURLID: string | null;
-    highlightedIAPP: string | null;
-    highlightedACTIVITY: any | null;
-    highlightedGeo: any | null;
 
     ActivityIDs: any[];
     activityRows: any[];
@@ -271,12 +263,8 @@ export interface MapState {
     IAPPLimit: number;
     IAPPSortField: string;
     IAPPSortDirection: string;
-
-    serverActivityIDs: any[];
-    serverIAPPIDs: any[];
   };
 
-  workingLayerName: string;
   layerPickerOpen: boolean;
 
   tileCacheMode: boolean;
@@ -350,18 +338,10 @@ const initialState: MapState = {
     limit: 5,
     page: 0,
     feature: null,
-    section: 'invasivesbc',
 
     clickedActivity: null,
     clickedActivityDescription: null,
     clickedIAPP: null,
-    clickedIAPPDescription: null,
-
-    highlightedType: null,
-    highlightedURLID: null,
-    highlightedIAPP: null,
-    highlightedACTIVITY: null,
-    highlightedGeo: null,
 
     loadingActivities: false,
     activityRows: [],
@@ -377,12 +357,8 @@ const initialState: MapState = {
     IAPPPage: 0,
     IAPPLimit: 5,
     IAPPSortField: 'earliest_survey',
-    IAPPSortDirection: SortFilter.Desc,
-
-    serverActivityIDs: [],
-    serverIAPPIDs: []
-  },
-  workingLayerName: ''
+    IAPPSortDirection: SortFilter.Desc
+  }
 };
 
 function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => MapState {
@@ -482,7 +458,6 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           clickedActivity: null,
           clickedActivityDescription: null,
           clickedIAPP: null,
-          clickedIAPPDescription: null,
           loadingActivities: true,
           loadingIAPP: true,
           feature: action.payload,
@@ -497,7 +472,6 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           clickedActivity: null,
           clickedActivityDescription: null,
           clickedIAPP: null,
-          clickedIAPPDescription: null,
           loadingActivities: false,
           loadingIAPP: false,
           feature: null,
@@ -514,8 +488,6 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
         });
       } else if (WhatsHere.server_filtered_ids_fetched.match(action)) {
         const { iapp, activities } = action.payload;
-        draftState.whatsHere.serverActivityIDs = activities;
-        draftState.whatsHere.serverIAPPIDs = iapp;
         const toggledOnActivityLayers = draftState.layers.filter(
           ({ type, layerState }) => type === RecordSetType.Activity && layerState.mapToggle
         );
@@ -568,7 +540,6 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
         draftState.whatsHere.toggle = !draftState.whatsHere.toggle;
       } else if (WhatsHere.map_change_section.match(action)) {
         Object.assign(draftState.whatsHere, {
-          section: action.payload,
           page: 0,
           limit: 5
         });
@@ -577,13 +548,6 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           id: action.payload,
           geometry: state?.whatsHere?.iappRows.filter((row) => row.site_id === action.payload)[0].geometry
         };
-        Object.assign(draftState.whatsHere, {
-          highlightedType: RecordSetType.IAPP,
-          highlightedURLID: action.payload,
-          highlightedIAPP: action.payload,
-          highlightedACTIVITY: null,
-          highlightedGeo: state?.whatsHere?.iappRows.filter((row) => row.site_id === action.payload)[0]
-        });
       } else if (WhatsHere.set_highlighted_activity.match(action)) {
         draftState.userRecordOnHoverRecordRow = {
           id: action.payload.id,
@@ -595,13 +559,6 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           ]
         };
         draftState.userRecordOnHoverRecordType = RecordSetType.Activity;
-        Object.assign(draftState.whatsHere, {
-          highlightedType: RecordSetType.Activity,
-          highlightedURLID: action.payload.id,
-          highlightedIAPP: null,
-          highlightedACTIVITY: action.payload.short_id,
-          highlightedGeo: state?.whatsHere?.activityRows.filter((row) => row.short_id === action.payload.short_id)[0]
-        });
       } else if (WhatsHere.iapp_rows_success.match(action)) {
         draftState.whatsHere.loadingIAPP = false;
         draftState.whatsHere.iappRows = [...action.payload];
@@ -614,7 +571,6 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           draftState.whatsHere.clickedActivityDescription = action.payload.description ?? null;
         } else if (action.payload.type === RecordSetType.IAPP) {
           draftState.whatsHere.clickedIAPP = action.payload.id;
-          draftState.whatsHere.clickedIAPPDescription = action.payload.description ?? null;
         }
       } else if (WhatsHere.map_page_limit.match(action)) {
         draftState.whatsHere.page = action.payload.page;
@@ -873,16 +829,13 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
             draftState.drawingCustomLayer = false;
             draftState.clientBoundaries.push({
               id: nanoid(),
-              title: draftState?.workingLayerName,
               geojson: action.payload,
               toggle: true
             });
-            draftState.workingLayerName = null;
             break;
           }
           case DRAW_CUSTOM_LAYER: {
             draftState.drawingCustomLayer = true;
-            draftState.workingLayerName = action.payload.name;
             break;
           }
 
@@ -1116,7 +1069,7 @@ const GeoJSONFilterSetForLayer = (draftState, state, typeToFilter, recordSetID, 
     };
     draftState.layers[index].loading = false;
   } else if (type === typeToFilter && type === RecordSetType.IAPP) {
-    const filtered = [];
+    const filtered: any[] = [];
     IDList.map((id) => {
       const f = draftState.IAPPGeoJSONDict[id];
       if (f !== undefined && f !== null && f.geometry !== null) {

--- a/app/src/state/reducers/map.ts
+++ b/app/src/state/reducers/map.ts
@@ -488,7 +488,9 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           feature: action.payload,
           toggle: state.whatsHere.toggle,
           limit: 5,
-          page: 0
+          page: 0,
+          IAPPPage: 0,
+          ActivityPage: 0
         });
       } else if (WhatsHere.clear_whats_here.match(action)) {
         Object.assign(draftState.whatsHere, {
@@ -564,7 +566,7 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           });
         }
         draftState.whatsHere.toggle = !draftState.whatsHere.toggle;
-      } else if (WhatsHere.map_set_section.match(action)) {
+      } else if (WhatsHere.map_change_section.match(action)) {
         Object.assign(draftState.whatsHere, {
           section: action.payload,
           page: 0,

--- a/app/src/state/reducers/map.ts
+++ b/app/src/state/reducers/map.ts
@@ -538,7 +538,7 @@ function createMapReducer(configuration: AppConfig): (MapState, AnyAction) => Ma
           });
         }
         draftState.whatsHere.toggle = !draftState.whatsHere.toggle;
-      } else if (WhatsHere.map_change_section.match(action)) {
+      } else if (WhatsHere.map_change_tab.match(action)) {
         Object.assign(draftState.whatsHere, {
           page: 0,
           limit: 5


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Fix issue where WhatsHere stops working intermittenly
    - was replicable by being paginated past page 1, then creating a new whatshere shape with less pages than you're on. Results would return 0 since request was `OFFSET`. New shapes now set current page to 0 on change.
    -  Closes #4001
- Convert WhatsHere button to use Popover instead of the static button
    - Consistency between menus
- State Cleanup
    - added ` | null` to some states in `map.ts` where states were being set null and were not part of the typing. 
    - Removed a small number of `WhatsHere` related redux states that were not used in the application.
    - Refactored WhatsHere container dependence on Redux to be a little less coupled.
        - Closes #4004

## ScreenShots 

Popover in IAPP 
![image](https://github.com/user-attachments/assets/61f8fa5c-4e51-488c-bb96-82c53151744d)
