### PR TITLE
[INV-4002] Fix Slope Validation, code cleanup

### DIFF
--- a/app/src/UI/Overlay/Records/Activity/Form.tsx
+++ b/app/src/UI/Overlay/Records/Activity/Form.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 import FormContainer from './form/FormContainer';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import './Form.css';
 
 import { ActivitySubtypeShortLabels } from 'sharedAPI';
@@ -12,8 +12,9 @@ import { UtmInputObj } from 'interfaces/prompt-interfaces';
 import GeoTracking from 'state/actions/geotracking/GeoTracking';
 import Prompt from 'state/actions/prompts/Prompt';
 import RecordHistory from '../RecordHistory/RecordHistory';
+import { useSelector } from 'utils/use_selector';
 
-export const ActivityForm = (props) => {
+export const ActivityForm = () => {
   const ref = useRef(0);
   ref.current += 1;
   if (RENDER_DEBUG) {
@@ -36,10 +37,10 @@ export const ActivityForm = (props) => {
     received_timestamp,
     batch_id,
     activity_history
-  } = useSelector((state: any) => state.ActivityPage?.activity);
+  } = useSelector((state) => state.ActivityPage?.activity);
 
-  const invasive_plant = useSelector((state: any) => state.ActivityPage?.activity?.invasive_plant);
-  const drawGeometryTracking = useSelector((state: any) => state.Map?.track_me_draw_geo);
+  const invasive_plant = useSelector((state) => state.ActivityPage?.activity?.invasive_plant);
+  const drawGeometryTracking = useSelector((state) => state.Map?.track_me_draw_geo);
 
   /**
    * @desc Handler for creating a manual UTM Entry initiated by user

--- a/app/src/UI/Overlay/Records/Activity/form/FormContainer.tsx
+++ b/app/src/UI/Overlay/Records/Activity/form/FormContainer.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, CircularProgress, createTheme, ThemeOptions, ThemeProvider } from '@mui/material';
+import { Box, Button, CircularProgress, createTheme, Theme, ThemeOptions, ThemeProvider } from '@mui/material';
 import { Form } from '@rjsf/mui';
 import CoreForm from '@rjsf/core';
 import { createRef, Fragment, RefObject, useCallback, useEffect, useRef, useState } from 'react';
@@ -51,7 +51,7 @@ const FormContainer = () => {
   );
 
   const accessRoles = useSelector((state) => state.Auth.accessRoles);
-  const activity_ID = useSelector((state) => state.ActivityPage.activity.activity_id);
+  const activity_ID = useSelector((state) => state.ActivityPage.activity?.activity_id);
   const activity_subtype = useSelector((state) => state.ActivityPage.activity.activity_subtype);
   const activitySchema = useSelector((state) => state.ActivityPage.schema);
   const activityUISchema = useSelector((state) => state.ActivityPage.uiSchema);
@@ -66,6 +66,7 @@ const FormContainer = () => {
   const [isCachedRecord, setIsCachedRecord] = useState<boolean>(!serializedActivities?.[activity_ID] && !connected);
   const [isDisabled, setIsDisabled] = useState<boolean>(!isCreatedByUser || isCachedRecord);
   const [userIsAdmin] = useState<boolean>(accessRoles?.some((role) => role.role_id === 18));
+  const theme = useRef<Theme>(createTheme(rjsfTheme as ThemeOptions));
 
   const debouncedFormChange = useCallback(
     debounce((event, _, lastField) => {
@@ -80,9 +81,8 @@ const FormContainer = () => {
   const customValidators = useCallback(() => {
     return validatorForActivity(activity_subtype, null);
   }, [JSON.stringify(activity_subtype)]);
-  const formRef: RefObject<CoreForm> = createRef();
 
-  const theme = createTheme(rjsfTheme as ThemeOptions);
+  const formRef: RefObject<CoreForm> = createRef();
 
   useEffect(() => {
     dispatch(Activity.setErrors(formRef.current?.state?.errors ?? []));
@@ -97,7 +97,7 @@ const FormContainer = () => {
     setIsDisabled(username !== created_by || isCachedRecord);
   }, [username, created_by, isCachedRecord]);
 
-  const isActivityChemTreatment = (): boolean =>
+  const isActivityChemTreatment =
     activity_subtype === 'Activity_Treatment_ChemicalPlantTerrestrial' ||
     activity_subtype === 'Activity_Treatment_ChemicalPlantAquatic';
 
@@ -106,7 +106,7 @@ const FormContainer = () => {
   }
   return (
     <Box sx={{ px: '15%' }}>
-      <ThemeProvider theme={theme}>
+      <ThemeProvider theme={theme.current}>
         <SelectAutoCompleteContextProvider>
           {userIsAdmin && !isCreatedByUser && !isCachedRecord && (
             <div className="editFormButtonCont">
@@ -147,7 +147,7 @@ const FormContainer = () => {
             <Fragment />
           </Form>
 
-          {isActivityChemTreatment() && (
+          {isActivityChemTreatment && (
             <ChemicalTreatmentDetailsForm
               activitySubType={activity_subtype}
               disabled={isDisabled}

--- a/app/src/UI/Overlay/Records/RecordSet/RecordTableHelpers.tsx
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordTableHelpers.tsx
@@ -54,10 +54,6 @@ export const getUnnestedFieldsForActivity = (activity) => {
     elevation: activity?.elevation,
     batch_id: activity?.batch_id,
     geometry: root?.geometry
-    // date_modified: new Date(root?.created_timestamp).toString(),
-    // reported_area: root?.form_data?.activity_data?.reported_area,
-    // latitude: root?.form_data?.activity_data?.latitude,
-    // longitude: root?.form_data?.activity_data?.longitude,
   };
 
   return JSON.parse(JSON.stringify(columns));

--- a/app/src/rjsf/business-rules/customValidation.ts
+++ b/app/src/rjsf/business-rules/customValidation.ts
@@ -110,7 +110,6 @@ export function getSlopeAspectBothFlatValidator(): rjsfValidator {
       return errors;
     }
     const { slope_code, aspect_code } = formData.activity_subtype_data.Observation_PlantTerrestrial_Information;
-    console.log('In Validation', slope_code, aspect_code);
     const onlyOneOfSuppliedCodesAreFlat = [aspect_code, slope_code].filter((val) => val === 'FL').length === 1;
     if (onlyOneOfSuppliedCodesAreFlat) {
       const shortHand = errors.activity_subtype_data?.Observation_PlantTerrestrial_Information;

--- a/app/src/rjsf/business-rules/customValidation.ts
+++ b/app/src/rjsf/business-rules/customValidation.ts
@@ -104,25 +104,18 @@ export function getPosAndNegObservationValidatorAquatic(): rjsfValidator {
 export function getSlopeAspectBothFlatValidator(): rjsfValidator {
   return (formData: any, errors: FormValidation): FormValidation => {
     if (
-      !formData ||
-      !formData.activity_subtype_data ||
-      !formData.activity_subtype_data.Observation_PlantTerrestrial_Information ||
-      !formData.activity_subtype_data.Observation_PlantTerrestrial_Information.slope_code ||
-      !formData.activity_subtype_data.Observation_PlantTerrestrial_Information.aspect_code
+      !formData?.activity_subtype_data?.Observation_PlantTerrestrial_Information?.slope_code ||
+      !formData?.activity_subtype_data?.Observation_PlantTerrestrial_Information?.aspect_code
     ) {
       return errors;
     }
     const { slope_code, aspect_code } = formData.activity_subtype_data.Observation_PlantTerrestrial_Information;
-    if (
-      (slope_code.includes('FL') && !aspect_code.includes('FL')) ||
-      (!slope_code.includes('FL') && aspect_code.includes('FL'))
-    ) {
-      errors.activity_subtype_data['Observation_PlantTerrestrial_Information']['aspect_code'].addError(
-        'If either Aspect or Slope is flat, both of them must be flat.'
-      );
-      errors.activity_subtype_data['Observation_PlantTerrestrial_Information']['slope_code'].addError(
-        'If either Aspect or Slope is flat, both of them must be flat.'
-      );
+    console.log('In Validation', slope_code, aspect_code);
+    const onlyOneOfSuppliedCodesAreFlat = [aspect_code, slope_code].filter((val) => val === 'FL').length === 1;
+    if (onlyOneOfSuppliedCodesAreFlat) {
+      const shortHand = errors.activity_subtype_data?.Observation_PlantTerrestrial_Information;
+      shortHand?.aspect_code?.addError('If either Aspect or Slope is flat, both of them must be flat.');
+      shortHand?.slope_code?.addError('If either Aspect or Slope is flat, both of them must be flat.');
     }
     return errors;
   };

--- a/app/src/rjsf/business-rules/populateCalculatedFields.ts
+++ b/app/src/rjsf/business-rules/populateCalculatedFields.ts
@@ -249,47 +249,6 @@ export const autoFillNameByPAC = (formData: any, appUsers: any) => {
   return newFormData;
 };
 
-export const autoFillSlopeAspect = (formData: any, lastField: string) => {
-  if (!lastField) {
-    return formData;
-  }
-  const fieldId = lastField[0];
-
-  let newFormData = formData;
-
-  if (
-    fieldId.includes('slope_code') &&
-    formData.activity_subtype_data.Observation_PlantTerrestrial_Information.slope_code === 'FL'
-  ) {
-    newFormData = {
-      ...formData,
-      activity_subtype_data: {
-        ...formData.activity_subtype_data,
-        Observation_PlantTerrestrial_Information: {
-          ...formData.activity_subtype_data.Observation_PlantTerrestrial_Information,
-          aspect_code: 'FL'
-        }
-      }
-    };
-  }
-  if (
-    fieldId.includes('aspect_code') &&
-    formData.activity_subtype_data.Observation_PlantTerrestrial_Information.aspect_code === 'FL'
-  ) {
-    newFormData = {
-      ...formData,
-      activity_subtype_data: {
-        ...formData.activity_subtype_data,
-        Observation_PlantTerrestrial_Information: {
-          ...formData.activity_subtype_data.Observation_PlantTerrestrial_Information,
-          slope_code: 'FL'
-        }
-      }
-    };
-  }
-  return newFormData;
-};
-
 //not sure about this one. should be working, don't know how to test
 export const autoFillTreeNumbers = (activitySubtypeData: any) => {
   if (activitySubtypeData.form_b) {

--- a/app/src/rjsf/widgets/SingleSelectAutoComplete.tsx
+++ b/app/src/rjsf/widgets/SingleSelectAutoComplete.tsx
@@ -77,22 +77,25 @@ const SingleSelectAutoComplete = (props: WidgetProps) => {
   const [renderKey, setRenderKey] = useState(props.id + nanoid());
 
   useEffect(() => {
+    const FLAT_CODE = 'FL';
     if (!lastFieldChanged?.id) {
       return;
     }
     if (
       lastFieldChanged?.id?.includes('slope_code') &&
-      lastFieldChanged?.option?.includes('FL') &&
+      lastFieldChanged?.option?.includes(FLAT_CODE) &&
       props.id.includes('aspect_code')
     ) {
-      setValue('FL');
+      setValue(FLAT_CODE);
+      props.onChange(FLAT_CODE);
     }
     if (
       lastFieldChanged?.id?.includes('aspect_code') &&
-      lastFieldChanged?.option?.includes('FL') &&
+      lastFieldChanged?.option?.includes(FLAT_CODE) &&
       props.id.includes('slope_code')
     ) {
-      setValue('FL');
+      setValue(FLAT_CODE);
+      props.onChange(FLAT_CODE);
     }
   }, [lastFieldChanged, props.id]);
 
@@ -127,7 +130,7 @@ const SingleSelectAutoComplete = (props: WidgetProps) => {
       inputValue={inputValue ?? ''}
       isOptionEqualToValue={(option) => !value || option.value === value || option.value === value.value}
       key={renderKey}
-      onChange={(event: any, option: AutoCompleteSelectOption, reason: string) => {
+      onChange={(_, option: AutoCompleteSelectOption, reason: string) => {
         if (reason === 'clear') {
           // NOTE: currently disabled.
           setValue(null);
@@ -138,7 +141,7 @@ const SingleSelectAutoComplete = (props: WidgetProps) => {
         }
       }}
       onFocus={(event) => props.onFocus(event.target.id, event.target.nodeValue)}
-      onInputChange={(event, newInputValue) => setInputValue(newInputValue)}
+      onInputChange={(_, newInputValue) => setInputValue(newInputValue)}
       openOnFocus
       options={listOptions}
       renderInput={(params) => (

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -321,7 +321,6 @@ export function* handle_ACTIVITY_ON_FORM_CHANGE_REQUEST(action) {
   try {
     const beforeState = yield select(selectActivity);
     const beforeActivity = beforeState.activity;
-    const lastField = action.payload.lastField;
 
     let updatedFormData = action.payload.eventFormData;
     if (

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -14,7 +14,6 @@ import { FeatureCollection, kinks } from '@turf/turf';
 import { PayloadAction } from '@reduxjs/toolkit';
 import {
   autoFillNameByPAC,
-  autoFillSlopeAspect,
   autoFillTotalBioAgentQuantity,
   autoFillTotalReleaseQuantity
 } from 'rjsf/business-rules/populateCalculatedFields';
@@ -325,7 +324,6 @@ export function* handle_ACTIVITY_ON_FORM_CHANGE_REQUEST(action) {
     const lastField = action.payload.lastField;
 
     let updatedFormData = action.payload.eventFormData;
-    updatedFormData = autoFillSlopeAspect(updatedFormData, lastField);
     if (
       beforeActivity.activity_type === ActivityType.Biocontrol ||
       beforeActivity.activity_subtype === ActivitySubtype.Treatment_BiologicalPlant ||


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Minor code cleanup that was done while hunting for the rendering issue.
- Fix bug where slope validation flips both to Flat but still shows error
    - This was caused from the Widget updating its values, but not calling the `prop.onChange` handler linked to rjsf 
    - Closes #4002
- Deleted `autoFillSlopeAspect()` The widget was handling the data change, this is likely tech debt.
- set `theme` in `FormContainer.tsx` to a useRef, as it doesn't change. 
- refactor `isActivityChemTreatment` from a boolean function, to just a boolean.
