### PR TITLE
[INV-3700] Add Cache Button to Recordset Headers

### DIFF
--- a/app/src/UI/Features/Records/RecordSet/RecordSet.css
+++ b/app/src/UI/Features/Records/RecordSet/RecordSet.css
@@ -16,14 +16,21 @@
 
 .recordSet_header {
   box-sizing: border-box;
-  padding-left: 5px;
-  height: 45px;
+  padding: 5px;
   width: 100%;
   top: 0;
   align-items: center;
   display: flex;
   flex-direction: row;
+  min-height: 45px;
+  max-height: 80px;
   justify-content: flex-start;
+  flex-wrap: wrap;
+  border-bottom: 1px solid black;
+  .recordset-cache-control {
+    margin-left: auto;
+    margin-right: 5pt;
+  }
 }
 
 .stickyHeader {
@@ -57,6 +64,7 @@
   padding-left: 2vw;
   font-size: large;
   font-weight: bold;
+  text-wrap: wrap;
   width: auto;
 }
 

--- a/app/src/UI/Features/Records/RecordSet/RecordSet.tsx
+++ b/app/src/UI/Features/Records/RecordSet/RecordSet.tsx
@@ -6,7 +6,6 @@ import { Tooltip } from '@mui/material';
 import { RecordTable } from './RecordTable';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
-
 import FilterAltIcon from '@mui/icons-material/FilterAlt';
 import FilterAltOffIcon from '@mui/icons-material/FilterAltOff';
 import ExcelExporter from '../ExcelExporter';
@@ -15,9 +14,10 @@ import Filter from './Filter';
 import { useSelector } from 'utils/use_selector';
 import { useEffect, useState } from 'react';
 import UserSettings from 'state/actions/userSettings/UserSettings';
-import { RecordSetType } from 'interfaces/UserRecordSet';
+import { RecordSetId, RecordSetType } from 'interfaces/UserRecordSet';
 import { IFilter } from 'state/actions/userSettings/RecordSet';
 import { RecordCacheServiceFactory } from 'utils/record-cache/context';
+import { RecordSetCacheButtons } from '../RecordSetCacheButtons';
 
 type PropTypes = { setID: string };
 
@@ -34,14 +34,16 @@ export const RecordSet = ({ setID }: PropTypes) => {
     history.push('/Records');
   };
 
+  const { MOBILE } = useSelector((state) => state.Configuration.current.build);
+  const CACHE_RECORDSETS = useSelector((state) => state.Configuration.current.features.CACHE_RECORDSETS.enabled);
+  const isCellPhoneWidth = useSelector((state) => state.AppMode.constraints.tinyScreen);
   const recordSet = useSelector((state) => state.UserSettings?.recordSets?.[setID]);
   const tableType = recordSet?.recordSetType;
 
   const [cacheFilters, setCacheFilters] = useState<IFilter[]>([]);
   const [filters, setFilters] = useState<ExtendedFilter[]>([]);
 
-  const { MOBILE } = useSelector((state) => state.Configuration.current.build);
-
+  const canCacheRecordset = MOBILE && CACHE_RECORDSETS && !Object.values(RecordSetId).includes(setID as RecordSetId);
   /**
    * Get filters from recordset metadata that were applied at time of caching.
    */
@@ -53,9 +55,11 @@ export const RecordSet = ({ setID }: PropTypes) => {
         const filtersInCache =
           (await service.getRepository(setID, ['filter_objects']))?.filter_objects?.tableFilters ?? [];
         setCacheFilters(filtersInCache);
+      } else {
+        setCacheFilters([]);
       }
     })();
-  }, []);
+  }, [recordSet?.cacheMetadataStatus]);
 
   /**
    * Disabled modification of filters that part of the Cache.
@@ -88,6 +92,11 @@ export const RecordSet = ({ setID }: PropTypes) => {
           <div className="recordSet_header_name">
             {recordSet?.recordSetName || `New Recordset - ${recordSet?.recordSetType}`}
           </div>
+          {canCacheRecordset && !isCellPhoneWidth && (
+            <div className="recordset-cache-control">
+              <RecordSetCacheButtons recordSet={recordSet} setId={setID} onCacheStateChange={() => {}} />
+            </div>
+          )}
         </div>
       </div>
       <div className="recordSet_container">


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Add Cache Button to inside the Recordset Header
    - removes user needing to back out then cache a recordset
    - Does not render on Small view widths (cell phone)
 
- Add border to header for clarity on bounds
- Closes #3700 

## Screenshots

![image](https://github.com/user-attachments/assets/2dcd6eef-9173-4d35-acb6-2915b7efc588)
![image](https://github.com/user-attachments/assets/825a908f-b303-4841-a5c2-b0ce8f199f0c)

![image](https://github.com/user-attachments/assets/5a5b1aae-e88d-4764-ab1c-bbdc36baba05)
