### PR TITLE
[INV-4109] pt2 More Component Tests

### DIFF
--- a/app/src/UI/AlertsContainer/AlertsContainer.test.tsx
+++ b/app/src/UI/AlertsContainer/AlertsContainer.test.tsx
@@ -11,15 +11,18 @@
 import { act, render, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { Provider } from 'react-redux';
-import setupStore from 'state/store';
-import { CONFIG } from 'state/config';
 import AlertsContainer from './AlertsContainer';
 import AlertMessage from 'interfaces/AlertMessage';
 import { AlertSeverity, AlertSubjects } from 'constants/alertEnums';
 import Alerts from 'state/actions/alerts/Alerts';
+import { createAlertsAndPromptsReducer } from 'state/reducers/alertsAndPrompts';
+import { configureStore } from '@reduxjs/toolkit';
 
-// Setup default Redux store for tests
-const { store } = setupStore(CONFIG);
+const createMockStore = () =>
+  configureStore({
+    reducer: { AlertsAndPrompts: createAlertsAndPromptsReducer() }
+  });
+const store = createMockStore();
 
 const testAlerts: Array<AlertMessage> = [
   {

--- a/app/src/UI/AndroidDownloadLink/AndroidDownloadLink.test.tsx
+++ b/app/src/UI/AndroidDownloadLink/AndroidDownloadLink.test.tsx
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import AndroidDownloadLink from './AndroidDownloadLink';
+import { configureStore } from '@reduxjs/toolkit';
+
+const configurationReducer =
+  (base_url) =>
+  (
+    state = {
+      current: {
+        ANDROID_APP_STORE_URL: base_url
+      }
+    }
+  ) =>
+    state;
+const createMockStore = (urlValue) =>
+  configureStore({
+    reducer: {
+      Configuration: configurationReducer(urlValue)
+    }
+  });
+
+describe('AndroidDownloadLink.tsx', () => {
+  it('should render null', () => {
+    const mockStore = createMockStore('unset');
+    const { queryByAltText } = render(
+      <Provider store={mockStore}>
+        <AndroidDownloadLink />
+      </Provider>
+    );
+    expect(queryByAltText('Download InvasivesBC For Android devices')).toBeNull();
+  });
+  it('should render with url', () => {
+    const url = 'http://localhost:3000';
+    const mockStore = createMockStore(url);
+    const { getByAltText } = render(
+      <Provider store={mockStore}>
+        <AndroidDownloadLink />
+      </Provider>
+    );
+    expect(getByAltText('Download InvasivesBC For Android devices')).toBeDefined();
+  });
+});

--- a/app/src/UI/AppLayout/ComponentizedMapLayout.tsx
+++ b/app/src/UI/AppLayout/ComponentizedMapLayout.tsx
@@ -23,7 +23,6 @@ const ComponentizedMapLayout = () => {
             <OverlayContent />
           </Overlay>
           <ButtonContainer />
-          <LayerPicker />
         </MainMap>
       ) : (
         <Map>

--- a/app/src/UI/AppLayout/LegacyMapLayout.tsx
+++ b/app/src/UI/AppLayout/LegacyMapLayout.tsx
@@ -6,8 +6,10 @@ import { ButtonContainer } from 'UI/LegacyMap/Controls/ButtonContainer';
 import { LayerPicker } from 'UI/LegacyMap/LayerPicker/LayerPicker';
 import CommonPrefixComponents from 'UI/AppLayout/Components/CommonPrefixComponents';
 import CommonPostfixComponents from 'UI/AppLayout/Components/CommonPostfixComponents';
+import { useSelector } from 'utils/use_selector';
 
 const LegacyMapLayout = () => {
+  const loggedInOrWorkingOffline = useSelector((state) => state.Auth.loggedInOrWorkingOffline);
   return (
     <>
       <CommonPrefixComponents />
@@ -17,7 +19,7 @@ const LegacyMapLayout = () => {
           <OverlayContent />
         </Overlay>
         <ButtonContainer />
-        <LayerPicker />
+        {loggedInOrWorkingOffline && <LayerPicker />}
       </Map>
 
       <CommonPostfixComponents />

--- a/app/src/UI/CustomPopover/CustomPopover.test.tsx
+++ b/app/src/UI/CustomPopover/CustomPopover.test.tsx
@@ -1,0 +1,94 @@
+import { render, waitFor } from '@testing-library/react';
+import CustomPopover from './CustomPopover';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+
+const defaultButtonText = 'Default Button';
+const componentText = 'Hello World!';
+// Uses Default Button
+const TestComponentNoButton = () => (
+  <div>
+    <CustomPopover buttonText={defaultButtonText}>
+      <p>{componentText}</p>
+      <button>Test</button>
+    </CustomPopover>
+  </div>
+);
+
+const TestComponentSelfClose = () => (
+  <div>
+    <CustomPopover buttonText={defaultButtonText} closeAfterPress>
+      <p>{componentText}</p>
+      <button>Test</button>
+    </CustomPopover>
+  </div>
+);
+
+// Provides Button to Popover
+const TestComponentWithButtonSelfClose = () => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  return (
+    <div>
+      <button onClick={(evt) => setAnchorEl(evt.currentTarget)}>Override Button</button>
+      <CustomPopover buttonOverrideOptions={{ anchorEl, setAnchorEl }} closeAfterPress>
+        <p>{componentText}</p>
+        <button>Test</button>
+      </CustomPopover>
+    </div>
+  );
+};
+
+describe('CustomPopover.tsx', () => {
+  it('Should Render with own button', async () => {
+    const { getByRole, getByText } = render(<TestComponentNoButton />);
+    await userEvent.click(getByRole('button'));
+    await waitFor(() => {
+      expect(getByText(componentText)).toBeDefined();
+    });
+    await userEvent.click(getByText('Test'));
+    await waitFor(() => {
+      expect(getByText(componentText)).toBeDefined();
+    });
+  });
+
+  it('Should Remain open after clicking button', async () => {
+    const { getByRole, getByText, queryByText } = render(<TestComponentNoButton />);
+    await userEvent.click(getByRole('button'));
+    await waitFor(() => {
+      expect(getByText(componentText)).toBeDefined();
+    });
+    await userEvent.click(getByText('Test'));
+    await waitFor(() => {
+      expect(getByText(componentText)).toBeDefined();
+    });
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(queryByText(componentText)).toBeNull();
+    });
+  });
+
+  it('Should Close self after clicking internal button', async () => {
+    const { getByRole, getByText, queryByText } = render(<TestComponentSelfClose />);
+    await userEvent.click(getByRole('button'));
+    await waitFor(() => {
+      expect(getByText(componentText)).toBeDefined();
+    });
+    await userEvent.click(getByText('Test'));
+    await waitFor(() => {
+      expect(queryByText(componentText)).toBeNull();
+    });
+  });
+
+  it('Should render with Supplied button and close after clicking internal button', async () => {
+    const { getByRole, getByText, queryAllByRole, queryByText } = render(<TestComponentWithButtonSelfClose />);
+    expect(queryAllByRole('button')).toHaveLength(1);
+    await userEvent.click(getByRole('button'));
+    await waitFor(() => {
+      expect(getByText(componentText)).toBeDefined();
+    });
+    await userEvent.click(getByText('Test'));
+    await waitFor(() => {
+      expect(queryByText(componentText)).toBeNull();
+    });
+  });
+});

--- a/app/src/UI/Footer/Footer.test.tsx
+++ b/app/src/UI/Footer/Footer.test.tsx
@@ -1,0 +1,13 @@
+/**
+ * Tests:
+ *  - It Renders (no moving parts)
+ */
+import { render } from '@testing-library/react';
+import { Footer } from './Footer';
+
+describe('Footer.tsx', () => {
+  it('Should Render', () => {
+    const { getByRole } = render(<Footer />);
+    expect(getByRole('img')).toBeDefined();
+  });
+});

--- a/app/src/UI/InvBcLogo/InvBCLogo.test.tsx
+++ b/app/src/UI/InvBcLogo/InvBCLogo.test.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react';
+import InvBcLogo from './InvBcLogo';
+
+describe('InvBCLogo.tsx', () => {
+  it('Should render', () => {
+    const { getByRole } = render(<InvBcLogo />);
+    expect(getByRole('img')).toBeDefined();
+  });
+});

--- a/app/src/UI/IosDownloadLink/IosDownloadLink.test.tsx
+++ b/app/src/UI/IosDownloadLink/IosDownloadLink.test.tsx
@@ -1,0 +1,44 @@
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+
+import { configureStore } from '@reduxjs/toolkit';
+import IosDownloadLink from './IosDownloadLink';
+
+const configurationReducer =
+  (base_url) =>
+  (
+    state = {
+      current: {
+        IOS_APP_STORE_URL: base_url
+      }
+    }
+  ) =>
+    state;
+const createMockStore = (urlValue) =>
+  configureStore({
+    reducer: {
+      Configuration: configurationReducer(urlValue)
+    }
+  });
+
+describe('IosDownloadLink.tsx', () => {
+  it('should render null', () => {
+    const mockStore = createMockStore('unset');
+    const { queryByAltText } = render(
+      <Provider store={mockStore}>
+        <IosDownloadLink />
+      </Provider>
+    );
+    expect(queryByAltText('Download InvasivesBC For iOS devices')).toBeNull();
+  });
+  it('should render with url', () => {
+    const url = 'http://localhost:3000';
+    const mockStore = createMockStore(url);
+    const { getByAltText } = render(
+      <Provider store={mockStore}>
+        <IosDownloadLink />
+      </Provider>
+    );
+    expect(getByAltText('Download InvasivesBC For iOS devices')).toBeDefined();
+  });
+});

--- a/app/src/UI/LegacyMap/Controls/AccuracyToggle.test.tsx
+++ b/app/src/UI/LegacyMap/Controls/AccuracyToggle.test.tsx
@@ -1,0 +1,41 @@
+import { act, render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AccuracyToggle } from './AccuracyToggle';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+
+const configurationReducer =
+  () =>
+  (
+    state = {
+      accuracyToggle: false,
+      positionTracking: true
+    }
+  ) =>
+    state;
+const createMockStore = () =>
+  configureStore({
+    reducer: {
+      Map: configurationReducer()
+    }
+  });
+
+const store = createMockStore();
+
+describe('NewRecord.tsx', () => {
+  it('should toggle className with accuracyToggle state', async () => {
+    const { container, getByRole } = render(
+      <Provider store={store}>
+        <AccuracyToggle />
+      </Provider>
+    );
+    expect(container.querySelector('map-btn-selected')).toBe(null);
+    act(() => {
+      userEvent.click(getByRole('button'));
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('map-btn-selected')).toBeDefined();
+    });
+  });
+});

--- a/app/src/UI/LegacyMap/Controls/AccuracyToggle.tsx
+++ b/app/src/UI/LegacyMap/Controls/AccuracyToggle.tsx
@@ -10,49 +10,31 @@ import AttributionIcon from '@mui/icons-material/Attribution';
 export const AccuracyToggle = () => {
   const dispatch = useDispatch();
   const accuracyToggle = useSelector((state) => state.Map.accuracyToggle);
-  const positionTracking = useSelector((state) => state.Map.positionTracking);
 
   const [show, setShow] = React.useState(false);
-
   const divRef = useRef<HTMLDivElement | null>(null);
 
-  if (!positionTracking) {
-    return <></>;
-  } else {
-    return (
-      <div ref={divRef} className={accuracyToggle ? 'map-btn-selected' : 'map-btn'}>
-        <Tooltip
-          open={show}
-          onMouseEnter={() => setShow(true)}
-          onMouseLeave={() => setShow(false)}
-          classes={{ tooltip: 'toolTip' }}
-          title={accuracyToggle ? 'Hide Accuracy' : 'Show Accuracy'}
-          placement="top-end"
-        >
-          <span>
-            <IconButton
-              className={'button'}
-              onClick={() => {
-                dispatch({ type: MAP_TOGGLE_ACCURACY });
-              }}
-            >
-              <AttributionIcon />
-            </IconButton>
-          </span>
-        </Tooltip>
-      </div>
-    );
-  }
-};
-
-export const AccuracyMarker = () => {
-  const accuracyToggle = useSelector((state) => state.Map.accuracyToggle);
-  const positionTracking = useSelector((state) => state.Map.positionTracking);
-  const userCoords = useSelector((state) => state.Map.userCoords);
-
-  if (accuracyToggle && positionTracking && userCoords?.long) {
-    return null;
-  } else {
-    return <></>;
-  }
+  return (
+    <div ref={divRef} className={accuracyToggle ? 'map-btn-selected' : 'map-btn'}>
+      <Tooltip
+        open={show}
+        onMouseEnter={() => setShow(true)}
+        onMouseLeave={() => setShow(false)}
+        classes={{ tooltip: 'toolTip' }}
+        title={accuracyToggle ? 'Hide Accuracy' : 'Show Accuracy'}
+        placement="top-end"
+      >
+        <span>
+          <IconButton
+            className={'button'}
+            onClick={() => {
+              dispatch({ type: MAP_TOGGLE_ACCURACY });
+            }}
+          >
+            <AttributionIcon />
+          </IconButton>
+        </span>
+      </Tooltip>
+    </div>
+  );
 };

--- a/app/src/UI/LegacyMap/Controls/ButtonContainer.tsx
+++ b/app/src/UI/LegacyMap/Controls/ButtonContainer.tsx
@@ -21,13 +21,17 @@ export const ButtonContainer = () => {
       {loggedInOrWorkingOffline && (
         <>
           <FindMeToggle />
-          {positionTracking && <TrackingButtonsContainer />}
+          {positionTracking && (
+            <>
+              <TrackingButtonsContainer />
+              <AccuracyToggle />
+            </>
+          )}
 
           <WebOnly>
             <LegendsButton />
           </WebOnly>
 
-          <AccuracyToggle />
           <WhatsHereButton />
           {writePrivilege.length > 0 && <NewRecord />}
 

--- a/app/src/UI/LegacyMap/Controls/NewRecord.test.tsx
+++ b/app/src/UI/LegacyMap/Controls/NewRecord.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+import { NewRecord } from './NewRecord';
+import UserSettings from 'state/actions/userSettings/UserSettings';
+import userEvent from '@testing-library/user-event';
+
+const mockDispatch = vi.fn();
+vi.mock('utils/use_selector', () => ({
+  useDispatch: () => mockDispatch
+}));
+
+describe('NewRecord.tsx', () => {
+  it('fires the openNewRecordDialogue event on click', async () => {
+    vi.spyOn(UserSettings, 'openNewRecordDialogue');
+
+    const { getByRole } = render(<NewRecord />);
+
+    await userEvent.click(getByRole('button'));
+    expect(mockDispatch).toHaveBeenCalled();
+  });
+});

--- a/app/src/UI/LegacyMap/Controls/NewRecord.tsx
+++ b/app/src/UI/LegacyMap/Controls/NewRecord.tsx
@@ -1,15 +1,15 @@
-import React, { useRef } from 'react';
-import { useDispatch } from 'react-redux';
+import { useRef, useState } from 'react';
 import { IconButton, Tooltip } from '@mui/material';
 import FiberNewIcon from '@mui/icons-material/FiberNew';
 import 'UI/Global.css';
 import UserSettings from 'state/actions/userSettings/UserSettings';
+import { useDispatch } from 'utils/use_selector';
 
 export const NewRecord = () => {
   const dispatch = useDispatch();
   const divRef = useRef();
 
-  const [show, setShow] = React.useState(false);
+  const [show, setShow] = useState(false);
 
   return (
     <div ref={divRef} className="map-btn">

--- a/app/src/UI/LegacyMap/LayerPicker/LayerPicker.css
+++ b/app/src/UI/LegacyMap/LayerPicker/LayerPicker.css
@@ -61,7 +61,7 @@ li > hr {
     overflow-y: auto;
   }
 
-  * > button {
+  * > button:not(:disabled) {
     color: black;
   }
 }

--- a/app/src/UI/LegacyMap/LayerPicker/LayerPicker.test.tsx
+++ b/app/src/UI/LegacyMap/LayerPicker/LayerPicker.test.tsx
@@ -1,0 +1,97 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { render, waitFor, within } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { LayerPicker } from './LayerPicker';
+import userEvent from '@testing-library/user-event';
+import { act } from 'react';
+import UserSettings from 'state/actions/userSettings/UserSettings';
+
+const userSettingsReducer = (state = { layerPickerIsAccordion: false }, action) => {
+  if (UserSettings.toggleLayerPickerAccordion.match(action)) {
+    return {
+      ...state,
+      layerPickerIsAccordion: !state.layerPickerIsAccordion
+    };
+  }
+  return state;
+};
+const networkReducer = (state = { connected: false }) => state;
+
+const createMockStore = () =>
+  configureStore({
+    reducer: {
+      UserSettings: userSettingsReducer,
+      Network: networkReducer
+    }
+  });
+
+describe('LayerPicker.tsx', () => {
+  const store = createMockStore();
+
+  it('should initial render to button and toggle between open/closed', async () => {
+    const { container, getByTestId } = render(
+      <Provider store={store}>
+        <LayerPicker />
+      </Provider>
+    );
+    const lpToggleButton = getByTestId('lp-open');
+    expect(lpToggleButton).toBeDefined();
+    expect(container.querySelector('#layer-picker-container')).toBeNull();
+
+    act(() => {
+      userEvent.click(lpToggleButton);
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('#layer-picker-container')).toBeDefined();
+      expect(getByTestId('lp-close')).toBeDefined();
+    });
+
+    await userEvent.click(getByTestId('lp-close'));
+
+    await waitFor(() => {
+      expect(container.querySelector('layer-picker-closed-icon')).toBeDefined();
+    });
+  });
+
+  it('Should display back button when rendering a module', async () => {
+    const { getByTestId, queryByText, queryAllByRole } = render(
+      <Provider store={store}>
+        <LayerPicker />
+      </Provider>
+    );
+
+    await userEvent.click(getByTestId('lp-open'));
+
+    await waitFor(() => {
+      expect(queryAllByRole('listitem').length).toBeGreaterThan(0);
+    });
+
+    const listItems = queryAllByRole('listitem');
+    await userEvent.click(within(listItems[0]).getByRole('button'));
+
+    await waitFor(() => {
+      expect(queryByText('Expand')).toBeNull();
+    });
+  });
+
+  it('should toggle to Accordion display', async () => {
+    const { getByRole, getByTestId, queryByRole } = render(
+      <Provider store={store}>
+        <LayerPicker />
+      </Provider>
+    );
+
+    await userEvent.click(getByTestId('lp-open'));
+
+    await waitFor(() => {
+      expect(queryByRole('list')).toBeDefined();
+    });
+
+    await userEvent.click(getByRole('checkbox'));
+
+    await waitFor(() => {
+      expect(queryByRole('list')).toBeNull();
+    });
+  });
+});

--- a/app/src/UI/LegacyMap/LayerPicker/LayerPicker.tsx
+++ b/app/src/UI/LegacyMap/LayerPicker/LayerPicker.tsx
@@ -28,7 +28,12 @@ export const LayerPicker = () => {
 
   if (!showLayerPicker) {
     return (
-      <button id="layer-picker-closed-icon" className="layer-picker-pos" onClick={() => setShowLayerPicker(true)}>
+      <button
+        data-testid="lp-open"
+        id="layer-picker-closed-icon"
+        className="layer-picker-pos"
+        onClick={() => setShowLayerPicker(true)}
+      >
         <LayersIcon />
       </button>
     );
@@ -46,12 +51,12 @@ export const LayerPicker = () => {
             </>
           ) : (
             <>
-              <Switch data-testid="lp-accordion-toggle" checked={accordionMode} onChange={toggleLayerPickerAccordion} />
+              <Switch checked={accordionMode} onChange={toggleLayerPickerAccordion} />
               <span className="small">Expand</span>
             </>
           )}
         </div>
-        <IconButton onClick={closeLayerPicker}>
+        <IconButton data-testid="lp-close" onClick={closeLayerPicker}>
           <CloseIcon />
         </IconButton>
       </div>

--- a/app/src/UI/LegacyMap/LayerPicker/LayerPicker.tsx
+++ b/app/src/UI/LegacyMap/LayerPicker/LayerPicker.tsx
@@ -23,13 +23,9 @@ export const LayerPicker = () => {
   const toggleLayerPickerAccordion = () => dispatch(UserSettings.toggleLayerPickerAccordion());
   const [pickerPath, setPickerPath] = useState<LpModules>(LpModules.Init);
   const [showLayerPicker, setShowLayerPicker] = useState<boolean>(false);
-  const isAuth = useSelector((state) => state.Auth.loggedInOrWorkingOffline);
   const accordionMode = useSelector((state) => state.UserSettings.layerPickerIsAccordion);
   const dispatch = useDispatch();
 
-  if (!isAuth) {
-    return;
-  }
   if (!showLayerPicker) {
     return (
       <button id="layer-picker-closed-icon" className="layer-picker-pos" onClick={() => setShowLayerPicker(true)}>
@@ -50,7 +46,7 @@ export const LayerPicker = () => {
             </>
           ) : (
             <>
-              <Switch checked={accordionMode} onChange={toggleLayerPickerAccordion} />
+              <Switch data-testid="lp-accordion-toggle" checked={accordionMode} onChange={toggleLayerPickerAccordion} />
               <span className="small">Expand</span>
             </>
           )}

--- a/app/src/UI/LegacyMap/LayerPicker/LpRecordSet/LpRecordSet.tsx
+++ b/app/src/UI/LegacyMap/LayerPicker/LpRecordSet/LpRecordSet.tsx
@@ -55,8 +55,6 @@ const LpRecordSet = ({ closePicker }: PropTypes) => {
     const newCustomRecordSets: UserRecordSet[] = [];
 
     filterRecordsetsByNetworkState(recordSets, userIsMobileAndOffline).forEach((recordSet) => {
-      console.dir(recordSet);
-
       if (defaultRecordSetIds.includes(recordSet)) {
         newDefaultRecordSets.push({ ...recordSets[recordSet], id: recordSet });
       } else {

--- a/app/src/UI/LegacyMap/LayerPicker/LpRecordSet/LpRecordSetOption.tsx
+++ b/app/src/UI/LegacyMap/LayerPicker/LpRecordSet/LpRecordSetOption.tsx
@@ -1,5 +1,5 @@
 import { Label, LabelOff, Layers, LayersClear, Palette } from '@mui/icons-material';
-import { Tooltip } from '@mui/material';
+import { IconButton, Tooltip } from '@mui/material';
 import { UserRecordSet } from 'interfaces/UserRecordSet';
 
 type PropTypes = {
@@ -28,23 +28,23 @@ const LpRecordSetOption = ({
             classes={{ tooltip: 'toolTip' }}
             title="Toggle viewing the labels on the map for this layer.  If more than 200 are in the extent, you may need to zoom in to see what you are looking for.  For people on slow computers - it recalculates on drag and zoom so fewer small drags will decrease loading time."
           >
-            <button onClick={() => toggleLabelVisibility(recordSet.id!)}>
+            <IconButton disabled={!recordSet.mapToggle} onClick={() => toggleLabelVisibility(recordSet.id!)}>
               {recordSet.labelToggle ? <Label /> : <LabelOff />}
-            </button>
+            </IconButton>
           </Tooltip>
           <Tooltip
             classes={{ tooltip: 'toolTip' }}
             title="Toggle viewing the layer on the map, and including these records in the Whats Here search results."
           >
-            <button onClick={() => toggleVisibility(recordSet.id!)}>
+            <IconButton onClick={() => toggleVisibility(recordSet.id!)}>
               {recordSet?.mapToggle ? <Layers /> : <LayersClear />}
-            </button>
+            </IconButton>
           </Tooltip>
           {canColour && (
             <Tooltip classes={{ tooltip: 'toolTip' }} title="Change the colour of this layer.">
-              <button onClick={() => cycleColour(recordSet.id!)}>
+              <IconButton onClick={() => cycleColour(recordSet.id!)}>
                 <Palette />
-              </button>
+              </IconButton>
             </Tooltip>
           )}
         </div>

--- a/app/src/UI/TooltipWithIcon/TooltipWithIcon.test.tsx
+++ b/app/src/UI/TooltipWithIcon/TooltipWithIcon.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * Tests:
+ *  - Tooltip Renders
+ *  - Hover displays Tip
+ *  - Click Displays Tip (Important for mobile)
+ */
+import { render, waitFor } from '@testing-library/react';
+import TooltipWithIcon from './TooltipWithIcon';
+import userEvent from '@testing-library/user-event';
+
+const toolTipText = 'Test Render';
+
+describe('TooltipWithText.tsx', () => {
+  it('should Render', () => {
+    const { getByTestId } = render(<TooltipWithIcon tooltipText={toolTipText} />);
+    expect(getByTestId('HelpOutlineIcon')).toBeDefined();
+  });
+
+  it('Should display tooltip on Hover', async () => {
+    const { getByTestId, getByText, queryByText } = render(<TooltipWithIcon tooltipText={toolTipText} />);
+    expect(queryByText(toolTipText)).toBeNull();
+    await userEvent.hover(getByTestId('HelpOutlineIcon'));
+    await waitFor(() => {
+      expect(getByText(toolTipText)).toBeDefined();
+    });
+  });
+
+  it('Should display tooltip on click', async () => {
+    const { getByRole, getByText, queryByText } = render(<TooltipWithIcon tooltipText={toolTipText} />);
+    expect(queryByText(toolTipText)).toBeNull();
+    await userEvent.click(getByRole('button'));
+    await waitFor(() => {
+      expect(getByText(toolTipText)).toBeDefined();
+    });
+  });
+});

--- a/app/src/setupTests.ts
+++ b/app/src/setupTests.ts
@@ -4,3 +4,20 @@ if (typeof window?.URL?.createObjectURL === 'undefined') {
     // Mock this function for mapbox-gl to work
   };
 }
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Silence MUI Warnings and Errors caused by using JSDom
+  vi.spyOn(console, 'warn').mockImplementation((msg) => {
+    if (typeof msg === 'string' && msg.startsWith('MUI:')) {
+      return '';
+    }
+    return msg;
+  });
+  vi.spyOn(console, 'error').mockImplementation((msg) => {
+    if (typeof msg === 'string' && msg.startsWith('MUI:')) {
+      return '';
+    }
+    return msg;
+  });
+});


### PR DESCRIPTION
# Overview

>[!NOTE]
> Merges into original Test PR
 
This PR includes the following proposed change(s):

- Add more Component tests to App
- Reduces state needs for Alerts tests 

Feature Changes:
- Remove Layer Picker from Unauth Componentized Map
- Remove null return from Layer Picker when not logged in (Should be controlled by the parent instead of coupled in)
- Remove null return from `AccuracyToggle.tsx`, remove unused component from file.
- Tighten imports in `NewRecord.tsx`
- Replace buttons with `IconButtons` in `LpRecords.tsx` more consistent to recordsets
    - Add disabled attribute to Labels (like in /Records)
    - Fix CSS to properly display Disabled
-  Modify SetupTests to ignore MUI Complaints
- Progress for #4109 