### PR TITLE
[INV-4014] Make Offline Recordsets sortable

### DIFF
--- a/api/src/paths/v2/activities/batch-request.ts
+++ b/api/src/paths/v2/activities/batch-request.ts
@@ -83,7 +83,7 @@ function getActivity(): RequestHandler {
 
       const sqlStatement: SQLStatement = getActivitiesByIdsSQL(idList);
       (await connection.query(sqlStatement.text, sqlStatement.values)).rows.forEach(async (a) => {
-        resObj[a.activity_id] = { ...a, ...a.activity_payload };
+        resObj[a.activity_id] = { ...a.activity_payload, ...a };
         delete resObj[a.activity_id].activity_payload;
         if (a?.media_keys?.length > 0) {
           try {

--- a/api/src/paths/v2/activities/cache-update-ids.ts
+++ b/api/src/paths/v2/activities/cache-update-ids.ts
@@ -86,7 +86,7 @@ function getUpdatedActivities(): RequestHandler {
 
       return res.status(200).json(response);
     } catch (error) {
-      console.log(error);
+      console.error(error);
       defaultLog.debug({ label: NAMESPACE, error: error, body: req.body });
       return res.sendStatus(500).json({
         message: 'Unable to provide list of ids.',

--- a/app/src/UI/Overlay/Records/RecordSet/RecordTable.tsx
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordTable.tsx
@@ -65,12 +65,13 @@ export const RecordTable = ({ setID, userOfflineMobile }: PropTypes) => {
     return mappedRow;
   });
   const sortColumns = (() => {
-    if (userOfflineMobile) return [];
     switch (recordSetType) {
       case RecordSetType.IAPP:
         return validIAPPSortColumns;
       case RecordSetType.Activity:
         return validActivitySortColumns;
+      default:
+        return [];
     }
   })();
 

--- a/app/src/interfaces/FilterObjects.ts
+++ b/app/src/interfaces/FilterObjects.ts
@@ -4,7 +4,7 @@ import { IFilter } from 'state/actions/userSettings/RecordSet';
 interface FilterObjects {
   limit?: number;
   page?: number;
-  recordSetType?: RecordSetType;
+  recordSetType: RecordSetType;
   selectColumns: string[];
   tableFilters: Array<IFilter>;
 }

--- a/app/src/state/sagas/map/dataAccess.ts
+++ b/app/src/state/sagas/map/dataAccess.ts
@@ -23,6 +23,8 @@ import { selectNetworkConnected } from 'state/reducers/network';
 import { selectUserSettings } from 'state/reducers/userSettings';
 import IappActions, { IappTableRowRequest } from 'state/actions/activity/Iapp';
 import Activity, { ActivityTableRowGetRequest, IGetIdsForRecordset } from 'state/actions/activity/Activity';
+import { getIappIdsForRecordsetFromCache } from './online';
+import { IQueryParams } from 'utils/record-cache';
 
 export function* handle_ACTIVITIES_GEOJSON_GET_REQUEST(action) {
   try {
@@ -260,10 +262,20 @@ export function* handle_ACTIVITIES_TABLE_GET_ROWS(action: PayloadAction<Activity
 export function* getRowsFromCachedRecordset(req: ActivityTableRowGetRequest) {
   try {
     const { recordSetID, page, limit, tableFiltersHash } = req;
+    const recordset = (yield select(selectUserSettings))[recordSetID];
     const service = yield RecordCacheServiceFactory.getPlatformInstance();
-    const recordSetIdList = yield service.getIdList(recordSetID);
-    const records = yield service.getPaginatedCachedActivityRecords(recordSetIdList, page, limit);
-
+    const queryObj: IQueryParams = {
+      limit: recordset.limit,
+      page: recordset.page,
+      tableFilters: recordset?.tableFilters,
+      recordSetType: recordset.recordSetType,
+      selectColumns: [],
+      sort: {
+        by: recordset.sortColumn,
+        order: recordset.sortOrder
+      }
+    };
+    const records = yield service.query(queryObj);
     yield put(
       Activity.getRowsSuccess({
         recordSetID: recordSetID,

--- a/app/src/state/sagas/map/dataAccess.ts
+++ b/app/src/state/sagas/map/dataAccess.ts
@@ -338,7 +338,7 @@ export function* getIappRowsFromCache(payload: IappTableRowRequest) {
       page: page,
       tableFilters: recordset?.tableFilters,
       recordSetType: recordset.recordSetType,
-      selectColumns: ['table_row'],
+      selectColumns: ['table_data'],
       sort: {
         by: recordset.sortColumn,
         order: recordset.sortOrder
@@ -349,7 +349,7 @@ export function* getIappRowsFromCache(payload: IappTableRowRequest) {
     yield put(
       IappActions.getRowsSuccess({
         recordSetID: recordSetID,
-        rows: records.map((r) => r?.table_row),
+        rows: records.map((r) => r?.table_data),
         tableFiltersHash: tableFiltersHash,
         page: page,
         limit: limit

--- a/app/src/state/sagas/map/dataAccess.ts
+++ b/app/src/state/sagas/map/dataAccess.ts
@@ -23,7 +23,6 @@ import { selectNetworkConnected } from 'state/reducers/network';
 import { selectUserSettings } from 'state/reducers/userSettings';
 import IappActions, { IappTableRowRequest } from 'state/actions/activity/Iapp';
 import Activity, { ActivityTableRowGetRequest, IGetIdsForRecordset } from 'state/actions/activity/Activity';
-import { getIappIdsForRecordsetFromCache } from './online';
 import { IQueryParams } from 'utils/record-cache';
 
 export function* handle_ACTIVITIES_GEOJSON_GET_REQUEST(action) {
@@ -262,24 +261,21 @@ export function* handle_ACTIVITIES_TABLE_GET_ROWS(action: PayloadAction<Activity
 export function* getRowsFromCachedRecordset(req: ActivityTableRowGetRequest) {
   try {
     const { recordSetID, page, limit, tableFiltersHash } = req;
-    const recordset = (yield select(selectUserSettings))[recordSetID];
+    const recordset = (yield select(selectUserSettings)).recordSets[recordSetID];
     const service = yield RecordCacheServiceFactory.getPlatformInstance();
     const queryObj: IQueryParams = {
-      limit: recordset.limit,
-      page: recordset.page,
+      limit: limit,
+      page: page,
       tableFilters: recordset?.tableFilters,
       recordSetType: recordset.recordSetType,
-      selectColumns: [],
-      sort: {
-        by: recordset.sortColumn,
-        order: recordset.sortOrder
-      }
+      selectColumns: ['data'],
+      sort: { by: recordset.sortColumn, order: recordset.sortOrder }
     };
     const records = yield service.query(queryObj);
     yield put(
       Activity.getRowsSuccess({
         recordSetID: recordSetID,
-        rows: records,
+        rows: records.map((r) => r.data),
         tableFiltersHash: tableFiltersHash,
         page: page,
         limit: limit
@@ -335,14 +331,25 @@ export function* handle_IAPP_TABLE_ROWS_GET_REQUEST(action: PayloadAction<IappTa
 export function* getIappRowsFromCache(payload: IappTableRowRequest) {
   try {
     const { recordSetID, page, limit, tableFiltersHash } = payload;
+    const recordset = (yield select(selectUserSettings)).recordSets[recordSetID];
     const service = yield RecordCacheServiceFactory.getPlatformInstance();
-    const recordSetIdList = yield service.getIdList(recordSetID.toString()) ?? [];
-    const records = yield service.getPaginatedCachedIappRecords(recordSetIdList, page, limit);
+    const queryObj: IQueryParams = {
+      limit: limit,
+      page: page,
+      tableFilters: recordset?.tableFilters,
+      recordSetType: recordset.recordSetType,
+      selectColumns: ['table_row'],
+      sort: {
+        by: recordset.sortColumn,
+        order: recordset.sortOrder
+      }
+    };
 
+    const records = yield service.query(queryObj);
     yield put(
       IappActions.getRowsSuccess({
         recordSetID: recordSetID,
-        rows: records,
+        rows: records.map((r) => r?.table_row),
         tableFiltersHash: tableFiltersHash,
         page: page,
         limit: limit

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -76,6 +76,13 @@ export interface CacheDownloadSpec {
   filterObjects: FilterObjects;
 }
 
+export interface IQueryParams extends FilterObjects {
+  sort?: {
+    order?: 'ASC' | 'DESC';
+    by: string;
+  };
+}
+
 abstract class RecordCacheService extends BaseCacheService<
   RepositoryMetadata,
   CacheDownloadSpec,
@@ -91,6 +98,8 @@ abstract class RecordCacheService extends BaseCacheService<
   static async getInstance(): Promise<RecordCacheService> {
     throw new Error('unimplemented in abstract base class');
   }
+  public abstract query(params: IQueryParams): Promise<UserRecord[] | IappRecord[]>;
+
   protected abstract addOrUpdateRepository(spec: RepositoryMetadata): Promise<void>;
 
   protected abstract deleteCachedRecordsFromIds(idsToDelete: string[], recordSetType: RecordSetType): Promise<void>;

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -37,13 +37,31 @@ class LocalForageRecordCacheService extends RecordCacheService {
     return LocalForageRecordCacheService._instance;
   }
 
+  /**
+   * @desc Query cached recordsets for results, orderable, filterable, limitable
+   *       LocalForage has no querying capabilities, but this is only used for Development.
+   */
   async query(params: IQueryParams): Promise<UserRecord[] | IappRecord[]> {
     if (this.store == null) {
       throw new Error('Cache not available');
     }
-    const records: Array<UserRecord | IappRecord> = [];
+    let records: Array<UserRecord | IappRecord> = [];
     await this.store.iterate((value: Record<PropertyKey, any>) => {
-      if (params.tableFilters.every((filter) => new RegExp(filter.filter, 'i').test(value[filter.field]))) {
+      if (
+        params.tableFilters.every((filter) => {
+          const pattern = new RegExp(filter.filter, 'i');
+          const columnVal = (() => {
+            if (value?.[filter.field]) {
+              return value[filter.field];
+            } else if (value?.row?.[filter.field]) {
+              return value.row[filter.field];
+            } else {
+              return '';
+            }
+          })();
+          return pattern.test(columnVal);
+        })
+      ) {
         records.push(value);
       }
     });
@@ -64,19 +82,34 @@ class LocalForageRecordCacheService extends RecordCacheService {
         records.reverse();
       }
     }
-
     if (params?.page != undefined && params?.limit != undefined) {
       const startPos = params.page * params.limit;
       const endPos = Math.min((params.page + 1) * params.limit, records.length);
-      return records.slice(startPos, endPos).map((record) => record.data);
+      records = records.slice(startPos, endPos);
     }
-    return records.map((record) => record.data);
+    if (params.selectColumns) {
+      return records.map((record) => {
+        const resObj: Record<PropertyKey, any> = {};
+        params.selectColumns.forEach((column) => {
+          if (column.toLowerCase() === 'table_row') {
+            resObj.table_row = record['row'];
+          } else if (column.toLowerCase() === 'table_data') {
+            resObj.table_data = record['record'];
+          } else {
+            resObj[column] = record[column];
+          }
+        });
+        return resObj;
+      });
+    }
+    return records;
   }
 
   async isCached(repositoryId: string): Promise<boolean> {
     try {
       return (await this.getRepository(repositoryId, ['status'])).status === UserRecordCacheStatus.CACHED;
     } catch (e) {
+      console.error(e);
       return false;
     }
   }

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -8,13 +8,15 @@ import {
   RepositoryMetadata,
   RecordCacheService,
   RecordSetSourceMetadata,
-  CacheDownloadMode
+  CacheDownloadMode,
+  IQueryParams
 } from 'utils/record-cache/index';
 import UserRecord from 'interfaces/UserRecord';
 import IappRecord from 'interfaces/IappRecord';
 import IappTableRow from 'interfaces/IappTableRecord';
 import { UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import bboxToPolygon from 'utils/bboxToPolygon';
+import { getUnnestedFieldsForActivity } from 'UI/Overlay/Records/RecordSet/RecordTableHelpers';
 
 class LocalForageRecordCacheService extends RecordCacheService {
   private static _instance: LocalForageRecordCacheService;
@@ -33,6 +35,42 @@ class LocalForageRecordCacheService extends RecordCacheService {
       await LocalForageRecordCacheService._instance.initializeCache();
     }
     return LocalForageRecordCacheService._instance;
+  }
+
+  async query(params: IQueryParams): Promise<UserRecord[] | IappRecord[]> {
+    if (this.store == null) {
+      throw new Error('Cache not available');
+    }
+    const records: Array<UserRecord | IappRecord> = [];
+    await this.store.iterate((value: Record<PropertyKey, any>) => {
+      if (params.tableFilters.every((filter) => new RegExp(filter.filter, 'i').test(value[filter.field]))) {
+        records.push(value);
+      }
+    });
+    if (params.sort) {
+      const { by, order } = params.sort;
+      records.sort((a, b) => {
+        if (!a[by] && !b[by]) {
+          return 0;
+        } else if (!a[by]) {
+          return 1;
+        } else if (!b[by]) {
+          return -1;
+        } else {
+          return a[by]?.localeCompare(b[by]);
+        }
+      });
+      if (order === 'DESC') {
+        records.reverse();
+      }
+    }
+
+    if (params?.page != undefined && params?.limit != undefined) {
+      const startPos = params.page * params.limit;
+      const endPos = Math.min((params.page + 1) * params.limit, records.length);
+      return records.slice(startPos, endPos).map((record) => record.data);
+    }
+    return records.map((record) => record.data);
   }
 
   async isCached(repositoryId: string): Promise<boolean> {
@@ -70,7 +108,13 @@ class LocalForageRecordCacheService extends RecordCacheService {
     if (this.store == null) {
       throw new Error('cache not available');
     }
-    await Promise.all(Object.keys(data).map((key) => this.store?.setItem(key, data[key])));
+    await Promise.all(
+      Object.keys(data).map((key) => {
+        const parsed = getUnnestedFieldsForActivity(data[key]);
+        parsed.data = data[key];
+        this.store?.setItem(key, parsed);
+      })
+    );
   }
 
   /**
@@ -165,13 +209,13 @@ class LocalForageRecordCacheService extends RecordCacheService {
       throw new Error('cache not available');
     }
 
-    const data = await this.store.getItem(id);
+    const data = (await this.store.getItem(id)) as UserRecord;
 
     if (!data) {
       throw new Error(`activity ${id} not found in cache`);
     }
 
-    return data;
+    return data?.data;
   }
 
   /**

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -91,10 +91,10 @@ class LocalForageRecordCacheService extends RecordCacheService {
       return records.map((record) => {
         const resObj: Record<PropertyKey, any> = {};
         params.selectColumns.forEach((column) => {
-          if (column.toLowerCase() === 'table_row') {
-            resObj.table_row = record['row'];
-          } else if (column.toLowerCase() === 'table_data') {
-            resObj.table_data = record['record'];
+          if (column.toLowerCase() === 'table_data') {
+            resObj.table_data = record['row'];
+          } else if (column.toLowerCase() === 'record_data') {
+            resObj.record_data = record['record'];
           } else {
             resObj[column] = record[column];
           }

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -88,11 +88,11 @@ class SQLiteRecordCacheService extends RecordCacheService {
     return (
       results?.values?.map((record) => {
         const parsedRecord: Record<PropertyKey, UserRecord | IappRecord> = {};
-        Object.keys(record).forEach((rec) => {
-          if (['TABLE_DATA', 'RECORD_DATA', 'DATA', 'RECORD_DATA', 'GEOJSON', 'CENTROID'].includes(rec)) {
-            parsedRecord[rec.toLowerCase()] = JSON.parse(record[rec]);
+        Object.keys(record).forEach((key) => {
+          if (['TABLE_DATA', 'RECORD_DATA', 'DATA', 'RECORD_DATA', 'GEOJSON', 'CENTROID'].includes(key)) {
+            parsedRecord[key.toLowerCase()] = JSON.parse(record[key]);
           } else {
-            parsedRecord[rec.toLowerCase()] = record[rec];
+            parsedRecord[key.toLowerCase()] = record[key];
           }
         });
         return parsedRecord;

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -14,13 +14,15 @@ import {
   RepositoryMetadata,
   RecordCacheService,
   RecordSetSourceMetadata,
-  CacheDownloadMode
+  CacheDownloadMode,
+  IQueryParams
 } from 'utils/record-cache/index';
 import { sqlite } from 'utils/sharedSQLiteInstance';
 import {
   getUnnestedFieldsForActivity,
   getUnnestedFieldsForIAPP
 } from 'UI/Overlay/Records/RecordSet/RecordTableHelpers';
+import { IFilter } from 'state/actions/userSettings/RecordSet';
 
 const CACHE_DB_NAME = 'record_cache.db';
 const CACHE_UNAVAILABLE = 'cache not available';
@@ -46,6 +48,56 @@ class SQLiteRecordCacheService extends RecordCacheService {
       await SQLiteRecordCacheService._instance.initializeRecordCache(sqlite);
     }
     return SQLiteRecordCacheService._instance;
+  }
+
+  public async query(params: IQueryParams): Promise<UserRecord[] | IappRecord[]> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const values: Array<string | number> = [];
+    const table = {
+      [RecordSetType.Activity]: 'CACHED_RECORDS',
+      [RecordSetType.IAPP]: 'CACHED_IAPP_RECORDS'
+    }[params.recordSetType];
+    const columns = params.selectColumns.length > 0 ? params.selectColumns.join(', ') : '*';
+    let where = '';
+
+    params.tableFilters.forEach((filter: IFilter, i: number) => {
+      where += i === 0 ? '\n WHERE ' : '\n AND ';
+      where += `${filter.field} LIKE '%${filter.filter}%'`;
+    });
+    let order = '';
+    if (params?.sort?.by) {
+      order = `ORDER BY ${params.sort.by} ${params.sort.order ?? 'ASC'}
+               NULLS ${params.sort.order === 'DESC' ? 'FIRST' : 'LAST'}`;
+    }
+    const limit = params?.limit ?? 50000;
+    const offset = params?.page != undefined && params?.limit != undefined ? params.page * params.limit : 0;
+    const query =
+      //language=SQLite
+      `SELECT ${columns} 
+       FROM ${table} 
+       ${where}
+       ${order}
+       LIMIT ${limit}
+       OFFSET ${offset}
+    `;
+
+    const results = await this.cacheDB.query(query, values);
+    console.log('Query Results', results, 'Query', query, 'Query values', values);
+    return (
+      results?.values?.map((record) => {
+        const parsedRecord: Record<PropertyKey, UserRecord | IappRecord> = {};
+        Object.keys(record).forEach((rec) => {
+          if (['TABLE_DATA', 'RECORD_DATA', 'DATA', 'RECORD_DATA', 'GEOJSON', 'CENTROID'].includes(rec)) {
+            parsedRecord[rec.toLowerCase()] = JSON.parse(record[rec]);
+          } else {
+            parsedRecord[rec.toLowerCase()] = record[rec];
+          }
+        });
+        return parsedRecord;
+      }) ?? []
+    );
   }
 
   private async initializeRecordCache(sqlite: SQLiteConnection) {

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -50,55 +50,6 @@ class SQLiteRecordCacheService extends RecordCacheService {
     return SQLiteRecordCacheService._instance;
   }
 
-  public async query(params: IQueryParams): Promise<UserRecord[] | IappRecord[]> {
-    if (this.cacheDB == null) {
-      throw new Error(CACHE_UNAVAILABLE);
-    }
-    const values: Array<string | number> = [];
-    const table = {
-      [RecordSetType.Activity]: 'CACHED_RECORDS',
-      [RecordSetType.IAPP]: 'CACHED_IAPP_RECORDS'
-    }[params.recordSetType];
-    const columns = params.selectColumns.length > 0 ? params.selectColumns.join(', ') : '*';
-    let where = '';
-
-    params.tableFilters.forEach((filter: IFilter, i: number) => {
-      where += i === 0 ? '\n WHERE ' : '\n AND ';
-      where += `${filter.field} LIKE '%${filter.filter}%'`;
-    });
-    let order = '';
-    if (params?.sort?.by) {
-      order = `ORDER BY ${params.sort.by} ${params.sort.order ?? 'ASC'}
-               NULLS ${params.sort.order === 'DESC' ? 'FIRST' : 'LAST'}`;
-    }
-    const limit = params?.limit ?? 50000;
-    const offset = params?.page != undefined && params?.limit != undefined ? params.page * params.limit : 0;
-    const query =
-      //language=SQLite
-      `SELECT ${columns} 
-       FROM ${table} 
-       ${where}
-       ${order}
-       LIMIT ${limit}
-       OFFSET ${offset}
-    `;
-
-    const results = await this.cacheDB.query(query, values);
-    return (
-      results?.values?.map((record) => {
-        const parsedRecord: Record<PropertyKey, UserRecord | IappRecord> = {};
-        Object.keys(record).forEach((key) => {
-          if (['TABLE_DATA', 'RECORD_DATA', 'DATA', 'RECORD_DATA', 'GEOJSON', 'CENTROID'].includes(key)) {
-            parsedRecord[key.toLowerCase()] = JSON.parse(record[key]);
-          } else {
-            parsedRecord[key.toLowerCase()] = record[key];
-          }
-        });
-        return parsedRecord;
-      }) ?? []
-    );
-  }
-
   private async initializeRecordCache(sqlite: SQLiteConnection) {
     await sqlite.addUpgradeStatement(CACHE_DB_NAME, MIGRATIONS);
 
@@ -621,6 +572,59 @@ class SQLiteRecordCacheService extends RecordCacheService {
       throw Error('No results found');
     }
     return JSON.parse(result.values[0][dataType]);
+  }
+
+  /**
+   * @desc Query Database using Parameters allowing for ordering, column filtering on all cached records
+   * @param {IQueryParams} params Query Parameters for search
+   */
+  public async query(params: IQueryParams): Promise<UserRecord[] | IappRecord[]> {
+    if (this.cacheDB == null) {
+      throw new Error(CACHE_UNAVAILABLE);
+    }
+    const values: Array<string | number> = [];
+    const table = {
+      [RecordSetType.Activity]: 'CACHED_RECORDS',
+      [RecordSetType.IAPP]: 'CACHED_IAPP_RECORDS'
+    }[params.recordSetType];
+    const columns = params.selectColumns.length > 0 ? params.selectColumns.join(', ') : '*';
+    let where = '';
+
+    params.tableFilters.forEach((filter: IFilter, i: number) => {
+      where += i === 0 ? '\n WHERE ' : '\n AND ';
+      where += `${filter.field} LIKE '%${filter.filter}%'`;
+    });
+    let order = '';
+    if (params?.sort?.by) {
+      order = `ORDER BY ${params.sort.by} ${params.sort.order ?? 'ASC'}
+               NULLS ${params.sort.order === 'DESC' ? 'FIRST' : 'LAST'}`;
+    }
+    const limit = params?.limit ?? 50000;
+    const offset = params?.page != undefined && params?.limit != undefined ? params.page * params.limit : 0;
+    const query =
+      //language=SQLite
+      `SELECT ${columns} 
+       FROM ${table} 
+       ${where}
+       ${order}
+       LIMIT ${limit}
+       OFFSET ${offset}
+    `;
+
+    const results = await this.cacheDB.query(query, values);
+    return (
+      results?.values?.map((record) => {
+        const parsedRecord: Record<PropertyKey, UserRecord | IappRecord> = {};
+        Object.keys(record).forEach((key) => {
+          if (['TABLE_DATA', 'RECORD_DATA', 'DATA', 'RECORD_DATA', 'GEOJSON', 'CENTROID'].includes(key)) {
+            parsedRecord[key.toLowerCase()] = JSON.parse(record[key]);
+          } else {
+            parsedRecord[key.toLowerCase()] = record[key];
+          }
+        });
+        return parsedRecord;
+      }) ?? []
+    );
   }
 
   /**

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -84,7 +84,6 @@ class SQLiteRecordCacheService extends RecordCacheService {
     `;
 
     const results = await this.cacheDB.query(query, values);
-    console.log('Query Results', results, 'Query', query, 'Query values', values);
     return (
       results?.values?.map((record) => {
         const parsedRecord: Record<PropertyKey, UserRecord | IappRecord> = {};


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Fix issue in `activity/batch-caching` where Activity Records were being destructured in the response resulting in some keys being overwritten that populate the record fields.
   - `Jurisdiction` is one example of this, where Ministry of Forests would cache as null, being overwritten by the destructure order.
- add new function to record caches `query` for being able to parse recordsets using the filter objects in the app, select specific columns, and more. 
   - Refactor `getRowsFromCachedRecordset` and `getIappRowsFromCache` to use these.
   - SQLite version runs a query builder based on the incoming params
   - Localforage `does not` support querying tools, so it has a much more rudimentary/unoptimized approach. Thankfully we only use it in local development...
- When viewing a recordset while offline, you can now order the columns by Desc/Asc in columns.
- Closes #4014
- Part of #3981