### PR TITLE
[INV-4108][MOBILE] Fix Form Spinner after submitting

### DIFF
--- a/app/src/UI/Features/Records/RecordSet/RecordTable.tsx
+++ b/app/src/UI/Features/Records/RecordSet/RecordTable.tsx
@@ -30,12 +30,12 @@ export const RecordTable = ({ setID }: PropTypes) => {
       if ('activity_id' in row) {
         return {
           id: row.activity_id,
-          geom: row.geometry[0] ?? undefined
+          geom: row?.geometry?.[0]
         };
       } else if ('site_id' in row) {
         return {
           id: row.site_id,
-          geom: row.geometry ?? undefined
+          geom: row?.geometry
         };
       }
       return { id: '', geom: undefined };

--- a/app/src/UI/StartupCoordinator/Tasks/RecordsetCache.ts
+++ b/app/src/UI/StartupCoordinator/Tasks/RecordsetCache.ts
@@ -1,11 +1,11 @@
-import { RecordCacheService } from 'utils/record-cache';
+import { RecordCacheServiceFactory } from 'utils/record-cache/context';
 import { StartupTask } from 'UI/StartupCoordinator/StartupCoordinator';
 
 const LOAD_RECORDSET_CACHES: StartupTask = {
   name: 'Load Recordset Caches',
   run: async ({ CONFIG }) => {
     if (CONFIG.build.MOBILE && CONFIG.features.CACHE_RECORDSETS.enabled) {
-      await RecordCacheService.getInstance();
+      await RecordCacheServiceFactory.getPlatformInstance();
     }
   }
 };

--- a/app/src/state/sagas/activity/offline.ts
+++ b/app/src/state/sagas/activity/offline.ts
@@ -17,6 +17,7 @@ import Activity, { ICreateLocal } from 'state/actions/activity/Activity';
 import { RecordCacheServiceFactory } from 'utils/record-cache/context';
 import { RecordSetId } from 'interfaces/UserRecordSet';
 import parseActivityForPermissions from 'utils/parseActivityForPermissions';
+import { selectActivity } from 'state/reducers/activity';
 
 function* handle_ACTIVITY_SAVE_OFFLINE(action) {
   yield put(
@@ -92,7 +93,7 @@ function* handle_ACTIVITY_GET_LOCAL_REQUEST(action: PayloadAction<string>) {
 
 function* handle_ACTIVITY_RUN_OFFLINE_SYNC() {
   const { serializedActivities } = yield select(selectOfflineActivity);
-
+  const { activeActivity, activeActivityPermissions } = yield select(selectActivity);
   const toSync: OfflineActivityRecord[] = Object.values(serializedActivities).filter(
     (s) =>
       typeof s === 'object' &&
@@ -132,12 +133,18 @@ function* handle_ACTIVITY_RUN_OFFLINE_SYNC() {
             sync_state: OfflineActivitySyncState.SYNCHRONIZED
           }
         });
-        yield put(
-          Activity.getSuccess({
-            ...hydrated,
-            sync_status: sync_status
-          })
-        );
+
+        if (hydrated.activity_id === activeActivity) {
+          yield put(
+            Activity.getSuccess({
+              activity: {
+                ...hydrated,
+                sync_status
+              },
+              permissions: activeActivityPermissions
+            })
+          );
+        }
         yield put(Activity.getIdsForRecordset({ recordSetID: RecordSetId.Drafts, tableFiltersHash: 'init' }));
       } else {
         yield put({


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Fix Activity.getSuccess that was setting the active activity to null.
    - Set Activity.getSuccess to only fire if the form was the current form (when syncing mobile)
    -  correct startup coordinator to call the correct record cache function (was causing crash in mobileMode)

- Closes #4108