### PR TITLE
[N/A] Minor Fixes

### DIFF
--- a/app/src/UI/Overlay/Records/RecordSet/RecordSet.css
+++ b/app/src/UI/Overlay/Records/RecordSet/RecordSet.css
@@ -126,7 +126,7 @@
   flex-direction: row;
   justify-content: center;
   color: white;
-  bottom: var(--footer-bar-height);
+  bottom: calc(var(--footer-bar-height) + env(safe-area-inset-bottom, 0));
   height: var(--record-table-footer-height);
   width: 100%;
   background-color: #036;

--- a/app/src/state/sagas/map/dataAccess.ts
+++ b/app/src/state/sagas/map/dataAccess.ts
@@ -141,7 +141,8 @@ export function* getIdsForRecordsetFromCache(action: IGetIdsForRecordset) {
       const queryObj: IQueryParams = {
         tableFilters: filters.tableFilters,
         recordSetType: filters.recordSetType,
-        selectColumns: ['id']
+        selectColumns: ['id'],
+        limit: 1000000 // Override 50k limit of query tool since known size is small.
       };
       const ids = yield service.query(queryObj);
       yield put(

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -436,5 +436,6 @@ export type {
   IQueryParams,
   CacheDownloadSpec,
   RecordCacheProgressCallbackParameters,
-  RecordSetSourceMetadata
+  RecordSetSourceMetadata,
+  RepositoryMetadata
 };


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):
- Adjust limit of `getIdsForRecordsetFromCache`, 50k default limit will cap out when creating IDList, showing artificial recordset limit in offline.
- Adjust CSS for RecordSetFooter to use the safe-area-inset value. 
    - @plasticviking Should be added before sending for App Review. 
- Export type that wasn't being exported (from previous ESLint run)