### PR TITLE
[INV-4074] Fix indexes of Herbicides

### DIFF
--- a/api/src/paths/activity.ts
+++ b/api/src/paths/activity.ts
@@ -403,6 +403,26 @@ function updateActivity(): RequestHandler {
     try {
       connection = await getDBConnection();
 
+      const isChemicalTreatment =
+        sanitizedActivityData.activity_type === 'Treatment' &&
+        sanitizedActivityData.activity_subtype.includes('Chemical');
+      /**
+       * UUIDs were appended to the Chemical Treatment Herbicides to ensure a proper render, and states updated correctly.
+       * Due to a Metabase report, its instrumental that the `index` key matches to what was in the array at the time.
+       * Keeping the key in line but pushing/popping causes awkward rerendering so UUIDs were introduced. To avoid plugging the DB, the UUIDs are removed before entering
+       */
+      if (isChemicalTreatment) {
+        const chemicalDetails = (sanitizedActivityData.activity_subtype_data as Record<PropertyKey, any>)
+          ?.chemical_treatment_details;
+        const herbicides = chemicalDetails.tank_mix
+          ? chemicalDetails?.tank_mix_object?.herbicides ?? []
+          : chemicalDetails?.herbicides ?? [];
+        herbicides.forEach((_, i) => {
+          herbicides[i].index = i;
+          delete herbicides[i]?.uuid;
+        });
+      }
+
       const sanitizedSearchCriteria: string = data.activity_id;
       const sqlStatementForCheck = getActivitySQL(sanitizedSearchCriteria);
 
@@ -462,22 +482,6 @@ function updateActivity(): RequestHandler {
           });
         }
       }
-      /*
-    if(response.rows[0].form_status === 'Submitted' && req?.body?.form_status === 'Draft') {
-          return res.status(400).json({
-            message: 'Invalid request, cannot convert back to draft from submitted',
-            request: req.body,
-            namespace: 'activity',
-            code: 401
-          });
-    }
-    */
-      /* disabled for now
-     if(response.rows[0].form_status === 'Submitted' && req?.body?.form_status === 'Draft') {
-       req.body.form_status = 'Submitted'
-       sanitizedActivityData.form_status = 'Submitted'
-     }
-     */
       const sqlStatements: IPutActivitySQL = putActivitySQL(sanitizedActivityData);
 
       if (!sqlStatements || !sqlStatements.createSQL) {

--- a/app/src/UI/Overlay/Records/Activity/form/ChemicalTreatmentDetailsForm/Components/accordions/HerbicidesAccordion.tsx
+++ b/app/src/UI/Overlay/Records/Activity/form/ChemicalTreatmentDetailsForm/Components/accordions/HerbicidesAccordion.tsx
@@ -26,16 +26,16 @@ const HerbicidesAccordion = ({ insideTankMix }: PropTypes) => {
           ? formDetails.form_data?.tank_mix_object?.herbicides?.map((herbicide) => (
               <Herbicide
                 insideTankMix={insideTankMix}
-                key={herbicide.index}
-                index={herbicide?.uuid ?? herbicide.index}
+                key={herbicide?.uuid ?? herbicide.index}
+                index={herbicide.index}
                 herbicide={herbicide}
               />
             ))
           : formDetails?.form_data?.herbicides?.map((herbicide) => (
               <Herbicide
                 insideTankMix={insideTankMix}
-                key={herbicide.index}
-                index={herbicide?.uuid ?? herbicide.index}
+                key={herbicide?.uuid ?? herbicide.index}
+                index={herbicide.index}
                 herbicide={herbicide}
               />
             ))}

--- a/app/src/UI/Overlay/Records/Activity/form/ChemicalTreatmentDetailsForm/Components/accordions/HerbicidesAccordion.tsx
+++ b/app/src/UI/Overlay/Records/Activity/form/ChemicalTreatmentDetailsForm/Components/accordions/HerbicidesAccordion.tsx
@@ -50,7 +50,7 @@ const HerbicidesAccordion = ({ insideTankMix }: PropTypes) => {
             if (insideTankMix) {
               setFormDetails((prevDetails) => {
                 const newHerbicidesArr = [...prevDetails.form_data.tank_mix_object.herbicides];
-                newHerbicidesArr.push({ index: newHerbicidesArr.length });
+                newHerbicidesArr.push({ index: newHerbicidesArr.length, uuid: nanoid() });
                 return {
                   ...prevDetails,
                   form_data: {
@@ -66,7 +66,7 @@ const HerbicidesAccordion = ({ insideTankMix }: PropTypes) => {
             } else {
               setFormDetails((prevDetails) => {
                 const newHerbicidesArr = [...prevDetails.form_data.herbicides];
-                newHerbicidesArr.push({ index: newHerbicidesArr.length });
+                newHerbicidesArr.push({ index: newHerbicidesArr.length, uuid: nanoid() });
                 return {
                   ...prevDetails,
                   form_data: {

--- a/app/src/UI/Overlay/Records/Activity/form/ChemicalTreatmentDetailsForm/Components/accordions/HerbicidesAccordion.tsx
+++ b/app/src/UI/Overlay/Records/Activity/form/ChemicalTreatmentDetailsForm/Components/accordions/HerbicidesAccordion.tsx
@@ -23,11 +23,21 @@ const HerbicidesAccordion = ({ insideTankMix }: PropTypes) => {
       <Typography variant="h5">Herbicides</Typography>
       <div id="herbicides_list">
         {insideTankMix
-          ? formDetails.form_data?.tank_mix_object?.herbicides?.map((herbicide, index) => (
-              <Herbicide insideTankMix={insideTankMix} key={herbicide.index} index={index} herbicide={herbicide} />
+          ? formDetails.form_data?.tank_mix_object?.herbicides?.map((herbicide) => (
+              <Herbicide
+                insideTankMix={insideTankMix}
+                key={herbicide.index}
+                index={herbicide?.uuid ?? herbicide.index}
+                herbicide={herbicide}
+              />
             ))
-          : formDetails?.form_data?.herbicides?.map((herbicide, index) => (
-              <Herbicide insideTankMix={insideTankMix} key={herbicide.index} index={index} herbicide={herbicide} />
+          : formDetails?.form_data?.herbicides?.map((herbicide) => (
+              <Herbicide
+                insideTankMix={insideTankMix}
+                key={herbicide.index}
+                index={herbicide?.uuid ?? herbicide.index}
+                herbicide={herbicide}
+              />
             ))}
       </div>
       <Box component="div">
@@ -35,10 +45,12 @@ const HerbicidesAccordion = ({ insideTankMix }: PropTypes) => {
           disabled={formDetails.disabled}
           id="btn_add_herbicide"
           onClick={() => {
+            /* Due to a metabase Report, we want to keep the Herbicides Array index in the Object.
+               But to prevent unnecessary Rererendering, we add the uuid key */
             if (insideTankMix) {
               setFormDetails((prevDetails) => {
                 const newHerbicidesArr = [...prevDetails.form_data.tank_mix_object.herbicides];
-                newHerbicidesArr.push({ index: nanoid() });
+                newHerbicidesArr.push({ index: newHerbicidesArr.length });
                 return {
                   ...prevDetails,
                   form_data: {
@@ -54,7 +66,7 @@ const HerbicidesAccordion = ({ insideTankMix }: PropTypes) => {
             } else {
               setFormDetails((prevDetails) => {
                 const newHerbicidesArr = [...prevDetails.form_data.herbicides];
-                newHerbicidesArr.push({ index: nanoid() });
+                newHerbicidesArr.push({ index: newHerbicidesArr.length });
                 return {
                   ...prevDetails,
                   form_data: {

--- a/app/src/UI/Overlay/Records/Activity/form/ChemicalTreatmentDetailsForm/Components/single-objects/Herbicide.tsx
+++ b/app/src/UI/Overlay/Records/Activity/form/ChemicalTreatmentDetailsForm/Components/single-objects/Herbicide.tsx
@@ -6,6 +6,8 @@ import { ChemicalTreatmentDetailsContext } from '../../ChemicalTreatmentDetailsC
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import isNumber from 'is-number';
 import { IHerbicide } from 'sharedAPI';
+import { shallowEqual } from 'react-redux';
+import { nanoid } from '@reduxjs/toolkit';
 
 enum ApplicationMethod {
   Spray,
@@ -155,11 +157,7 @@ const Herbicide = ({ herbicide, index, insideTankMix }: PropTypes) => {
 
   return (
     <div className={'herbicide_list_item'}>
-      <Typography variant="h5">
-        {optionValueLabels[herbicide.herbicide_code]
-          ? optionValueLabels[herbicide.herbicide_code]
-          : `Herbicide #${index + 1}`}
-      </Typography>
+      <Typography variant="h5">{optionValueLabels[herbicide.herbicide_code] ?? `Herbicide #${index + 1}`}</Typography>
       <div className="input-field">
         <Tooltip
           style={{ float: 'right', marginBottom: 5, color: 'rgb(170, 170, 170)' }}
@@ -178,10 +176,7 @@ const Herbicide = ({ herbicide, index, insideTankMix }: PropTypes) => {
           label={'Herbicide Type'}
           parentState={{ herbicide, setCurrentHerbicide }}
           onChange={(_: ChangeEvent, value) => {
-            if (value === null) {
-              return;
-            }
-
+            if (value == null) return;
             setCurrentHerbicide((prevHerbicide) => ({ ...prevHerbicide, herbicide_type_code: value.value }));
           }}
         />
@@ -203,12 +198,8 @@ const Herbicide = ({ herbicide, index, insideTankMix }: PropTypes) => {
           actualValue={herbicide.herbicide_code}
           parentState={{ herbicide, setCurrentHerbicide }}
           onChange={(_: ChangeEvent, value) => {
-            if (value === null) {
-              return;
-            }
-            setCurrentHerbicide((prevHerbicide) => {
-              return { ...prevHerbicide, herbicide_code: value.value };
-            });
+            if (value == null) return;
+            setCurrentHerbicide((prevHerbicide) => ({ ...prevHerbicide, herbicide_code: value.value }));
           }}
         />
       </div>
@@ -230,9 +221,7 @@ const Herbicide = ({ herbicide, index, insideTankMix }: PropTypes) => {
             actualValue={herbicide.calculation_type}
             parentState={{ herbicide, setCurrentHerbicide }}
             onChange={(_: ChangeEvent, value) => {
-              if (value === null) {
-                return;
-              }
+              if (value == null) return;
               setCurrentHerbicide((prevHerbicide) => ({ ...prevHerbicide, calculation_type: value.value }));
             }}
           />
@@ -556,10 +545,20 @@ const Herbicide = ({ herbicide, index, insideTankMix }: PropTypes) => {
         disabled={formDetails.disabled}
         onClick={() => {
           if (insideTankMix) {
+            /**
+             * UUIDs were appended to the Chemical Treatment Herbicides to ensure a proper render, and states updated correctly.
+             * Due to a Metabase report, its instrumental that the `index` key matches to what was in the array at the time.
+             * Keeping the key in line but pushing/popping causes awkward rerendering so UUIDs were introduced. To avoid plugging the DB, the UUIDs are removed before entering
+             */
             setFormDetails((prevDetails) => {
-              const newHerbicidesArr = [...prevDetails.form_data.tank_mix_object.herbicides];
-              const sliceIndex = newHerbicidesArr.findIndex((herb) => herb.index === herbicide.index);
-              newHerbicidesArr.splice(sliceIndex, 1);
+              const newHerbicidesArr = prevDetails.form_data.tank_mix_object.herbicides.map((h) => ({ ...h }));
+              const sliceIndex = newHerbicidesArr.findIndex((herb) => shallowEqual(herb, herbicide));
+              if (sliceIndex !== -1) {
+                newHerbicidesArr.splice(sliceIndex, 1);
+                newHerbicidesArr.forEach(
+                  (_, i) => (newHerbicidesArr[i] = { uuid: nanoid(), ...newHerbicidesArr[i], index: i })
+                );
+              }
               return {
                 ...prevDetails,
                 form_data: {
@@ -573,9 +572,14 @@ const Herbicide = ({ herbicide, index, insideTankMix }: PropTypes) => {
             });
           } else {
             setFormDetails((prevDetails) => {
-              const newHerbicidesArr = [...prevDetails.form_data.herbicides];
-              const sliceIndex = newHerbicidesArr.findIndex((herb) => herb.index === herbicide.index);
-              newHerbicidesArr.splice(sliceIndex, 1);
+              const newHerbicidesArr = prevDetails.form_data.herbicides.map((h) => ({ ...h }));
+              const sliceIndex = newHerbicidesArr.findIndex((herb) => shallowEqual(herb, herbicide));
+              if (sliceIndex !== -1) {
+                newHerbicidesArr.splice(sliceIndex, 1);
+                newHerbicidesArr.forEach(
+                  (_, i) => (newHerbicidesArr[i] = { uuid: nanoid(), ...newHerbicidesArr[i], index: i })
+                );
+              }
               return {
                 ...prevDetails,
                 form_data: { ...prevDetails.form_data, herbicides: newHerbicidesArr }


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

## Background

Three months ago a fix was made where the indexes of Herbicides in Chemical Treatments would overwrite each other because their sequence was based on the current length of the array. So if it was the 4th entry, it became `herbicide.index 4`
Problem with that was that the if you delete an item and add a new one, you have another object with index 4.
The solution for this was to use `nanoid()` as it as unique, and fixed a lot of rendering issues, and let the correct objects get deleted as map `key` values were getting confused, wiping fields, deleting wrong entries and causing issue.

Now it is mentioned that the true purpose of the index keys was for metabase records. With new details brought up now, a fix had to be made to satisfy requirements

> [!IMPORTANT]
> The current implementation with nanoids is `breaking` but no records have been made in 3 months to have caught it previously

1. The index key needs to match the array index (Previously this would fail for earlier mentioned reasons)
    - This was mentioned as a very niche edge case in the metabase records where trying to do it through SQL would fail. by @brennanwebster  
2. We `need` a unique identifier to ensure things are rendering properly
3. It was specifically `requested` we don't save the UUIDs to the DB.

Given that scenario. this is the solution:

- On the frontend, Add a UUID to ensure things are rendering as expected. This is important when items are being added or removed (the source of the woe)
- When an item is deleted, update the index keys of all objects to ensure they match).
- When the record is submitted to the API, Remove the UUID from Herbicides.
- Add comments explaining this so the next dev to see this understands why.
 