### PR TITLE
[INV-4015] Allow Cached records to have more Filters applied

### DIFF
--- a/app/src/UI/Overlay/Records/RecordSet/Filter.tsx
+++ b/app/src/UI/Overlay/Records/RecordSet/Filter.tsx
@@ -9,12 +9,12 @@ import { IFilter, IUpdateFilter } from 'state/actions/userSettings/RecordSet';
 
 type PropTypes = {
   setID: string;
-  userOfflineMobile: boolean;
+  disabled: boolean;
   filterSet: IFilter;
   recordSetType: RecordSetType;
 };
 
-const Filter = ({ setID, userOfflineMobile, filterSet, recordSetType }: PropTypes) => {
+const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
   const TIME_TO_AUTO_UPDATE_IN_SECONDS = 0.75;
 
   /**
@@ -73,7 +73,7 @@ const Filter = ({ setID, userOfflineMobile, filterSet, recordSetType }: PropType
         return (
           <input
             className="filterSelect"
-            disabled={userOfflineMobile}
+            disabled={disabled}
             onChange={handleInputChange}
             type="text"
             value={inputValue}
@@ -83,7 +83,7 @@ const Filter = ({ setID, userOfflineMobile, filterSet, recordSetType }: PropType
         return (
           <select
             className="filterSelect"
-            disabled={userOfflineMobile}
+            disabled={disabled}
             onChange={(e) => updateFilter({ filter: e.target.value })}
             value={filterSet.filter}
           >
@@ -98,7 +98,7 @@ const Filter = ({ setID, userOfflineMobile, filterSet, recordSetType }: PropType
         return (
           <select
             className="filterSelect"
-            disabled={userOfflineMobile}
+            disabled={disabled}
             onChange={(e) => updateFilter({ filter: e.target.value })}
             value={filterSet.filter}
           >
@@ -134,7 +134,7 @@ const Filter = ({ setID, userOfflineMobile, filterSet, recordSetType }: PropType
       <td>
         <select
           className="filterSelect"
-          disabled={userOfflineMobile}
+          disabled={disabled}
           onChange={(e) => updateFilter({ operator2: e.target.value })}
           value={filterSet.operator2}
         >
@@ -177,7 +177,7 @@ const Filter = ({ setID, userOfflineMobile, filterSet, recordSetType }: PropType
       <td>
         <select
           className="filterSelect"
-          disabled={userOfflineMobile}
+          disabled={disabled}
           onChange={(e) => updateFilter({ operator: e.target.value })}
           value={filterSet.operator}
         >
@@ -220,7 +220,7 @@ const Filter = ({ setID, userOfflineMobile, filterSet, recordSetType }: PropType
       <td>
         <select
           className="filterTypeSelect"
-          disabled={userOfflineMobile}
+          disabled={disabled}
           onChange={(e) => {
             const payload: Partial<IUpdateFilter> = {
               filterType: e.target.value,
@@ -259,7 +259,7 @@ const Filter = ({ setID, userOfflineMobile, filterSet, recordSetType }: PropType
       <td>
         <select
           className="filterSelect"
-          disabled={userOfflineMobile}
+          disabled={disabled}
           value={filterSet.field}
           onChange={(e) => updateFilter({ filterID: filterSet.id, field: e.target.value, filterType: 'tableFilter' })}
         >
@@ -282,7 +282,7 @@ const Filter = ({ setID, userOfflineMobile, filterSet, recordSetType }: PropType
           <span>
             <Button
               className={'deleteButton'}
-              disabled={userOfflineMobile}
+              disabled={disabled}
               onClick={() => removeFilter('tableFilter')}
               variant="contained"
             >

--- a/app/src/UI/Overlay/Records/RecordSet/RecordSet.tsx
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordSet.tsx
@@ -1,4 +1,4 @@
-import { useDispatch } from 'react-redux';
+import { shallowEqual, useDispatch } from 'react-redux';
 import './RecordSet.css';
 import Button from '@mui/material/Button';
 import { useHistory } from 'react-router';
@@ -17,9 +17,13 @@ import { MOBILE } from 'state/build-time-config';
 import { useEffect, useState } from 'react';
 import UserSettings from 'state/actions/userSettings/UserSettings';
 import { RecordSetType } from 'interfaces/UserRecordSet';
+import { IFilter } from 'state/actions/userSettings/RecordSet';
+import { RecordCacheServiceFactory } from 'utils/record-cache/context';
 
 type PropTypes = { setID: string };
-
+interface ExtendedFilter extends IFilter {
+  disabled: boolean;
+}
 export const RecordSet = ({ setID }: PropTypes) => {
   const viewFilters = useSelector((state) => state.Map.viewFilters);
   const connected = useSelector((state) => state.Network.connected);
@@ -36,8 +40,42 @@ export const RecordSet = ({ setID }: PropTypes) => {
   useEffect(() => {
     setUserOfflineMobile(MOBILE && !connected);
   }, [connected]);
+
+  const [cacheFilters, setCacheFilters] = useState<IFilter[]>([]);
+  const [filters, setFilters] = useState<ExtendedFilter[]>([]);
+
+  /**
+   * Get filters from recordset metadata that were applied at time of caching.
+   */
+  useEffect(() => {
+    if (!MOBILE) return;
+    (async () => {
+      const service = await RecordCacheServiceFactory.getPlatformInstance();
+      if (await service.isCached(setID)) {
+        const filtersInCache =
+          (await service.getRepository(setID, ['filter_objects']))?.filter_objects?.tableFilters ?? [];
+        setCacheFilters(filtersInCache);
+      }
+    })();
+  }, []);
+
+  /**
+   * Disabled modification of filters that part of the Cache.
+   * Enabling a user to filter into their cache, but not move out of it
+   */
+  useEffect(() => {
+    if (!MOBILE) return;
+    const disabledFilters: ExtendedFilter[] = (recordSet?.tableFilters ?? []).map((filter, i) => {
+      let filterCopy = { ...filter }; // Decouple from immutable Selector
+      filterCopy['disabled'] = cacheFilters?.[i] && shallowEqual(cacheFilters?.[i], filter);
+      return filterCopy as ExtendedFilter;
+    });
+    setFilters(disabledFilters);
+  }, [cacheFilters, recordSet?.tableFilters]);
+
   const onlyFilterIsForDrafts =
     recordSet?.tableFilters?.length === 1 && recordSet?.tableFilters[0]?.field === 'form_status';
+
   if (!recordSet) {
     return;
   }
@@ -62,7 +100,7 @@ export const RecordSet = ({ setID }: PropTypes) => {
               <span>
                 <Button
                   size={'small'}
-                  disabled={userOfflineMobile}
+                  disabled={cacheFilters.length > 0}
                   onClick={() => dispatch(UserSettings.RecordSet.clearFilters({ setID }))}
                   variant="contained"
                 >
@@ -77,7 +115,6 @@ export const RecordSet = ({ setID }: PropTypes) => {
               <span>
                 <Button
                   size={'small'}
-                  disabled={userOfflineMobile}
                   onClick={() => dispatch(UserSettings.RecordSet.hideFilters())}
                   variant="contained"
                 >
@@ -143,7 +180,7 @@ export const RecordSet = ({ setID }: PropTypes) => {
                   </tr>
                 </thead>
                 <tbody>
-                  {recordSet.tableFilters.map((filter) => {
+                  {filters.map((filter) => {
                     if (filter.field !== 'form_status') {
                       return (
                         <Filter
@@ -151,7 +188,7 @@ export const RecordSet = ({ setID }: PropTypes) => {
                           recordSetType={recordSet.recordSetType}
                           setID={setID}
                           filterSet={filter}
-                          userOfflineMobile={userOfflineMobile}
+                          disabled={filter.disabled}
                         />
                       );
                     }

--- a/app/src/UI/Overlay/Records/RecordSet/RecordSet.tsx
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordSet.tsx
@@ -146,7 +146,6 @@ export const RecordSet = ({ setID }: PropTypes) => {
               <span>
                 <Button
                   size={'small'}
-                  disabled={userOfflineMobile}
                   onClick={() =>
                     dispatch(
                       UserSettings.RecordSet.addFilter({
@@ -193,13 +192,20 @@ export const RecordSet = ({ setID }: PropTypes) => {
                       );
                     }
                   })}
+                  <tr>
+                    {MOBILE && cacheFilters.length > 0 && (
+                      <td colSpan={5}>
+                        <i>Filters applied after caching will not be reflected on the map.</i>
+                      </td>
+                    )}
+                  </tr>
                 </tbody>
               </table>
             )}
           </div>
           <ExcelExporter setName={setID} />
         </div>
-        <RecordTable setID={setID} userOfflineMobile={userOfflineMobile} />
+        <RecordTable setID={setID} />
       </div>
       <RecordSetFooter setID={setID} />
     </>

--- a/app/src/UI/Overlay/Records/RecordSet/RecordTable.tsx
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordTable.tsx
@@ -15,10 +15,9 @@ import CustomPopover from 'UI/CustomPopover/CustomPopover';
 
 type PropTypes = {
   setID: string;
-  userOfflineMobile: boolean;
 };
 
-export const RecordTable = ({ setID, userOfflineMobile }: PropTypes) => {
+export const RecordTable = ({ setID }: PropTypes) => {
   const onUserHoveredRecord = (row: UserRecord) => {
     dispatch({
       type: USER_HOVERED_RECORD,

--- a/app/src/state/actions/userSettings/RecordSet.ts
+++ b/app/src/state/actions/userSettings/RecordSet.ts
@@ -72,7 +72,7 @@ class RecordSet {
 
       // these will be passed to the reducer, which can then mark the record sets as cached
       return cachedSets.map((set) => {
-        return { setId: set.setId };
+        return { setId: set.set_id };
       });
     }
   );

--- a/app/src/state/sagas/map/dataAccess.ts
+++ b/app/src/state/sagas/map/dataAccess.ts
@@ -4,7 +4,6 @@ import intersect from '@turf/intersect';
 import { booleanPointInPolygon, multiPolygon, point, polygon } from '@turf/turf';
 import getSelectColumnsByRecordSetType from 'sharedAPI/src/getSelectColumnsByRecordSetType';
 import { PayloadAction } from '@reduxjs/toolkit';
-import { getIappIdsForRecordsetFromCache } from './online';
 import {
   ACTIVITIES_GEOJSON_GET_ONLINE,
   ACTIVITIES_GEOJSON_GET_SUCCESS,
@@ -135,11 +134,18 @@ export function* getIdsForRecordsetFromCache(action: IGetIdsForRecordset) {
   try {
     const service = yield RecordCacheServiceFactory.getPlatformInstance();
     if (yield service.isCached(action.recordSetID)) {
-      const ids = yield service.getIdList(action.recordSetID);
+      const { recordSets } = yield select(selectUserSettings);
+      const recordSet = recordSets[action.recordSetID];
+      const queryObj: IQueryParams = {
+        tableFilters: recordSet.tableFilters,
+        recordSetType: recordSet.recordSetType,
+        selectColumns: ['id']
+      };
+      const ids = yield service.query(queryObj);
       yield put(
         Activity.getIdsForRecordsetSuccess({
           recordSetID: action.recordSetID,
-          IDList: ids ?? [],
+          IDList: ids.map((record) => record.id) ?? [],
           tableFiltersHash: action.tableFiltersHash
         })
       );
@@ -172,7 +178,7 @@ export function* handle_IAPP_GET_IDS_FOR_RECORDSET_REQUEST(action) {
         })
       );
     } else {
-      yield getIappIdsForRecordsetFromCache(action.payload);
+      yield getIdsForRecordsetFromCache(action.payload);
     }
   } catch (e) {
     console.error(e);

--- a/app/src/state/sagas/map/online.ts
+++ b/app/src/state/sagas/map/online.ts
@@ -261,20 +261,6 @@ export function* handle_IAPP_GET_IDS_FOR_RECORDSET_ONLINE(action) {
       })
     );
   } else if (MOBILE) {
-    yield getIappIdsForRecordsetFromCache(action.payload);
-  }
-}
-
-export function* getIappIdsForRecordsetFromCache(action: IappTableRowRequest) {
-  const service = yield RecordCacheServiceFactory.getPlatformInstance();
-  if (yield service.isCached(action.recordSetID)) {
-    const ids = yield service.getIdList(action.recordSetID);
-    yield put(
-      IappActions.getIdsForRecordsetSuccess({
-        recordSetID: action.recordSetID,
-        IDList: ids,
-        tableFiltersHash: action.tableFiltersHash
-      })
-    );
+    yield getIdsForRecordsetFromCache(action.payload);
   }
 }

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -132,8 +132,6 @@ abstract class RecordCacheService extends BaseCacheService<
 
   public abstract isCached(repositoryId: string): Promise<boolean>;
 
-  public abstract getIdList(repositoryId: string): Promise<string[]>;
-
   protected abstract createIappRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata>;
 
   protected abstract createActivityRecordsetSourceMetadata(ids: string[]): Promise<RecordSetSourceMetadata>;

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -135,10 +135,6 @@ class LocalForageRecordCacheService extends RecordCacheService {
     return repos[foundIndex];
   }
 
-  async getIdList(repositoryId: string): Promise<string[]> {
-    return (await this.getRepository(repositoryId, ['cached_ids'])).cached_ids ?? [];
-  }
-
   async saveActivity(data: Record<PropertyKey, UserRecord>): Promise<void> {
     if (this.store == null) {
       throw new Error('cache not available');

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -95,6 +95,8 @@ class LocalForageRecordCacheService extends RecordCacheService {
             resObj.table_data = record['row'];
           } else if (column.toLowerCase() === 'record_data') {
             resObj.record_data = record['record'];
+          } else if (column.toLowerCase() === 'id') {
+            resObj.id = record.activity_id ?? record.site_id ?? '';
           } else {
             resObj[column] = record[column];
           }

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -96,7 +96,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
           } else if (column.toLowerCase() === 'record_data') {
             resObj.record_data = record['record'];
           } else if (column.toLowerCase() === 'id') {
-            resObj.id = record.activity_id ?? record.site_id ?? '';
+            resObj.id = record.activity_id ?? record['row'].site_id ?? '';
           } else {
             resObj[column] = record[column];
           }

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -345,13 +345,6 @@ class SQLiteRecordCacheService extends RecordCacheService {
     return idList;
   }
 
-  async getIdList(repositoryId: string): Promise<string[]> {
-    if (this.cacheDB == null) {
-      throw Error(CACHE_UNAVAILABLE);
-    }
-    return (await this.getRepository(repositoryId, ['cached_ids'])).cached_ids ?? [];
-  }
-
   /**
    * @desc fetch `n` records for a given recordset, supporting pagination
    * @param recordSetID Recordset to filter from


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Allow Users to add new filters to a cache
    - Don't allow users to remove original filters that defined the cache
    - Add Disclaimer when viewing a record that has been cached
- Refactor getIdsForRecordsetFromCache to use `query`
  - Condense IAPP and ACtivity functions into this singular function
- Remove `getIdList` cache Method.
    - Deprecated by Query 
- Cleanup Props in Recordset
    - `isOfflineUser` is now more clear to action `disabled` 
- Closes #4015
- 
## Screenshots

![image](https://github.com/user-attachments/assets/7fc2cf3d-3b97-4620-94d6-0959d8763fc6)
