### PR TITLE
Add Android memory report to status bar

### DIFF
--- a/app/android/app/src/main/java/bc/gov/invasivesbc/AuthBridge.java
+++ b/app/android/app/src/main/java/bc/gov/invasivesbc/AuthBridge.java
@@ -23,12 +23,9 @@ import net.openid.appauth.AuthorizationService;
 import net.openid.appauth.AuthorizationServiceConfiguration;
 import net.openid.appauth.ResponseTypeValues;
 
-import org.json.JSONException;
-
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;

--- a/app/android/app/src/main/java/bc/gov/invasivesbc/DeviceInformation.java
+++ b/app/android/app/src/main/java/bc/gov/invasivesbc/DeviceInformation.java
@@ -1,0 +1,34 @@
+package bc.gov.invasivesbc;
+
+import static android.content.Context.ACTIVITY_SERVICE;
+
+import android.app.ActivityManager;
+
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+
+@CapacitorPlugin(name = "DeviceInformation")
+
+public class DeviceInformation extends Plugin {
+
+
+  final Runtime runtime = Runtime.getRuntime();
+
+  @PluginMethod()
+  public void deviceCharacteristics(PluginCall call) {
+
+    ActivityManager.MemoryInfo memoryInfo = new ActivityManager.MemoryInfo();
+    ActivityManager activityManager = (ActivityManager) this.getContext().getSystemService(ACTIVITY_SERVICE);
+    activityManager.getMemoryInfo(memoryInfo);
+
+    JSObject ret = new JSObject();
+    ret.put("totalBytes", memoryInfo.totalMem);
+    ret.put("availableBytes", memoryInfo.availMem);
+    ret.put("lowMemoryCondition", memoryInfo.lowMemory);
+
+    call.resolve(ret);
+  }
+}

--- a/app/android/app/src/main/java/bc/gov/invasivesbc/MainActivity.java
+++ b/app/android/app/src/main/java/bc/gov/invasivesbc/MainActivity.java
@@ -8,6 +8,7 @@ public class MainActivity extends BridgeActivity {
   @Override
   public void onCreate(Bundle savedInstanceState) {
     registerPlugin(AuthBridge.class);
+    registerPlugin(DeviceInformation.class);
     super.onCreate(savedInstanceState);
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -142,7 +142,7 @@
   },
   "scripts": {
     "pre-commit": "lint-staged",
-    "build:android": "cross-env CONFIGURATION_SOURCE=Provided VITE_DEBUG=FALSE VITE_MOBILE=TRUE VITE_TARGET_PLATFORM=android vite build --emptyOutDir",
+    "build:android": "cross-env CONFIGURATION_SOURCE=Provided VITE_DEBUG=TRUE VITE_MOBILE=TRUE VITE_TARGET_PLATFORM=android vite build --emptyOutDir",
     "build:ios": "cross-env CONFIGURATION_SOURCE=Provided VITE_DEBUG=FALSE VITE_MOBILE=TRUE VITE_TARGET_PLATFORM=ios vite build --emptyOutDir",
     "test": "cross-env CONFIGURATION_SOURCE=Provided VITE_MOBILE=FALSE vitest --config vitest.config.ts",
     "state_test_coverage": "cross-env CONFIGURATION_SOURCE=Provided vitest run --coverage --coverage.include=state/**/*.ts --config vitest.config.ts",

--- a/app/src/UI/Header/Mobile/AndroidMemoryReport.css
+++ b/app/src/UI/Header/Mobile/AndroidMemoryReport.css
@@ -1,0 +1,21 @@
+div.memory-report {
+  color: white;
+  padding: 0;
+  margin: 0;
+
+  dl {
+    font-family: monospace;
+    font-size: 8px;
+    line-height: 1.1;
+
+    dt {
+      padding: 0;
+      margin: 0;
+    }
+
+    dd {
+      padding: 0;
+      margin: 0;
+    }
+  }
+}

--- a/app/src/UI/Header/Mobile/AndroidMemoryReport.tsx
+++ b/app/src/UI/Header/Mobile/AndroidMemoryReport.tsx
@@ -1,0 +1,39 @@
+import { useDispatch, useSelector } from 'utils/use_selector';
+import { useEffect } from 'react';
+import EventActions from 'state/actions/events/EventActions';
+import './AndroidMemoryReport.css';
+
+const AndroidMemoryReport = () => {
+  const memoryInformation = useSelector((state) => state.AppMode.constraints.memory);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(EventActions.deviceMemoryReport());
+  }, []);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      dispatch(EventActions.deviceMemoryReport());
+    }, 2000);
+    return () => {
+      clearInterval(id);
+    };
+  }, []);
+
+  if (!memoryInformation) {
+    return <div className={'memory-report'}>Device Memory Information Not Available</div>;
+  }
+  return (
+    <div className={'memory-report'}>
+      <dl>
+        <dt>total mem MiB</dt>
+        <dd>{`${Math.floor(memoryInformation.totalBytes / (1024 * 1024))}`}</dd>
+        <dt>available mem MiB</dt>
+        <dd>{`${Math.floor(memoryInformation.availableBytes / (1024 * 1024))}`}</dd>
+        <dt>low memory condition</dt>
+        <dd>{memoryInformation.lowMemoryCondition ? 'YES' : 'NO'}</dd>
+      </dl>
+    </div>
+  );
+};
+export { AndroidMemoryReport };

--- a/app/src/UI/Header/Mobile/MobileHeader.tsx
+++ b/app/src/UI/Header/Mobile/MobileHeader.tsx
@@ -7,6 +7,8 @@ import { useSelector } from 'utils/use_selector';
 import { Home, Map } from '@mui/icons-material';
 import HeaderPopover from 'UI/Header/Mobile/HeaderPopover';
 import { OfflineSyncHeaderButton } from 'UI/Header/OfflineSyncHeaderButton';
+import { AndroidMemoryReport } from 'UI/Header/Mobile/AndroidMemoryReport';
+import { Platform, PLATFORM } from 'state/build-time-config';
 
 const MobileHeader = () => {
   const activeIAPP = useSelector((state) => state.UserSettings.activeIAPP) || undefined;
@@ -77,6 +79,7 @@ const MobileHeader = () => {
         </NavTab>
         <OfflineSyncHeaderButton />
       </nav>
+      {PLATFORM == Platform.ANDROID && <AndroidMemoryReport />}
       <HeaderPopover />
     </header>
   );

--- a/app/src/state/actions/events/EventActions.ts
+++ b/app/src/state/actions/events/EventActions.ts
@@ -1,4 +1,6 @@
-import { createAction } from '@reduxjs/toolkit';
+import { createAction, createAsyncThunk } from '@reduxjs/toolkit';
+import DeviceInformation from 'utils/memory-report/memoryReport';
+import { Platform, PLATFORM } from 'state/build-time-config';
 
 interface ViewportResizePayload {
   width: number;
@@ -11,6 +13,12 @@ class EventActions {
   /* fired for window.onfocus and window.visibilitychange (with document.hidden == false). for detecting wakeups on mobile. */
   static readonly wakeup = createAction(`${this.PREFIX}/wakeup`);
   static readonly viewportResize = createAction<ViewportResizePayload>(`${this.PREFIX}/viewportResize`);
+  static readonly deviceMemoryReport = createAsyncThunk(`${this.PREFIX}/deviceMemoryReport`, async () => {
+    if (PLATFORM !== Platform.ANDROID) {
+      throw new Error('This action is only meaningful on Android');
+    }
+    return await DeviceInformation.deviceCharacteristics({});
+  });
 }
 
 export default EventActions;

--- a/app/src/state/reducers/appMode.ts
+++ b/app/src/state/reducers/appMode.ts
@@ -1,6 +1,7 @@
 import { createNextState } from '@reduxjs/toolkit';
 import { SET_APP_MODE, TOGGLE_PANEL, URL_CHANGE } from 'state/actions';
 import EventActions from 'state/actions/events/EventActions';
+import { DeviceMemoryInformation } from 'utils/memory-report/memoryReport';
 
 enum appModeEnum {
   'Records',
@@ -17,6 +18,7 @@ interface AppModeState {
   panelFullScreen: boolean;
   url: string | null;
   constraints: {
+    memory: DeviceMemoryInformation | null;
     screenWidth: number | undefined;
     tinyScreen: boolean;
   };
@@ -28,6 +30,7 @@ const initialState: AppModeState = {
   panelFullScreen: false,
   url: null,
   constraints: {
+    memory: null,
     screenWidth: window.innerWidth,
     tinyScreen: window.innerWidth < 400
   }
@@ -38,8 +41,17 @@ export default function appMode(state = initialState, action: any): AppModeState
     return {
       ...state,
       constraints: {
+        ...state.constraints,
         screenWidth: action.payload.width,
         tinyScreen: action.payload.width < 500
+      }
+    };
+  } else if (EventActions.deviceMemoryReport.fulfilled.match(action)) {
+    return {
+      ...state,
+      constraints: {
+        ...state.constraints,
+        memory: action.payload
       }
     };
   } else {

--- a/app/src/state/store.ts
+++ b/app/src/state/store.ts
@@ -104,7 +104,7 @@ export function setupStore(configuration: AppConfig) {
   document.addEventListener('focus', () => {
     store.dispatch(EventActions.wakeup());
   });
-  
+
   // throttled updates. used to control some layouts (eg alternative button text on very tiny screens)
   const debouncedResize = debounce(() => {
     store.dispatch(EventActions.viewportResize({ width: window.innerWidth, height: window.innerHeight }));

--- a/app/src/utils/memory-report/memoryReport.ts
+++ b/app/src/utils/memory-report/memoryReport.ts
@@ -1,0 +1,16 @@
+import { registerPlugin } from '@capacitor/core';
+
+interface DeviceMemoryInformation {
+  availableBytes: number;
+  totalBytes: number;
+  lowMemoryCondition: boolean;
+}
+
+interface DeviceInformationPlugin {
+  deviceCharacteristics(options: Record<string, never>): Promise<DeviceMemoryInformation>;
+}
+
+const DeviceInformation = registerPlugin<DeviceInformationPlugin>('DeviceInformation');
+
+export default DeviceInformation;
+export type { DeviceMemoryInformation };


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Add a status display on Android, with periodically updating device memory information
<img width="838" alt="Screenshot 2025-05-06 at 20 23 27" src="https://github.com/user-attachments/assets/1ba04ccf-c671-4f31-b1ad-be62d87ab1c4" />
- No impact on other platforms

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
