### PR TITLE
[INV-4109] Add simple component tests

### DIFF
--- a/app/src/UI/Features/Legend/InvasivePlantTable.test.tsx
+++ b/app/src/UI/Features/Legend/InvasivePlantTable.test.tsx
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react';
+import InvasivePlantTable from './InvasivePlantTable';
+
+describe('Invasive Plant Table', () => {
+  it('Should Render', () => {
+    render(<InvasivePlantTable />);
+  });
+});

--- a/app/src/UI/Features/Legend/LegendsPopup.test.tsx
+++ b/app/src/UI/Features/Legend/LegendsPopup.test.tsx
@@ -1,0 +1,46 @@
+import { render, RenderResult, waitFor } from '@testing-library/react';
+import { historySingleton } from 'state/store';
+import LegendsPopup from './LegendsPopup';
+import { Router } from 'react-router';
+import userEvent from '@testing-library/user-event';
+
+describe('LegendsPopup.tsx', () => {
+  let utils: RenderResult;
+
+  beforeEach(() => {
+    utils = render(
+      <Router history={historySingleton}>
+        <LegendsPopup />
+      </Router>
+    );
+  });
+
+  it('Should Render', () => {
+    const { getByText } = utils;
+    expect(getByText(/InvasivesBC Map Legend/)).toBeDefined();
+  });
+
+  it('Should Open Map Code list', async () => {
+    const { getByText } = utils;
+    userEvent.click(getByText('Two Letter Invasive Plant Species Map Codes'));
+    await waitFor(() => {
+      expect(getByText('Scientific name')).toBeDefined();
+    });
+  });
+
+  it('Should Display DataBC Layers', async () => {
+    const { getByText } = utils;
+    userEvent.click(getByText('Source for Layers in the Layer Picker'));
+    await waitFor(() => {
+      expect(getByText('Layer Picker Label')).toBeDefined();
+    });
+  });
+
+  it('Should Display Activity Map Layers descriptions', async () => {
+    const { getByAltText, getByText } = utils;
+    userEvent.click(getByText('InvasivesBC Activity Map Colors'));
+    await waitFor(() => {
+      expect(getByAltText('Purple records')).toBeDefined();
+    });
+  });
+});

--- a/app/src/UI/Reusable/Spinner/Spinner.test.tsx
+++ b/app/src/UI/Reusable/Spinner/Spinner.test.tsx
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react';
+import Spinner from './Spinner';
+
+describe('Spinner.tsx', () => {
+  it('should render', () => {
+    render(<Spinner />);
+  });
+});


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):
>[!IMPORTANT]
> Due to incoming major refactors inbound around state/components, this is the last of the component level testing I will be doing until Android launch. To avoid immediately deprecating the tests and creating more overhead.

>[!NOTE]
>Merges into Pt 6 of Component Testing, not Dev

## Tests
- Invasive Plant Table
- LegendsPopup
- Spinner

## Functionality
- None