### PR TITLE
[N/A] Finish removing Categories Hook

### DIFF
--- a/app/src/UI/Overlay/Reports/EmbeddedReportsPage.tsx
+++ b/app/src/UI/Overlay/Reports/EmbeddedReportsPage.tsx
@@ -37,16 +37,6 @@ const EmbeddedReportsPage: React.FC = () => {
 
     api.listEmbeddedMetabaseReports().then((data) => {
       setReports(data.result);
-      setCategories(
-        data.result
-          .map((report) => report.category)
-          .reduce((all_categories, category) => {
-            if (!all_categories.includes(category)) {
-              return all_categories.concat(category);
-            }
-            return all_categories;
-          }, [])
-      );
       setLoading(false);
     });
   }, [authState?.authenticated]);


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- `[categories, setCategories]` were removed in an ESLint run, but setCategories still had a call in a useEffect. This removes that.
    - `categories` was unused before this lint run occurred

Error when opening Reports page
![image](https://github.com/user-attachments/assets/5a46a144-3d3c-4bee-9632-bd9b926e8411)
