### PR TITLE
[INV-4078] Fix renders based on user state

### DIFF
--- a/api/src/paths/activity.ts
+++ b/api/src/paths/activity.ts
@@ -271,10 +271,16 @@ function createActivity(): RequestHandler {
   return async (req: InvasivesRequest, res) => {
     defaultLog.debug({ label: 'activity', message: 'createActivity', body: req.params });
 
+    if (!req.authContext.roles || req.authContext.roles.length === 0) {
+      return res.status(401).json({
+        message: 'Unauthorized, user lacks sufficient roles',
+        namespace: 'activity',
+        code: 401
+      });
+    }
     const data = { ...req.body, media_keys: req['media_keys'], user_role: req.authContext?.roles[0] };
 
     const sanitizedActivityData = new ActivityPostRequestBody(data);
-
     if (!(req.authContext && req.authContext.preferredUsername && req.authContext.friendlyUsername)) {
       return res.status(401).json({
         message: 'Invalid request, authContext provides insufficient data to complete record metadata',

--- a/app/src/UI/AppLayout/ComponentizedMapLayout.tsx
+++ b/app/src/UI/AppLayout/ComponentizedMapLayout.tsx
@@ -11,13 +11,13 @@ import CommonPrefixComponents from 'UI/AppLayout/Components/CommonPrefixComponen
 import CommonPostfixComponents from 'UI/AppLayout/Components/CommonPostfixComponents';
 
 const ComponentizedMapLayout = () => {
-  const authenticated = useSelector((state) => state.Auth.authenticated);
+  const loggedInOrWorkingOffline = useSelector((state) => state.Auth.loggedInOrWorkingOffline);
 
   return (
     <MapProvider>
       <CommonPrefixComponents />
 
-      {!authenticated ? (
+      {!loggedInOrWorkingOffline ? (
         <MainMap>
           <Overlay>
             <OverlayContent />

--- a/app/src/UI/Header/Header.tsx
+++ b/app/src/UI/Header/Header.tsx
@@ -71,7 +71,7 @@ const Tab: React.FC<TabProps> = ({ predicate, platform, children, path, label, p
 
   const dispatch = useDispatch();
   const authenticated = useSelector((state) => state.Auth.authenticated && state?.Auth.roles.length > 0);
-  const { workingOffline, loggedInOrWorkingOffline } = useSelector(selectAuth);
+  const { workingOffline, loggedInOrWorkingOffline, roles } = useSelector(selectAuth);
 
   const canDisplayCallBack = useCallback(() => {
     if (platform === 'mobile' && !MOBILE) {
@@ -93,7 +93,7 @@ const Tab: React.FC<TabProps> = ({ predicate, platform, children, path, label, p
       case 'working_offline':
         return workingOffline;
       case 'authenticated_any':
-        return loggedInOrWorkingOffline;
+        return loggedInOrWorkingOffline && roles.length > 0;
     }
   }, [authenticated, workingOffline, predicate, platform, MOBILE, JSON.stringify(path)]);
 

--- a/app/src/UI/Header/Header.tsx
+++ b/app/src/UI/Header/Header.tsx
@@ -71,7 +71,7 @@ const Tab: React.FC<TabProps> = ({ predicate, platform, children, path, label, p
 
   const dispatch = useDispatch();
   const authenticated = useSelector((state) => state.Auth.authenticated && state?.Auth.roles.length > 0);
-  const { workingOffline, loggedInOrWorkingOffline, roles } = useSelector(selectAuth);
+  const { workingOffline, loggedInOrWorkingOffline } = useSelector(selectAuth);
 
   const canDisplayCallBack = useCallback(() => {
     if (platform === 'mobile' && !MOBILE) {

--- a/app/src/UI/Header/Header.tsx
+++ b/app/src/UI/Header/Header.tsx
@@ -296,7 +296,7 @@ const LoginOrOutMemo = React.memo(() => {
   useEffect(() => {
     if (!MOBILE) {
       setOfflineUserSelectionAvailable(false);
-    } else if (loggedInOrWorkingOffline) {
+    } else if (authenticated || workingOffline) {
       setOfflineUserSelectionAvailable(false);
     } else if (offlineUsers.length > 0) {
       setOfflineUserSelectionAvailable(true);
@@ -384,7 +384,7 @@ const LoginOrOutMemo = React.memo(() => {
           <LoginButton labelText={'Go Online (IDIR)'} idpHint={'idir'} key={'idir-go'} />,
           <LoginButton labelText={'Login (BCEID Business)'} idpHint={'bceidbusiness'} key={'bceidbusiness-go'} />
         ]}
-        {loggedInOrWorkingOffline ? (
+        {authenticated || workingOffline ? (
           <LogoutButton />
         ) : (
           [

--- a/app/src/UI/Header/Header.tsx
+++ b/app/src/UI/Header/Header.tsx
@@ -93,7 +93,7 @@ const Tab: React.FC<TabProps> = ({ predicate, platform, children, path, label, p
       case 'working_offline':
         return workingOffline;
       case 'authenticated_any':
-        return loggedInOrWorkingOffline && roles.length > 0;
+        return loggedInOrWorkingOffline;
     }
   }, [authenticated, workingOffline, predicate, platform, MOBILE, JSON.stringify(path)]);
 

--- a/app/src/UI/LegacyMap/Controls/ButtonContainer.tsx
+++ b/app/src/UI/LegacyMap/Controls/ButtonContainer.tsx
@@ -13,31 +13,34 @@ import { PrimaryLayerSelect } from 'UI/LegacyMap/Controls/PrimaryLayerSelect';
 import { RecordSetType } from 'interfaces/UserRecordSet';
 
 export const ButtonContainer = () => {
-  const { authenticated, workingOffline } = useSelector((state) => state.Auth);
+  const { loggedInOrWorkingOffline } = useSelector((state) => state.Auth);
   const { positionTracking } = useSelector((state) => state.Map);
 
   return (
     <div id="map-btn-container">
       <PrimaryLayerSelect />
 
-      {(authenticated || workingOffline) && <FindMeToggle />}
-      {positionTracking && <TrackingButtonsContainer />}
+      {loggedInOrWorkingOffline && (
+        <>
+          <FindMeToggle />
+          {positionTracking && <TrackingButtonsContainer />}
 
-      <WebOnly>
-        <LegendsButton />
-      </WebOnly>
+          <WebOnly>
+            <LegendsButton />
+          </WebOnly>
 
-      <AccuracyToggle />
+          <AccuracyToggle />
 
-      {(authenticated || workingOffline) && <WhatsHereButton />}
+          <WhatsHereButton />
+          <NewRecord />
 
-      {(authenticated || workingOffline) && <NewRecord />}
-
-      <WebOnly>
-        {authenticated && <CenterCurrentRecord type={RecordSetType.Activity} />}
-        {authenticated && <CenterCurrentRecord type={RecordSetType.IAPP} />}
-        <QuickPanToRecordToggle />
-      </WebOnly>
+          <WebOnly>
+            <CenterCurrentRecord type={RecordSetType.Activity} />
+            <CenterCurrentRecord type={RecordSetType.IAPP} />
+            <QuickPanToRecordToggle />
+          </WebOnly>
+        </>
+      )}
     </div>
   );
 };

--- a/app/src/UI/LegacyMap/Map.tsx
+++ b/app/src/UI/LegacyMap/Map.tsx
@@ -325,7 +325,7 @@ export const Map = ({ children }) => {
 
   useEffect(() => {
     if (!mapReady) return;
-    if (authenticated) {
+    if (authenticated && loggedInOrWorkingOffline) {
       addServerBoundariesIfNotExists(serverBoundaries, map);
       refreshServerBoundariesOnToggle(serverBoundaries, map);
     }

--- a/app/src/UI/Overlay/WhatsHere/Subcomponents/RenderTableActivity.tsx
+++ b/app/src/UI/Overlay/WhatsHere/Subcomponents/RenderTableActivity.tsx
@@ -13,7 +13,7 @@ type PropTypes = {
 
 const RenderTableActivity = ({ setAnchorEl }: PropTypes) => {
   const dispatch = useDispatch();
-  const { loggedInOrWorkingOffline, roles } = useSelector((state) => state.Auth);
+  const { loggedInOrWorkingOffline } = useSelector((state) => state.Auth);
   const whatsHere = useSelector((state) => state.Map?.whatsHere);
 
   const dispatchUpdatedID = (params) => {
@@ -93,7 +93,7 @@ const RenderTableActivity = ({ setAnchorEl }: PropTypes) => {
               dispatch(WhatsHere.sort_filter_update(RecordSetType.Activity, c.field));
             }}
             onCellClick={(params, evt: MuiEvent<MouseEvent | TouchEvent>) => {
-              if (loggedInOrWorkingOffline && roles.length > 0) {
+              if (loggedInOrWorkingOffline) {
                 setAnchorEl(evt.currentTarget as HTMLElement);
                 highlightActivity(params);
               }

--- a/app/src/UI/Overlay/WhatsHere/Subcomponents/RenderTablePOI.tsx
+++ b/app/src/UI/Overlay/WhatsHere/Subcomponents/RenderTablePOI.tsx
@@ -12,7 +12,7 @@ type PropTypes = {
 };
 const RenderTablePOI = ({ setAnchorEl }: PropTypes) => {
   const dispatch = useDispatch();
-  const { loggedInOrWorkingOffline, roles } = useSelector((state) => state.Auth);
+  const { loggedInOrWorkingOffline } = useSelector((state) => state.Auth);
   const whatsHere = useSelector((state) => state.Map?.whatsHere);
 
   const dispatchUpdatedID = (params) => {
@@ -79,7 +79,7 @@ const RenderTablePOI = ({ setAnchorEl }: PropTypes) => {
               dispatch(WhatsHere.sort_filter_update(RecordSetType.IAPP, c.field));
             }}
             onCellClick={(params: GridCellParams, event: MuiEvent<MouseEvent | TouchEvent>) => {
-              if (loggedInOrWorkingOffline && roles.length > 0) {
+              if (loggedInOrWorkingOffline) {
                 setAnchorEl(event.currentTarget as HTMLElement);
                 highlightPOI(params);
               }

--- a/app/src/state/reducers/auth.ts
+++ b/app/src/state/reducers/auth.ts
@@ -151,7 +151,6 @@ function loadCurrentStateFromIdToken(idToken: string): object {
   const authenticated = !!idToken;
 
   if (authenticated) {
-    loggedInOrWorkingOffline = true;
     try {
       const parsedToken = JSON.parse(
         decodeURIComponent(
@@ -270,7 +269,7 @@ function createAuthReducer(_configuration: AppConfig) {
           draftState.username = found.username;
           draftState.displayName = found.displayName;
           draftState.workingOffline = true;
-          draftState.loggedInOrWorkingOffline = true;
+          draftState.loggedInOrWorkingOffline = found.roles.length > 0;
         }
       } else if (AuthActions.initializeComplete.match(action)) {
         draftState.initialized = true;
@@ -335,6 +334,7 @@ function createAuthReducer(_configuration: AppConfig) {
       } else if (AuthActions.refreshRolesComplete.match(action)) {
         const { all_roles, roles, extendedInfo, v2BetaAccess } = action.payload;
         draftState.roles = roles;
+        draftState.loggedInOrWorkingOffline = roles.length > 0;
         draftState.accessRoles = computeAccessRoles(all_roles, roles);
         draftState.extendedInfo = extendedInfo;
         draftState.rolesInitialized = true;

--- a/app/src/state/sagas/map/layer-eligibility.ts
+++ b/app/src/state/sagas/map/layer-eligibility.ts
@@ -15,20 +15,19 @@ function* recomputeEligibleMapLayers(action) {
     return;
   }
 
-  const WORKING_OFFLINE = yield select((state) => (state as RootState).Auth.workingOffline);
-  const ONLINE_AUTHENTICATED = yield select((state) => (state as RootState).Auth.authenticated);
+  const loggedInOrWorkingOffline = yield select((state) => state.Auth.loggedInOrWorkingOffline);
 
-  const AUTHENTICATED = WORKING_OFFLINE || ONLINE_AUTHENTICATED;
+  const AUTHENTICATED = loggedInOrWorkingOffline;
 
-  const CONNECTED = yield select((state) => (state as RootState).Network.connected);
+  const CONNECTED = yield select((state) => state.Network.connected);
 
-  const CURRENT_ELIGIBLE_BASEMAP_LIST = yield select((state) => (state as RootState).Map.availableBaseMapLayers);
-  const CURRENT_ELIGIBLE_OVERLAY_LIST = yield select((state) => (state as RootState).Map.availableOverlayLayers);
+  const CURRENT_ELIGIBLE_BASEMAP_LIST = yield select((state) => state.Map.availableBaseMapLayers);
+  const CURRENT_ELIGIBLE_OVERLAY_LIST = yield select((state) => state.Map.availableOverlayLayers);
 
   const UPDATED_BASEMAP_LIST: string[] = [];
   const UPDATED_OVERLAY_LIST: string[] = [];
 
-  const offlineDefinitions = (yield select((state) => (state as RootState).TileCache?.mapSpecifications)) || [];
+  const offlineDefinitions = (yield select((state) => state.TileCache?.mapSpecifications)) ?? [];
 
   // evaluate each potential map definition and remove those not eligible at this moment
   for (const l of [...MAP_DEFINITIONS, ...offlineDefinitions] as MapSourceAndLayerDefinition[]) {

--- a/app/src/state/sagas/map/layer-eligibility.ts
+++ b/app/src/state/sagas/map/layer-eligibility.ts
@@ -4,7 +4,6 @@ import {
   MapSourceAndLayerDefinition,
   MapSourceAndLayerDefinitionMode
 } from 'UI/LegacyMap/helpers/functional/layer-definitions';
-import { RootState } from 'state/reducers/rootReducer';
 import { MOBILE } from 'state/build-time-config';
 import MapActions from 'state/actions/map';
 


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Base `loggedInOrWorkingOffline` on userRoles to better differentiate online/offline status
- Prevent UI components from rendering to `non-registered` users
    - Components did not allow access to anything, but presented lots of dead ends and blank pages.
- Closes #4078 