### PR TITLE
[INV-N/A] Css tweaks

### DIFF
--- a/app/src/UI/LegacyMap/map.css
+++ b/app/src/UI/LegacyMap/map.css
@@ -80,7 +80,7 @@
 
 :root:has(#map-btn-container, #overlaydiv.map__overlay--show) {
   .maplibregl-ctrl-bottom-right {
-    bottom: calc(var(--overlay-height) + var(--overlay-grip-height));
+    bottom: calc(var(--overlay-height) - 7px);
     transition: bottom 0.1s ease 0.3s;
   }
 

--- a/app/src/UI/Overlay/Records/RecordHistory/RecordHistory.css
+++ b/app/src/UI/Overlay/Records/RecordHistory/RecordHistory.css
@@ -1,11 +1,11 @@
 #record-history {
-  position: fixed;
+  position: absolute;
   background-color: white;
   left: 50%;
-  top: 50%;
+  top: 4rem;
   height: 350pt;
-  transform: translate(-50%, -50%);
-  z-index: 100000;
+  transform: translateX(-50%);
+  z-index: 2;
   width: 100%;
   max-width: 450pt;
   flex-direction: column;
@@ -23,7 +23,7 @@
     box-sizing: border-box;
     align-items: center;
     background-color: var(--bc-blue);
-    justify-content: flex-start;
+    justify-content: space-between;
     border-bottom: 2pt solid var(--bc-yellow);
     h2 {
       color: white;
@@ -95,7 +95,7 @@
       background-color: transparent;
       height: 30pt;
       width: 60pt;
-      border-radius: 12pt;
+      border-radius: 4pt;
       transition: 0.5s color;
     }
     button:hover {
@@ -106,6 +106,6 @@
 
 @media screen and (width > 450pt) {
   #record-history {
-    border-radius: 8pt;
+    border-radius: 4pt;
   }
 }

--- a/app/src/UI/Overlay/Records/RecordHistory/RecordHistory.tsx
+++ b/app/src/UI/Overlay/Records/RecordHistory/RecordHistory.tsx
@@ -1,4 +1,6 @@
+import { IconButton } from '@mui/material';
 import './RecordHistory.css';
+import { Close } from '@mui/icons-material';
 
 type PropTypes = {
   show: boolean;
@@ -19,6 +21,9 @@ const RecordHistory = ({ activityHistory, show, handleClick }: PropTypes) => {
     <div id="record-history">
       <div className="history-header">
         <h2>Record History</h2>
+        <IconButton onClick={handleClick}>
+          <Close htmlColor="#FFF" />
+        </IconButton>
       </div>
       <div className="history-content">
         <ul className="outer-record-history">

--- a/app/src/UI/Overlay/Records/RecordSet/RecordSet.css
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordSet.css
@@ -113,8 +113,12 @@
   border: 1px solid black;
   color: black;
   border-radius: 5px;
+  &:disabled {
+    color: rgba(0, 0, 0, 0.26);
+    background-color: rgba(0, 0, 0, 0.12);
+    border-color: rgba(0, 0, 0, 0.12);
+  }
 }
-
 .recordSet_footer {
   flex-direction: row;
   justify-content: center;

--- a/app/src/UI/Overlay/Records/RecordSet/RecordSet.css
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordSet.css
@@ -15,6 +15,7 @@
 }
 
 .recordSet_header {
+  padding-left: 5px;
   height: 5vh;
   width: 100%;
   top: 0;


### PR DESCRIPTION
# Overview


This PR includes the following proposed change(s):

>[!NOTE]
> These are some fixes to issues that I noticed while I've been working on the Record Caching v2 functionality.

- CSS Touchups
- Add close button to top of Record History


## Screenshots

### Drop position of map attribution to not overlap the nav buttons
![image](https://github.com/user-attachments/assets/9efc6f99-1a85-46b9-bd78-bdb77627eb75)

### Bump padding of Record set header to button not nested against confines
![image](https://github.com/user-attachments/assets/9df100c0-2231-4cdf-8e11-2d3c00721656)

### Fade out Filter inputs when disabled (CSS values derived from MUI buttons)
![image](https://github.com/user-attachments/assets/e450897e-4a0d-4967-ab79-785084c6adbf)

#### Previous
They looked the same as undisabled, but the Input blurred out
![image](https://github.com/user-attachments/assets/4144cb59-4719-4d41-a009-f7b2b63bef55)

### Clean up the Record history component
- Reduce border-radius
- Add close button on top
- Make position relative to modal since there was no winning on the z-index front given where the component lives, and moving to higher level was moot.
![image](https://github.com/user-attachments/assets/85b1a89a-2e9c-4a73-8ae7-cfa1ba1e5a1b)

#### Previous
- Would overlap with Overlay Header or get overflowed away depending on browser
![image](https://github.com/user-attachments/assets/6332c186-efae-48b8-bf48-f15bff062fab)
