### PR TITLE
[INV-4013] Update device DB for Cached Records

### DIFF
--- a/app/src/UI/LegacyMap/helpers/functional/recordset-layers.ts
+++ b/app/src/UI/LegacyMap/helpers/functional/recordset-layers.ts
@@ -28,13 +28,13 @@ export const createCachedIappLayer = async (map: maplibregl.Map, layer: any) => 
     return;
   }
   const service = await RecordCacheServiceFactory.getPlatformInstance();
-  const repo = await service.getRepository(layer.recordSetID);
+  const repo = await service.getRepository(layer.recordSetID, ['cached_geojson']);
 
-  if (!repo?.cachedGeoJson) {
+  if (!repo?.cached_geojson) {
     return;
   }
   const layerID = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
-  const source: GeoJSONSourceSpecification = repo.cachedGeoJson;
+  const source: GeoJSONSourceSpecification = repo.cached_geojson;
   const color: string = layer.layerState.color ?? FALLBACK_COLOR;
   const labelLayer: SymbolLayerSpecification = getLabelLayer(layerID, { color, minzoom: 10, get_tag: 'name' });
   const circleLayer: CircleLayerSpecification = getCircleMarkerZoomedOutLayer(layerID, { color });
@@ -196,9 +196,9 @@ export const createCachedActivityLayer = async (map: maplibregl.Map, layer: any)
     return;
   }
   const service = await RecordCacheServiceFactory.getPlatformInstance();
-  const metadata = await service.getRepository(layer.recordSetID);
+  const repo = await service.getRepository(layer.recordSetID, ['cached_geojson', 'cached_geojson']);
 
-  if (!metadata?.cachedCentroid || !metadata?.cachedGeoJson) {
+  if (!repo?.cached_centroid || !repo?.cached_geojson) {
     return;
   }
 
@@ -207,8 +207,8 @@ export const createCachedActivityLayer = async (map: maplibregl.Map, layer: any)
   const CENTROID_ID = `${GEOJSON_ID}-centroid`;
   const color = getPaintBySchemeOrColor(layer);
 
-  const geoJsonSourceObj: GeoJSONSourceSpecification = metadata.cachedGeoJson;
-  const centroidSourceObj: GeoJSONSourceSpecification = metadata.cachedCentroid;
+  const geoJsonSourceObj: GeoJSONSourceSpecification = repo.cached_geojson;
+  const centroidSourceObj: GeoJSONSourceSpecification = repo.cached_centroid;
 
   const circleMarkerZoomedOutLayerCentroid: CircleLayerSpecification = getCircleMarkerZoomedOutLayer(CENTROID_ID, {
     color,

--- a/app/src/UI/LegacyMap/helpers/functional/recordset-layers.ts
+++ b/app/src/UI/LegacyMap/helpers/functional/recordset-layers.ts
@@ -196,7 +196,7 @@ export const createCachedActivityLayer = async (map: maplibregl.Map, layer: any)
     return;
   }
   const service = await RecordCacheServiceFactory.getPlatformInstance();
-  const repo = await service.getRepository(layer.recordSetID, ['cached_geojson', 'cached_geojson']);
+  const repo = await service.getRepository(layer.recordSetID, ['cached_geojson', 'cached_centroid']);
 
   if (!repo?.cached_centroid || !repo?.cached_geojson) {
     return;
@@ -206,9 +206,6 @@ export const createCachedActivityLayer = async (map: maplibregl.Map, layer: any)
   const GEOJSON_ID = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
   const CENTROID_ID = `${GEOJSON_ID}-centroid`;
   const color = getPaintBySchemeOrColor(layer);
-
-  const geoJsonSourceObj: GeoJSONSourceSpecification = repo.cached_geojson;
-  const centroidSourceObj: GeoJSONSourceSpecification = repo.cached_centroid;
 
   const circleMarkerZoomedOutLayerCentroid: CircleLayerSpecification = getCircleMarkerZoomedOutLayer(CENTROID_ID, {
     color,
@@ -234,13 +231,13 @@ export const createCachedActivityLayer = async (map: maplibregl.Map, layer: any)
 
   const existingSource = map.getSource(GEOJSON_ID);
   if (existingSource) return; // Due to the async nature of the local DB Calls, check the layer wasn't created during a re-render
-  map.addSource(GEOJSON_ID, geoJsonSourceObj);
+  map.addSource(GEOJSON_ID, repo.cached_geojson);
   map.addLayer(fillLayer, LAYER_Z_FOREGROUND);
   map.addLayer(borderLayer, LAYER_Z_FOREGROUND);
   map.addLayer(circleMarkerZoomedOutLayer, LAYER_Z_FOREGROUND);
   map.addLayer(labelLayer, LAYER_Z_FOREGROUND);
 
-  map.addSource(CENTROID_ID, centroidSourceObj);
+  map.addSource(CENTROID_ID, repo.cached_centroid);
   map.addLayer(labelLayerCentroid, LAYER_Z_FOREGROUND);
   map.addLayer(circleMarkerZoomedOutLayerCentroid, LAYER_Z_FOREGROUND);
 };

--- a/app/src/UI/Overlay/Records/RecordSet/OfflineRecordSet.tsx
+++ b/app/src/UI/Overlay/Records/RecordSet/OfflineRecordSet.tsx
@@ -66,7 +66,7 @@ export const OfflineRecordSet = ({ setID }: PropTypes) => {
   try {
     unsyncedOfflineActivities = transformOfflineActivitiesForRecordTable(unsyncedOfflineActivities, listOptions);
   } catch (error) {
-    console.log(error);
+    console.error(error);
   }
 
   return (

--- a/app/src/constants/offline_state_version.ts
+++ b/app/src/constants/offline_state_version.ts
@@ -1,5 +1,5 @@
 /*
-handle purging the offline storage on app version upgrade
- */
-export const CURRENT_MIGRATION_VERSION = 20250331;
+  handle purging the offline storage on app version upgrade
+*/
+export const CURRENT_MIGRATION_VERSION = 20250402;
 export const MIGRATION_VERSION_KEY = '_persistedMigrationVersion';

--- a/app/src/state/sagas/userSettings.ts
+++ b/app/src/state/sagas/userSettings.ts
@@ -159,12 +159,12 @@ function* handle_USER_SETTINGS_GET_INITIAL_STATE_REQUEST(action) {
       const repos = yield service.listRepositories();
       repos.forEach((repo: RepositoryMetadata) => {
         // recordSet is immutable, so append it to defaultRecordSet
-        if (repo.status === UserRecordCacheStatus.CACHED && !defaultRecordSet[repo.setId]) {
-          const backedUpRecordSet = UserSettings.RecordSet.createDefaultRecordset(repo.recordSetType);
-          backedUpRecordSet.tableFilters = repo.filterObjects.tableFilters;
+        if (repo.status === UserRecordCacheStatus.CACHED && !defaultRecordSet[repo.set_id]) {
+          const backedUpRecordSet = UserSettings.RecordSet.createDefaultRecordset(repo.record_set_type);
+          backedUpRecordSet.tableFilters = repo.filter_objects.tableFilters;
           backedUpRecordSet.cacheMetadataStatus = repo.status;
-          backedUpRecordSet.recordSetName = repo.setName ?? '';
-          defaultRecordSet[repo.setId] = backedUpRecordSet;
+          backedUpRecordSet.recordSetName = repo.set_name ?? '';
+          defaultRecordSet[repo.set_id] = backedUpRecordSet;
         }
       });
     }

--- a/app/src/state/sagas/userSettings.ts
+++ b/app/src/state/sagas/userSettings.ts
@@ -156,12 +156,12 @@ function* handle_USER_SETTINGS_GET_INITIAL_STATE_REQUEST(action) {
     if (!recordSets || Object.keys(recordSets).length === 0) {
       // RecordSets are empty, try to recover whats in the local database
       const service = yield RecordCacheServiceFactory.getPlatformInstance();
-      const repos = yield service.listRepositories();
+      const repos = yield service.listRepositories(['filter_objects', 'status', 'record_set_type', 'set_id']);
       repos.forEach((repo: RepositoryMetadata) => {
         // recordSet is immutable, so append it to defaultRecordSet
         if (repo.status === UserRecordCacheStatus.CACHED && !defaultRecordSet[repo.set_id]) {
           const backedUpRecordSet = UserSettings.RecordSet.createDefaultRecordset(repo.record_set_type);
-          backedUpRecordSet.tableFilters = repo.filter_objects.tableFilters;
+          backedUpRecordSet.tableFilters = repo?.filter_objects?.tableFilters;
           backedUpRecordSet.cacheMetadataStatus = repo.status;
           backedUpRecordSet.recordSetName = repo.set_name ?? '';
           defaultRecordSet[repo.set_id] = backedUpRecordSet;

--- a/app/src/utils/addActivity.ts
+++ b/app/src/utils/addActivity.ts
@@ -341,7 +341,7 @@ export function transformOfflineActivitiesForRecordTable(
     });
     return offlineActivities;
   } catch (error) {
-    console.log(error);
+    console.error(error);
     return {};
   }
 }

--- a/app/src/utils/base-classes/BaseCacheService.ts
+++ b/app/src/utils/base-classes/BaseCacheService.ts
@@ -25,10 +25,18 @@ abstract class BaseCacheService<
   public abstract deleteRepository(repositoryId: string): Promise<void>;
 
   /** Pull metadata for one Repository in the Collection */
-  public abstract getRepository(repositoryId: string): Promise<RepoMetadata | null>;
+  public abstract getRepository(repositoryId: string): Promise<RepoMetadata>;
+  public abstract getRepository(
+    repositoryId: string,
+    fields: Array<keyof RepoMetadata>
+  ): Promise<RepoMetadata | Partial<RepoMetadata>>;
 
   /** List metadata for all Repositories */
+  /**
+   * @param fields Specific keys to filter for, reducing payload size.
+   */
   public abstract listRepositories(): Promise<RepoMetadata[]>;
+  public abstract listRepositories(fields: Array<keyof RepoMetadata>): Promise<Partial<RepoMetadata>[]>;
 
   /** Change the status for a given Repository */
   public abstract setRepositoryStatus(repositoryId: string, status: RepositoryStatusSchema): Promise<void>;

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -412,7 +412,7 @@ abstract class RecordCacheService extends BaseCacheService<
     const currentTime = new Date();
     const [newestRecordDate, repositories] = await Promise.all([
       this.dateOfMostRecentRecord(),
-      this.listRepositories(['record_set_type', 'status', 'filter_objects', 'cached_ids'])
+      this.listRepositories(['record_set_type', 'status', 'filter_objects', 'cached_ids', 'set_id'])
     ]);
     const updatedRecords: string[] = []; // don't re-download records that crossover other recordsets
     for (const r of repositories) {

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -38,16 +38,16 @@ export interface RecordCacheDownloadRequestSpec {
  * @property { UserRecordCacheStatus } status Cache Status.
  */
 export interface RepositoryMetadata {
-  setId: string;
-  setName?: string;
-  cacheTime: Date;
-  cachedIds: string[];
-  recordSetType: RecordSetType;
-  cachedGeoJson?: GeoJSONSourceSpecification;
-  cachedCentroid?: GeoJSONSourceSpecification;
+  set_id: string;
+  set_name?: string;
+  cache_time: Date;
+  cached_ids: string[];
+  record_set_type: RecordSetType;
+  cached_geojson?: GeoJSONSourceSpecification;
+  cached_centroid?: GeoJSONSourceSpecification;
   bbox?: RepositoryBoundingBoxSpec;
   status: UserRecordCacheStatus;
-  filterObjects: FilterObjects;
+  filter_objects: FilterObjects;
 }
 
 export interface RecordSetSourceMetadata {
@@ -151,13 +151,13 @@ abstract class RecordCacheService extends BaseCacheService<
     };
 
     await this.addOrUpdateRepository({
-      setId: spec.setId,
-      cacheTime: new Date(),
-      cachedIds: spec.idsToCache,
-      recordSetType: spec.recordSetType,
+      set_id: spec.setId,
+      cache_time: new Date(),
+      cached_ids: spec.idsToCache,
+      record_set_type: spec.recordSetType,
       status: UserRecordCacheStatus.DOWNLOADING,
       bbox: spec.bbox,
-      filterObjects: spec.filterObjects
+      filter_objects: spec.filterObjects
     });
 
     let downloadMode: CacheDownloadMode = CacheDownloadMode.DEFAULT;
@@ -175,16 +175,16 @@ abstract class RecordCacheService extends BaseCacheService<
 
     if (!downloadMode) {
       await this.addOrUpdateRepository({
-        setId: spec.setId,
-        cacheTime: new Date(),
-        setName: spec.setName,
-        cachedIds: spec.idsToCache,
-        recordSetType: spec.recordSetType,
+        set_id: spec.setId,
+        cache_time: new Date(),
+        set_name: spec.setName,
+        cached_ids: spec.idsToCache,
+        record_set_type: spec.recordSetType,
         status: UserRecordCacheStatus.CACHED,
-        cachedGeoJson: responseData.cachedGeoJson,
-        cachedCentroid: responseData.cachedCentroid,
+        cached_geojson: responseData.cachedGeoJson,
+        cached_centroid: responseData.cachedCentroid,
         bbox: spec.bbox,
-        filterObjects: spec.filterObjects
+        filter_objects: spec.filterObjects
       });
     } else if (downloadMode == CacheDownloadMode.ABORT) {
       this.deleteRepository(spec.setId);
@@ -426,11 +426,11 @@ abstract class RecordCacheService extends BaseCacheService<
     ]);
     const updatedRecords: string[] = []; // don't re-download records that crossover other recordsets
     for (const r of repositories) {
-      if (r.recordSetType === RecordSetType.Activity && r.status === UserRecordCacheStatus.CACHED) {
-        const idList = (await this.getListOfNewIds(r.filterObjects, newestRecordDate)).filter(
+      if (r.record_set_type === RecordSetType.Activity && r.status === UserRecordCacheStatus.CACHED) {
+        const idList = (await this.getListOfNewIds(r.filter_objects, newestRecordDate)).filter(
           (id) => !updatedRecords.includes(id)
         );
-        const newIds = idList.filter((id) => !r.cachedIds.includes(id)); // Filter out IDs not already in cache to add later
+        const newIds = idList.filter((id) => !r.cached_ids.includes(id)); // Filter out IDs not already in cache to add later
         for (let i = 0; i < idList.length; i += this.BATCH_AMOUNT) {
           const ids = idList.slice(i, i + this.BATCH_AMOUNT);
           const url = `${CONFIGURATION_API_BASE}/api/v2/activities/batch-request?idList=${JSON.stringify(ids)}`;
@@ -440,12 +440,12 @@ abstract class RecordCacheService extends BaseCacheService<
           const newRecords = (await rez.json()) ?? {};
           await this.saveActivity(newRecords);
         }
-        const updatedShapes = await this.createActivityRecordsetSourceMetadata([...r.cachedIds, ...newIds]);
+        const updatedShapes = await this.createActivityRecordsetSourceMetadata([...r.cached_ids, ...newIds]);
         this.addOrUpdateRepository({
           ...r,
           ...updatedShapes,
-          cachedIds: [...r.cachedIds, ...newIds],
-          cacheTime: currentTime
+          cached_ids: [...r.cached_ids, ...newIds],
+          cache_time: currentTime
         });
         updatedRecords.push(...newIds);
       }

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -97,7 +97,6 @@ abstract class RecordCacheService extends BaseCacheService<
 
   protected abstract deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void>;
 
-  /** */
   public abstract loadActivity(id: string): Promise<unknown>;
 
   public abstract loadIapp(id: string, type: IappRecordMode): Promise<IappRecord | IappTableRow>;
@@ -338,41 +337,30 @@ abstract class RecordCacheService extends BaseCacheService<
   }
 
   public async stopDownload(repositoryId: string): Promise<void> {
-    const repositories = await this.listRepositories();
-    const foundIndex = repositories.findIndex((repo) => repo.setId === repositoryId);
-    if (foundIndex === -1) throw Error(`Repository ${repositoryId} wasn't found`);
-
-    if (
-      [UserRecordCacheStatus.DOWNLOADING, UserRecordCacheStatus.PAUSED, UserRecordCacheStatus.QUEUED].includes(
-        repositories[foundIndex].status
-      )
-    ) {
-      await this.setRepositoryStatus(repositoryId, UserRecordCacheStatus.DELETING);
-    } else if (repositories[foundIndex].status === UserRecordCacheStatus.CACHED) {
-      await this.deleteRepository(repositoryId);
+    try {
+      const repo = await this.getRepository(repositoryId, ['status']);
+      if (
+        [UserRecordCacheStatus.DOWNLOADING, UserRecordCacheStatus.PAUSED, UserRecordCacheStatus.QUEUED].includes(
+          repo.status!
+        )
+      ) {
+        await this.setRepositoryStatus(repositoryId, UserRecordCacheStatus.DELETING);
+      } else if (repo.status === UserRecordCacheStatus.CACHED) {
+        await this.deleteRepository(repositoryId);
+      }
+    } catch (err) {
+      console.error(err);
     }
   }
 
   public async pauseDownload(repositoryId: string): Promise<void> {
-    const repositories = await this.listRepositories();
-    const foundIndex = repositories.findIndex((repo) => repo.setId === repositoryId);
+    const repositories = await this.listRepositories(['set_id', 'status']);
+    const foundIndex = repositories.findIndex((repo) => repo?.set_id === repositoryId);
     if (foundIndex === -1) throw Error(`Repository ${repositoryId} wasn't found`);
 
-    if (repositories[foundIndex].status === UserRecordCacheStatus.DOWNLOADING) {
+    if (repositories[foundIndex]?.status === UserRecordCacheStatus.DOWNLOADING) {
       await this.setRepositoryStatus(repositoryId, UserRecordCacheStatus.PAUSED);
     }
-  }
-
-  /**
-   * @desc Get repositories filtered to a geographic area
-   * @param geom Area of target
-   * @returns Repositories overlapping with target area
-   */
-  public async getOverlappingRepositories(geom: Feature): Promise<RepositoryMetadata[]> {
-    return (await this.listRepositories()).filter(
-      (r) =>
-        r.status === UserRecordCacheStatus.CACHED && r.cachedGeoJson && booleanIntersects(bboxToPolygon(r.bbox!), geom)
-    );
   }
 
   /**
@@ -381,23 +369,25 @@ abstract class RecordCacheService extends BaseCacheService<
    * @returns { string[] } Overlapping record Ids
    */
   public async getRecordIdsOverlappingFeature(geom: Feature): Promise<string[]> {
-    const repos = await this.getOverlappingRepositories(geom);
+    const reposInBoundingBox = ((await this.listRepositories(['set_id', 'status', 'bbox'])) ?? [])?.filter(
+      (r) => r?.status === UserRecordCacheStatus.CACHED && booleanIntersects(bboxToPolygon(r.bbox!), geom)
+    );
+
     const featureMap: Record<PropertyKey, Feature> = {};
     const overlappingRecords: string[] = [];
 
     // Multiple Repos could contain the same record, so iterate them into an object to filter the duplicates
-    repos.forEach((repo) => {
-      (repo.cachedGeoJson?.data as any).features.forEach(
-        (feature: Feature, i: number) => (featureMap[feature?.properties?.name + i] ??= feature)
-      );
-    });
-
+    for (const r of reposInBoundingBox) {
+      const repo = await this.getRepository(r.set_id!, ['cached_geojson']);
+      (repo?.cached_geojson?.data as any)?.features.forEach((feature: Feature, i: number) => {
+        featureMap[feature?.properties?.name + i] ??= feature;
+      });
+    }
     Object.values(featureMap).forEach((feature) => {
       if (booleanIntersects(geom, feature)) {
         overlappingRecords.push(feature?.properties?.description);
       }
     });
-
     return overlappingRecords;
   }
   /**
@@ -422,15 +412,15 @@ abstract class RecordCacheService extends BaseCacheService<
     const currentTime = new Date();
     const [newestRecordDate, repositories] = await Promise.all([
       this.dateOfMostRecentRecord(),
-      this.listRepositories()
+      this.listRepositories(['record_set_type', 'status', 'filter_objects', 'cached_ids'])
     ]);
     const updatedRecords: string[] = []; // don't re-download records that crossover other recordsets
     for (const r of repositories) {
-      if (r.record_set_type === RecordSetType.Activity && r.status === UserRecordCacheStatus.CACHED) {
-        const idList = (await this.getListOfNewIds(r.filter_objects, newestRecordDate)).filter(
+      if (r?.record_set_type === RecordSetType.Activity && r.status === UserRecordCacheStatus.CACHED) {
+        const idList = (await this.getListOfNewIds(r.filter_objects!, newestRecordDate)).filter(
           (id) => !updatedRecords.includes(id)
         );
-        const newIds = idList.filter((id) => !r.cached_ids.includes(id)); // Filter out IDs not already in cache to add later
+        const newIds = idList.filter((id) => !r.cached_ids?.includes(id)); // Filter out IDs not already in cache to add later
         for (let i = 0; i < idList.length; i += this.BATCH_AMOUNT) {
           const ids = idList.slice(i, i + this.BATCH_AMOUNT);
           const url = `${CONFIGURATION_API_BASE}/api/v2/activities/batch-request?idList=${JSON.stringify(ids)}`;
@@ -440,13 +430,13 @@ abstract class RecordCacheService extends BaseCacheService<
           const newRecords = (await rez.json()) ?? {};
           await this.saveActivity(newRecords);
         }
-        const updatedShapes = await this.createActivityRecordsetSourceMetadata([...r.cached_ids, ...newIds]);
-        this.addOrUpdateRepository({
+        const updatedShapes = await this.createActivityRecordsetSourceMetadata([...r.cached_ids!, ...newIds]);
+        await this.addOrUpdateRepository({
           ...r,
           ...updatedShapes,
-          cached_ids: [...r.cached_ids, ...newIds],
+          cached_ids: [...r.cached_ids!, ...newIds],
           cache_time: currentTime
-        });
+        } as RepositoryMetadata);
         updatedRecords.push(...newIds);
       }
     }

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -1,5 +1,4 @@
 import { GeoJSONSourceSpecification } from 'maplibre-gl';
-import booleanIntersects from '@turf/boolean-intersects';
 import { Feature } from '@turf/helpers';
 import IappRecord from 'interfaces/IappRecord';
 import IappTableRow from 'interfaces/IappTableRecord';
@@ -8,7 +7,6 @@ import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import { getCurrentJWT } from 'state/sagas/auth/auth';
 import BaseCacheService from 'utils/base-classes/BaseCacheService';
 import { RepositoryBoundingBoxSpec } from 'utils/tile-cache';
-import bboxToPolygon from 'utils/bboxToPolygon';
 import FilterObjects from 'interfaces/FilterObjects';
 
 export enum IappRecordMode {
@@ -96,6 +94,8 @@ abstract class RecordCacheService extends BaseCacheService<
   protected abstract addOrUpdateRepository(spec: RepositoryMetadata): Promise<void>;
 
   protected abstract deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void>;
+
+  public abstract getRecordIdsOverlappingFeature(geom: Feature): Promise<string[]>;
 
   public abstract loadActivity(id: string): Promise<unknown>;
 
@@ -363,33 +363,6 @@ abstract class RecordCacheService extends BaseCacheService<
     }
   }
 
-  /**
-   * @desc Returns list of IDs that overlap with a GeoJSON Object
-   * @param {Feature} geom GeoJSON Object to find overlaps
-   * @returns { string[] } Overlapping record Ids
-   */
-  public async getRecordIdsOverlappingFeature(geom: Feature): Promise<string[]> {
-    const reposInBoundingBox = ((await this.listRepositories(['set_id', 'status', 'bbox'])) ?? [])?.filter(
-      (r) => r?.status === UserRecordCacheStatus.CACHED && booleanIntersects(bboxToPolygon(r.bbox!), geom)
-    );
-
-    const featureMap: Record<PropertyKey, Feature> = {};
-    const overlappingRecords: string[] = [];
-
-    // Multiple Repos could contain the same record, so iterate them into an object to filter the duplicates
-    for (const r of reposInBoundingBox) {
-      const repo = await this.getRepository(r.set_id!, ['cached_geojson']);
-      (repo?.cached_geojson?.data as any)?.features.forEach((feature: Feature, i: number) => {
-        featureMap[feature?.properties?.name + i] ??= feature;
-      });
-    }
-    Object.values(featureMap).forEach((feature) => {
-      if (booleanIntersects(geom, feature)) {
-        overlappingRecords.push(feature?.properties?.description);
-      }
-    });
-    return overlappingRecords;
-  }
   /**
    * @desc Get list of IDs that have had updates or been created since last update.
    * @param filterObjects Filters used at time of Cache

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -42,21 +42,19 @@ class LocalForageRecordCacheService extends RecordCacheService {
       return false;
     }
   }
-  getRepository(repositoryId: string, fields: Array<keyof RepositoryMetadata>): Promise<Partial<RepositoryMetadata>>;
+  getRepository(repositoryId: string, columns: Array<keyof RepositoryMetadata>): Promise<Partial<RepositoryMetadata>>;
   getRepository(repositoryId: string): Promise<RepositoryMetadata>;
   async getRepository(
     repositoryId: string,
-    fields?: Array<keyof RepositoryMetadata>
+    columns?: Array<keyof RepositoryMetadata>
   ): Promise<RepositoryMetadata | Partial<RepositoryMetadata>> {
     const repos = await this.listRepositories();
-    console.log('Repos Result', repos);
-    console.log(repositoryId);
     const foundIndex = repos.findIndex((p) => p.set_id == repositoryId);
     if (foundIndex === -1) throw Error(`Repository ${repositoryId} not found`);
-    if (fields) {
+    if (columns) {
       const res: Partial<Record<keyof RepositoryMetadata, any>> = {};
-      fields.map((field) => {
-        res[field] = repos[foundIndex]?.[field];
+      columns.forEach((column) => {
+        res[column] = repos[foundIndex]?.[column];
       });
       return res;
     }
@@ -340,10 +338,10 @@ class LocalForageRecordCacheService extends RecordCacheService {
     await this.store.setItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY, cachedSets);
   }
 
-  listRepositories(fields: Array<keyof RepositoryMetadata>): Promise<Partial<RepositoryMetadata>[]>;
+  listRepositories(columns: Array<keyof RepositoryMetadata>): Promise<Partial<RepositoryMetadata>[]>;
   listRepositories(): Promise<RepositoryMetadata[]>;
   async listRepositories(
-    fields?: Array<keyof RepositoryMetadata>
+    columns?: Array<keyof RepositoryMetadata>
   ): Promise<RepositoryMetadata[] | Partial<RepositoryMetadata>[]> {
     if (this.store == null) {
       return [];
@@ -355,10 +353,10 @@ class LocalForageRecordCacheService extends RecordCacheService {
       console.error('expected key not found');
       return [];
     }
-    if (fields) {
+    if (columns) {
       return metadata.map((repo) => {
         const res: Partial<Record<keyof RepositoryMetadata, any>> = {};
-        fields.map((field) => {
+        columns.forEach((field) => {
           res[field] = repo?.[field];
         });
         return res;

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -13,6 +13,8 @@ import UserRecord from 'interfaces/UserRecord';
 import IappRecord from 'interfaces/IappRecord';
 import IappTableRow from 'interfaces/IappTableRecord';
 import { UserRecordCacheStatus } from 'interfaces/UserRecordSet';
+import booleanIntersects from '@turf/boolean-intersects';
+import bboxToPolygon from 'utils/bboxToPolygon';
 
 class LocalForageRecordCacheService extends RecordCacheService {
   private static _instance: LocalForageRecordCacheService;
@@ -70,6 +72,34 @@ class LocalForageRecordCacheService extends RecordCacheService {
       throw new Error('cache not available');
     }
     await Promise.all(Object.keys(data).map((key) => this.store?.setItem(key, data[key])));
+  }
+
+  /**
+   * @desc Returns list of IDs that overlap with a GeoJSON Object
+   * @param {Feature} geom GeoJSON Object to find overlaps
+   * @returns { string[] } Overlapping record Ids
+   */
+  public async getRecordIdsOverlappingFeature(geom: Feature): Promise<string[]> {
+    const reposInBoundingBox = ((await this.listRepositories(['set_id', 'status', 'bbox'])) ?? [])?.filter(
+      (r) => r?.status === UserRecordCacheStatus.CACHED && booleanIntersects(bboxToPolygon(r.bbox!), geom)
+    );
+
+    const featureMap: Record<PropertyKey, Feature> = {};
+    const overlappingRecords: string[] = [];
+
+    // Multiple Repos could contain the same record, so iterate them into an object to filter the duplicates
+    for (const r of reposInBoundingBox) {
+      const repo = await this.getRepository(r.set_id!, ['cached_geojson']);
+      (repo?.cached_geojson?.data as any)?.features.forEach((feature: Feature, i: number) => {
+        featureMap[feature?.properties?.name + i] ??= feature;
+      });
+    }
+    Object.values(featureMap).forEach((feature) => {
+      if (booleanIntersects(geom, feature)) {
+        overlappingRecords.push(feature?.properties?.description);
+      }
+    });
+    return overlappingRecords;
   }
 
   async setRepositoryStatus(cacheId: string, status: UserRecordCacheStatus) {

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -35,22 +35,34 @@ class LocalForageRecordCacheService extends RecordCacheService {
 
   async isCached(repositoryId: string): Promise<boolean> {
     try {
-      return (await this.getRepository(repositoryId)).status === UserRecordCacheStatus.CACHED;
+      return (await this.getRepository(repositoryId, ['status'])).status === UserRecordCacheStatus.CACHED;
     } catch (e) {
       return false;
     }
   }
-
-  async getRepository(repositoryId: string): Promise<RepositoryMetadata> {
+  getRepository(repositoryId: string, fields: Array<keyof RepositoryMetadata>): Promise<Partial<RepositoryMetadata>>;
+  getRepository(repositoryId: string): Promise<RepositoryMetadata>;
+  async getRepository(
+    repositoryId: string,
+    fields?: Array<keyof RepositoryMetadata>
+  ): Promise<RepositoryMetadata | Partial<RepositoryMetadata>> {
     const repos = await this.listRepositories();
-    const foundIndex = repos.findIndex((p) => p.setId === repositoryId);
+    console.log('Repos Result', repos);
+    console.log(repositoryId);
+    const foundIndex = repos.findIndex((p) => p.set_id == repositoryId);
     if (foundIndex === -1) throw Error(`Repository ${repositoryId} not found`);
-
+    if (fields) {
+      const res: Partial<Record<keyof RepositoryMetadata, any>> = {};
+      fields.map((field) => {
+        res[field] = repos[foundIndex]?.[field];
+      });
+      return res;
+    }
     return repos[foundIndex];
   }
 
   async getIdList(repositoryId: string): Promise<string[]> {
-    return (await this.getRepository(repositoryId)).cachedIds ?? [];
+    return (await this.getRepository(repositoryId, ['cached_ids'])).cached_ids ?? [];
   }
 
   async saveActivity(data: Record<PropertyKey, UserRecord>): Promise<void> {
@@ -65,7 +77,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
       throw Error('Cache not available');
     }
     const cachedSets = await this.listRepositories();
-    const foundIndex = cachedSets.findIndex((p) => p.setId === cacheId);
+    const foundIndex = cachedSets.findIndex((p) => p.set_id === cacheId);
     if (foundIndex !== -1) {
       Object.assign(cachedSets[foundIndex], { status });
       await this.store.setItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY, cachedSets);
@@ -74,7 +86,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
 
   async checkPauseOrAbort(id: string): Promise<CacheDownloadMode> {
     const sets = await this.listRepositories();
-    const index = sets.findIndex((p) => p.setId === id);
+    const index = sets.findIndex((p) => p.set_id === id);
     if (index !== -1) {
       if (sets[index].status === UserRecordCacheStatus.DELETING) return CacheDownloadMode.ABORT;
       else if (sets[index].status === UserRecordCacheStatus.PAUSED) return CacheDownloadMode.PAUSE;
@@ -237,17 +249,17 @@ class LocalForageRecordCacheService extends RecordCacheService {
     if (this.store == null) {
       throw new Error('cache not available');
     }
-    const cachedSets = await this.listRepositories();
-    const foundIndex = cachedSets.findIndex((p) => p.setId === repositoryId);
+    const cachedSets = await this.listRepositories(['cached_ids', 'set_id']);
+    const foundIndex = cachedSets.findIndex((p) => p.set_id === repositoryId);
 
     if (foundIndex === -1) return;
 
     await this.setRepositoryStatus(repositoryId, UserRecordCacheStatus.DELETING);
-    const deleteList = cachedSets[foundIndex].cachedIds;
+    const deleteList = cachedSets[foundIndex].cached_ids ?? [];
     const ids: Record<PropertyKey, number> = {};
 
     cachedSets
-      .flatMap((set) => set.cachedIds)
+      .flatMap((set) => set?.cached_ids ?? [])
       .forEach((id) => {
         ids[id] ??= 0;
         ids[id]++;
@@ -288,7 +300,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
     }
 
     const cachedSets = (await this.listRepositories()) ?? [];
-    const foundIndex = cachedSets.findIndex((p) => p.setId === newSet.setId);
+    const foundIndex = cachedSets.findIndex((p) => p.set_id === newSet.set_id);
 
     if (foundIndex === -1) {
       cachedSets.push(newSet);
@@ -298,7 +310,11 @@ class LocalForageRecordCacheService extends RecordCacheService {
     await this.store.setItem(LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY, cachedSets);
   }
 
-  async listRepositories(): Promise<RepositoryMetadata[]> {
+  listRepositories(fields: Array<keyof RepositoryMetadata>): Promise<Partial<RepositoryMetadata>[]>;
+  listRepositories(): Promise<RepositoryMetadata[]>;
+  async listRepositories(
+    fields?: Array<keyof RepositoryMetadata>
+  ): Promise<RepositoryMetadata[] | Partial<RepositoryMetadata>[]> {
     if (this.store == null) {
       return [];
     }
@@ -308,6 +324,15 @@ class LocalForageRecordCacheService extends RecordCacheService {
     if (metadata == null) {
       console.error('expected key not found');
       return [];
+    }
+    if (fields) {
+      return metadata.map((repo) => {
+        const res: Partial<Record<keyof RepositoryMetadata, any>> = {};
+        fields.map((field) => {
+          res[field] = repo?.[field];
+        });
+        return res;
+      });
     }
     return metadata;
   }

--- a/app/src/utils/record-cache/migrations.ts
+++ b/app/src/utils/record-cache/migrations.ts
@@ -85,10 +85,8 @@ const RECORD_CACHE_DB_MIGRATIONS_6 = [
     TABLE_DATA                             TEXT        NOT NULL,
     RECORD_DATA                            TEXT        NOT NULL,
     GEOJSON                                TEXT        NOT NULL,
-    CENTROID                               TEXT        NOT NULL,
     LATITUDE                               NUMBER      NOT NULL,
     LONGITUDE                              NUMBER      NOT NULL,
-
     SITE_ID                                TEXT,
     SITE_PAPER_FILE_ID                     TEXT,
     JURISDICTIONS_FLATTENED                TEXT,

--- a/app/src/utils/record-cache/migrations.ts
+++ b/app/src/utils/record-cache/migrations.ts
@@ -47,6 +47,63 @@ const RECORD_CACHE_DB_MIGRATIONS_5 = [
     ADD COLUMN DATE_CREATED TEXT;`
 ];
 
+const RECORD_CACHE_DB_MIGRATIONS_6 = [
+  'DROP TABLE CACHED_RECORDS;',
+  `CREATE TABLE CACHED_RECORDS(
+    LATITUDE                   NUMBER NOT NULL,
+    LONGITUDE                  NUMBER NOT NULL,
+    GEOJSON                    TEXT NOT NULL,
+    DATA                       TEXT NOT NULL,
+    DATE_CREATED               TEXT NOT NULL,
+
+    ACTIVITY_ID                VARCHAR(64) NOT NULL UNIQUE PRIMARY KEY,
+    ACTIVITY_TYPE              TEXT NOT NULL,
+    SHORT_ID                   TEXT NOT NULL,
+    ACTIVITY_SUBTYPE           TEXT NOT NULL,
+    ACTIVITY_DATE              TEXT,
+    PROJECT_CODE               TEXT,
+    JURISDICTION_DISPLAY       TEXT,
+    INVASIVE_PLANT             TEXT,
+    SPECIES_POSITIVE_FULL      TEXT,
+    SPECIES_NEGATIVE_FULL      TEXT,
+    HAS_CURRENT_POSITIVE       TEXT,
+    CURRENT_POSITIVE_SPECIES   TEXT,
+    HAS_CURRENT_NEGATIVE       TEXT,
+    CURRENT_NEGATIVE_SPECIES   TEXT,
+    SPECIES_TREATED_FULL       TEXT,
+    SPECIES_BIOCONTROL_FULL    TEXT,
+    CREATED_BY                 TEXT,
+    UPDATED_BY                 TEXT,
+    AGENCY                     TEXT
+  );`,
+  `DROP TABLE CACHED_IAPP_RECORDS;`,
+  `CREATE TABLE CACHED_IAPP_RECORDS
+  (
+    ID                                     VARCHAR(64) NOT NULL UNIQUE PRIMARY KEY,
+    TABLE_DATA                             TEXT NOT NULL,
+    RECORD_DATA                            TEXT NOT NULL,
+    GEOJSON                                TEXT NOT NULL,
+    LATITUDE                               NUMBER NOT NULL,
+    LONGITUDE                              NUMBER NOT NULL,
+
+    SITE_PAPER_FILE_ID                     TEXT,
+    JURISDICTIONS_FLATTENED                TEXT,
+    MIN_SURVEY                             TEXT,
+    ALL_SPECIES_ON_SITE                    TEXT,
+    BIOLOGICAL_AGENT                       TEXT,
+    MAX_SURVEY                             TEXT,
+    AGENCIES                               TEXT,
+    HAS_BIOLOGICAL_TREATMENTS              TEXT,
+    HAS_CHEMICAL_TREATMENTS                TEXT,
+    HAS_MECHANICAL_TREATMENTS              TEXT,
+    HAS_BIOLOGICAL_DISPERSALS              TEXT,
+    MONITORED                              TEXT,
+    REGIONAL_DISTRICT                      TEXT,
+    REGIONAL_INVASIVE_SPECIES_ORGANIZATION TEXT,
+    INVASIVE_PLANT_MANAGEMENT_AREA         TEXT
+  );`
+];
+
 // Hold Migrations as named variable so we can use length to update the Db version automagically
 // Note: toVersion must be an integer.
 const MIGRATIONS = [
@@ -69,6 +126,10 @@ const MIGRATIONS = [
   {
     toVersion: 5,
     statements: RECORD_CACHE_DB_MIGRATIONS_5
+  },
+  {
+    toVersion: 6,
+    statements: RECORD_CACHE_DB_MIGRATIONS_6
   }
 ];
 

--- a/app/src/utils/record-cache/migrations.ts
+++ b/app/src/utils/record-cache/migrations.ts
@@ -47,19 +47,21 @@ const RECORD_CACHE_DB_MIGRATIONS_5 = [
     ADD COLUMN DATE_CREATED TEXT;`
 ];
 
+// Recreate Tables used by SQLite, Adding more normalization and enhancing the queries we can do on data
 const RECORD_CACHE_DB_MIGRATIONS_6 = [
   'DROP TABLE CACHED_RECORDS;',
   `CREATE TABLE CACHED_RECORDS(
-    LATITUDE                   NUMBER NOT NULL,
-    LONGITUDE                  NUMBER NOT NULL,
-    GEOJSON                    TEXT NOT NULL,
-    DATA                       TEXT NOT NULL,
-    DATE_CREATED               TEXT NOT NULL,
-
-    ACTIVITY_ID                VARCHAR(64) NOT NULL UNIQUE PRIMARY KEY,
-    ACTIVITY_TYPE              TEXT NOT NULL,
-    SHORT_ID                   TEXT NOT NULL,
-    ACTIVITY_SUBTYPE           TEXT NOT NULL,
+    ID                         VARCHAR(64) NOT NULL UNIQUE PRIMARY KEY,
+    LATITUDE                   NUMBER      NOT NULL,
+    LONGITUDE                  NUMBER      NOT NULL,
+    GEOJSON                    TEXT        NOT NULL,
+    CENTROID                   TEXT        NOT NULL,
+    DATA                       TEXT        NOT NULL,
+    DATE_CREATED               TEXT        NOT NULL,
+    ACTIVITY_ID                VARCHAR(64) NOT NULL,
+    ACTIVITY_TYPE              TEXT        NOT NULL,
+    SHORT_ID                   TEXT        NOT NULL,
+    ACTIVITY_SUBTYPE           TEXT        NOT NULL,
     ACTIVITY_DATE              TEXT,
     PROJECT_CODE               TEXT,
     JURISDICTION_DISPLAY       TEXT,
@@ -80,12 +82,14 @@ const RECORD_CACHE_DB_MIGRATIONS_6 = [
   `CREATE TABLE CACHED_IAPP_RECORDS
   (
     ID                                     VARCHAR(64) NOT NULL UNIQUE PRIMARY KEY,
-    TABLE_DATA                             TEXT NOT NULL,
-    RECORD_DATA                            TEXT NOT NULL,
-    GEOJSON                                TEXT NOT NULL,
-    LATITUDE                               NUMBER NOT NULL,
-    LONGITUDE                              NUMBER NOT NULL,
+    TABLE_DATA                             TEXT        NOT NULL,
+    RECORD_DATA                            TEXT        NOT NULL,
+    GEOJSON                                TEXT        NOT NULL,
+    CENTROID                               TEXT        NOT NULL,
+    LATITUDE                               NUMBER      NOT NULL,
+    LONGITUDE                              NUMBER      NOT NULL,
 
+    SITE_ID                                TEXT,
     SITE_PAPER_FILE_ID                     TEXT,
     JURISDICTIONS_FLATTENED                TEXT,
     MIN_SURVEY                             TEXT,
@@ -101,7 +105,21 @@ const RECORD_CACHE_DB_MIGRATIONS_6 = [
     REGIONAL_DISTRICT                      TEXT,
     REGIONAL_INVASIVE_SPECIES_ORGANIZATION TEXT,
     INVASIVE_PLANT_MANAGEMENT_AREA         TEXT
-  );`
+  );`,
+  `DROP TABLE CACHE_METADATA;`,
+  `CREATE TABLE CACHE_METADATA
+   (
+     SET_ID          VARCHAR(64) NOT NULL UNIQUE PRIMARY KEY,
+     CACHE_TIME      TEXT        NOT NULL,
+     STATUS          TEXT        NOT NULL,
+     SET_NAME        TEXT,
+     CACHED_IDS      TEXT,
+     RECORD_SET_TYPE TEXT,
+     CACHED_GEOJSON  TEXT,
+     CACHED_CENTROID TEXT,
+     BBOX            TEXT,
+     FILTER_OBJECTS  TEXT
+   );`
 ];
 
 // Hold Migrations as named variable so we can use length to update the Db version automagically

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -727,24 +727,24 @@ class SQLiteRecordCacheService extends RecordCacheService {
       stringifiedData, // DATA
       activityDate, // DATE_CREATED
       id, // ACTIVITY_ID
-      normalizedRows.activity_type || null,
-      normalizedRows.short_id || null,
-      normalizedRows.activity_subtype || null,
-      normalizedRows.activity_date || null,
-      normalizedRows.project_code || null,
-      normalizedRows.jurisdiction_display || null,
-      normalizedRows.invasive_plant || null,
-      normalizedRows.species_positive_full || null,
-      normalizedRows.species_negative_full || null,
-      normalizedRows.has_current_positive || null,
-      normalizedRows.current_positive_species || null,
-      normalizedRows.has_current_negative || null,
-      normalizedRows.current_negative_species || null,
-      normalizedRows.species_treated_full || null,
-      normalizedRows.species_biocontrol_full || null,
-      normalizedRows.created_by || null,
-      normalizedRows.updated_by || null,
-      normalizedRows.agency || null
+      normalizedRows.activity_type ?? null,
+      normalizedRows.short_id ?? null,
+      normalizedRows.activity_subtype ?? null,
+      normalizedRows.activity_date ?? null,
+      normalizedRows.project_code ?? null,
+      normalizedRows.jurisdiction_display ?? null,
+      normalizedRows.invasive_plant ?? null,
+      normalizedRows.species_positive_full ?? null,
+      normalizedRows.species_negative_full ?? null,
+      normalizedRows.has_current_positive ?? null,
+      normalizedRows.current_positive_species ?? null,
+      normalizedRows.has_current_negative ?? null,
+      normalizedRows.current_negative_species ?? null,
+      normalizedRows.species_treated_full ?? null,
+      normalizedRows.species_biocontrol_full ?? null,
+      normalizedRows.created_by ?? null,
+      normalizedRows.updated_by ?? null,
+      normalizedRows.agency ?? null
     ];
   }
 
@@ -772,22 +772,22 @@ class SQLiteRecordCacheService extends RecordCacheService {
       stringGeo, // GEOJSON
       geojson.geometry.coordinates[1], // LATITUDE
       geojson.geometry.coordinates[0], // LONGITUDE
-      normalizedRows.site_id || null,
-      normalizedRows.site_paper_file_id || null,
-      normalizedRows.jurisdictions_flattened || null,
-      normalizedRows.min_survey || null,
-      normalizedRows.all_species_on_site || null,
-      normalizedRows.max_survey || null,
-      normalizedRows.agencies || null,
-      normalizedRows.biological_agent || null,
-      normalizedRows.has_biological_treatments || null,
-      normalizedRows.has_chemical_treatments || null,
-      normalizedRows.has_mechanical_treatments || null,
-      normalizedRows.has_biological_dispersals || null,
-      normalizedRows.monitored || null,
-      normalizedRows.regional_district || null,
-      normalizedRows.regional_invasive_species_organization || null,
-      normalizedRows.invasive_plant_management_area || null
+      normalizedRows.site_id ?? null,
+      normalizedRows.site_paper_file_id ?? null,
+      normalizedRows.jurisdictions_flattened ?? null,
+      normalizedRows.min_survey ?? null,
+      normalizedRows.all_species_on_site ?? null,
+      normalizedRows.max_survey ?? null,
+      normalizedRows.agencies ?? null,
+      normalizedRows.biological_agent ?? null,
+      normalizedRows.has_biological_treatments ?? null,
+      normalizedRows.has_chemical_treatments ?? null,
+      normalizedRows.has_mechanical_treatments ?? null,
+      normalizedRows.has_biological_dispersals ?? null,
+      normalizedRows.monitored ?? null,
+      normalizedRows.regional_district ?? null,
+      normalizedRows.regional_invasive_species_organization ?? null,
+      normalizedRows.invasive_plant_management_area ?? null
     ];
   }
 }

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -15,6 +15,7 @@ import {
 } from 'utils/record-cache/index';
 import { sqlite } from 'utils/sharedSQLiteInstance';
 import MIGRATIONS from './migrations';
+import { getUnnestedFieldsForActivity } from 'UI/Overlay/Records/RecordSet/RecordTableHelpers';
 
 const CACHE_DB_NAME = 'record_cache.db';
 const CACHE_UNAVAILABLE = 'cache not available';
@@ -45,18 +46,22 @@ class SQLiteRecordCacheService extends RecordCacheService {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
-
+    const columns: Array<string> = [];
+    const values: Array<string | number> = [];
+    Object.keys(spec).forEach((key) => {
+      columns.push(key);
+      values.push(spec[key]);
+    });
     try {
       await this.cacheDB.query(
         //language=SQLite`
-        `INSERT INTO CACHE_METADATA(SET_ID, STATUS, CACHE_TIME, DATA)
-         VALUES(?, ?, ?, ?)
+        `INSERT INTO CACHE_METADATA(${columns.join(', ')})
+         VALUES(${columns.map(() => '?').join(', ')})
          ON CONFLICT(SET_ID)
          DO UPDATE SET
           STATUS = excluded.STATUS,
-          CACHE_TIME = excluded.CACHE_TIME,
-          DATA = excluded.DATA`,
-        [spec.setId, spec.status, spec.cacheTime.toString(), JSON.stringify(spec)]
+          CACHE_TIME = excluded.CACHE_TIME`,
+        [...values]
       );
     } catch (error) {
       console.error(error);
@@ -98,7 +103,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     if (this.cacheDB == null) {
       throw Error(CACHE_UNAVAILABLE);
     }
-    return (await this.getRepository(repositoryId)).cachedIds ?? [];
+    return (await this.getRepository(repositoryId)).cached_ids ?? [];
   }
 
   async deleteRepository(repositoryId: string): Promise<void> {
@@ -142,11 +147,17 @@ class SQLiteRecordCacheService extends RecordCacheService {
     }
     const repositories = await this.cacheDB.query(
       //language=SQLite
-      `SELECT DATA
+      `SELECT *
        FROM CACHE_METADATA`
     );
-    const response = repositories?.values?.map((entry) => JSON.parse(entry['DATA']) as RepositoryMetadata) ?? [];
-    return response;
+    const response = repositories?.values?.map((repo) => {
+      const parsedRepo = {};
+      Object.keys(repo).forEach((key) => {
+        parsedRepo[key.toLowerCase()] = JSON.parse(repo[key]);
+      });
+      return parsedRepo as RepositoryMetadata;
+    });
+    return response ?? [];
   }
 
   async setRepositoryStatus(repositoryId: string, status: UserRecordCacheStatus): Promise<void> {
@@ -310,39 +321,119 @@ class SQLiteRecordCacheService extends RecordCacheService {
     return JSON.parse(result.values[0]['DATA']);
   }
   private transformActivity(id: string, data: UserRecord): Array<any> {
-    const stringified = JSON.stringify(data);
-    const short_id = (data as Record<PropertyKey, Feature[]>)?.short_id;
+    const normalizedRows = getUnnestedFieldsForActivity(data);
+    const stringifiedData = JSON.stringify(data);
     const geometry = (data as Record<PropertyKey, Feature[]>)?.geometry;
-    const map_symbol = (data as Record<PropertyKey, Feature[]>)?.map_symbol;
     const activityDate = (data as Record<PropertyKey, any>)?.date_created;
     geometry.forEach((_, i) => {
       geometry[i].properties = {
-        name: short_id + `${map_symbol ? '\n' + map_symbol : ''}`,
+        name: normalizedRows.short_id + `${data?.map_symbol ? '\n' + data.map_symbol : ''}`,
         description: id
       };
     });
+    const centroidObj = centroid(geometry[0] as Feature);
+    centroidObj.properties = { ...geometry[0].properties };
     const geojson = JSON.stringify(geometry) ?? null;
-    return [id, stringified, geojson, short_id, activityDate];
+    return [
+      id, // ID
+      centroidObj.geometry.coordinates[1], // LATITUDE
+      centroidObj.geometry.coordinates[0], // LONGITUDE
+      geojson, // GEOJSON
+      JSON.stringify(centroidObj), // CENTROID
+      stringifiedData, // DATA
+      activityDate, // DATE_CREATED
+      id, // ACTIVITY_ID
+      normalizedRows.activity_type || null,
+      normalizedRows.short_id || null,
+      normalizedRows.activity_subtype || null,
+      normalizedRows.activity_date || null,
+      normalizedRows.project_code || null,
+      normalizedRows.jurisdiction_display || null,
+      normalizedRows.invasive_plant || null,
+      normalizedRows.species_positive_full || null,
+      normalizedRows.species_negative_full || null,
+      normalizedRows.has_current_positive || null,
+      normalizedRows.current_positive_species || null,
+      normalizedRows.has_current_negative || null,
+      normalizedRows.current_negative_species || null,
+      normalizedRows.species_treated_full || null,
+      normalizedRows.species_biocontrol_full || null,
+      normalizedRows.created_by || null,
+      normalizedRows.updated_by || null,
+      normalizedRows.agency || null
+    ];
   }
 
   async saveActivity(data: Record<PropertyKey, UserRecord>): Promise<void> {
+    const NUM_ACTIVITY_COLUMNS = 26;
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
-    const entry = `( ?, ?, ?, ?, ? )`;
+    const entry = `( ${Array(NUM_ACTIVITY_COLUMNS).fill('?').join(',')} )`;
     const values: Array<any> = [];
     Object.keys(data).forEach((key) => values.push(this.transformActivity(key, data[key])));
-    let query = 'INSERT INTO CACHED_RECORDS(ID, DATA, GEOJSON, SHORT_ID, DATE_CREATED) VALUES ';
+    let query = `INSERT INTO CACHED_RECORDS(
+      ID,
+      LATITUDE,
+      LONGITUDE,
+      GEOJSON,
+      CENTROID,
+      DATA,
+      DATE_CREATED,
+      ACTIVITY_ID,
+      ACTIVITY_TYPE,
+      SHORT_ID,
+      ACTIVITY_SUBTYPE,
+      ACTIVITY_DATE,
+      PROJECT_CODE,
+      JURISDICTION_DISPLAY,
+      INVASIVE_PLANT,
+      SPECIES_POSITIVE_FULL,
+      SPECIES_NEGATIVE_FULL,
+      HAS_CURRENT_POSITIVE,
+      CURRENT_POSITIVE_SPECIES,
+      HAS_CURRENT_NEGATIVE,
+      CURRENT_NEGATIVE_SPECIES,
+      SPECIES_TREATED_FULL,
+      SPECIES_BIOCONTROL_FULL,
+      CREATED_BY,
+      UPDATED_BY,
+      AGENCY
+    ) VALUES `;
+
     query += values.map(() => entry).join(', ');
     query += `
       ON CONFLICT (ID)
       DO UPDATE SET
+      GEOJSON = excluded.GEOJSON,
+      CENTROID = excluded.CENTROID,
+      LATITUDE = excluded.LATITUDE,
+      LONGITUDE =  excluded.LONGITUDE,
+      GEOJSON =  excluded.GEOJSON,
       DATA = excluded.DATA,
       DATE_CREATED = excluded.DATE_CREATED,
-      GEOJSON = excluded.GEOJSON`;
-
+      ACTIVITY_TYPE = excluded.ACTIVITY_TYPE,
+      SHORT_ID = excluded.SHORT_ID,
+      ACTIVITY_SUBTYPE = excluded.ACTIVITY_SUBTYPE,
+      ACTIVITY_DATE = excluded.ACTIVITY_DATE,
+      PROJECT_CODE = excluded.PROJECT_CODE,
+      JURISDICTION_DISPLAY = excluded.JURISDICTION_DISPLAY,
+      INVASIVE_PLANT = excluded.INVASIVE_PLANT,
+      SPECIES_POSITIVE_FULL = excluded.SPECIES_POSITIVE_FULL,
+      SPECIES_NEGATIVE_FULL = excluded.SPECIES_NEGATIVE_FULL,
+      HAS_CURRENT_POSITIVE = excluded.HAS_CURRENT_POSITIVE,
+      CURRENT_POSITIVE_SPECIES = excluded.CURRENT_POSITIVE_SPECIES,
+      HAS_CURRENT_NEGATIVE = excluded.HAS_CURRENT_NEGATIVE,
+      CURRENT_NEGATIVE_SPECIES = excluded.CURRENT_NEGATIVE_SPECIES,
+      SPECIES_TREATED_FULL = excluded.SPECIES_TREATED_FULL,
+      SPECIES_BIOCONTROL_FULL = excluded.SPECIES_BIOCONTROL_FULL,
+      CREATED_BY = excluded.CREATED_BY,
+      UPDATED_BY = excluded.UPDATED_BY,
+      AGENCY = excluded.AGENCY
+    `;
     await this.cacheDB.run(query, values.flat(), false);
   }
+
   protected async dateOfMostRecentRecord() {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -689,15 +689,13 @@ class SQLiteRecordCacheService extends RecordCacheService {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
-    const currData = await this.getRepository(repositoryId);
-    if (Object.keys(currData).length === 0) return; // Repo doesn't exist.
-    currData.status = status;
-
-    await this.addOrUpdateRepository({
-      ...currData,
-      set_id: repositoryId,
-      status: status
-    });
+    await this.cacheDB.query(
+      // language=SQLite
+      `UPDATE CACHE_METADATA
+       SET STATUS = ?
+       WHERE ID = ?`,
+      [status, repositoryId]
+    );
   }
 
   /**

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -47,6 +47,26 @@ class SQLiteRecordCacheService extends RecordCacheService {
     return SQLiteRecordCacheService._instance;
   }
 
+  private async initializeRecordCache(sqlite: SQLiteConnection) {
+    await sqlite.addUpgradeStatement(CACHE_DB_NAME, MIGRATIONS);
+
+    const ret = await sqlite.checkConnectionsConsistency();
+    const isConn = (await sqlite.isConnection(CACHE_DB_NAME, false)).result;
+
+    if (ret.result && isConn) {
+      this.cacheDB = await sqlite.retrieveConnection(CACHE_DB_NAME, false);
+    } else {
+      this.cacheDB = await sqlite.createConnection(CACHE_DB_NAME, false, 'no-encryption', MIGRATIONS.length, false);
+    }
+    try {
+      await this.cacheDB.open().catch((e) => {
+        console.error(e);
+      });
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
   async addOrUpdateRepository(spec: RepositoryMetadata): Promise<void> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
@@ -83,80 +103,6 @@ class SQLiteRecordCacheService extends RecordCacheService {
   }
 
   /**
-   * @desc Returns list of IDs that overlap with a GeoJSON Object
-   * @param {Feature} geom GeoJSON Object to find overlaps
-   * @returns { string[] } Overlapping record Ids
-   */
-  public async getRecordIdsOverlappingFeature(geom: Feature): Promise<string[]> {
-    if (this.cacheDB == null) {
-      throw new Error(CACHE_UNAVAILABLE);
-    }
-    const BUFFER = 0.0045; // Roughly 0.5KM
-    const [minX, minY, maxX, maxY] = bbox(geom);
-    const shapesInBufferedArea = await this.cacheDB.query(
-      //language=SQLite
-      `SELECT GEOJSON
-       FROM CACHED_RECORDS
-       WHERE LATITUDE BETWEEN ? AND ?
-       AND LONGITUDE BETWEEN ? AND ?
-       UNION ALL
-       SELECT GEOJSON
-       FROM CACHED_IAPP_RECORDS
-       WHERE LATITUDE BETWEEN ? AND ?
-       AND LONGITUDE BETWEEN ? AND ?
-      `,
-      [
-        minY - BUFFER,
-        maxY + BUFFER,
-        minX - BUFFER,
-        maxX + BUFFER,
-        minY - BUFFER,
-        maxY + BUFFER,
-        minX - BUFFER,
-        maxX + BUFFER
-      ]
-    );
-
-    const overlappingRecords: string[] = [];
-    (shapesInBufferedArea.values ?? []).forEach((entry) => {
-      entry = JSON.parse(entry['GEOJSON']);
-      if (Object.hasOwn(entry, 'length')) {
-        entry?.forEach((shape: Feature) => {
-          if (booleanIntersects(geom, shape)) {
-            overlappingRecords.push(shape?.properties?.description);
-          }
-        });
-      } else {
-        if (booleanIntersects(geom, entry)) {
-          overlappingRecords.push(entry?.properties?.description);
-        }
-      }
-    });
-    return overlappingRecords;
-  }
-
-  getRepository(repositoryId: string, columns: Array<keyof RepositoryMetadata>): Promise<Partial<RepositoryMetadata>>;
-  getRepository(repositoryId: string): Promise<RepositoryMetadata>;
-  async getRepository(
-    repositoryId: string,
-    columns?: Array<keyof RepositoryMetadata>
-  ): Promise<RepositoryMetadata | Partial<RepositoryMetadata>> {
-    if (this.cacheDB == null) {
-      throw new Error(CACHE_UNAVAILABLE);
-    }
-    const repoData = await this.cacheDB.query(
-      //language=SQLite
-      `SELECT ${columns?.join(', ') ?? '*'}
-       FROM CACHE_METADATA
-       WHERE SET_ID = ?
-       LIMIT 1`,
-      [repositoryId]
-    );
-
-    return this.cacheMetadataTransformer(repoData.values?.[0] ?? {});
-  }
-
-  /**
    * @desc Return handler, ensures keys are in lower snakecase
    * @param {RepositoryMetadata | Partial<RepositoryMetadata> } record entry from Db
    * @returns {RepositoryMetadata | Partial<RepositoryMetadata> } Parsed Entry.
@@ -173,80 +119,6 @@ class SQLiteRecordCacheService extends RecordCacheService {
       resp[key.toLowerCase()] = value;
     });
     return resp;
-  }
-
-  async isCached(repositoryId: string): Promise<boolean> {
-    if (this.cacheDB == null) {
-      throw new Error(CACHE_UNAVAILABLE);
-    }
-    const { status } = await this.getRepository(repositoryId, ['status']);
-    return status === UserRecordCacheStatus.CACHED;
-  }
-
-  async getIdList(repositoryId: string): Promise<string[]> {
-    if (this.cacheDB == null) {
-      throw Error(CACHE_UNAVAILABLE);
-    }
-    return (await this.getRepository(repositoryId, ['cached_ids'])).cached_ids ?? [];
-  }
-
-  async deleteRepository(repositoryId: string): Promise<void> {
-    if (this.cacheDB == null) {
-      throw new Error(CACHE_UNAVAILABLE);
-    }
-    const repositoryMetadata = await this.listRepositories(['set_id', 'cached_ids', 'record_set_type']);
-    const targetIndex = repositoryMetadata.findIndex((set) => set.set_id == repositoryId);
-    if (targetIndex === -1) return;
-
-    const { cached_ids, record_set_type } = repositoryMetadata[targetIndex];
-
-    const ids: Record<PropertyKey, number> = {};
-    repositoryMetadata
-      .flatMap((set) => set.cached_ids!)
-      .forEach((id) => {
-        ids[id] ??= 0;
-        ids[id]++;
-      });
-    const recordsToErase = cached_ids!.filter((id) => ids[id] <= 1);
-
-    await this.deleteCachedRecordsFromIds(recordsToErase, record_set_type!);
-    await this.cacheDB.query(
-      //language=SQLite
-      `DELETE FROM CACHE_METADATA
-       WHERE SET_ID = ?`,
-      [repositoryId]
-    );
-  }
-
-  listRepositories(columns: Array<keyof RepositoryMetadata>): Promise<Partial<RepositoryMetadata>[]>;
-  listRepositories(): Promise<RepositoryMetadata[]>;
-  async listRepositories(
-    columns?: Array<keyof RepositoryMetadata>
-  ): Promise<RepositoryMetadata[] | Partial<RepositoryMetadata>[]> {
-    if (this.cacheDB == null) {
-      throw new Error(CACHE_UNAVAILABLE);
-    }
-    const repositories = await this.cacheDB.query(
-      //language=SQLite
-      `SELECT ${columns?.join(',') ?? '*'}
-       FROM CACHE_METADATA`
-    );
-    return repositories?.values?.map((repo) => this.cacheMetadataTransformer(repo)) ?? [];
-  }
-
-  async setRepositoryStatus(repositoryId: string, status: UserRecordCacheStatus): Promise<void> {
-    if (this.cacheDB == null) {
-      throw new Error(CACHE_UNAVAILABLE);
-    }
-    const currData = await this.getRepository(repositoryId);
-    if (Object.keys(currData).length === 0) return; // Repo doesn't exist.
-    currData.status = status;
-
-    await this.addOrUpdateRepository({
-      ...currData,
-      set_id: repositoryId,
-      status: status
-    });
   }
 
   async checkForAbort(repositoryId: string): Promise<boolean> {
@@ -270,329 +142,6 @@ class SQLiteRecordCacheService extends RecordCacheService {
       default:
         return CacheDownloadMode.DEFAULT;
     }
-  }
-
-  /**
-   * @desc fetch `n` records for a given recordset, supporting pagination
-   * @param recordSetID Recordset to filter from
-   * @param page Page to start pagination on
-   * @param limit Maximum results per page
-   * @returns { UserRecord[] } Filter Objects
-   */
-  async getPaginatedCachedActivityRecords(
-    recordSetIdList: string[],
-    page: number = 0,
-    limit: number = recordSetIdList.length
-  ): Promise<UserRecord[]> {
-    if (!recordSetIdList || recordSetIdList.length === 0) {
-      return [];
-    }
-
-    const startPos = page * limit;
-    const subset = recordSetIdList.slice(startPos, startPos + limit);
-    const results = await this.cacheDB?.query(
-      // language=SQLite
-      `SELECT DATA
-       FROM CACHED_RECORDS
-       WHERE ID IN (${subset.map(() => '?').join(', ')})`,
-      [...subset]
-    );
-
-    if (!results?.values || results.values?.length === 0) {
-      return [];
-    }
-
-    const response = results.values
-      .map((item) => {
-        try {
-          return JSON.parse(item['DATA']) as UserRecord;
-        } catch (e) {
-          console.error('Error parsing record:', e);
-          return null;
-        }
-      })
-      .filter((record) => record !== null);
-
-    return response;
-  }
-
-  async getPaginatedCachedIappRecords(recordSetIdList: string[], page: number, limit: number): Promise<IappRecord[]> {
-    if (!recordSetIdList || recordSetIdList.length === 0) {
-      return [];
-    }
-
-    const startPos = page * limit;
-    const results = await this.cacheDB?.query(
-      // language=SQLite
-      `SELECT TABLE_DATA
-       FROM CACHED_IAPP_RECORDS
-       WHERE ID IN (${recordSetIdList.map(() => '?').join(', ')})
-       LIMIT ?, ?`,
-      [...recordSetIdList, startPos, limit]
-    );
-
-    if (!results?.values || results.values?.length === 0) {
-      return [];
-    }
-    const response = results.values
-      .map((item) => {
-        try {
-          return JSON.parse(item['TABLE_DATA']) as IappRecord;
-        } catch (e) {
-          console.error('Error parsing record:', e);
-          return null;
-        }
-      })
-      .filter((record) => record !== null);
-    return response;
-  }
-
-  async loadActivity(id: string): Promise<unknown> {
-    if (this.cacheDB == null) {
-      throw new Error(CACHE_UNAVAILABLE);
-    }
-    const result = await this.cacheDB.query(
-      //language=SQLite
-      `SELECT DATA
-       FROM CACHED_RECORDS
-       WHERE ID = ?`,
-      [id]
-    );
-
-    if (!result?.values) {
-      return null;
-    }
-
-    if (result.values.length !== 1) {
-      console.error(`Unexpected result set size ${result.values.length} when querying cached_records table`);
-      return null;
-    }
-
-    return JSON.parse(result.values[0]['DATA']);
-  }
-  private transformActivity(id: string, data: UserRecord): Array<any> {
-    const normalizedRows = getUnnestedFieldsForActivity(data);
-    const stringifiedData = JSON.stringify(data);
-    const geometry = (data as Record<PropertyKey, Feature[]>)?.geometry;
-    const activityDate = (data as Record<PropertyKey, any>)?.date_created;
-    geometry.forEach((_, i) => {
-      geometry[i].properties = {
-        name: normalizedRows.short_id + `${data?.map_symbol ? '\n' + data.map_symbol : ''}`,
-        description: id
-      };
-    });
-    const centroidObj = centroid(geometry[0] as Feature);
-    centroidObj.properties = { ...geometry[0].properties };
-    const geojson = JSON.stringify(geometry) ?? null;
-    return [
-      id, // ID
-      centroidObj.geometry.coordinates[1], // LATITUDE
-      centroidObj.geometry.coordinates[0], // LONGITUDE
-      geojson, // GEOJSON
-      JSON.stringify(centroidObj), // CENTROID
-      stringifiedData, // DATA
-      activityDate, // DATE_CREATED
-      id, // ACTIVITY_ID
-      normalizedRows.activity_type || null,
-      normalizedRows.short_id || null,
-      normalizedRows.activity_subtype || null,
-      normalizedRows.activity_date || null,
-      normalizedRows.project_code || null,
-      normalizedRows.jurisdiction_display || null,
-      normalizedRows.invasive_plant || null,
-      normalizedRows.species_positive_full || null,
-      normalizedRows.species_negative_full || null,
-      normalizedRows.has_current_positive || null,
-      normalizedRows.current_positive_species || null,
-      normalizedRows.has_current_negative || null,
-      normalizedRows.current_negative_species || null,
-      normalizedRows.species_treated_full || null,
-      normalizedRows.species_biocontrol_full || null,
-      normalizedRows.created_by || null,
-      normalizedRows.updated_by || null,
-      normalizedRows.agency || null
-    ];
-  }
-
-  async saveActivity(data: Record<PropertyKey, UserRecord>): Promise<void> {
-    const NUM_ACTIVITY_COLUMNS = 26;
-    if (this.cacheDB == null) {
-      throw new Error(CACHE_UNAVAILABLE);
-    }
-    const entry = `( ${Array(NUM_ACTIVITY_COLUMNS).fill('?').join(',')} )`;
-    const values: Array<any> = [];
-    Object.keys(data).forEach((key) => values.push(this.transformActivity(key, data[key])));
-    let query = `INSERT INTO CACHED_RECORDS(
-      ID,
-      LATITUDE,
-      LONGITUDE,
-      GEOJSON,
-      CENTROID,
-      DATA,
-      DATE_CREATED,
-      ACTIVITY_ID,
-      ACTIVITY_TYPE,
-      SHORT_ID,
-      ACTIVITY_SUBTYPE,
-      ACTIVITY_DATE,
-      PROJECT_CODE,
-      JURISDICTION_DISPLAY,
-      INVASIVE_PLANT,
-      SPECIES_POSITIVE_FULL,
-      SPECIES_NEGATIVE_FULL,
-      HAS_CURRENT_POSITIVE,
-      CURRENT_POSITIVE_SPECIES,
-      HAS_CURRENT_NEGATIVE,
-      CURRENT_NEGATIVE_SPECIES,
-      SPECIES_TREATED_FULL,
-      SPECIES_BIOCONTROL_FULL,
-      CREATED_BY,
-      UPDATED_BY,
-      AGENCY
-    ) VALUES `;
-
-    query += values.map(() => entry).join(', ');
-    query += `
-      ON CONFLICT (ID)
-      DO UPDATE SET
-      GEOJSON = excluded.GEOJSON,
-      CENTROID = excluded.CENTROID,
-      LATITUDE = excluded.LATITUDE,
-      LONGITUDE =  excluded.LONGITUDE,
-      GEOJSON =  excluded.GEOJSON,
-      DATA = excluded.DATA,
-      DATE_CREATED = excluded.DATE_CREATED,
-      ACTIVITY_TYPE = excluded.ACTIVITY_TYPE,
-      SHORT_ID = excluded.SHORT_ID,
-      ACTIVITY_SUBTYPE = excluded.ACTIVITY_SUBTYPE,
-      ACTIVITY_DATE = excluded.ACTIVITY_DATE,
-      PROJECT_CODE = excluded.PROJECT_CODE,
-      JURISDICTION_DISPLAY = excluded.JURISDICTION_DISPLAY,
-      INVASIVE_PLANT = excluded.INVASIVE_PLANT,
-      SPECIES_POSITIVE_FULL = excluded.SPECIES_POSITIVE_FULL,
-      SPECIES_NEGATIVE_FULL = excluded.SPECIES_NEGATIVE_FULL,
-      HAS_CURRENT_POSITIVE = excluded.HAS_CURRENT_POSITIVE,
-      CURRENT_POSITIVE_SPECIES = excluded.CURRENT_POSITIVE_SPECIES,
-      HAS_CURRENT_NEGATIVE = excluded.HAS_CURRENT_NEGATIVE,
-      CURRENT_NEGATIVE_SPECIES = excluded.CURRENT_NEGATIVE_SPECIES,
-      SPECIES_TREATED_FULL = excluded.SPECIES_TREATED_FULL,
-      SPECIES_BIOCONTROL_FULL = excluded.SPECIES_BIOCONTROL_FULL,
-      CREATED_BY = excluded.CREATED_BY,
-      UPDATED_BY = excluded.UPDATED_BY,
-      AGENCY = excluded.AGENCY
-    `;
-    await this.cacheDB.run(query, values.flat(), false);
-  }
-
-  protected async dateOfMostRecentRecord() {
-    if (this.cacheDB == null) {
-      throw new Error(CACHE_UNAVAILABLE);
-    }
-    try {
-      return (
-        await this.cacheDB.query(
-          //language=SQLite
-          `SELECT MAX(DATE(DATE_CREATED)) as MAX_DATE
-           FROM CACHED_RECORDS
-           WHERE DATE_CREATED NOT NULL`
-        )
-      )?.values?.[0]?.['MAX_DATE'];
-    } catch (e) {
-      console.error(e);
-    }
-  }
-
-  private transformIapp(id: string, iappRecord: IappRecord, iappRow: IappTableRow): Array<any> {
-    const normalizedRows = getUnnestedFieldsForIAPP(iappRow);
-    const geojson = iappRow.geojson;
-    const map_symbol = geojson?.properties?.map_symbol;
-    geojson.properties = {
-      name: id + (map_symbol ? '\n' + map_symbol : ''),
-      description: id
-    };
-    const stringRecord = JSON.stringify(iappRecord);
-    const stringRow = JSON.stringify(iappRow);
-    const stringGeo = JSON.stringify(geojson);
-    return [
-      id.toString(), // ID
-      stringRow, // TABLE_DATA
-      stringRecord, // RECORD_DATA
-      stringGeo, // GEOJSON
-      geojson.geometry.coordinates[1], // LATITUDE
-      geojson.geometry.coordinates[0], // LONGITUDE
-      normalizedRows.site_id || null,
-      normalizedRows.site_paper_file_id || null,
-      normalizedRows.jurisdictions_flattened || null,
-      normalizedRows.min_survey || null,
-      normalizedRows.all_species_on_site || null,
-      normalizedRows.max_survey || null,
-      normalizedRows.agencies || null,
-      normalizedRows.biological_agent || null,
-      normalizedRows.has_biological_treatments || null,
-      normalizedRows.has_chemical_treatments || null,
-      normalizedRows.has_mechanical_treatments || null,
-      normalizedRows.has_biological_dispersals || null,
-      normalizedRows.monitored || null,
-      normalizedRows.regional_district || null,
-      normalizedRows.regional_invasive_species_organization || null,
-      normalizedRows.invasive_plant_management_area || null
-    ];
-  }
-
-  async saveIapp(data: Record<PropertyKey, { record: IappRecord; row: IappTableRow }>): Promise<void> {
-    const NUM_IAPP_COLUMNS = 22;
-    if (this.cacheDB == null) {
-      throw new Error(CACHE_UNAVAILABLE);
-    }
-    const entry = ` ( ${Array(NUM_IAPP_COLUMNS).fill('?').join(',')} ) `;
-    const values: Array<any> = [];
-    Object.keys(data).forEach((id) => values.push(this.transformIapp(id, data[id].record, data[id].row)));
-    let query = `INSERT INTO CACHED_IAPP_RECORDS(
-      ID,
-      TABLE_DATA,
-      RECORD_DATA,
-      GEOJSON,
-      LATITUDE,
-      LONGITUDE,
-      SITE_ID,
-      SITE_PAPER_FILE_ID,
-      JURISDICTIONS_FLATTENED,
-      MIN_SURVEY,
-      ALL_SPECIES_ON_SITE,
-      BIOLOGICAL_AGENT,
-      MAX_SURVEY,
-      AGENCIES,
-      HAS_BIOLOGICAL_TREATMENTS,
-      HAS_CHEMICAL_TREATMENTS,
-      HAS_MECHANICAL_TREATMENTS,
-      HAS_BIOLOGICAL_DISPERSALS,
-      MONITORED,
-      REGIONAL_DISTRICT,
-      REGIONAL_INVASIVE_SPECIES_ORGANIZATION,
-      INVASIVE_PLANT_MANAGEMENT_AREA
-    ) VALUES `;
-    query += values.map(() => entry).join(', ');
-    query += 'ON CONFLICT (ID) DO NOTHING';
-    await this.cacheDB.run(query, values.flat(), false);
-  }
-
-  async loadIapp(id: string, type: IappRecordMode): Promise<IappRecord | IappTableRow> {
-    if (this.cacheDB == null) {
-      throw new Error(CACHE_UNAVAILABLE);
-    }
-    const dataType = type === IappRecordMode.Record ? 'RECORD_DATA' : 'TABLE_DATA';
-    const result = await this.cacheDB.query(
-      //language=SQLite
-      `SELECT ${dataType}
-         FROM CACHED_IAPP_RECORDS
-         WHERE ID = ?
-         LIMIT 1`,
-      [id.toString()]
-    );
-    if (!result?.values) {
-      throw Error('No results found');
-    }
-    return JSON.parse(result.values[0][dataType]);
   }
 
   async createIappRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata> {
@@ -671,6 +220,27 @@ class SQLiteRecordCacheService extends RecordCacheService {
     };
     return { cachedCentroid, cachedGeoJson };
   }
+  /**
+   * @desc Gets the date of the most recently updated Activity Record. Used for determining Cache updates.
+   * @returns Most Recent Record Date.
+   */
+  protected async dateOfMostRecentRecord() {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    try {
+      return (
+        await this.cacheDB.query(
+          //language=SQLite
+          `SELECT MAX(DATE(DATE_CREATED)) as MAX_DATE
+           FROM CACHED_RECORDS
+           WHERE DATE_CREATED NOT NULL`
+        )
+      )?.values?.[0]?.['MAX_DATE'];
+    } catch (e) {
+      console.error(e);
+    }
+  }
 
   async deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void> {
     if (this.cacheDB == null) {
@@ -700,6 +270,34 @@ class SQLiteRecordCacheService extends RecordCacheService {
       await this.cacheDB.rollbackTransaction();
       throw e;
     }
+  }
+
+  async deleteRepository(repositoryId: string): Promise<void> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const repositoryMetadata = await this.listRepositories(['set_id', 'cached_ids', 'record_set_type']);
+    const targetIndex = repositoryMetadata.findIndex((set) => set.set_id == repositoryId);
+    if (targetIndex === -1) return;
+
+    const { cached_ids, record_set_type } = repositoryMetadata[targetIndex];
+
+    const ids: Record<PropertyKey, number> = {};
+    repositoryMetadata
+      .flatMap((set) => set.cached_ids!)
+      .forEach((id) => {
+        ids[id] ??= 0;
+        ids[id]++;
+      });
+    const recordsToErase = cached_ids!.filter((id) => ids[id] <= 1);
+
+    await this.deleteCachedRecordsFromIds(recordsToErase, record_set_type!);
+    await this.cacheDB.query(
+      //language=SQLite
+      `DELETE FROM CACHE_METADATA
+       WHERE SET_ID = ?`,
+      [repositoryId]
+    );
   }
 
   protected async getAllCachedIds(): Promise<string[]> {
@@ -744,24 +342,455 @@ class SQLiteRecordCacheService extends RecordCacheService {
     return idList;
   }
 
-  private async initializeRecordCache(sqlite: SQLiteConnection) {
-    await sqlite.addUpgradeStatement(CACHE_DB_NAME, MIGRATIONS);
-
-    const ret = await sqlite.checkConnectionsConsistency();
-    const isConn = (await sqlite.isConnection(CACHE_DB_NAME, false)).result;
-
-    if (ret.result && isConn) {
-      this.cacheDB = await sqlite.retrieveConnection(CACHE_DB_NAME, false);
-    } else {
-      this.cacheDB = await sqlite.createConnection(CACHE_DB_NAME, false, 'no-encryption', MIGRATIONS.length, false);
+  async getIdList(repositoryId: string): Promise<string[]> {
+    if (this.cacheDB == null) {
+      throw Error(CACHE_UNAVAILABLE);
     }
-    try {
-      await this.cacheDB.open().catch((e) => {
-        console.error(e);
-      });
-    } catch (e) {
-      console.error(e);
+    return (await this.getRepository(repositoryId, ['cached_ids'])).cached_ids ?? [];
+  }
+
+  /**
+   * @desc fetch `n` records for a given recordset, supporting pagination
+   * @param recordSetID Recordset to filter from
+   * @param page Page to start pagination on
+   * @param limit Maximum results per page
+   * @returns { UserRecord[] } Filter Objects
+   */
+  async getPaginatedCachedActivityRecords(
+    recordSetIdList: string[],
+    page: number = 0,
+    limit: number = recordSetIdList.length
+  ): Promise<UserRecord[]> {
+    if (!recordSetIdList || recordSetIdList.length === 0) {
+      return [];
     }
+
+    const startPos = page * limit;
+    const subset = recordSetIdList.slice(startPos, startPos + limit);
+    const results = await this.cacheDB?.query(
+      // language=SQLite
+      `SELECT DATA
+       FROM CACHED_RECORDS
+       WHERE ID IN (${subset.map(() => '?').join(', ')})`,
+      [...subset]
+    );
+
+    if (!results?.values || results.values?.length === 0) {
+      return [];
+    }
+
+    const response = results.values
+      .map((item) => {
+        try {
+          return JSON.parse(item['DATA']) as UserRecord;
+        } catch (e) {
+          console.error('Error parsing record:', e);
+          return null;
+        }
+      })
+      .filter((record) => record !== null);
+
+    return response;
+  }
+
+  async getPaginatedCachedIappRecords(recordSetIdList: string[], page: number, limit: number): Promise<IappRecord[]> {
+    if (!recordSetIdList || recordSetIdList.length === 0) {
+      return [];
+    }
+
+    const startPos = page * limit;
+    const results = await this.cacheDB?.query(
+      // language=SQLite
+      `SELECT TABLE_DATA
+       FROM CACHED_IAPP_RECORDS
+       WHERE ID IN (${recordSetIdList.map(() => '?').join(', ')})
+       LIMIT ?, ?`,
+      [...recordSetIdList, startPos, limit]
+    );
+
+    if (!results?.values || results.values?.length === 0) {
+      return [];
+    }
+    const response = results.values
+      .map((item) => {
+        try {
+          return JSON.parse(item['TABLE_DATA']) as IappRecord;
+        } catch (e) {
+          console.error('Error parsing record:', e);
+          return null;
+        }
+      })
+      .filter((record) => record !== null);
+    return response;
+  }
+
+  /**
+   * @desc Returns list of IDs that overlap with a GeoJSON Object.
+   * @param {Feature} geom GeoJSON Object to find overlaps
+   * @returns { string[] } Overlapping record Ids
+   */
+  public async getRecordIdsOverlappingFeature(geom: Feature): Promise<string[]> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    // Because local shapes are compared against a centroids lat/long, buffer the area of effect to catch what centroids may have missed
+    const BUFFER = 0.0045; // Roughly 0.5KM
+    const [minX, minY, maxX, maxY] = bbox(geom);
+    const shapesInBufferedArea = await this.cacheDB.query(
+      //language=SQLite
+      `SELECT GEOJSON
+       FROM CACHED_RECORDS
+       WHERE LATITUDE BETWEEN ? AND ?
+       AND LONGITUDE BETWEEN ? AND ?
+       UNION ALL
+       SELECT GEOJSON
+       FROM CACHED_IAPP_RECORDS
+       WHERE LATITUDE BETWEEN ? AND ?
+       AND LONGITUDE BETWEEN ? AND ?
+      `,
+      [
+        minY - BUFFER,
+        maxY + BUFFER,
+        minX - BUFFER,
+        maxX + BUFFER,
+        minY - BUFFER,
+        maxY + BUFFER,
+        minX - BUFFER,
+        maxX + BUFFER
+      ]
+    );
+    const overlappingRecords: string[] = [];
+    (shapesInBufferedArea.values ?? []).forEach((entry) => {
+      entry = JSON.parse(entry['GEOJSON']);
+      // IAPP is Shape, but InvBC records are Array<Shape>
+      const recordIsActivity = Object.hasOwn(entry, 'length');
+      if (recordIsActivity) {
+        entry?.forEach((shape: Feature) => {
+          if (booleanIntersects(geom, shape)) {
+            overlappingRecords.push(shape?.properties?.description);
+          }
+        });
+      } else if (booleanIntersects(geom, entry)) {
+        overlappingRecords.push(entry?.properties?.description);
+      }
+    });
+    return overlappingRecords;
+  }
+
+  getRepository(repositoryId: string, columns: Array<keyof RepositoryMetadata>): Promise<Partial<RepositoryMetadata>>;
+  getRepository(repositoryId: string): Promise<RepositoryMetadata>;
+  async getRepository(
+    repositoryId: string,
+    columns?: Array<keyof RepositoryMetadata>
+  ): Promise<RepositoryMetadata | Partial<RepositoryMetadata>> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const repoData = await this.cacheDB.query(
+      //language=SQLite
+      `SELECT ${columns?.join(', ') ?? '*'}
+       FROM CACHE_METADATA
+       WHERE SET_ID = ?
+       LIMIT 1`,
+      [repositoryId]
+    );
+
+    return this.cacheMetadataTransformer(repoData.values?.[0] ?? {});
+  }
+
+  async isCached(repositoryId: string): Promise<boolean> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const { status } = await this.getRepository(repositoryId, ['status']);
+    return status === UserRecordCacheStatus.CACHED;
+  }
+
+  listRepositories(columns: Array<keyof RepositoryMetadata>): Promise<Partial<RepositoryMetadata>[]>;
+  listRepositories(): Promise<RepositoryMetadata[]>;
+  async listRepositories(
+    columns?: Array<keyof RepositoryMetadata>
+  ): Promise<RepositoryMetadata[] | Partial<RepositoryMetadata>[]> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const repositories = await this.cacheDB.query(
+      //language=SQLite
+      `SELECT ${columns?.join(',') ?? '*'}
+       FROM CACHE_METADATA`
+    );
+    return repositories?.values?.map((repo) => this.cacheMetadataTransformer(repo)) ?? [];
+  }
+
+  async loadActivity(id: string): Promise<unknown> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const result = await this.cacheDB.query(
+      //language=SQLite
+      `SELECT DATA
+       FROM CACHED_RECORDS
+       WHERE ID = ?`,
+      [id]
+    );
+
+    if (!result?.values) {
+      return null;
+    }
+
+    if (result.values.length !== 1) {
+      console.error(`Unexpected result set size ${result.values.length} when querying cached_records table`);
+      return null;
+    }
+
+    return JSON.parse(result.values[0]['DATA']);
+  }
+
+  /**
+   * @desc Fetches an IAPP Record from the local Database in requested format
+   * @param id Site ID of Record
+   * @param type Format Requested, e.g For Record Table, Full Record
+   * @returns Formatted IAPP Information
+   */
+  async loadIapp(id: string, type: IappRecordMode): Promise<IappRecord | IappTableRow> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const dataType = type === IappRecordMode.Record ? 'RECORD_DATA' : 'TABLE_DATA';
+    const result = await this.cacheDB.query(
+      //language=SQLite
+      `SELECT ${dataType}
+         FROM CACHED_IAPP_RECORDS
+         WHERE ID = ?
+         LIMIT 1`,
+      [id.toString()]
+    );
+    if (!result?.values) {
+      throw Error('No results found');
+    }
+    return JSON.parse(result.values[0][dataType]);
+  }
+  /**
+   * @desc Upserts an Invasives Activity into the local Database.
+   * @param data Incoming Activity Data
+   */
+  async saveActivity(data: Record<PropertyKey, UserRecord>): Promise<void> {
+    const NUM_ACTIVITY_COLUMNS = 26;
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const entry = `( ${Array(NUM_ACTIVITY_COLUMNS).fill('?').join(',')} )`;
+    const values: Array<any> = [];
+    Object.keys(data).forEach((key) => values.push(this.transformActivity(key, data[key])));
+    let query = `INSERT INTO CACHED_RECORDS(
+      ID,
+      LATITUDE,
+      LONGITUDE,
+      GEOJSON,
+      CENTROID,
+      DATA,
+      DATE_CREATED,
+      ACTIVITY_ID,
+      ACTIVITY_TYPE,
+      SHORT_ID,
+      ACTIVITY_SUBTYPE,
+      ACTIVITY_DATE,
+      PROJECT_CODE,
+      JURISDICTION_DISPLAY,
+      INVASIVE_PLANT,
+      SPECIES_POSITIVE_FULL,
+      SPECIES_NEGATIVE_FULL,
+      HAS_CURRENT_POSITIVE,
+      CURRENT_POSITIVE_SPECIES,
+      HAS_CURRENT_NEGATIVE,
+      CURRENT_NEGATIVE_SPECIES,
+      SPECIES_TREATED_FULL,
+      SPECIES_BIOCONTROL_FULL,
+      CREATED_BY,
+      UPDATED_BY,
+      AGENCY
+    ) VALUES `;
+
+    query += values.map(() => entry).join(', ');
+    query += `
+      ON CONFLICT (ID)
+      DO UPDATE SET
+      GEOJSON = excluded.GEOJSON,
+      CENTROID = excluded.CENTROID,
+      LATITUDE = excluded.LATITUDE,
+      LONGITUDE =  excluded.LONGITUDE,
+      GEOJSON =  excluded.GEOJSON,
+      DATA = excluded.DATA,
+      DATE_CREATED = excluded.DATE_CREATED,
+      ACTIVITY_TYPE = excluded.ACTIVITY_TYPE,
+      SHORT_ID = excluded.SHORT_ID,
+      ACTIVITY_SUBTYPE = excluded.ACTIVITY_SUBTYPE,
+      ACTIVITY_DATE = excluded.ACTIVITY_DATE,
+      PROJECT_CODE = excluded.PROJECT_CODE,
+      JURISDICTION_DISPLAY = excluded.JURISDICTION_DISPLAY,
+      INVASIVE_PLANT = excluded.INVASIVE_PLANT,
+      SPECIES_POSITIVE_FULL = excluded.SPECIES_POSITIVE_FULL,
+      SPECIES_NEGATIVE_FULL = excluded.SPECIES_NEGATIVE_FULL,
+      HAS_CURRENT_POSITIVE = excluded.HAS_CURRENT_POSITIVE,
+      CURRENT_POSITIVE_SPECIES = excluded.CURRENT_POSITIVE_SPECIES,
+      HAS_CURRENT_NEGATIVE = excluded.HAS_CURRENT_NEGATIVE,
+      CURRENT_NEGATIVE_SPECIES = excluded.CURRENT_NEGATIVE_SPECIES,
+      SPECIES_TREATED_FULL = excluded.SPECIES_TREATED_FULL,
+      SPECIES_BIOCONTROL_FULL = excluded.SPECIES_BIOCONTROL_FULL,
+      CREATED_BY = excluded.CREATED_BY,
+      UPDATED_BY = excluded.UPDATED_BY,
+      AGENCY = excluded.AGENCY
+    `;
+    await this.cacheDB.run(query, values.flat(), false);
+  }
+
+  /**
+   * @desc Upserts an Invasives Activity into the local Database.
+   * @param data Incoming Activity Data
+   */
+  async saveIapp(data: Record<PropertyKey, { record: IappRecord; row: IappTableRow }>): Promise<void> {
+    const NUM_IAPP_COLUMNS = 22;
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const entry = ` ( ${Array(NUM_IAPP_COLUMNS).fill('?').join(',')} ) `;
+    const values: Array<any> = [];
+    Object.keys(data).forEach((id) => values.push(this.transformIapp(id, data[id].record, data[id].row)));
+    let query = `INSERT INTO CACHED_IAPP_RECORDS(
+      ID,
+      TABLE_DATA,
+      RECORD_DATA,
+      GEOJSON,
+      LATITUDE,
+      LONGITUDE,
+      SITE_ID,
+      SITE_PAPER_FILE_ID,
+      JURISDICTIONS_FLATTENED,
+      MIN_SURVEY,
+      ALL_SPECIES_ON_SITE,
+      BIOLOGICAL_AGENT,
+      MAX_SURVEY,
+      AGENCIES,
+      HAS_BIOLOGICAL_TREATMENTS,
+      HAS_CHEMICAL_TREATMENTS,
+      HAS_MECHANICAL_TREATMENTS,
+      HAS_BIOLOGICAL_DISPERSALS,
+      MONITORED,
+      REGIONAL_DISTRICT,
+      REGIONAL_INVASIVE_SPECIES_ORGANIZATION,
+      INVASIVE_PLANT_MANAGEMENT_AREA
+    ) VALUES `;
+    query += values.map(() => entry).join(', ');
+    query += 'ON CONFLICT (ID) DO NOTHING';
+    await this.cacheDB.run(query, values.flat(), false);
+  }
+
+  async setRepositoryStatus(repositoryId: string, status: UserRecordCacheStatus): Promise<void> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const currData = await this.getRepository(repositoryId);
+    if (Object.keys(currData).length === 0) return; // Repo doesn't exist.
+    currData.status = status;
+
+    await this.addOrUpdateRepository({
+      ...currData,
+      set_id: repositoryId,
+      status: status
+    });
+  }
+
+  /**
+   * @desc Takes the incoming Activity payload, and maps the column information to the fields, preps any geometry to contain Activity IDs and information.
+   * @param id ID of New record
+   * @param data Incoming Activity data
+   * @returns Database entry for Activity
+   */
+  private transformActivity(id: string, data: UserRecord): Array<any> {
+    const normalizedRows = getUnnestedFieldsForActivity(data);
+    const stringifiedData = JSON.stringify(data);
+    const geometry = (data as Record<PropertyKey, Feature[]>)?.geometry;
+    const activityDate = (data as Record<PropertyKey, any>)?.date_created;
+    geometry.forEach((_, i) => {
+      geometry[i].properties = {
+        name: normalizedRows.short_id + `${data?.map_symbol ? '\n' + data.map_symbol : ''}`,
+        description: id
+      };
+    });
+    const centroidObj = centroid(geometry[0]);
+    centroidObj.properties = { ...geometry[0].properties };
+    const geojson = JSON.stringify(geometry) ?? null;
+    return [
+      id, // ID
+      centroidObj.geometry.coordinates[1], // LATITUDE
+      centroidObj.geometry.coordinates[0], // LONGITUDE
+      geojson, // GEOJSON
+      JSON.stringify(centroidObj), // CENTROID
+      stringifiedData, // DATA
+      activityDate, // DATE_CREATED
+      id, // ACTIVITY_ID
+      normalizedRows.activity_type || null,
+      normalizedRows.short_id || null,
+      normalizedRows.activity_subtype || null,
+      normalizedRows.activity_date || null,
+      normalizedRows.project_code || null,
+      normalizedRows.jurisdiction_display || null,
+      normalizedRows.invasive_plant || null,
+      normalizedRows.species_positive_full || null,
+      normalizedRows.species_negative_full || null,
+      normalizedRows.has_current_positive || null,
+      normalizedRows.current_positive_species || null,
+      normalizedRows.has_current_negative || null,
+      normalizedRows.current_negative_species || null,
+      normalizedRows.species_treated_full || null,
+      normalizedRows.species_biocontrol_full || null,
+      normalizedRows.created_by || null,
+      normalizedRows.updated_by || null,
+      normalizedRows.agency || null
+    ];
+  }
+
+  /**
+   * @desc Takes the incoming IAPP payload, and maps the column information to the fields, preps any geometry to contain IAPP IDs and information.
+   * @param id ID of New record
+   * @param data Incoming IAPP data
+   * @returns Database entry for IAPP
+   */
+  private transformIapp(id: string, iappRecord: IappRecord, iappRow: IappTableRow): Array<any> {
+    const normalizedRows = getUnnestedFieldsForIAPP(iappRow);
+    const geojson = iappRow.geojson;
+    const map_symbol = geojson?.properties?.map_symbol;
+    geojson.properties = {
+      name: id + (map_symbol ? '\n' + map_symbol : ''),
+      description: id
+    };
+    const stringRecord = JSON.stringify(iappRecord);
+    const stringRow = JSON.stringify(iappRow);
+    const stringGeo = JSON.stringify(geojson);
+    return [
+      id.toString(), // ID
+      stringRow, // TABLE_DATA
+      stringRecord, // RECORD_DATA
+      stringGeo, // GEOJSON
+      geojson.geometry.coordinates[1], // LATITUDE
+      geojson.geometry.coordinates[0], // LONGITUDE
+      normalizedRows.site_id || null,
+      normalizedRows.site_paper_file_id || null,
+      normalizedRows.jurisdictions_flattened || null,
+      normalizedRows.min_survey || null,
+      normalizedRows.all_species_on_site || null,
+      normalizedRows.max_survey || null,
+      normalizedRows.agencies || null,
+      normalizedRows.biological_agent || null,
+      normalizedRows.has_biological_treatments || null,
+      normalizedRows.has_chemical_treatments || null,
+      normalizedRows.has_mechanical_treatments || null,
+      normalizedRows.has_biological_dispersals || null,
+      normalizedRows.monitored || null,
+      normalizedRows.regional_district || null,
+      normalizedRows.regional_invasive_species_organization || null,
+      normalizedRows.invasive_plant_management_area || null
+    ];
   }
 }
 

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -135,18 +135,18 @@ class SQLiteRecordCacheService extends RecordCacheService {
     return overlappingRecords;
   }
 
-  getRepository(repositoryId: string, fields: Array<keyof RepositoryMetadata>): Promise<Partial<RepositoryMetadata>>;
+  getRepository(repositoryId: string, columns: Array<keyof RepositoryMetadata>): Promise<Partial<RepositoryMetadata>>;
   getRepository(repositoryId: string): Promise<RepositoryMetadata>;
   async getRepository(
     repositoryId: string,
-    fields?: Array<keyof RepositoryMetadata>
+    columns?: Array<keyof RepositoryMetadata>
   ): Promise<RepositoryMetadata | Partial<RepositoryMetadata>> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
     const repoData = await this.cacheDB.query(
       //language=SQLite
-      `SELECT ${fields?.join(', ') ?? '*'}
+      `SELECT ${columns?.join(', ') ?? '*'}
        FROM CACHE_METADATA
        WHERE SET_ID = ?
        LIMIT 1`,
@@ -218,17 +218,17 @@ class SQLiteRecordCacheService extends RecordCacheService {
     );
   }
 
-  listRepositories(fields: Array<keyof RepositoryMetadata>): Promise<Partial<RepositoryMetadata>[]>;
+  listRepositories(columns: Array<keyof RepositoryMetadata>): Promise<Partial<RepositoryMetadata>[]>;
   listRepositories(): Promise<RepositoryMetadata[]>;
   async listRepositories(
-    fields?: Array<keyof RepositoryMetadata>
+    columns?: Array<keyof RepositoryMetadata>
   ): Promise<RepositoryMetadata[] | Partial<RepositoryMetadata>[]> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
     const repositories = await this.cacheDB.query(
       //language=SQLite
-      `SELECT ${fields?.join(',') ?? '*'}
+      `SELECT ${columns?.join(',') ?? '*'}
        FROM CACHE_METADATA`
     );
     return repositories?.values?.map((repo) => this.cacheMetadataTransformer(repo)) ?? [];

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -15,7 +15,10 @@ import {
 } from 'utils/record-cache/index';
 import { sqlite } from 'utils/sharedSQLiteInstance';
 import MIGRATIONS from './migrations';
-import { getUnnestedFieldsForActivity } from 'UI/Overlay/Records/RecordSet/RecordTableHelpers';
+import {
+  getUnnestedFieldsForActivity,
+  getUnnestedFieldsForIAPP
+} from 'UI/Overlay/Records/RecordSet/RecordTableHelpers';
 
 const CACHE_DB_NAME = 'record_cache.db';
 const CACHE_UNAVAILABLE = 'cache not available';
@@ -453,6 +456,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
   }
 
   private transformIapp(id: string, iappRecord: IappRecord, iappRow: IappTableRow): Array<any> {
+    const normalizedRows = getUnnestedFieldsForIAPP(iappRow);
     const geojson = iappRow.geojson;
     const map_symbol = geojson?.properties?.map_symbol;
     geojson.properties = {
@@ -462,17 +466,64 @@ class SQLiteRecordCacheService extends RecordCacheService {
     const stringRecord = JSON.stringify(iappRecord);
     const stringRow = JSON.stringify(iappRow);
     const stringGeo = JSON.stringify(geojson);
-    return [id.toString(), stringRecord, stringRow, stringGeo];
+    return [
+      id.toString(), // ID
+      stringRow, // TABLE_DATA
+      stringRecord, // RECORD_DATA
+      stringGeo, // GEOJSON
+      geojson.geometry.coordinates[1], // LATITUDE
+      geojson.geometry.coordinates[0], // LONGITUDE
+      normalizedRows.site_id || null,
+      normalizedRows.site_paper_file_id || null,
+      normalizedRows.jurisdictions_flattened || null,
+      normalizedRows.min_survey || null,
+      normalizedRows.all_species_on_site || null,
+      normalizedRows.max_survey || null,
+      normalizedRows.agencies || null,
+      normalizedRows.biological_agent || null,
+      normalizedRows.has_biological_treatments || null,
+      normalizedRows.has_chemical_treatments || null,
+      normalizedRows.has_mechanical_treatments || null,
+      normalizedRows.has_biological_dispersals || null,
+      normalizedRows.monitored || null,
+      normalizedRows.regional_district || null,
+      normalizedRows.regional_invasive_species_organization || null,
+      normalizedRows.invasive_plant_management_area || null
+    ];
   }
 
   async saveIapp(data: Record<PropertyKey, { record: IappRecord; row: IappTableRow }>): Promise<void> {
+    const NUM_IAPP_COLUMNS = 22;
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
-    const entry = ` ( ?, ?, ?, ? ) `;
+    const entry = ` ( ${Array(NUM_IAPP_COLUMNS).fill('?').join(',')} ) `;
     const values: Array<any> = [];
     Object.keys(data).forEach((id) => values.push(this.transformIapp(id, data[id].record, data[id].row)));
-    let query = 'INSERT INTO CACHED_IAPP_RECORDS(ID, RECORD_DATA, TABLE_DATA, GEOJSON) VALUES ';
+    let query = `INSERT INTO CACHED_IAPP_RECORDS(
+      ID,
+      TABLE_DATA,
+      RECORD_DATA,
+      GEOJSON,
+      LATITUDE,
+      LONGITUDE,
+      SITE_ID,
+      SITE_PAPER_FILE_ID,
+      JURISDICTIONS_FLATTENED,
+      MIN_SURVEY,
+      ALL_SPECIES_ON_SITE,
+      BIOLOGICAL_AGENT,
+      MAX_SURVEY,
+      AGENCIES,
+      HAS_BIOLOGICAL_TREATMENTS,
+      HAS_CHEMICAL_TREATMENTS,
+      HAS_MECHANICAL_TREATMENTS,
+      HAS_BIOLOGICAL_DISPERSALS,
+      MONITORED,
+      REGIONAL_DISTRICT,
+      REGIONAL_INVASIVE_SPECIES_ORGANIZATION,
+      INVASIVE_PLANT_MANAGEMENT_AREA
+    ) VALUES `;
     query += values.map(() => entry).join(', ');
     query += 'ON CONFLICT (ID) DO NOTHING';
     await this.cacheDB.run(query, values.flat(), false);

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -77,13 +77,17 @@ class SQLiteRecordCacheService extends RecordCacheService {
     }
     const repoData = await this.cacheDB.query(
       //language=SQLite
-      `SELECT DATA
+      `SELECT *
        FROM CACHE_METADATA
        WHERE SET_ID = ?
        LIMIT 1`,
       [repositoryId]
     );
-    return JSON.parse(repoData?.values?.[0]['DATA']) ?? {};
+    const resp = {};
+    Object.entries(repoData.values?.[0] ?? {}).forEach(([key, value]) => {
+      resp[key.toLowerCase()] = value;
+    });
+    return resp as RepositoryMetadata;
   }
 
   async isCached(repositoryId: string): Promise<boolean> {

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -53,8 +53,18 @@ class SQLiteRecordCacheService extends RecordCacheService {
     const values: Array<string | number> = [];
     Object.keys(spec).forEach((key) => {
       columns.push(key);
-      values.push(spec[key]);
+      if (typeof spec[key] === 'string' || !spec[key]) {
+        values.push(spec[key] ?? null);
+      } else {
+        values.push(JSON.stringify(spec[key]));
+      }
     });
+
+    const updates = columns
+      .filter((column) => !RegExp(/SET_ID/i).test(column))
+      .map((key) => `${key} = excluded.${key}`)
+      .join(', ');
+
     try {
       await this.cacheDB.query(
         //language=SQLite`
@@ -62,8 +72,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
          VALUES(${columns.map(() => '?').join(', ')})
          ON CONFLICT(SET_ID)
          DO UPDATE SET
-          STATUS = excluded.STATUS,
-          CACHE_TIME = excluded.CACHE_TIME`,
+        ${updates}`,
         [...values]
       );
     } catch (error) {
@@ -119,27 +128,33 @@ class SQLiteRecordCacheService extends RecordCacheService {
     }
     const rawRepositoryMetadata = await this.cacheDB.query(
       //language=SQLite
-      `SELECT DATA
-       FROM CACHE_METADATA`
+      `SELECT SET_ID, CACHED_IDS, RECORD_SET_TYPE
+       FROM CACHE_METADATA
+       WHERE CACHED_IDS NOT NULL`
     );
-    const repositoryMetadata: RepositoryMetadata[] =
-      rawRepositoryMetadata?.values?.map((set) => JSON.parse(set['DATA'])) ?? [];
-    const targetIndex = repositoryMetadata.findIndex((set) => set.setId === repositoryId);
+    const repositoryMetadata: Array<Partial<RepositoryMetadata>> = (rawRepositoryMetadata?.values ?? []).map(
+      (repo) => ({
+        set_id: repo['SET_ID'],
+        cached_ids: JSON.parse(repo['CACHED_IDS']),
+        record_set_type: repo['RECORD_SET_TYPE']
+      })
+    );
 
+    const targetIndex = repositoryMetadata.findIndex((set) => set.set_id == repositoryId);
     if (targetIndex === -1) return;
 
-    const { cachedIds, recordSetType } = repositoryMetadata[targetIndex];
+    const { cached_ids, record_set_type } = repositoryMetadata[targetIndex];
 
     const ids: Record<PropertyKey, number> = {};
     repositoryMetadata
-      .flatMap((set) => set.cachedIds)
+      .flatMap((set) => set.cached_ids!)
       .forEach((id) => {
         ids[id] ??= 0;
         ids[id]++;
       });
-    const recordsToErase = cachedIds.filter((id) => ids[id] <= 1);
+    const recordsToErase = cached_ids!.filter((id) => ids[id] <= 1);
 
-    await this.deleteCachedRecordsFromIds(recordsToErase, recordSetType);
+    await this.deleteCachedRecordsFromIds(recordsToErase, record_set_type!);
     await this.cacheDB.query(
       //language=SQLite
       `DELETE FROM CACHE_METADATA
@@ -177,7 +192,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
 
     this.addOrUpdateRepository({
       ...currData,
-      setId: repositoryId,
+      set_id: repositoryId,
       status: status
     });
   }

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -19,6 +19,8 @@ import {
   getUnnestedFieldsForActivity,
   getUnnestedFieldsForIAPP
 } from 'UI/Overlay/Records/RecordSet/RecordTableHelpers';
+import booleanIntersects from '@turf/boolean-intersects';
+import bbox from '@turf/bbox';
 
 const CACHE_DB_NAME = 'record_cache.db';
 const CACHE_UNAVAILABLE = 'cache not available';
@@ -80,66 +82,119 @@ class SQLiteRecordCacheService extends RecordCacheService {
     }
   }
 
-  async getRepository(repositoryId: string): Promise<RepositoryMetadata> {
+  /**
+   * @desc Returns list of IDs that overlap with a GeoJSON Object
+   * @param {Feature} geom GeoJSON Object to find overlaps
+   * @returns { string[] } Overlapping record Ids
+   */
+  public async getRecordIdsOverlappingFeature(geom: Feature): Promise<string[]> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const BUFFER = 0.0045; // Roughly 0.5KM
+    const [minX, minY, maxX, maxY] = bbox(geom);
+    const shapesInBufferedArea = await this.cacheDB.query(
+      //language=SQLite
+      `SELECT GEOJSON
+       FROM CACHED_RECORDS
+       WHERE LATITUDE BETWEEN ? AND ?
+       AND LONGITUDE BETWEEN ? AND ?
+       UNION ALL
+       SELECT GEOJSON
+       FROM CACHED_IAPP_RECORDS
+       WHERE LATITUDE BETWEEN ? AND ?
+       AND LONGITUDE BETWEEN ? AND ?
+      `,
+      [
+        minY - BUFFER,
+        maxY + BUFFER,
+        minX - BUFFER,
+        maxX + BUFFER,
+        minY - BUFFER,
+        maxY + BUFFER,
+        minX - BUFFER,
+        maxX + BUFFER
+      ]
+    );
+
+    const overlappingRecords: string[] = [];
+    (shapesInBufferedArea.values ?? []).forEach((entry) => {
+      entry = JSON.parse(entry['GEOJSON']);
+      if (Object.hasOwn(entry, 'length')) {
+        entry?.forEach((shape: Feature) => {
+          if (booleanIntersects(geom, shape)) {
+            overlappingRecords.push(shape?.properties?.description);
+          }
+        });
+      } else {
+        if (booleanIntersects(geom, entry)) {
+          overlappingRecords.push(entry?.properties?.description);
+        }
+      }
+    });
+    return overlappingRecords;
+  }
+
+  getRepository(repositoryId: string, fields: Array<keyof RepositoryMetadata>): Promise<Partial<RepositoryMetadata>>;
+  getRepository(repositoryId: string): Promise<RepositoryMetadata>;
+  async getRepository(
+    repositoryId: string,
+    fields?: Array<keyof RepositoryMetadata>
+  ): Promise<RepositoryMetadata | Partial<RepositoryMetadata>> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
     const repoData = await this.cacheDB.query(
       //language=SQLite
-      `SELECT *
+      `SELECT ${fields?.join(', ') ?? '*'}
        FROM CACHE_METADATA
        WHERE SET_ID = ?
        LIMIT 1`,
       [repositoryId]
     );
-    const resp = {};
-    Object.entries(repoData.values?.[0] ?? {}).forEach(([key, value]) => {
+
+    return this.cacheMetadataTransformer(repoData.values?.[0] ?? {});
+  }
+
+  /**
+   * @desc Return handler, ensures keys are in lower snakecase
+   * @param {RepositoryMetadata | Partial<RepositoryMetadata> } record entry from Db
+   * @returns {RepositoryMetadata | Partial<RepositoryMetadata> } Parsed Entry.
+   */
+  private cacheMetadataTransformer(
+    record: Partial<RepositoryMetadata> | RepositoryMetadata
+  ): Partial<RepositoryMetadata> | RepositoryMetadata {
+    const primitiveKeys = ['SET_ID', 'SET_NAME', 'RECORD_SET_TYPE', 'STATUS'];
+    const resp: Partial<RepositoryMetadata> | RepositoryMetadata = {};
+    Object.entries(record).forEach(([key, value]) => {
+      if (!primitiveKeys.includes(key)) {
+        value = JSON.parse(value);
+      }
       resp[key.toLowerCase()] = value;
     });
-    return resp as RepositoryMetadata;
+    return resp;
   }
 
   async isCached(repositoryId: string): Promise<boolean> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
-    const metadata = await this.cacheDB.query(
-      //language=SQLite
-      `SELECT STATUS
-       FROM CACHE_METADATA
-       WHERE SET_ID = ?
-       LIMIT 1
-      `,
-      [repositoryId]
-    );
-    return metadata?.values?.[0]?.['STATUS'] === UserRecordCacheStatus.CACHED;
+    const { status } = await this.getRepository(repositoryId, ['status']);
+    return status === UserRecordCacheStatus.CACHED;
   }
 
   async getIdList(repositoryId: string): Promise<string[]> {
     if (this.cacheDB == null) {
       throw Error(CACHE_UNAVAILABLE);
     }
-    return (await this.getRepository(repositoryId)).cached_ids ?? [];
+    return (await this.getRepository(repositoryId, ['cached_ids'])).cached_ids ?? [];
   }
 
   async deleteRepository(repositoryId: string): Promise<void> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
-    const rawRepositoryMetadata = await this.cacheDB.query(
-      //language=SQLite
-      `SELECT SET_ID, CACHED_IDS, RECORD_SET_TYPE
-       FROM CACHE_METADATA
-       WHERE CACHED_IDS NOT NULL`
-    );
-    const repositoryMetadata: Array<Partial<RepositoryMetadata>> = (rawRepositoryMetadata?.values ?? []).map(
-      (repo) => ({
-        set_id: repo['SET_ID'],
-        cached_ids: JSON.parse(repo['CACHED_IDS']),
-        record_set_type: repo['RECORD_SET_TYPE']
-      })
-    );
-
+    const repositoryMetadata = await this.listRepositories(['set_id', 'cached_ids', 'record_set_type']);
     const targetIndex = repositoryMetadata.findIndex((set) => set.set_id == repositoryId);
     if (targetIndex === -1) return;
 
@@ -163,23 +218,20 @@ class SQLiteRecordCacheService extends RecordCacheService {
     );
   }
 
-  async listRepositories(): Promise<RepositoryMetadata[]> {
+  listRepositories(fields: Array<keyof RepositoryMetadata>): Promise<Partial<RepositoryMetadata>[]>;
+  listRepositories(): Promise<RepositoryMetadata[]>;
+  async listRepositories(
+    fields?: Array<keyof RepositoryMetadata>
+  ): Promise<RepositoryMetadata[] | Partial<RepositoryMetadata>[]> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
     const repositories = await this.cacheDB.query(
       //language=SQLite
-      `SELECT *
+      `SELECT ${fields?.join(',') ?? '*'}
        FROM CACHE_METADATA`
     );
-    const response = repositories?.values?.map((repo) => {
-      const parsedRepo = {};
-      Object.keys(repo).forEach((key) => {
-        parsedRepo[key.toLowerCase()] = JSON.parse(repo[key]);
-      });
-      return parsedRepo as RepositoryMetadata;
-    });
-    return response ?? [];
+    return repositories?.values?.map((repo) => this.cacheMetadataTransformer(repo)) ?? [];
   }
 
   async setRepositoryStatus(repositoryId: string, status: UserRecordCacheStatus): Promise<void> {
@@ -190,7 +242,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     if (Object.keys(currData).length === 0) return; // Repo doesn't exist.
     currData.status = status;
 
-    this.addOrUpdateRepository({
+    await this.addOrUpdateRepository({
       ...currData,
       set_id: repositoryId,
       status: status
@@ -201,40 +253,16 @@ class SQLiteRecordCacheService extends RecordCacheService {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
-    const metadata = await this.cacheDB.query(
-      //language=SQLite
-      `SELECT STATUS
-       FROM CACHE_METADATA
-       WHERE SET_ID = ?
-       LIMIT 1
-      `,
-      [repositoryId]
-    );
-
-    const cacheStatus = metadata?.values?.[0]['STATUS'];
-    if (cacheStatus) {
-      return cacheStatus === UserRecordCacheStatus.DELETING;
-    }
-    return true;
+    const { status } = await this.getRepository(repositoryId, ['status']);
+    return status ? status === UserRecordCacheStatus.DELETING : true;
   }
 
   async checkPauseOrAbort(repositoryId: string): Promise<CacheDownloadMode> {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
-    const metadata = await this.cacheDB.query(
-      //language=SQLite
-      `SELECT STATUS
-       FROM CACHE_METADATA
-       WHERE SET_ID = ?
-       LIMIT 1
-      `,
-      [repositoryId]
-    );
-
-    const cacheStatus = metadata?.values?.[0]['STATUS'];
-
-    switch (cacheStatus) {
+    const { status } = await this.getRepository(repositoryId, ['status']);
+    switch (status) {
       case UserRecordCacheStatus.PAUSED:
         return CacheDownloadMode.PAUSE;
       case UserRecordCacheStatus.DELETING:
@@ -687,10 +715,10 @@ class SQLiteRecordCacheService extends RecordCacheService {
           await this.cacheDB.query(
             //language=SQLite
             `SELECT ID
-           FROM CACHED_RECORDS
-           ORDER BY ID ASC
-           LIMIT ?
-           OFFSET ?`,
+             FROM CACHED_RECORDS
+             ORDER BY ID ASC
+             LIMIT ?
+             OFFSET ?`,
             [this.QUERY_LIMIT, this.QUERY_LIMIT * offsetMultiplier]
           )
         )?.values ?? [];
@@ -699,10 +727,10 @@ class SQLiteRecordCacheService extends RecordCacheService {
           await this.cacheDB.query(
             //language=SQLite
             `SELECT ID
-           FROM CACHED_IAPP_RECORDS
-           ORDER BY ID ASC
-           LIMIT ?
-           OFFSET ?`,
+             FROM CACHED_IAPP_RECORDS
+             ORDER BY ID ASC
+             LIMIT ?
+             OFFSET ?`,
             [this.QUERY_LIMIT, this.QUERY_LIMIT * offsetMultiplier]
           )
         )?.values ?? [];


### PR DESCRIPTION
# Overview

> [!IMPORTANT]
> This should be given a dry run on devices to ensure old caches are wiped as expected, and offline functionality works as expected

## This PR includes the following proposed change(s):
- Overhaul the SQLite DB for Cached Records by adding more columns to handle data
   - Will later be used to add the Sorting / Filtering logic for offline Cachines being updated/modified 
- Overhaul the Repository Metadata for Caches to use columns instead of an entire JSON object
    - Reduces Payload sizes when fetching data. Very important for larger caches coming in that are pulling huge GeoJSON objects and entire Recordset lists that get JSON parsed out. 
- Overhaul the `listRepositories()` and `getRepository()` functions to allow for selecting Columns, reducing overall Payload size. 
- Update repository metadata keys to be lower snake_case, better emulating the Database tables *(Can also use the keys to query/set records in the local DB)*
- Changed some console.`log` to console.`error`
- Closes #4013 
- Part 1 for #3981

## Some Checks that occurred (but you should check as well)
- [x] Records Opened as expected
- [x] IAPP Records opened as expected
- [x] Whats Here worked as Expected
- [x] Copy Geometry worked as expected
- [x] Linked Treatment ID worked as expected
- [x] Shapes appeared on the map as expected 

## Additional Notes
- These changes decouple the `cached_geojson` and `cached_centroid` objects from the query functions like Whats Here and linked Treatments on Mobile, improving speed on MOBILE devices. Localforage still relies on it for local functionality.
