### PR TITLE
[INV-4032] Add `NOT` and Spatial queries to Cached Record Checks

### DIFF
--- a/app/src/UI/Overlay/Records/RecordSet/RecordSet.tsx
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordSet.tsx
@@ -26,20 +26,15 @@ interface ExtendedFilter extends IFilter {
 }
 export const RecordSet = ({ setID }: PropTypes) => {
   const viewFilters = useSelector((state) => state.Map.viewFilters);
-  const connected = useSelector((state) => state.Network.connected);
   const history = useHistory();
   const dispatch = useDispatch();
 
   const onClickBackButton = () => {
     history.push('/Records');
   };
-  const [userOfflineMobile, setUserOfflineMobile] = useState<boolean>(!connected && MOBILE);
+
   const recordSet = useSelector((state) => state.UserSettings?.recordSets?.[setID]);
   const tableType = recordSet?.recordSetType;
-
-  useEffect(() => {
-    setUserOfflineMobile(MOBILE && !connected);
-  }, [connected]);
 
   const [cacheFilters, setCacheFilters] = useState<IFilter[]>([]);
   const [filters, setFilters] = useState<ExtendedFilter[]>([]);
@@ -67,7 +62,7 @@ export const RecordSet = ({ setID }: PropTypes) => {
     if (!MOBILE) return;
     const disabledFilters: ExtendedFilter[] = (recordSet?.tableFilters ?? []).map((filter, i) => {
       let filterCopy = { ...filter }; // Decouple from immutable Selector
-      filterCopy['disabled'] = cacheFilters?.[i] && shallowEqual(cacheFilters?.[i], filter);
+      filterCopy['disabled'] = cacheFilters?.[i]?.id === filterCopy.id;
       return filterCopy as ExtendedFilter;
     });
     setFilters(disabledFilters);

--- a/app/src/UI/Overlay/Records/RecordSet/RecordSet.tsx
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordSet.tsx
@@ -1,4 +1,4 @@
-import { shallowEqual, useDispatch } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import './RecordSet.css';
 import Button from '@mui/material/Button';
 import { useHistory } from 'react-router';

--- a/app/src/state/actions/userSettings/RecordSet.ts
+++ b/app/src/state/actions/userSettings/RecordSet.ts
@@ -2,6 +2,7 @@ import { createAction, createAsyncThunk, nanoid } from '@reduxjs/toolkit';
 import { RECORD_COLOURS } from 'constants/colors';
 import { RecordSetType, UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
 import { MOBILE } from 'state/build-time-config';
+import { Feature } from '@turf/helpers';
 import { RootState } from 'state/reducers/rootReducer';
 import { RecordCacheServiceFactory } from 'utils/record-cache/context';
 import { CacheDownloadMode } from 'utils/record-cache';
@@ -25,6 +26,7 @@ interface IFilter {
   filter: string;
   operator: string;
   operator2: string;
+  geojson?: Feature;
 }
 
 interface IAddFilter extends Partial<IFilter> {
@@ -134,4 +136,4 @@ class RecordSet {
 }
 
 export default RecordSet;
-export { IUpdateFilter, IRemoveFilter, IFilter, IAddFilter };
+export type { IUpdateFilter, IRemoveFilter, IFilter, IAddFilter };

--- a/app/src/state/sagas/map/dataAccess.ts
+++ b/app/src/state/sagas/map/dataAccess.ts
@@ -134,11 +134,13 @@ export function* getIdsForRecordsetFromCache(action: IGetIdsForRecordset) {
   try {
     const service = yield RecordCacheServiceFactory.getPlatformInstance();
     if (yield service.isCached(action.recordSetID)) {
-      const { recordSets } = yield select(selectUserSettings);
-      const recordSet = recordSets[action.recordSetID];
+      const userSettingsState = yield select(selectUserSettings);
+      const clientBoundaries = yield select((state) => state.Map.clientBoundaries);
+      const filters = getRecordFilterObjectFromStateForAPI(action.recordSetID, userSettingsState, clientBoundaries);
+
       const queryObj: IQueryParams = {
-        tableFilters: recordSet.tableFilters,
-        recordSetType: recordSet.recordSetType,
+        tableFilters: filters.tableFilters,
+        recordSetType: filters.recordSetType,
         selectColumns: ['id']
       };
       const ids = yield service.query(queryObj);
@@ -197,19 +199,12 @@ export const getRecordFilterObjectFromStateForAPI = (recordSetID, recordSetsStat
   const sortColumn = recordSet?.sortColumn;
   const sortOrder = recordSet?.sortOrder;
   const tableFilters = recordSet?.tableFilters;
-  let modifiedTableFilters = tableFilters?.map((filter) => {
-    return filter.filterType !== 'spatialFilterDrawn'
-      ? filter
-      : { ...filter, geojson: getFilterWithDrawnShape(filter.filter) };
-  });
+  let modifiedTableFilters = tableFilters?.map((filter) =>
+    filter.filterType !== 'spatialFilterDrawn' ? filter : { ...filter, geojson: getFilterWithDrawnShape(filter.filter) }
+  );
 
-  if (!modifiedTableFilters) {
-    modifiedTableFilters = [];
-  }
-
-  const selectColumns = recordSet?.selectColumns
-    ? recordSet?.selectColumns
-    : getSelectColumnsByRecordSetType(recordSetType);
+  modifiedTableFilters ??= [];
+  const selectColumns = recordSet?.selectColumns ?? getSelectColumnsByRecordSetType(recordSetType);
 
   return {
     recordSetType: recordSetType,
@@ -267,15 +262,17 @@ export function* handle_ACTIVITIES_TABLE_GET_ROWS(action: PayloadAction<Activity
 export function* getRowsFromCachedRecordset(req: ActivityTableRowGetRequest) {
   try {
     const { recordSetID, page, limit, tableFiltersHash } = req;
-    const recordset = (yield select(selectUserSettings)).recordSets[recordSetID];
+    const userSettingsState = yield select(selectUserSettings);
+    const clientBoundaries = yield select((state) => state.Map.clientBoundaries);
+    const filters = getRecordFilterObjectFromStateForAPI(recordSetID, userSettingsState, clientBoundaries);
     const service = yield RecordCacheServiceFactory.getPlatformInstance();
     const queryObj: IQueryParams = {
       limit: limit,
       page: page,
-      tableFilters: recordset?.tableFilters,
-      recordSetType: recordset.recordSetType,
+      tableFilters: filters.tableFilters,
+      recordSetType: filters.recordSetType,
       selectColumns: ['data'],
-      sort: { by: recordset.sortColumn, order: recordset.sortOrder }
+      sort: { by: filters.sortColumn, order: filters.sortOrder }
     };
     const records = yield service.query(queryObj);
     yield put(
@@ -337,17 +334,19 @@ export function* handle_IAPP_TABLE_ROWS_GET_REQUEST(action: PayloadAction<IappTa
 export function* getIappRowsFromCache(payload: IappTableRowRequest) {
   try {
     const { recordSetID, page, limit, tableFiltersHash } = payload;
-    const recordset = (yield select(selectUserSettings)).recordSets[recordSetID];
+    const userSettingsState = yield select(selectUserSettings);
+    const clientBoundaries = yield select((state) => state.Map.clientBoundaries);
+    const filters = getRecordFilterObjectFromStateForAPI(recordSetID, userSettingsState, clientBoundaries);
     const service = yield RecordCacheServiceFactory.getPlatformInstance();
     const queryObj: IQueryParams = {
       limit: limit,
       page: page,
-      tableFilters: recordset?.tableFilters,
-      recordSetType: recordset.recordSetType,
+      tableFilters: filters?.tableFilters,
+      recordSetType: filters.recordSetType,
       selectColumns: ['table_data'],
       sort: {
-        by: recordset.sortColumn,
-        order: recordset.sortOrder
+        by: filters.sortColumn,
+        order: filters.sortOrder
       }
     };
 

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -68,7 +68,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
               return '';
             }
           })();
-          return pattern.test(columnVal);
+          return filter.operator === 'CONTAINS' ? pattern.test(columnVal) : !pattern.test(columnVal);
         })
       ) {
         records.push(value);

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -46,9 +46,18 @@ class LocalForageRecordCacheService extends RecordCacheService {
       throw new Error('Cache not available');
     }
     let records: Array<UserRecord | IappRecord> = [];
-    await this.store.iterate((value: Record<PropertyKey, any>) => {
+    await this.store.iterate((value: Record<PropertyKey, any>, key: PropertyKey) => {
+      if (key === LocalForageRecordCacheService.CACHED_SETS_METADATA_KEY) return;
       if (
         params.tableFilters.every((filter) => {
+          if (filter.filterType === 'spatialFilterDrawn') {
+            const shape = value?.record?.geom?.geometry ?? value?.geometry ?? null;
+            if (Object.hasOwn(shape, 'length')) {
+              return shape.some((cachedFeature: Feature) => booleanIntersects(cachedFeature, filter.geojson));
+            } else if (shape) {
+              return booleanIntersects(shape, filter.geojson);
+            }
+          }
           const pattern = new RegExp(filter.filter, 'i');
           const columnVal = (() => {
             if (value?.[filter.field]) {

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -575,17 +575,27 @@ class SQLiteRecordCacheService extends RecordCacheService {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
+    const spatialQueries = params.tableFilters.filter((filter) => filter.filterType === 'spatialFilterDrawn');
     const values: Array<string | number> = [];
     const table = {
       [RecordSetType.Activity]: 'CACHED_RECORDS',
       [RecordSetType.IAPP]: 'CACHED_IAPP_RECORDS'
     }[params.recordSetType];
+
+    if (spatialQueries.length > 0 && params.selectColumns.length > 0 && !params.selectColumns.includes('GEOJSON')) {
+      params.selectColumns.push('GEOJSON');
+    }
     const columns = params.selectColumns.length > 0 ? params.selectColumns.join(', ') : '*';
     let where = '';
 
     params.tableFilters.forEach((filter: IFilter, i: number) => {
       where += i === 0 ? '\n WHERE ' : '\n AND ';
-      where += `${filter.field} LIKE '%${filter.filter}%'`;
+      if (filter.filterType === 'spatialFilterDrawn') {
+        const [minX, minY, maxX, maxY] = bbox(filter.geojson);
+        where += `LATITUDE BETWEEN ${minY} AND ${maxY} AND LONGITUDE BETWEEN ${minX} AND ${maxX}`;
+      } else {
+        where += `${filter.field} ${filter.operator === 'CONTAINS' ? 'LIKE' : 'NOT LIKE'} '%${filter.filter}%'`;
+      }
     });
     let order = '';
     if (params?.sort?.by) {
@@ -604,9 +614,20 @@ class SQLiteRecordCacheService extends RecordCacheService {
        OFFSET ${offset}
     `;
 
-    const results = await this.cacheDB.query(query, values);
+    let results = (await this.cacheDB.query(query, values))?.values ?? [];
+    if (spatialQueries.length > 0) {
+      results = results.filter((result) => {
+        const geojson = JSON.parse(result['GEOJSON']);
+        if (Object.hasOwn(geojson, 'length')) {
+          return geojson.every((shape: Feature) =>
+            spatialQueries.every((query) => booleanIntersects(shape, query.geojson))
+          );
+        }
+        return spatialQueries.every((spatialFilter) => booleanIntersects(spatialFilter.geojson, geojson));
+      });
+    }
     return (
-      results?.values?.map((record) => {
+      results.map((record) => {
         const parsedRecord: Record<PropertyKey, UserRecord | IappRecord> = {};
         Object.keys(record).forEach((key) => {
           if (['TABLE_DATA', 'RECORD_DATA', 'DATA', 'RECORD_DATA', 'GEOJSON', 'CENTROID'].includes(key)) {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- `NOT` operand functional for `.query()` functions
- Spatial queries working for `.query()` functions
    - Less optimal due to SQLite limitations. 
- Change filter disabling to disable by matching ID's
    - ShallowEqual doesn't work for Spatial Filters because of the 3-depth nested objects. 
    - IDs are unique and assigned at creation, so are suitable replacement.
- Update IFilter interface
    - add optional geojson key
- Refactor functions that use `.query` to also use `getRecordFilterObjectFromStateForAPI` 
    - Required due to limitation of the GeoJSON not being in the filter, but is mapped when needed
- Closes #4032 
- Closes #3981