### PR TITLE
[INV-4109] Pt5 Component Testing

### DIFF
--- a/app/src/UI/LegacyMap/LayerPicker/LpLayers/LpLayers.test.tsx
+++ b/app/src/UI/LegacyMap/LayerPicker/LpLayers/LpLayers.test.tsx
@@ -1,0 +1,163 @@
+import { render, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import LpLayers from './LpLayers';
+import { createMockStore, mockState } from '../../../../../testutils';
+import { createMapReducer, DEFAULT_LOCAL_LAYERS } from 'state/reducers/map';
+import userEvent from '@testing-library/user-event';
+
+describe('LpLayers.tsx', () => {
+  const store = (online: boolean) =>
+    createMockStore({
+      Map: createMapReducer(),
+      Network: mockState({
+        connected: online
+      })
+    });
+  const storeWithShapes = createMockStore({
+    Map: mockState({
+      simplePickerLayers2: [],
+      serverBoundaries: [
+        {
+          id: 760,
+          title: 'Custom KML Layer',
+          geojson: {
+            type: 'FeatureCollection',
+            features: [
+              {
+                type: 'Feature',
+                properties: {},
+                geometry: {
+                  type: 'Polygon',
+                  coordinates: [
+                    [
+                      [-119.2840107, 50.2770137],
+                      [-119.2840107, 50.2570137],
+                      [-119.2600107, 50.2570137],
+                      [-119.2600107, 50.2770137],
+                      [-119.2840107, 50.2770137]
+                    ]
+                  ]
+                }
+              }
+            ]
+          },
+          toggle: false
+        }
+      ],
+      clientBoundaries: [
+        {
+          id: 'WSwyw5TT0cYaqjhLUzt23',
+          geojson: {
+            id: 'M69pR7xJCINFhXnHnWvqh69LvbLJNilS',
+            type: 'Feature',
+            properties: {},
+            geometry: {
+              coordinates: [
+                [
+                  [-123.44300292570466, 50.150372726241585],
+                  [-122.64557556213512, 50.53206702398313],
+                  [-122.44621872124287, 49.90587783429376],
+                  [-123.44300292570466, 50.150372726241585]
+                ]
+              ],
+              type: 'Polygon'
+            }
+          },
+          toggle: true,
+          title: 'Custom Defined Layer'
+        }
+      ]
+    }),
+    Network: mockState({
+      connected: false
+    })
+  });
+  const dispatchSpy = vi.spyOn(storeWithShapes, 'dispatch');
+
+  it('[Online] should render and show DataBC Layers', () => {
+    const { getByText } = render(
+      <Provider store={store(true)}>
+        <LpLayers />
+      </Provider>
+    );
+    expect(getByText(DEFAULT_LOCAL_LAYERS[0].title)).toBeDefined();
+  });
+
+  it('[Offline] should render DataBC layers unavailable', () => {
+    const { getByText, queryByText } = render(
+      <Provider store={store(false)}>
+        <LpLayers />
+      </Provider>
+    );
+    expect(getByText('DataBC layers unavailable when offline')).toBeDefined();
+    expect(queryByText(DEFAULT_LOCAL_LAYERS[0].title)).toBeNull();
+  });
+
+  it('DataBC Layers should be togglable', async () => {
+    const testStore = store(true);
+    const dispatchSpy = vi.spyOn(testStore, 'dispatch');
+    const { getAllByTestId } = render(
+      <Provider store={testStore}>
+        <LpLayers />
+      </Provider>
+    );
+    const firstWMSOption = getAllByTestId('lp-layers-option-button')[0];
+    await userEvent.click(firstWMSOption);
+    const calledExpectedEvent = dispatchSpy.mock.calls.every(([action]) => (action.type = 'TOGGLE_WMS_LAYER'));
+    expect(dispatchSpy).toHaveBeenCalledOnce();
+    expect(calledExpectedEvent).toBe(true);
+  });
+
+  it('Should fire dispatch for Custom Layers Toggle', async () => {
+    const testStore = store(false);
+    const dispatchSpy = vi.spyOn(testStore, 'dispatch');
+    const { getByTestId } = render(
+      <Provider store={testStore}>
+        <LpLayers />
+      </Provider>
+    );
+    await userEvent.click(getByTestId('custom-layer-button'));
+    const calledExpectedEvent = dispatchSpy.mock.calls.every(([action]) => (action.type = 'TOGGLE_CUSTOM_LAYERS'));
+    expect(dispatchSpy).toHaveBeenCalledOnce();
+    expect(calledExpectedEvent).toBe(true);
+  });
+
+  it('Should have Empty collections for KML and Custom Layers', () => {
+    const { getByText } = render(
+      <Provider store={store(false)}>
+        <LpLayers />
+      </Provider>
+    );
+    expect(getByText('You do not have any custom layers')).toBeDefined();
+    expect(getByText('You have not uploaded any KML Layers')).toBeDefined();
+  });
+
+  it('Should render with KML and Custom Layer entries visible', () => {
+    const { getByText } = render(
+      <Provider store={storeWithShapes}>
+        <LpLayers />
+      </Provider>
+    );
+    expect(getByText('Custom KML Layer')).toBeDefined();
+    expect(getByText('Custom Defined Layer')).toBeDefined();
+  });
+
+  it('Clicking Custom/KML layers should fire events', async () => {
+    const { getByText, getAllByTestId } = render(
+      <Provider store={storeWithShapes}>
+        <LpLayers />
+      </Provider>
+    );
+    expect(getByText('Custom KML Layer')).toBeDefined();
+    expect(getByText('Custom Defined Layer')).toBeDefined();
+    const layerButtons = getAllByTestId('lp-layers-option-button');
+    layerButtons.forEach(async (button) => await userEvent.click(button));
+    await waitFor(() => {
+      expect(dispatchSpy).toHaveBeenCalledTimes(2);
+      const calledExpectedEvents = dispatchSpy.mock.calls.every(([action]) =>
+        ['TOGGLE_KML_LAYER', 'TOGGLE_DRAWN_LAYER'].includes(action.type)
+      );
+      expect(calledExpectedEvents).toBe(true);
+    });
+  });
+});

--- a/app/src/UI/LegacyMap/LayerPicker/LpLayers/LpLayers.tsx
+++ b/app/src/UI/LegacyMap/LayerPicker/LpLayers/LpLayers.tsx
@@ -38,7 +38,6 @@ const LpLayers = () => {
   const WmsLayers = useSelector((state) => state.Map?.simplePickerLayers2);
   const KmlLayers = useSelector((state) => state.Map?.serverBoundaries);
   const drawnLayers = useSelector((state) => state.Map?.clientBoundaries);
-
   return (
     <div id="lp-layers">
       <h3>
@@ -109,7 +108,7 @@ const LpLayers = () => {
           <EmptyCollection text={'You do not have any custom layers'} />
         )}
         <div className="control">
-          <button className="create-custom-layers" onClick={handleCreateCustom}>
+          <button data-testid="custom-layer-button" className="create-custom-layers" onClick={handleCreateCustom}>
             Edit Custom Layers
             <Layers />
             <Settings />

--- a/app/src/UI/LegacyMap/LayerPicker/LpLayers/LpLayersOption.tsx
+++ b/app/src/UI/LegacyMap/LayerPicker/LpLayers/LpLayersOption.tsx
@@ -14,7 +14,9 @@ const LpLayersOption = ({ onClick, layer, lastChild }: PropTypes) => {
   return (
     <>
       <li className="lp-layers-item">
-        <button onClick={() => onClick(layer)}>{layer?.toggle ? <Visibility /> : <VisibilityOff />}</button>
+        <button data-testid="lp-layers-option-button" onClick={() => onClick(layer)}>
+          {layer?.toggle ? <Visibility /> : <VisibilityOff />}
+        </button>
         <p>{layer.title ?? 'Layer name is null'}</p>
       </li>
       {!lastChild && (

--- a/app/src/UI/Overlay/WhatsHere/Subcomponents/NoRowsInSearch.test.tsx
+++ b/app/src/UI/Overlay/WhatsHere/Subcomponents/NoRowsInSearch.test.tsx
@@ -1,0 +1,49 @@
+import { createMockStore, mockState } from '../../../../../testutils';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import NoRowsInSearch from './NoRowsInSearch';
+import { Router } from 'react-router';
+import { historySingleton } from 'state/store';
+import UserSettings from 'state/actions/userSettings/UserSettings';
+import { RecordSetType } from 'interfaces/UserRecordSet';
+
+describe('NoRowsInSearch.tsx', () => {
+  const storeWithoutRecordSetToggled = createMockStore({
+    UserSettings: mockState({
+      recordSets: { '1': UserSettings.RecordSet.createDefaultRecordset(RecordSetType.Activity) }
+    })
+  });
+
+  const recordSet = UserSettings.RecordSet.createDefaultRecordset(RecordSetType.Activity);
+  recordSet.mapToggle = true;
+
+  const storeWithRecordSetToggled = createMockStore({
+    UserSettings: mockState({
+      recordSets: { '1': recordSet }
+    })
+  });
+
+  it('should render with no recordsets warning', () => {
+    const { getByRole, getByText } = render(
+      <Provider store={storeWithoutRecordSetToggled}>
+        <Router history={historySingleton}>
+          <NoRowsInSearch />
+        </Router>
+      </Provider>
+    );
+    expect(getByRole('link')).toBeDefined();
+    expect(getByText('There are no Recordsets currently visible on the map.'));
+  });
+
+  it('should render with no pointsOfInterest warning', () => {
+    const { getByRole, getByText } = render(
+      <Provider store={storeWithRecordSetToggled}>
+        <Router history={historySingleton}>
+          <NoRowsInSearch />
+        </Router>
+      </Provider>
+    );
+    expect(getByRole('link')).toBeDefined();
+    expect(getByText('There are no points of interest in the selected area.'));
+  });
+});

--- a/app/src/UI/UserInputModals/ManualUtmModal.test.tsx
+++ b/app/src/UI/UserInputModals/ManualUtmModal.test.tsx
@@ -1,0 +1,101 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import UserInputModalController from './UserInputModalController';
+import { createAlertsAndPromptsReducer } from 'state/reducers/alertsAndPrompts';
+import Prompt from 'state/actions/prompts/Prompt';
+import { ManualUtmModalInterface, UtmInputObj } from 'interfaces/prompt-interfaces';
+import userEvent from '@testing-library/user-event';
+import { createMockStore } from '../../../testutils';
+
+const utmCallback = (num: UtmInputObj) => {
+  if (num) {
+    return [{ type: 'SUCCESS' }];
+  }
+};
+
+const testA: ManualUtmModalInterface = {
+  cancelText: 'Cancel Override',
+  callback: utmCallback,
+  confirmText: 'Confirmation Override',
+  prompt: 'Manual UTM Test',
+  title: 'TestA'
+};
+const testB: ManualUtmModalInterface = {
+  disableCancel: true,
+  callback: utmCallback,
+  prompt: ['Manual UTM Test', 'multi-paragraph'],
+  title: 'TestB'
+};
+
+describe('ManualUtmModal.tsx', () => {
+  const store = createMockStore({
+    AlertsAndPrompts: createAlertsAndPromptsReducer()
+  });
+  let utils;
+  beforeEach(() => {
+    utils = render(
+      <Provider store={store}>
+        <UserInputModalController />
+      </Provider>
+    );
+  });
+  afterEach(() => {});
+  it('should render with non-default text', async () => {
+    act(() => {
+      store.dispatch(Prompt.utm(testA));
+    });
+    const { getByText } = utils;
+
+    await waitFor(() => {
+      expect(getByText(testA.prompt as string)).toBeDefined();
+      expect(getByText(testA.title)).toBeDefined();
+      expect(getByText(testA.cancelText!)).toBeDefined();
+      expect(getByText(testA.confirmText!)).toBeDefined();
+    });
+  });
+
+  it('should close on cancel', async () => {
+    const { queryByText, getByTestId } = utils;
+
+    await waitFor(() => {
+      expect(queryByText(testA.confirmText)).toBeDefined();
+      expect(getByTestId('utm-modal-cancel')).toBeDefined();
+    });
+
+    userEvent.click(getByTestId('utm-modal-cancel'));
+    await waitFor(() => {
+      expect(queryByText(testA.title)).toBeNull();
+    });
+  });
+
+  it('should render with multiple prompt lines and no cancel button', async () => {
+    act(() => {
+      store.dispatch(Prompt.utm(testB));
+    });
+    const { queryByTestId, queryAllByRole } = utils;
+
+    await waitFor(() => {
+      expect(queryAllByRole('paragraph').length).toEqual(2);
+      expect(queryAllByRole('paragraph').length).toEqual(2);
+      expect(queryByTestId('utm-modal-cancel')).toBeNull();
+    });
+  });
+
+  it('should be disabled until all three fields are filled', async () => {
+    const getInput = (label: string) => utils.getAllByLabelText(label)[0];
+    const getConfirmButton = () => utils.queryByTestId('utm-modal-confirm');
+    expect(getConfirmButton().disabled).toBe(true);
+
+    await userEvent.type(getInput('Easting'), '10');
+    expect(getConfirmButton().disabled).toBe(true);
+
+    await userEvent.type(getInput('Northing'), '10');
+    expect(getConfirmButton().disabled).toBe(true);
+
+    await userEvent.type(getInput('Zone'), '10');
+    expect(getConfirmButton().disabled).toBe(false);
+
+    await userEvent.click(getConfirmButton());
+    expect(getConfirmButton()).toBeNull();
+  });
+});

--- a/app/src/UI/UserInputModals/ManualUtmModal.tsx
+++ b/app/src/UI/UserInputModals/ManualUtmModal.tsx
@@ -115,8 +115,12 @@ const ManualUtmModal = ({
         </FormControl>
         <Divider />
         <DialogActions>
-          {!disableCancel && <Button onClick={handleClose}>{cancelText ?? 'Cancel'}</Button>}
-          <Button onClick={handleConfirmation} disabled={results.length === 0}>
+          {!disableCancel && (
+            <Button data-testid="utm-modal-cancel" onClick={handleClose}>
+              {cancelText ?? 'Cancel'}
+            </Button>
+          )}
+          <Button data-testid="utm-modal-confirm" onClick={handleConfirmation} disabled={results.length === 0}>
             {confirmText ?? 'Confirm'}
           </Button>
         </DialogActions>

--- a/app/src/UI/UserInputModals/NumberModal.test.tsx
+++ b/app/src/UI/UserInputModals/NumberModal.test.tsx
@@ -1,0 +1,138 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import UserInputModalController from './UserInputModalController';
+import { createAlertsAndPromptsReducer } from 'state/reducers/alertsAndPrompts';
+import Prompt from 'state/actions/prompts/Prompt';
+import { NumberModalInterface } from 'interfaces/prompt-interfaces';
+import userEvent from '@testing-library/user-event';
+import { createMockStore } from '../../../testutils';
+
+const numberCallback = (num: number) => {
+  if (num) {
+    return [{ type: 'SUCCESS' }];
+  }
+};
+
+const testA: NumberModalInterface = {
+  callback: numberCallback,
+  cancelText: 'Override Cancel',
+  confirmText: 'Override Confirm',
+  label: 'Number Input Label',
+  prompt: 'Testing Button Overrides',
+  title: 'TestA'
+};
+const testB: NumberModalInterface = {
+  callback: numberCallback,
+  label: 'Expect size between',
+  disableCancel: true,
+  max: 8,
+  min: 6,
+  prompt: ['Testing response', 'for set length'],
+  title: 'TestB'
+};
+
+const testC: NumberModalInterface = {
+  prompt: 'Testing Select Options',
+  callback: numberCallback,
+  label: 'Select Options',
+  selectOptions: [1, 2, 3, 4],
+  title: 'TestD'
+};
+
+describe('NumberModal.tsx', () => {
+  const store = createMockStore({
+    AlertsAndPrompts: createAlertsAndPromptsReducer()
+  });
+  let utils;
+  beforeEach(() => {
+    utils = render(
+      <Provider store={store}>
+        <UserInputModalController />
+      </Provider>
+    );
+  });
+  afterEach(() => {});
+  it('should render with non-default text', async () => {
+    act(() => {
+      store.dispatch(Prompt.number(testA));
+    });
+    const { getByText } = utils;
+
+    await waitFor(() => {
+      expect(getByText(testA.prompt as string)).toBeDefined();
+      expect(getByText(testA.title)).toBeDefined();
+      expect(getByText(testA.cancelText!)).toBeDefined();
+      expect(getByText(testA.confirmText!)).toBeDefined();
+    });
+  });
+
+  it('should close on cancel', async () => {
+    const { queryByText, getByTestId } = utils;
+
+    await waitFor(() => {
+      expect(queryByText(testA.confirmText)).toBeDefined();
+      expect(getByTestId('number-modal-cancel')).toBeDefined();
+    });
+
+    userEvent.click(getByTestId('number-modal-cancel'));
+    await waitFor(() => {
+      expect(queryByText(testA.title)).toBeNull();
+    });
+  });
+
+  it('should render with multiple prompt lines and no cancel button', async () => {
+    act(() => {
+      store.dispatch(Prompt.number(testB));
+    });
+    const { queryByTestId, queryAllByRole } = utils;
+
+    await waitFor(() => {
+      expect(queryAllByRole('paragraph').length).toEqual(2);
+      expect(queryAllByRole('paragraph').length).toEqual(2);
+      expect(queryByTestId('number-modal-cancel')).toBeNull();
+    });
+  });
+
+  it('should show error text and block submit if response not in parameters characters', async () => {
+    const { getByLabelText, getByText, queryByTestId, queryByText } = utils;
+    const expectedError = 'Number must be between (6) and (8)';
+
+    const getConfirmButton = () => queryByTestId('number-modal-confirm');
+    const input = getByLabelText(testB.label);
+    await userEvent.type(input, '11');
+    await waitFor(() => {
+      expect(getByText(expectedError)).toBeDefined();
+    });
+    await userEvent.clear(input); // Clear existing input
+    await userEvent.type(input, '7');
+    expect(queryByText(expectedError)).toBeNull();
+    await userEvent.click(queryByTestId('number-modal-confirm'));
+    expect(getConfirmButton()).toBeNull(); // Prompt Gone
+  });
+
+  it('should use select options when provided', async () => {
+    act(() => {
+      store.dispatch(Prompt.number(testC));
+    });
+    const { getByLabelText, getByTestId, getByText, queryByText } = utils;
+    const select = getByLabelText(testC.label);
+
+    expect(getByText(testC.prompt)).toBeDefined(); // Prompt is open
+    expect(select).toBeDefined();
+    expect(getByTestId('number-modal-confirm').disabled).toBe(true);
+
+    await userEvent.click(select);
+    await waitFor(() => {
+      expect(getByText(testC.selectOptions![0])).toBeDefined();
+      expect(getByText(testC.selectOptions![1])).toBeDefined();
+    });
+    await userEvent.click(getByText(testC.selectOptions![1]));
+    await waitFor(() => {
+      expect(queryByText(testC.selectOptions![0])).toBeNull(); // Select Items closed after selecting second option
+    });
+    await userEvent.click(getByTestId('number-modal-confirm'));
+    await waitFor(() => {
+      expect(queryByText(testC.prompt)).toBeNull(); // Prompt closed with Confirmation
+    });
+  });
+});

--- a/app/src/UI/UserInputModals/NumberModal.tsx
+++ b/app/src/UI/UserInputModals/NumberModal.tsx
@@ -130,8 +130,16 @@ const NumberModal = ({
         </FormControl>
         <Divider />
         <DialogActions>
-          {!disableCancel && <Button onClick={handleClose}>{cancelText ?? 'Cancel'}</Button>}
-          <Button onClick={handleConfirmation} disabled={validationError !== '' || !userNumber}>
+          {!disableCancel && (
+            <Button data-testid="number-modal-cancel" onClick={handleClose}>
+              {cancelText ?? 'Cancel'}
+            </Button>
+          )}
+          <Button
+            data-testid="number-modal-confirm"
+            onClick={handleConfirmation}
+            disabled={validationError !== '' || !userNumber}
+          >
             {confirmText ?? 'Confirm'}
           </Button>
         </DialogActions>

--- a/app/src/UI/UserInputModals/RadioModal.test.tsx
+++ b/app/src/UI/UserInputModals/RadioModal.test.tsx
@@ -73,6 +73,9 @@ describe('RadioModal.tsx', () => {
   });
 
   it('should close on cancel', async () => {
+    act(() => {
+      store.dispatch(Prompt.radio(testA));
+    });
     const { queryByText, getByTestId } = utils;
 
     await waitFor(() => {

--- a/app/src/UI/UserInputModals/RadioModal.test.tsx
+++ b/app/src/UI/UserInputModals/RadioModal.test.tsx
@@ -1,0 +1,114 @@
+import { act, render, RenderResult, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import UserInputModalController from './UserInputModalController';
+import { createAlertsAndPromptsReducer } from 'state/reducers/alertsAndPrompts';
+import Prompt from 'state/actions/prompts/Prompt';
+import { RadioModalInterface } from 'interfaces/prompt-interfaces';
+import userEvent from '@testing-library/user-event';
+import { createMockStore } from '../../../testutils';
+
+const textCallBack = (str: string | number) => {
+  if (str) {
+    return [{ type: 'SUCCESS' }];
+  }
+};
+
+const testA: RadioModalInterface = {
+  callback: textCallBack,
+  cancelText: 'Override Cancel',
+  confirmText: 'Override Confirm',
+  label: 'Radio Test [String]',
+  options: ['Hello', 'World'],
+  prompt: 'Testing Radio',
+  title: 'Radio [String]'
+};
+
+const testB: RadioModalInterface = {
+  callback: textCallBack,
+  label: 'Radio Test [String]',
+  disableCancel: true,
+  options: [1, 2, 3],
+  prompt: ['Testing Radio', 'With Array Prompt'],
+  title: 'Radio [Number]'
+};
+
+describe('RadioModal.tsx', () => {
+  const store = createMockStore({ AlertsAndPrompts: createAlertsAndPromptsReducer() });
+  let utils: RenderResult;
+  beforeEach(() => {
+    utils = render(
+      <Provider store={store}>
+        <UserInputModalController />
+      </Provider>
+    );
+  });
+  afterEach(() => {});
+  it('should render with non-default text', async () => {
+    act(() => {
+      store.dispatch(Prompt.radio(testA));
+    });
+    const { getByText } = utils;
+
+    await waitFor(() => {
+      expect(getByText(testA.prompt as string)).toBeDefined();
+      expect(getByText(testA.title)).toBeDefined();
+      expect(getByText(testA.cancelText!)).toBeDefined();
+      expect(getByText(testA.confirmText!)).toBeDefined();
+    });
+  });
+  it('renders all provided options [string] and submits', async () => {
+    const { getByLabelText, getByRole, getByTestId, queryByText } = utils;
+    const getByOption = (index: number) => getByLabelText(testA.options[index]) as HTMLInputElement;
+
+    testA.options.forEach((option) => {
+      expect(getByLabelText(option)).toBeDefined();
+      expect(getByRole('radio', { name: option })).toBeDefined();
+    });
+
+    await userEvent.click(getByOption(1));
+    expect(getByOption(0).checked).toBe(false);
+    expect(getByOption(1).checked).toBe(true);
+    await userEvent.click(getByTestId('radio-modal-confirm'));
+    expect(queryByText(testB.title)).toBeNull();
+  });
+
+  it('should close on cancel', async () => {
+    const { queryByText, getByTestId } = utils;
+
+    await waitFor(() => {
+      expect(getByTestId('radio-modal-cancel')).toBeDefined();
+    });
+
+    userEvent.click(getByTestId('radio-modal-cancel'));
+    await waitFor(() => {
+      expect(queryByText(testA.title)).toBeNull();
+    });
+  });
+
+  it('should render with multiple prompt lines and no cancel button', async () => {
+    act(() => {
+      store.dispatch(Prompt.radio(testB));
+    });
+    const { queryByTestId, queryAllByRole } = utils;
+
+    await waitFor(() => {
+      expect(queryAllByRole('paragraph').length).toEqual(testB.prompt.length);
+      expect(queryByTestId('radio-modal-cancel')).toBeNull();
+    });
+  });
+
+  it('renders all provided options [number] and submits', async () => {
+    const { getByLabelText, getByRole, getByTestId, queryByText } = utils;
+    testB.options.forEach((option) => {
+      expect(getByLabelText(option)).toBeDefined();
+      expect(getByRole('radio', { name: option })).toBeDefined();
+    });
+    const getByOption = (index: number) => getByLabelText(testB.options[index]) as HTMLInputElement;
+
+    await userEvent.click(getByOption(2));
+    expect(getByOption(0).checked).toBe(false);
+    expect(getByOption(2).checked).toBe(true);
+    await userEvent.click(getByTestId('radio-modal-confirm'));
+    expect(queryByText(testB.title)).toBeNull();
+  });
+});

--- a/app/src/UI/UserInputModals/RadioModal.tsx
+++ b/app/src/UI/UserInputModals/RadioModal.tsx
@@ -86,8 +86,16 @@ const RadioModal = ({
         </DialogContent>
         <Divider />
         <DialogActions>
-          {!disableCancel && <Button onClick={handleClose}>{cancelText ?? 'Cancel'}</Button>}
-          <Button onClick={handleConfirmation} disabled={!(options as any[]).includes(userInput)}>
+          {!disableCancel && (
+            <Button data-testid="radio-modal-cancel" onClick={handleClose}>
+              {cancelText ?? 'Cancel'}
+            </Button>
+          )}
+          <Button
+            data-testid="radio-modal-confirm"
+            onClick={handleConfirmation}
+            disabled={!(options as Array<string | number>).includes(userInput)}
+          >
             {confirmText ?? 'Confirm'}
           </Button>
         </DialogActions>

--- a/app/src/UI/UserInputModals/TextModal.test.tsx
+++ b/app/src/UI/UserInputModals/TextModal.test.tsx
@@ -1,0 +1,173 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import UserInputModalController from './UserInputModalController';
+import { configureStore } from '@reduxjs/toolkit';
+import { createAlertsAndPromptsReducer } from 'state/reducers/alertsAndPrompts';
+import Prompt from 'state/actions/prompts/Prompt';
+import { TextModalInterface } from 'interfaces/prompt-interfaces';
+import userEvent from '@testing-library/user-event';
+
+const createMockStore = () =>
+  configureStore({
+    reducer: {
+      AlertsAndPrompts: createAlertsAndPromptsReducer()
+    }
+  });
+
+const textCallBack = (str: string) => {
+  if (str) {
+    return [{ type: 'SUCCESS' }];
+  }
+};
+
+const testA: TextModalInterface = {
+  callback: textCallBack,
+  cancelText: 'Override Cancel',
+  confirmText: 'Override Confirm',
+  label: 'Text Input Label',
+  prompt: 'Testing Button Overrides',
+  title: 'TestA'
+};
+const testB: TextModalInterface = {
+  callback: textCallBack,
+  disableCancel: true,
+  label: 'Length Test',
+  max: 8,
+  min: 6,
+  prompt: ['Testing response', 'for set length'],
+  title: 'Length Test'
+};
+
+const testC: TextModalInterface = {
+  callback: textCallBack,
+  label: 'Regex Test',
+  prompt: 'Testing Regex',
+  regex: /^Hello World$/,
+  regexErrorText: 'does not conform to pattern',
+  title: 'Regex Text'
+};
+
+const testD: TextModalInterface = {
+  prompt: 'Testing Select Options',
+  callback: textCallBack,
+  label: 'Select Options',
+  selectOptions: ['Hello', 'World'],
+  title: 'Test Select'
+};
+
+describe('TextModal.tsx', () => {
+  const store = createMockStore();
+  let utils;
+  beforeEach(() => {
+    utils = render(
+      <Provider store={store}>
+        <UserInputModalController />
+      </Provider>
+    );
+  });
+  afterEach(() => {});
+  it('should render with non-default text', async () => {
+    act(() => {
+      store.dispatch(Prompt.text(testA));
+    });
+    const { getByText } = utils;
+
+    await waitFor(() => {
+      expect(getByText(testA.prompt as string)).toBeDefined();
+      expect(getByText(testA.title)).toBeDefined();
+      expect(getByText(testA.cancelText!)).toBeDefined();
+      expect(getByText(testA.confirmText!)).toBeDefined();
+    });
+  });
+
+  it('should close on cancel', async () => {
+    const { queryByText, getByTestId } = utils;
+
+    await waitFor(() => {
+      expect(getByTestId('text-modal-cancel')).toBeDefined();
+    });
+
+    userEvent.click(getByTestId('text-modal-cancel'));
+    await waitFor(() => {
+      expect(queryByText(testA.title)).toBeNull();
+    });
+  });
+
+  it('should render with multiple prompt lines and no cancel button', async () => {
+    act(() => {
+      store.dispatch(Prompt.text(testB));
+    });
+    const { queryByTestId, queryAllByRole } = utils;
+
+    await waitFor(() => {
+      expect(queryAllByRole('paragraph').length).toEqual(2);
+      expect(queryByTestId('text-modal-cancel')).toBeNull();
+    });
+  });
+
+  it('should show error text and block submit if response not 7 characters', async () => {
+    const { getByLabelText, getByText, getByTestId, queryByText } = utils;
+    const getConfirmButton = () => getByTestId('text-modal-confirm') as HTMLButtonElement;
+    const input = getByLabelText(testB.label);
+    await userEvent.type(input, 'short');
+    await userEvent.click(getConfirmButton()); // Trigger Blur event
+    await waitFor(() => {
+      expect(getByText('Response must be between (6) and (8) characters in length')).toBeDefined();
+    });
+    await userEvent.clear(input); // Clear existing input
+    await userEvent.type(input, 'Testing');
+    await userEvent.click(getConfirmButton()); // Trigger Blur event
+    await waitFor(() => {
+      expect(queryByText('Response must be between (6) and (8) characters in length')).toBeNull();
+    });
+  });
+
+  it('should test against supplied regex pattern', async () => {
+    act(() => {
+      store.dispatch(Prompt.text(testC));
+    });
+    const { getByLabelText, getByText, getByTestId, queryByText } = utils;
+    const getConfirmButton = () => getByTestId('text-modal-confirm') as HTMLButtonElement;
+    const input = getByLabelText(testC.label);
+    await userEvent.type(input, 'World Hello');
+    await userEvent.click(getConfirmButton()); // Trigger Blur event
+    await waitFor(() => {
+      expect(getByText(testC.regexErrorText)).toBeDefined();
+    });
+    await userEvent.clear(input); // Clear existing input
+    await userEvent.type(input, 'Hello World');
+    await userEvent.click(getConfirmButton()); // Trigger Blur event
+    await waitFor(() => {
+      expect(queryByText(testC.regexErrorText)).toBeNull();
+      expect(queryByText(testC.label)).toBeNull(); // Prompt is closed
+    });
+  });
+
+  it('should use select options when provided', async () => {
+    act(() => {
+      store.dispatch(Prompt.text(testD));
+    });
+    const { getByLabelText, getByTestId, getByText, queryByText } = utils;
+    const select = getByLabelText(testD.label);
+    await waitFor(() => {
+      expect(getByText(testD.prompt)).toBeDefined(); // Prompt is open
+      expect(select).toBeDefined();
+    });
+    await userEvent.click(getByTestId('text-modal-confirm'));
+    expect(getByText('You need to select an option from the menu')).toBeDefined();
+
+    await userEvent.click(select);
+    await waitFor(() => {
+      expect(getByText(testD.selectOptions![0])).toBeDefined();
+      expect(getByText(testD.selectOptions![1])).toBeDefined();
+    });
+    await userEvent.click(getByText(testD.selectOptions![1]));
+    await waitFor(() => {
+      expect(queryByText(testD.selectOptions![0])).toBeNull(); // Select Items closed after selecting second option
+    });
+    await userEvent.click(getByTestId('text-modal-confirm'));
+    await waitFor(() => {
+      expect(queryByText(testD.prompt)).toBeNull(); // Prompt closed with Confirmation
+    });
+  });
+});

--- a/app/src/UI/UserInputModals/TextModal.test.tsx
+++ b/app/src/UI/UserInputModals/TextModal.test.tsx
@@ -1,18 +1,11 @@
 import { act, render, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import UserInputModalController from './UserInputModalController';
-import { configureStore } from '@reduxjs/toolkit';
 import { createAlertsAndPromptsReducer } from 'state/reducers/alertsAndPrompts';
 import Prompt from 'state/actions/prompts/Prompt';
 import { TextModalInterface } from 'interfaces/prompt-interfaces';
 import userEvent from '@testing-library/user-event';
-
-const createMockStore = () =>
-  configureStore({
-    reducer: {
-      AlertsAndPrompts: createAlertsAndPromptsReducer()
-    }
-  });
+import { createMockStore } from '../../../testutils';
 
 const textCallBack = (str: string) => {
   if (str) {
@@ -56,7 +49,9 @@ const testD: TextModalInterface = {
 };
 
 describe('TextModal.tsx', () => {
-  const store = createMockStore();
+  const store = createMockStore({
+    AlertsAndPrompts: createAlertsAndPromptsReducer()
+  });
   let utils;
   beforeEach(() => {
     utils = render(

--- a/app/src/UI/UserInputModals/TextModal.test.tsx
+++ b/app/src/UI/UserInputModals/TextModal.test.tsx
@@ -35,7 +35,7 @@ const testB: TextModalInterface = {
   max: 8,
   min: 6,
   prompt: ['Testing response', 'for set length'],
-  title: 'Length Test'
+  title: 'TestB'
 };
 
 const testC: TextModalInterface = {
@@ -44,7 +44,7 @@ const testC: TextModalInterface = {
   prompt: 'Testing Regex',
   regex: /^Hello World$/,
   regexErrorText: 'does not conform to pattern',
-  title: 'Regex Text'
+  title: 'TestC'
 };
 
 const testD: TextModalInterface = {
@@ -52,7 +52,7 @@ const testD: TextModalInterface = {
   callback: textCallBack,
   label: 'Select Options',
   selectOptions: ['Hello', 'World'],
-  title: 'Test Select'
+  title: 'TestD'
 };
 
 describe('TextModal.tsx', () => {

--- a/app/src/UI/UserInputModals/TextModal.tsx
+++ b/app/src/UI/UserInputModals/TextModal.tsx
@@ -100,6 +100,7 @@ const TextModal = ({
             </TextField>
           ) : (
             <TextField
+              data-test-id="text-modal-input"
               aria-label="Text Input"
               error={!!validationError}
               helperText={validationError}
@@ -112,8 +113,14 @@ const TextModal = ({
         </FormControl>
         <Divider />
         <DialogActions>
-          {!disableCancel && <Button onClick={handleClose}>{cancelText ?? 'Cancel'}</Button>}
-          <Button onClick={handleConfirmation}>{confirmText ?? 'Confirm'}</Button>
+          {!disableCancel && (
+            <Button data-testid="text-modal-cancel" onClick={handleClose}>
+              {cancelText ?? 'Cancel'}
+            </Button>
+          )}
+          <Button data-testid="text-modal-confirm" onClick={handleConfirmation}>
+            {confirmText ?? 'Confirm'}
+          </Button>
         </DialogActions>
       </Box>
     </Modal>

--- a/app/testutils.ts
+++ b/app/testutils.ts
@@ -1,0 +1,32 @@
+/**
+ * Helpers and Shorthand functions for Writing Tests and Mocks
+ */
+import { configureStore } from '@reduxjs/toolkit';
+
+/**
+ * @param stateProperties Mocked state properties
+ * @returns reducer
+ */
+const mockState =
+  // eslint-disable-next-line
+  (stateProps: Record<PropertyKey, any>) =>
+    (
+      state = {
+        ...stateProps
+      }
+    ) =>
+      state;
+
+/**
+ * @desc Shorthand Mock Store creator
+ * @param reducers Supplied reducers for creation. e.g. {Configuration: createConfigurationReducer()}
+ */
+// eslint-disable-next-line
+const createMockStore = (reducers: Record<PropertyKey, any>) =>
+  configureStore({
+    reducer: {
+      ...reducers
+    }
+  });
+
+export { createMockStore, mockState };


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

## Tests

- LpLayers
- LpLayersOptions
- NoRowsInSearch
- ManualUtmModal
- NumberModal
- TextModal
- RadioModal

> Have not figured out how to get around the Render challenges with the DateModal in jsdom

## Functionality

- Add `testutils` file for mocking tests faster / easier 
    - Currently has handlers to simplify creating mock stores.
- Modified components just have `data-testid` added in places.