### PR TITLE
[INV-4078] Fix renders based on user state

### DIFF
--- a/api/src/paths/activity.ts
+++ b/api/src/paths/activity.ts
@@ -271,6 +271,13 @@ function createActivity(): RequestHandler {
   return async (req: InvasivesRequest, res) => {
     defaultLog.debug({ label: 'activity', message: 'createActivity', body: req.params });
 
+    if (!req.authContext.roles || req.authContext.roles.length === 0) {
+      return res.status(401).json({
+        message: 'Unauthorized, user lacks sufficient roles',
+        namespace: 'activity',
+        code: 401
+      });
+    }
     const data = { ...req.body, media_keys: req['media_keys'], user_role: req.authContext?.roles[0] };
 
     const sanitizedActivityData = new ActivityPostRequestBody(data);

--- a/app/src/UI/AppLayout/ComponentizedMapLayout.tsx
+++ b/app/src/UI/AppLayout/ComponentizedMapLayout.tsx
@@ -11,13 +11,13 @@ import CommonPrefixComponents from 'UI/AppLayout/Components/CommonPrefixComponen
 import CommonPostfixComponents from 'UI/AppLayout/Components/CommonPostfixComponents';
 
 const ComponentizedMapLayout = () => {
-  const authenticated = useSelector((state) => state.Auth.authenticated);
+  const loggedInOrWorkingOffline = useSelector((state) => state.Auth.loggedInOrWorkingOffline);
 
   return (
     <MapProvider>
       <CommonPrefixComponents />
 
-      {!authenticated ? (
+      {!loggedInOrWorkingOffline ? (
         <MainMap>
           <Overlay>
             <OverlayContent />

--- a/app/src/UI/Header/Mobile/HeaderPopover.tsx
+++ b/app/src/UI/Header/Mobile/HeaderPopover.tsx
@@ -14,6 +14,7 @@ import MapActions from 'state/actions/map';
 import { TOGGLE_PANEL } from 'state/actions';
 import { selectAuth } from 'state/reducers/auth';
 import 'UI/Header/Mobile/MobileHeader.css';
+import { MOBILE } from 'state/build-time-config';
 
 const LogoutButton = () => {
   const dispatch = useDispatch();
@@ -85,13 +86,14 @@ const HeaderPopover = () => {
   const loginInProgress = useSelector((state) => state.Auth.loginInProgress);
   const [offlineUserSelectionAvailable, setOfflineUserSelectionAvailable] = useState(false);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
   useEffect(() => {
-    if (loggedInOrWorkingOffline) {
+    if (!MOBILE || authenticated || workingOffline) {
       setOfflineUserSelectionAvailable(false);
     } else if (offlineUsers.length > 0) {
       setOfflineUserSelectionAvailable(true);
     }
-  }, [offlineUsers, loggedInOrWorkingOffline]);
+  }, [offlineUsers, authenticated, workingOffline]);
 
   return (
     <>
@@ -147,7 +149,7 @@ const HeaderPopover = () => {
                 disabled={loginInProgress}
               />
             ]}
-            {loggedInOrWorkingOffline ? (
+            {authenticated || workingOffline ? (
               <LogoutButton />
             ) : (
               [

--- a/app/src/UI/Header/Mobile/MobileHeader.css
+++ b/app/src/UI/Header/Mobile/MobileHeader.css
@@ -23,9 +23,13 @@
   max-width: 500px;
   padding: 0;
   width: 100%;
-  .offlineSyncButton svg {
-    display: flex;
-    height: 100%;
+  .offlineSyncButton {
+    margin-bottom: auto;
+    margin-top: auto;
+    svg {
+      display: flex;
+      height: 100%;
+    }
   }
   & > * {
     display: flex;

--- a/app/src/UI/Header/Mobile/MobileHeader.tsx
+++ b/app/src/UI/Header/Mobile/MobileHeader.tsx
@@ -11,7 +11,7 @@ import { OfflineSyncHeaderButton } from 'UI/Header/OfflineSyncHeaderButton';
 const MobileHeader = () => {
   const activeIAPP = useSelector((state) => state.UserSettings.activeIAPP) || undefined;
   const activeActivity = useSelector((state) => state.UserSettings.activeActivity) || undefined;
-
+  const loggedInOrWorkingOffline = useSelector((state) => state.Auth.loggedInOrWorkingOffline);
   const isCellPhoneWidth = useSelector((state) => state.AppMode.constraints.tinyScreen);
 
   return (
@@ -75,7 +75,7 @@ const MobileHeader = () => {
             style={{ marginBottom: '0px', maxWidth: '20px', objectFit: 'contain' }}
           />
         </NavTab>
-        <OfflineSyncHeaderButton />
+        {loggedInOrWorkingOffline && <OfflineSyncHeaderButton />}
       </nav>
       <HeaderPopover />
     </header>

--- a/app/src/UI/LegacyMap/Controls/ButtonContainer.tsx
+++ b/app/src/UI/LegacyMap/Controls/ButtonContainer.tsx
@@ -13,31 +13,32 @@ import { PrimaryLayerSelect } from 'UI/LegacyMap/Controls/PrimaryLayerSelect';
 import { RecordSetType } from 'interfaces/UserRecordSet';
 
 export const ButtonContainer = () => {
-  const { authenticated, workingOffline } = useSelector((state) => state.Auth);
+  const { loggedInOrWorkingOffline } = useSelector((state) => state.Auth);
   const { positionTracking } = useSelector((state) => state.Map);
 
   return (
     <div id="map-btn-container">
       <PrimaryLayerSelect />
+      {loggedInOrWorkingOffline && (
+        <>
+          <FindMeToggle />
+          {positionTracking && <TrackingButtonsContainer />}
 
-      {(authenticated || workingOffline) && <FindMeToggle />}
-      {positionTracking && <TrackingButtonsContainer />}
+          <WebOnly>
+            <LegendsButton />
+          </WebOnly>
 
-      <WebOnly>
-        <LegendsButton />
-      </WebOnly>
+          <AccuracyToggle />
+          <WhatsHereButton />
+          <NewRecord />
 
-      <AccuracyToggle />
-
-      {(authenticated || workingOffline) && <WhatsHereButton />}
-
-      {(authenticated || workingOffline) && <NewRecord />}
-
-      <WebOnly>
-        {authenticated && <CenterCurrentRecord type={RecordSetType.Activity} />}
-        {authenticated && <CenterCurrentRecord type={RecordSetType.IAPP} />}
-        <QuickPanToRecordToggle />
-      </WebOnly>
+          <WebOnly>
+            <CenterCurrentRecord type={RecordSetType.Activity} />
+            <CenterCurrentRecord type={RecordSetType.IAPP} />
+            <QuickPanToRecordToggle />
+          </WebOnly>
+        </>
+      )}
     </div>
   );
 };

--- a/app/src/UI/LegacyMap/Map.tsx
+++ b/app/src/UI/LegacyMap/Map.tsx
@@ -325,7 +325,7 @@ export const Map = ({ children }) => {
 
   useEffect(() => {
     if (!mapReady) return;
-    if (authenticated) {
+    if (authenticated && loggedInOrWorkingOffline) {
       addServerBoundariesIfNotExists(serverBoundaries, map);
       refreshServerBoundariesOnToggle(serverBoundaries, map);
     }

--- a/app/src/UI/Overlay/WhatsHere/Subcomponents/RenderTableActivity.tsx
+++ b/app/src/UI/Overlay/WhatsHere/Subcomponents/RenderTableActivity.tsx
@@ -13,7 +13,7 @@ type PropTypes = {
 
 const RenderTableActivity = ({ setAnchorEl }: PropTypes) => {
   const dispatch = useDispatch();
-  const { loggedInOrWorkingOffline, roles } = useSelector((state) => state.Auth);
+  const { loggedInOrWorkingOffline } = useSelector((state) => state.Auth);
   const whatsHere = useSelector((state) => state.Map?.whatsHere);
 
   const dispatchUpdatedID = (params) => {
@@ -93,7 +93,7 @@ const RenderTableActivity = ({ setAnchorEl }: PropTypes) => {
               dispatch(WhatsHere.sort_filter_update(RecordSetType.Activity, c.field));
             }}
             onCellClick={(params, evt: MuiEvent<MouseEvent | TouchEvent>) => {
-              if (loggedInOrWorkingOffline && roles.length > 0) {
+              if (loggedInOrWorkingOffline) {
                 setAnchorEl(evt.currentTarget as HTMLElement);
                 highlightActivity(params);
               }

--- a/app/src/UI/Overlay/WhatsHere/Subcomponents/RenderTablePOI.tsx
+++ b/app/src/UI/Overlay/WhatsHere/Subcomponents/RenderTablePOI.tsx
@@ -12,7 +12,7 @@ type PropTypes = {
 };
 const RenderTablePOI = ({ setAnchorEl }: PropTypes) => {
   const dispatch = useDispatch();
-  const { loggedInOrWorkingOffline, roles } = useSelector((state) => state.Auth);
+  const { loggedInOrWorkingOffline } = useSelector((state) => state.Auth);
   const whatsHere = useSelector((state) => state.Map?.whatsHere);
 
   const dispatchUpdatedID = (params) => {
@@ -79,7 +79,7 @@ const RenderTablePOI = ({ setAnchorEl }: PropTypes) => {
               dispatch(WhatsHere.sort_filter_update(RecordSetType.IAPP, c.field));
             }}
             onCellClick={(params: GridCellParams, event: MuiEvent<MouseEvent | TouchEvent>) => {
-              if (loggedInOrWorkingOffline && roles.length > 0) {
+              if (loggedInOrWorkingOffline) {
                 setAnchorEl(event.currentTarget as HTMLElement);
                 highlightPOI(params);
               }

--- a/app/src/state/reducers/auth.ts
+++ b/app/src/state/reducers/auth.ts
@@ -151,7 +151,6 @@ function loadCurrentStateFromIdToken(idToken: string): object {
   const authenticated = !!idToken;
 
   if (authenticated) {
-    loggedInOrWorkingOffline = true;
     try {
       const parsedToken = JSON.parse(
         decodeURIComponent(
@@ -270,7 +269,7 @@ function createAuthReducer(_configuration: AppConfig) {
           draftState.username = found.username;
           draftState.displayName = found.displayName;
           draftState.workingOffline = true;
-          draftState.loggedInOrWorkingOffline = true;
+          draftState.loggedInOrWorkingOffline = found.roles.length > 0;
         }
       } else if (AuthActions.initializeComplete.match(action)) {
         draftState.initialized = true;
@@ -335,6 +334,7 @@ function createAuthReducer(_configuration: AppConfig) {
       } else if (AuthActions.refreshRolesComplete.match(action)) {
         const { all_roles, roles, extendedInfo, v2BetaAccess } = action.payload;
         draftState.roles = roles;
+        draftState.loggedInOrWorkingOffline = roles.length > 0;
         draftState.accessRoles = computeAccessRoles(all_roles, roles);
         draftState.extendedInfo = extendedInfo;
         draftState.rolesInitialized = true;

--- a/app/src/state/sagas/map/layer-eligibility.ts
+++ b/app/src/state/sagas/map/layer-eligibility.ts
@@ -15,20 +15,17 @@ function* recomputeEligibleMapLayers(action) {
     return;
   }
 
-  const WORKING_OFFLINE = yield select((state) => (state as RootState).Auth.workingOffline);
-  const ONLINE_AUTHENTICATED = yield select((state) => (state as RootState).Auth.authenticated);
+  const AUTHENTICATED = yield select((state) => state.Auth.loggedInOrWorkingOffline);
 
-  const AUTHENTICATED = WORKING_OFFLINE || ONLINE_AUTHENTICATED;
+  const CONNECTED = yield select((state) => state.Network.connected);
 
-  const CONNECTED = yield select((state) => (state as RootState).Network.connected);
-
-  const CURRENT_ELIGIBLE_BASEMAP_LIST = yield select((state) => (state as RootState).Map.availableBaseMapLayers);
-  const CURRENT_ELIGIBLE_OVERLAY_LIST = yield select((state) => (state as RootState).Map.availableOverlayLayers);
+  const CURRENT_ELIGIBLE_BASEMAP_LIST = yield select((state) => state.Map.availableBaseMapLayers);
+  const CURRENT_ELIGIBLE_OVERLAY_LIST = yield select((state) => state.Map.availableOverlayLayers);
 
   const UPDATED_BASEMAP_LIST: string[] = [];
   const UPDATED_OVERLAY_LIST: string[] = [];
 
-  const offlineDefinitions = (yield select((state) => (state as RootState).TileCache?.mapSpecifications)) || [];
+  const offlineDefinitions = (yield select((state) => state.TileCache?.mapSpecifications)) ?? [];
 
   // evaluate each potential map definition and remove those not eligible at this moment
   for (const l of [...MAP_DEFINITIONS, ...offlineDefinitions] as MapSourceAndLayerDefinition[]) {

--- a/app/src/state/sagas/map/layer-eligibility.ts
+++ b/app/src/state/sagas/map/layer-eligibility.ts
@@ -4,7 +4,6 @@ import {
   MapSourceAndLayerDefinition,
   MapSourceAndLayerDefinitionMode
 } from 'UI/LegacyMap/helpers/functional/layer-definitions';
-import { RootState } from 'state/reducers/rootReducer';
 import { MOBILE } from 'state/build-time-config';
 import MapActions from 'state/actions/map';
 


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Base `loggedInOrWorkingOffline` on userRoles to better differentiate online/offline status
- Prevent UI components from rendering to `non-registered` users
    - Components did not allow access to anything, but presented lots of dead ends and blank pages.
- Closes #4078 