### PR TITLE
[INV-4034] missing layer names

### DIFF
--- a/app/src/constants/offline_state_version.ts
+++ b/app/src/constants/offline_state_version.ts
@@ -1,5 +1,5 @@
 /*
   handle purging the offline storage on app version upgrade
 */
-export const CURRENT_MIGRATION_VERSION = 20250402;
+export const CURRENT_MIGRATION_VERSION = 20250422;
 export const MIGRATION_VERSION_KEY = '_persistedMigrationVersion';

--- a/app/src/state/reducers/map.ts
+++ b/app/src/state/reducers/map.ts
@@ -209,6 +209,7 @@ interface MapState {
   currentOpenSet: string | null;
   customizeLayersToggle: boolean;
   drawingCustomLayer: boolean;
+  drawingCustomLayerName: string;
   error: boolean;
   initialized: boolean;
   labelBoundsPolygon: any;
@@ -300,6 +301,7 @@ const initialState: MapState = {
   currentOpenSet: null,
   customizeLayersToggle: false,
   drawingCustomLayer: false,
+  drawingCustomLayerName: '',
   error: false,
   initialized: false,
   labelBoundsPolygon: undefined,
@@ -829,12 +831,15 @@ function createMapReducer(): (MapState, AnyAction) => MapState {
             draftState.clientBoundaries.push({
               id: nanoid(),
               geojson: action.payload,
-              toggle: true
+              toggle: true,
+              title: draftState.drawingCustomLayerName
             });
+            draftState.drawingCustomLayerName = '';
             break;
           }
           case DRAW_CUSTOM_LAYER: {
             draftState.drawingCustomLayer = true;
+            draftState.drawingCustomLayerName = action.payload.name;
             break;
           }
 


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Resolve issue where `CUSTOM LAYER` name gets lost between filling in input and drawing the shape for the layer.
- Closes #4034 