### PR TITLE
[INV-4109] Better Testing, implement type guards on Mocks

### DIFF
--- a/app/src/UI/Features/Landing/Landing.test.tsx
+++ b/app/src/UI/Features/Landing/Landing.test.tsx
@@ -1,53 +1,42 @@
-import { configureStore } from '@reduxjs/toolkit';
 import { render, waitFor, within } from '@testing-library/react';
 import { LandingComponent } from 'UI/Features/Landing/Landing';
 import { Provider } from 'react-redux';
 import userEvent from '@testing-library/user-event';
-import { createMockConfigurationReducer, DEFAULT_TEST_CONFIGURATION, IOS_TEST_CONFIGURATION } from 'test/testUtils';
+import {
+  createMockConfigurationReducer,
+  createMockStore,
+  DEFAULT_TEST_CONFIGURATION,
+  IOS_TEST_CONFIGURATION,
+  mockSliceReducer
+} from 'test/testUtils';
 import { UnifiedConfig } from 'state/configuration/unified-config';
 
-const createMockAuthReducer =
-  (isAuth: boolean) =>
-  (
-    state = {
-      authenticated: isAuth,
-      loggedInOrWorkingOffline: isAuth,
+const createStore = (auth: boolean, config: UnifiedConfig) =>
+  createMockStore({
+    ...mockSliceReducer('Auth', {
+      authenticated: auth,
+      loggedInOrWorkingOffline: auth,
       workingOffline: false,
       username: 'johnsmith',
       displayName: 'John Smith',
       email: 'JSmith@mail.ca',
-      roles: isAuth ? [{ role_id: 1, role_name: 'Test Role', role_description: 'Testing Role' }] : []
-    }
-  ) =>
-    state;
-
-const mockUserInfoReducer = (
-  state = {
-    loaded: true,
-    activated: false
-  }
-) => state;
-
-const mockNetworkReducer = (
-  state = {
-    connected: true
-  }
-) => state;
-
-const createMockStore = (auth: boolean, config: UnifiedConfig) =>
-  configureStore({
-    reducer: {
-      Auth: createMockAuthReducer(auth),
-      UserInfo: mockUserInfoReducer,
-      Network: mockNetworkReducer,
-      Configuration: createMockConfigurationReducer(config)
-    }
+      roles: auth ? [{ role_id: 1, role_name: 'Test Role' }] : []
+    }),
+    ...mockSliceReducer('UserInfo', {
+      loaded: true,
+      activated: false
+    }),
+    ...mockSliceReducer('Network', {
+      connected: true
+    }),
+    ...mockSliceReducer('Configuration', { current: config }),
+    Configuration: createMockConfigurationReducer(config)
   });
 
 describe('Landing.tsx', async () => {
   it('should Render and display user details + roles', () => {
     const { getByText } = render(
-      <Provider store={createMockStore(true, DEFAULT_TEST_CONFIGURATION)}>
+      <Provider store={createStore(true, DEFAULT_TEST_CONFIGURATION)}>
         <LandingComponent />
       </Provider>
     );
@@ -63,7 +52,7 @@ describe('Landing.tsx', async () => {
       MOBILE: true
     }));
     const { getByText } = render(
-      <Provider store={createMockStore(true, IOS_TEST_CONFIGURATION)}>
+      <Provider store={createStore(true, IOS_TEST_CONFIGURATION)}>
         <LandingComponent />
       </Provider>
     );
@@ -72,7 +61,7 @@ describe('Landing.tsx', async () => {
 
   it('should present call to action to "request access" if not authenticated', async () => {
     const { getByText, queryAllByRole } = render(
-      <Provider store={createMockStore(false, DEFAULT_TEST_CONFIGURATION)}>
+      <Provider store={createStore(false, DEFAULT_TEST_CONFIGURATION)}>
         <LandingComponent />
       </Provider>
     );
@@ -105,7 +94,7 @@ describe('[Web] Landing.tsx', () => {
 
   it('should Render with Download Link section', async () => {
     const { getByText } = render(
-      <Provider store={createMockStore(true, DEFAULT_TEST_CONFIGURATION)}>
+      <Provider store={createStore(true, DEFAULT_TEST_CONFIGURATION)}>
         <LandingComponent />
       </Provider>
     );

--- a/app/src/UI/Features/LegacyMap/Controls/AccuracyToggle.test.tsx
+++ b/app/src/UI/Features/LegacyMap/Controls/AccuracyToggle.test.tsx
@@ -1,26 +1,15 @@
 import { act, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AccuracyToggle } from 'UI/Features/LegacyMap/Controls/AccuracyToggle';
-import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
+import { createMockStore, mockSliceReducer } from 'test/testUtils';
 
-const configurationReducer =
-  () =>
-  (
-    state = {
-      accuracyToggle: true,
-      positionTracking: true
-    }
-  ) =>
-    state;
-const createMockStore = () =>
-  configureStore({
-    reducer: {
-      Map: configurationReducer()
-    }
-  });
-
-const store = createMockStore();
+const store = createMockStore({
+  ...mockSliceReducer('Map', {
+    accuracyToggle: true,
+    positionTracking: true
+  })
+});
 
 describe('AccuracyToggle.tsx', () => {
   it('should toggle className with accuracyToggle state', async () => {

--- a/app/src/UI/Features/LegacyMap/Controls/WhatsHereButton.test.tsx
+++ b/app/src/UI/Features/LegacyMap/Controls/WhatsHereButton.test.tsx
@@ -1,4 +1,3 @@
-import { configureStore } from '@reduxjs/toolkit';
 import { render, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { WhatsHereButton } from 'UI/Features/LegacyMap/Controls/WhatsHereButton';
@@ -8,14 +7,12 @@ import userEvent from '@testing-library/user-event';
 import { createMapReducer } from 'state/reducers/map';
 import Alerts from 'state/actions/alerts/Alerts';
 import AlertMessage from 'interfaces/AlertMessage';
-
-const createMockStore = () =>
-  configureStore({
-    reducer: { Map: createMapReducer() }
-  });
+import { createMockStore } from 'test/testUtils';
 
 describe('WhatsHereButton.tsx', () => {
-  const store = createMockStore();
+  const store = createMockStore({
+    Map: createMapReducer()
+  });
   const dispatchSpy = vi.spyOn(store, 'dispatch');
   it('should render', async () => {
     const { getByTestId } = render(

--- a/app/src/UI/Features/LegacyMap/LayerPicker/LayerPicker.test.tsx
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LayerPicker.test.tsx
@@ -1,34 +1,26 @@
-import { configureStore } from '@reduxjs/toolkit';
 import { render, waitFor, within } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { LayerPicker } from 'UI/Features/LegacyMap/LayerPicker/LayerPicker';
 import userEvent from '@testing-library/user-event';
 import { act } from 'react';
 import UserSettings from 'state/actions/userSettings/UserSettings';
-
-const userSettingsReducer = (state = { layerPickerIsAccordion: false }, action) => {
-  if (UserSettings.toggleLayerPickerAccordion.match(action)) {
-    return {
-      ...state,
-      layerPickerIsAccordion: !state.layerPickerIsAccordion
-    };
-  }
-  return state;
-};
-const networkReducer = (state = { connected: false }) => state;
-const configurationReducer = (state = { current: { build: { MOBILE: true } } }) => state;
-
-const createMockStore = () =>
-  configureStore({
-    reducer: {
-      Configuration: configurationReducer,
-      UserSettings: userSettingsReducer,
-      Network: networkReducer
-    }
-  });
+import { createMockConfigurationReducer, createMockStore, mockSliceReducer } from 'test/testUtils';
 
 describe('LayerPicker.tsx', () => {
-  const store = createMockStore();
+  const userSettingsReducer = (state = { layerPickerIsAccordion: false }, action) => {
+    if (UserSettings.toggleLayerPickerAccordion.match(action)) {
+      return {
+        ...state,
+        layerPickerIsAccordion: !state.layerPickerIsAccordion
+      };
+    }
+    return state;
+  };
+  const store = createMockStore({
+    ...mockSliceReducer('Network', { connected: false }),
+    Configuration: createMockConfigurationReducer(),
+    UserSettings: userSettingsReducer
+  });
 
   it('should initial render to button and toggle between open/closed', async () => {
     const { container, getByTestId } = render(

--- a/app/src/UI/Features/LegacyMap/LayerPicker/LpLayers/LpLayers.test.tsx
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LpLayers/LpLayers.test.tsx
@@ -1,7 +1,7 @@
 import { render, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import LpLayers from './LpLayers';
-import { createMockStore, mockState } from 'test/testUtils';
+import { createMockStore, mockSliceReducer } from 'test/testUtils';
 import { createMapReducer, DEFAULT_LOCAL_LAYERS } from 'state/reducers/map';
 import userEvent from '@testing-library/user-event';
 
@@ -9,12 +9,12 @@ describe('LpLayers.tsx', () => {
   const store = (online: boolean) =>
     createMockStore({
       Map: createMapReducer(),
-      Network: mockState({
+      ...mockSliceReducer('Network', {
         connected: online
       })
     });
   const storeWithShapes = createMockStore({
-    Map: mockState({
+    ...mockSliceReducer('Map', {
       simplePickerLayers2: [],
       serverBoundaries: [
         {
@@ -68,7 +68,7 @@ describe('LpLayers.tsx', () => {
         }
       ]
     }),
-    Network: mockState({
+    ...mockSliceReducer('Network', {
       connected: false
     })
   });

--- a/app/src/UI/Features/LegacyMap/helpers/components/AccuracyDisplay/AccuracyDisplay.test.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/AccuracyDisplay/AccuracyDisplay.test.tsx
@@ -1,12 +1,11 @@
 import { render, waitFor } from '@testing-library/react';
 import AccuracyDisplay from 'UI/Features/LegacyMap/helpers/components/AccuracyDisplay/AccuracyDisplay';
 import { Provider } from 'react-redux';
-import { configureStore } from '@reduxjs/toolkit';
+import { createMockStore, mockSliceReducer } from 'test/testUtils';
 
-const configurationReducerRender =
-  () =>
-  (
-    state = {
+describe('AccuracyDisplay.tsx', () => {
+  const accuracyOnStore = createMockStore({
+    ...mockSliceReducer('Map', {
       accuracyToggle: true,
       positionTracking: true,
       userCoords: {
@@ -15,14 +14,11 @@ const configurationReducerRender =
         accuracy: 3,
         heading: 20
       }
-    }
-  ) =>
-    state;
-const configurationReducerNullRender =
-  () =>
-  (
-    state = {
-      accuracyToggle: false,
+    })
+  });
+  const accuracyOffStore = createMockStore({
+    ...mockSliceReducer('Map', {
+      accuracyToggle: true,
       positionTracking: true,
       userCoords: {
         lat: 54.1,
@@ -30,21 +26,11 @@ const configurationReducerNullRender =
         accuracy: 3,
         heading: 20
       }
-    }
-  ) =>
-    state;
-const createMockStore = (reducerCase) =>
-  configureStore({
-    reducer: {
-      Map: reducerCase
-    }
+    })
   });
-
-describe('AccuracyDisplay.tsx', () => {
   it('should render', async () => {
-    const store = createMockStore(configurationReducerRender);
     const { getByText } = render(
-      <Provider store={store}>
+      <Provider store={accuracyOnStore}>
         <AccuracyDisplay />
       </Provider>
     );
@@ -54,9 +40,8 @@ describe('AccuracyDisplay.tsx', () => {
   });
 
   it('should return blank if "accuracyToggle" is false', async () => {
-    const store = createMockStore(configurationReducerNullRender);
     const { queryByText } = render(
-      <Provider store={store}>
+      <Provider store={accuracyOffStore}>
         <AccuracyDisplay />
       </Provider>
     );

--- a/app/src/UI/Features/LegacyMap/helpers/components/DisplayComposite/DisplayComposite.test.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/DisplayComposite/DisplayComposite.test.tsx
@@ -1,26 +1,12 @@
 import { render } from '@testing-library/react';
 import DisplayComposite from 'UI/Features/LegacyMap/helpers/components/DisplayComposite/DisplayComposite';
 import { Provider } from 'react-redux';
-import { configureStore } from '@reduxjs/toolkit';
-
-const configurationReducer =
-  () =>
-  (
-    state = {
-      accuracyToggle: false,
-      positionTracking: true
-    }
-  ) =>
-    state;
-const createMockStore = () =>
-  configureStore({
-    reducer: {
-      Map: configurationReducer()
-    }
-  });
+import { createMockStore, mockSliceReducer } from 'test/testUtils';
 
 describe('DisplayComposite.tsx', () => {
-  const store = createMockStore();
+  const store = createMockStore({
+    ...mockSliceReducer('Map', { accuracyToggle: false, positionTracking: true })
+  });
 
   it('should render', () => {
     const { container } = render(

--- a/app/src/UI/Features/WhatsHere/Subcomponents/NoRowsInSearch.test.tsx
+++ b/app/src/UI/Features/WhatsHere/Subcomponents/NoRowsInSearch.test.tsx
@@ -1,4 +1,4 @@
-import { createMockStore, mockState } from 'test/testUtils';
+import { createMockStore, mockSliceReducer } from 'test/testUtils';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import NoRowsInSearch from './NoRowsInSearch';
@@ -9,7 +9,7 @@ import { RecordSetType } from 'interfaces/UserRecordSet';
 
 describe('NoRowsInSearch.tsx', () => {
   const storeWithoutRecordSetToggled = createMockStore({
-    UserSettings: mockState({
+    ...mockSliceReducer('UserSettings', {
       recordSets: { '1': UserSettings.RecordSet.createDefaultRecordset(RecordSetType.Activity) }
     })
   });
@@ -18,7 +18,7 @@ describe('NoRowsInSearch.tsx', () => {
   recordSet.mapToggle = true;
 
   const storeWithRecordSetToggled = createMockStore({
-    UserSettings: mockState({
+    ...mockSliceReducer('UserSettings', {
       recordSets: { '1': recordSet }
     })
   });

--- a/app/src/UI/Layout/AlertsContainer/AlertsContainer.test.tsx
+++ b/app/src/UI/Layout/AlertsContainer/AlertsContainer.test.tsx
@@ -16,13 +16,7 @@ import AlertMessage from 'interfaces/AlertMessage';
 import { AlertSeverity, AlertSubjects } from 'constants/alertEnums';
 import Alerts from 'state/actions/alerts/Alerts';
 import { createAlertsAndPromptsReducer } from 'state/reducers/alertsAndPrompts';
-import { configureStore } from '@reduxjs/toolkit';
-
-const createMockStore = () =>
-  configureStore({
-    reducer: { AlertsAndPrompts: createAlertsAndPromptsReducer() }
-  });
-const store = createMockStore();
+import { createMockStore } from 'test/testUtils';
 
 const testAlerts: Array<AlertMessage> = [
   {
@@ -57,7 +51,12 @@ const testAlerts: Array<AlertMessage> = [
     severity: AlertSeverity.Info
   }
 ];
+
 describe('Records.tsx', () => {
+  const store = createMockStore({
+    AlertsAndPrompts: createAlertsAndPromptsReducer()
+  });
+
   it('shouldRender', () => {
     render(
       <Provider store={store}>

--- a/app/src/UI/Reusable/AndroidDownloadLink/AndroidDownloadLink.test.tsx
+++ b/app/src/UI/Reusable/AndroidDownloadLink/AndroidDownloadLink.test.tsx
@@ -1,30 +1,22 @@
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
+import { createMockStore, DEFAULT_TEST_CONFIGURATION, mockSliceReducer } from 'test/testUtils';
 import AndroidDownloadLink from 'UI/Reusable/AndroidDownloadLink/AndroidDownloadLink';
-import { configureStore } from '@reduxjs/toolkit';
-
-const configurationReducer =
-  (base_url) =>
-  (
-    state = {
-      current: {
-        runtime: {
-          ANDROID_APP_STORE_URL: base_url
-        }
-      }
-    }
-  ) =>
-    state;
-const createMockStore = (urlValue) =>
-  configureStore({
-    reducer: {
-      Configuration: configurationReducer(urlValue)
-    }
-  });
 
 describe('AndroidDownloadLink.tsx', () => {
+  const createStore = (base_url: string) =>
+    createMockStore({
+      ...mockSliceReducer('Configuration', {
+        current: {
+          build: DEFAULT_TEST_CONFIGURATION.build,
+          features: DEFAULT_TEST_CONFIGURATION.features,
+          runtime: { ...DEFAULT_TEST_CONFIGURATION.runtime, ANDROID_APP_STORE_URL: base_url }
+        }
+      })
+    });
+
   it('should render null', () => {
-    const mockStore = createMockStore('unset');
+    const mockStore = createStore('unset');
     const { queryByAltText } = render(
       <Provider store={mockStore}>
         <AndroidDownloadLink />
@@ -34,7 +26,7 @@ describe('AndroidDownloadLink.tsx', () => {
   });
   it('should render with url', () => {
     const url = 'http://localhost:3000';
-    const mockStore = createMockStore(url);
+    const mockStore = createStore(url);
     const { getByAltText } = render(
       <Provider store={mockStore}>
         <AndroidDownloadLink />

--- a/app/src/UI/Reusable/IosDownloadLink/IosDownloadLink.test.tsx
+++ b/app/src/UI/Reusable/IosDownloadLink/IosDownloadLink.test.tsx
@@ -1,31 +1,22 @@
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
-
-import { configureStore } from '@reduxjs/toolkit';
 import IosDownloadLink from 'UI/Reusable/IosDownloadLink/IosDownloadLink';
-
-const configurationReducer =
-  (base_url) =>
-  (
-    state = {
-      current: {
-        runtime: {
-          IOS_APP_STORE_URL: base_url
-        }
-      }
-    }
-  ) =>
-    state;
-const createMockStore = (urlValue) =>
-  configureStore({
-    reducer: {
-      Configuration: configurationReducer(urlValue)
-    }
-  });
+import { createMockStore, DEFAULT_TEST_CONFIGURATION, mockSliceReducer } from 'test/testUtils';
 
 describe('IosDownloadLink.tsx', () => {
+  const createStore = (base_url: string) =>
+    createMockStore({
+      ...mockSliceReducer('Configuration', {
+        current: {
+          build: DEFAULT_TEST_CONFIGURATION.build,
+          features: DEFAULT_TEST_CONFIGURATION.features,
+          runtime: { ...DEFAULT_TEST_CONFIGURATION.runtime, IOS_APP_STORE_URL: base_url }
+        }
+      })
+    });
+
   it('should render null', () => {
-    const mockStore = createMockStore('unset');
+    const mockStore = createStore('unset');
     const { queryByAltText } = render(
       <Provider store={mockStore}>
         <IosDownloadLink />
@@ -35,7 +26,7 @@ describe('IosDownloadLink.tsx', () => {
   });
   it('should render with url', () => {
     const url = 'http://localhost:3000';
-    const mockStore = createMockStore(url);
+    const mockStore = createStore(url);
     const { getByAltText } = render(
       <Provider store={mockStore}>
         <IosDownloadLink />

--- a/app/src/UI/Reusable/UserInputModals/ConfirmationModal.test.tsx
+++ b/app/src/UI/Reusable/UserInputModals/ConfirmationModal.test.tsx
@@ -1,18 +1,11 @@
 import { act, render, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import UserInputModalController from 'UI/Reusable/UserInputModals/UserInputModalController';
-import { configureStore } from '@reduxjs/toolkit';
 import { createAlertsAndPromptsReducer } from 'state/reducers/alertsAndPrompts';
 import Prompt from 'state/actions/prompts/Prompt';
 import { ConfirmationModalInterface } from 'interfaces/prompt-interfaces';
 import userEvent from '@testing-library/user-event';
-
-const createMockStore = () =>
-  configureStore({
-    reducer: {
-      AlertsAndPrompts: createAlertsAndPromptsReducer()
-    }
-  });
+import { createMockStore } from 'test/testUtils';
 
 const confirmationCallBack = (bool: boolean) => {
   if (bool) {
@@ -36,7 +29,9 @@ const testB: ConfirmationModalInterface = {
 };
 
 describe('ConfirmationModal.tsx', () => {
-  const store = createMockStore();
+  const store = createMockStore({
+    AlertsAndPrompts: createAlertsAndPromptsReducer()
+  });
   let utils;
   beforeEach(() => {
     utils = render(

--- a/app/src/UI/Reusable/UserInputModals/TextModal.tsx
+++ b/app/src/UI/Reusable/UserInputModals/TextModal.tsx
@@ -112,8 +112,14 @@ const TextModal = ({
         </FormControl>
         <Divider />
         <DialogActions>
-          {!disableCancel && <Button onClick={handleClose}>{cancelText ?? 'Cancel'}</Button>}
-          <Button onClick={handleConfirmation}>{confirmText ?? 'Confirm'}</Button>
+          {!disableCancel && (
+            <Button data-testid="text-modal-cancel" onClick={handleClose}>
+              {cancelText ?? 'Cancel'}
+            </Button>
+          )}
+          <Button data-testid="text-modal-confirm" onClick={handleConfirmation}>
+            {confirmText ?? 'Confirm'}
+          </Button>
         </DialogActions>
       </Box>
     </Modal>

--- a/app/src/test/testUtils.ts
+++ b/app/src/test/testUtils.ts
@@ -1,31 +1,30 @@
 /**
  * Helpers and Shorthand functions for Writing Tests and Mocks
  */
-import { configureStore } from '@reduxjs/toolkit';
+import { configureStore, Reducer } from '@reduxjs/toolkit';
 import { UnifiedConfig } from 'state/configuration/unified-config';
 import { Platform } from 'state/configuration/build-time-config';
 import { BASELINE_FEATURES } from 'state/configuration/feature-flags';
+import { RootState } from 'state/reducers/rootReducer';
 
 /**
- * @param stateProperties Mocked state properties
- * @returns reducer
+ * @param key Key of { RootState } Enforces Type Guards for creation
+ * @param config Slice of RootState key to create
+ * @returns mock reducer with type guards added
  */
-const mockState =
-  // eslint-disable-next-line
-  (stateProps: Record<PropertyKey, any>) =>
-    (
-      state = {
-        ...stateProps
-      }
-    ) =>
-      state;
+function mockSliceReducer<K extends keyof RootState>(
+  key: K,
+  config: Partial<RootState[K]>
+): { [P in K]: (state: Partial<RootState[K]>) => Partial<RootState[K]> } {
+  const reducer = (state: Partial<RootState[K]> = config): Partial<RootState[K]> => state;
+  return { [key]: reducer } as { [P in K]: (state: Partial<RootState[K]>) => Partial<RootState[K]> };
+}
 
 /**
- * @desc Shorthand Mock Store creator
+ * @desc Shorthand for creating and implementing a mock redux store
  * @param reducers Supplied reducers for creation. e.g. {Configuration: createConfigurationReducer()}
  */
-// eslint-disable-next-line
-const createMockStore = (reducers: Record<PropertyKey, any>) =>
+const createMockStore = (reducers: Record<PropertyKey, Reducer>) =>
   configureStore({
     reducer: {
       ...reducers
@@ -53,7 +52,6 @@ const DEFAULT_TEST_CONFIGURATION: UnifiedConfig = {
   features: BASELINE_FEATURES
 };
 
-
 const IOS_TEST_CONFIGURATION: UnifiedConfig = {
   runtime: {
     API_BASE: 'http://localhost/',
@@ -74,7 +72,6 @@ const IOS_TEST_CONFIGURATION: UnifiedConfig = {
   },
   features: BASELINE_FEATURES
 };
-
 
 const ANDROID_TEST_CONFIGURATION: UnifiedConfig = {
   runtime: {
@@ -97,7 +94,6 @@ const ANDROID_TEST_CONFIGURATION: UnifiedConfig = {
   features: BASELINE_FEATURES
 };
 
-
 /**
  * @desc type-safe configuration reducer mock
  **/
@@ -109,4 +105,11 @@ function createMockConfigurationReducer(config: UnifiedConfig = DEFAULT_TEST_CON
   ) => state;
 }
 
-export { createMockStore, mockState, createMockConfigurationReducer, DEFAULT_TEST_CONFIGURATION, ANDROID_TEST_CONFIGURATION, IOS_TEST_CONFIGURATION };
+export {
+  createMockStore,
+  createMockConfigurationReducer,
+  mockSliceReducer,
+  DEFAULT_TEST_CONFIGURATION,
+  ANDROID_TEST_CONFIGURATION,
+  IOS_TEST_CONFIGURATION
+};


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Modify testUtils to use type guards when create mock reducers to ensure we are testing the correct values against things.
- Refactor Old tests to use the mocked function

## Example Usage

Example flags `username` and `connected` values as they do not correspond to the correct types defined in RootState, `string`, and `boolean` respectively

![image](https://github.com/user-attachments/assets/2df71d76-49b1-4a55-ab84-27451da9af0a)

Constraints satisfied

![image](https://github.com/user-attachments/assets/795882e6-a8f3-44a9-b6b3-60825cae9ac8)
