### PR TITLE
[INV-4129] Add protected column to IAPP Sites/Views

### DIFF
--- a/api/src/paths/v2/iapp.ts
+++ b/api/src/paths/v2/iapp.ts
@@ -13,7 +13,7 @@ import { escapeLiteralUnquoted } from 'utils/dbutils';
 
 const defaultLog = getLogger('IAPP');
 
-export const POST: Operation = [getIAPPSitesBySearchFilterCriteria()];
+const POST: Operation = [getIAPPSitesBySearchFilterCriteria()];
 
 POST.apiDoc = {
   description: 'Fetches all sites based on search criteria.',
@@ -79,7 +79,7 @@ POST.apiDoc = {
   }
 };
 
-export function sanitizeIAPPFilterObject(filterObject: any, req: any) {
+function sanitizeIAPPFilterObject(filterObject: any, req: InvasivesRequest) {
   const sanitizedSearchCriteria = {
     serverSideNamedFilters: {},
     selectColumns: [],
@@ -94,21 +94,16 @@ export function sanitizeIAPPFilterObject(filterObject: any, req: any) {
     sanitizedSearchCriteria.z = req.params.z;
   }
 
-  const roleName = req.authContext.roles?.[0]?.role_name;
   const isAuth = req.authContext?.user !== null;
   const user_role = req.authContext?.roles?.[0]?.role_id;
   if (user_role) {
     const user_roles = Array.from({ length: user_role }, (_, i) => i + 1);
     sanitizedSearchCriteria.user_roles = user_roles;
   }
-  if (!isAuth || !roleName || roleName.includes('animal')) {
-    sanitizedSearchCriteria.serverSideNamedFilters.hideTreatmentsAndMonitoring = true;
-  } else {
-    sanitizedSearchCriteria.serverSideNamedFilters.hideTreatmentsAndMonitoring = false;
-  }
   if (!isAuth) {
     sanitizedSearchCriteria.serverSideNamedFilters.hideEditedByFields = true;
   } else {
+    sanitizedSearchCriteria.user_id = req.authContext.user.user_id;
     sanitizedSearchCriteria.serverSideNamedFilters.hideEditedByFields = false;
   }
 
@@ -285,7 +280,6 @@ function getIAPPSitesBySearchFilterCriteria(): RequestHandler {
       }
 
       sql = getIAPPSQLv2(filterObject);
-
       if (filterObject.isCSV) {
         await streamIAPPResult(filterObject, res, sql);
       } else {
@@ -314,7 +308,7 @@ function getIAPPSitesBySearchFilterCriteria(): RequestHandler {
   };
 }
 
-export function getIAPPSQLv2(filterObject: any) {
+function getIAPPSQLv2(filterObject: any) {
   try {
     let sqlStatement: SQLStatement = SQL``;
     sqlStatement = initialWithStatement(sqlStatement);
@@ -445,8 +439,8 @@ sites as (
   b.regional_invasive_species_organization,
   b.invasive_plant_management_area,
   b.geojson,
-  b.geog as geog
-
+  b.geog as geog,
+  b.protected
   `);
 
   sqlStatement.append(`
@@ -544,11 +538,7 @@ function fromStatement(sqlStatement: SQLStatement, filterObject: any) {
 
 function whereStatement(sqlStatement: SQLStatement, filterObject: any) {
   const where = filterObject.vt_request ? sqlStatement.append(`and 1=1 `) : sqlStatement.append(`where 1=1  `);
-  if (filterObject.serverSideNamedFilters.hideTreatmentsAndMonitoring) {
-    //TODO do i need to hide any    where.append(`and iapp_sites.activity_type not in ('Treatment','Monitoring') `);
-  }
 
-  where.append(' and ( 1=1 ');
   filterObject.clientReqTableFilters.forEach((filter) => {
     switch (filter.field) {
       case 'site_id':
@@ -673,6 +663,17 @@ function whereStatement(sqlStatement: SQLStatement, filterObject: any) {
         break;
     }
   });
+  if (filterObject?.user_id) {
+    where.append(
+      `AND (
+        sites.protected = FALSE 
+        OR (
+        SELECT BOOL_OR(can_read_sensitive_biocontrol)
+        FROM get_user_permissions(${filterObject.user_id})
+       ) 
+      `
+    );
+  }
   where.append(' )  ');
 
   if (filterObject.ids_to_filter && filterObject.ids_to_filter.length > 0) {
@@ -682,7 +683,7 @@ function whereStatement(sqlStatement: SQLStatement, filterObject: any) {
   return where;
 }
 
-function groupByStatement(sqlStatement: SQLStatement, filterObject: any) {
+function groupByStatement(sqlStatement: SQLStatement, _: any) {
   const groupBy = sqlStatement.append(``);
   return groupBy;
 }
@@ -705,3 +706,5 @@ function offSetStatement(sqlStatement: SQLStatement, filterObject: any) {
   const offset = sqlStatement.append(` offset ${filterObject.offset};`);
   return offset;
 }
+
+export { getIAPPSQLv2, POST, sanitizeIAPPFilterObject };

--- a/database/src/migrations/0035_add_iapp_column.ts
+++ b/database/src/migrations/0035_add_iapp_column.ts
@@ -1,0 +1,345 @@
+/**
+ * @desc recreates the IAPP table views adding a new column to the site extracts table
+ * @author brennanwebster
+ */
+
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  // Add new 'Protected' column to side extract
+  await knex.raw(
+    //language=PostgreSQL
+    `
+    ALTER TABLE invasivesbc.site_selection_extract
+      ADD COLUMN IF NOT EXISTS protected boolean NOT NULL DEFAULT false;
+    `
+  );
+
+  // Drop and Cascade the View/Subviews
+  await knex.raw(
+    //language=PostgreSQL
+    `DROP VIEW IF EXISTS invasivesbc.iapp_site_summary_slow CASCADE;`
+  );
+
+  // Recreate base view, with added protected column
+  await knex.raw(
+    //language=PostgreSQL
+    `
+    CREATE VIEW invasivesbc.iapp_site_summary_slow AS
+      WITH sites_grouped AS (SELECT site_selection_extract.site_id,
+                                    site_selection_extract.all_species_on_site,
+                                    string_agg(iim.char_code, ', ' order by char_code) as map_symbol,
+                                    site_selection_extract.decimal_longitude,
+                                    site_selection_extract.decimal_latitude,
+                                    bool_or(site_selection_extract.protected) as protected
+                             FROM invasivesbc.site_selection_extract
+                                    left join invasivesbc.iapp_invbc_mapping iim
+                                              on iim.iapp_description = site_selection_extract.invasive_plant
+                             GROUP BY site_selection_extract.site_id, site_selection_extract.all_species_on_site,
+                                      site_selection_extract.decimal_longitude,
+                                      site_selection_extract.decimal_latitude),
+           date_summary AS (SELECT sse_1.site_id,
+                                   (SELECT string_agg(DISTINCT (bio_agents.biological_agent)::text,
+                                                      ', '::text) AS string_agg
+                                    FROM (SELECT biological_dispersal_extract.biological_agent
+                                          FROM invasivesbc.biological_dispersal_extract
+                                          WHERE (biological_dispersal_extract.site_id = sse_1.site_id)
+                                          UNION
+                                          SELECT biological_treatment_extract.biological_agent
+                                          FROM invasivesbc.biological_treatment_extract
+                                          WHERE (biological_treatment_extract.site_id = sse_1.site_id)
+                                          UNION
+                                          SELECT biological_monitoring_extract.biological_agent
+                                          FROM invasivesbc.biological_monitoring_extract
+                                          WHERE (biological_monitoring_extract.site_id = sse_1.site_id)) bio_agents) AS biological_agent,
+                                   min(se.survey_date)                                                               AS min_survey,
+                                   max(se.survey_date)                                                               AS max_survey,
+                                   min(cte.treatment_date)                                                           AS min_chemical_treatment_dates,
+                                   max(cte.treatment_date)                                                           AS max_chemical_treatment_dates,
+                                   min(cme.inspection_date)                                                          AS min_chemical_treatment_monitoring_dates,
+                                   max(cme.inspection_date)                                                          AS max_chemical_treatment_monitoring_dates,
+                                   min(bde.inspection_date)                                                          AS min_bio_dispersal_dates,
+                                   max(bde.inspection_date)                                                          AS max_bio_dispersal_dates,
+                                   min(bte.treatment_date)                                                           AS min_bio_treatment_dates,
+                                   max(bte.treatment_date)                                                           AS max_bio_treatment_dates,
+                                   min(bme.inspection_date)                                                          AS min_bio_treatment_monitoring_dates,
+                                   max(bme.inspection_date)                                                          AS max_bio_treatment_monitoring_dates,
+                                   min(mte.treatment_date)                                                           AS min_mechanical_treatment_dates,
+                                   max(mte.treatment_date)                                                           AS max_mechanical_treatment_dates,
+                                   min(mme.inspection_date)                                                          AS min_mechanical_treatment_monitoring_dates,
+                                   max(mme.inspection_date)                                                          AS max_mechanical_treatment_monitoring_dates
+                            FROM ((((((((sites_grouped sse_1
+                              LEFT JOIN invasivesbc.survey_extract se ON ((sse_1.site_id = se.site_id)))
+                              LEFT JOIN invasivesbc.chemical_treatment_extract cte
+                                        ON ((sse_1.site_id = cte.site_id)))
+                              LEFT JOIN invasivesbc.chemical_monitoring_extract cme
+                                       ON ((sse_1.site_id = cme.site_id)))
+                              LEFT JOIN invasivesbc.biological_dispersal_extract bde
+                                      ON ((sse_1.site_id = bde.site_id)))
+                              LEFT JOIN invasivesbc.biological_treatment_extract bte
+                                     ON ((sse_1.site_id = bte.site_id)))
+                              LEFT JOIN invasivesbc.biological_monitoring_extract bme
+                                    ON ((sse_1.site_id = bme.site_id)))
+                              LEFT JOIN invasivesbc.mechanical_treatment_extract mte
+                                   ON ((sse_1.site_id = mte.site_id)))
+                              LEFT JOIN invasivesbc.mechanical_monitoring_extract mme
+                                  ON ((sse_1.site_id = mme.site_id)))
+                            GROUP BY sse_1.site_id)
+      SELECT sse.site_id,
+             sse.all_species_on_site,
+             sse.map_symbol,
+             ds.biological_agent,
+             sse.decimal_longitude,
+             sse.decimal_latitude,
+             ds.min_survey,
+             ds.max_survey,
+             ds.min_chemical_treatment_dates,
+             ds.max_chemical_treatment_dates,
+             ds.min_chemical_treatment_monitoring_dates,
+             ds.max_chemical_treatment_monitoring_dates,
+             ds.min_bio_dispersal_dates,
+             ds.max_bio_dispersal_dates,
+             ds.min_bio_treatment_dates,
+             ds.max_bio_treatment_dates,
+             ds.min_bio_treatment_monitoring_dates,
+             ds.max_bio_treatment_monitoring_dates,
+             ds.min_mechanical_treatment_dates,
+             ds.max_mechanical_treatment_dates,
+             ds.min_mechanical_treatment_monitoring_dates,
+             ds.max_mechanical_treatment_monitoring_dates,
+             CASE
+               WHEN (ds.min_survey IS NULL) THEN false
+               ELSE true
+               END AS has_surveys,
+             CASE
+               WHEN (ds.max_bio_treatment_monitoring_dates IS NULL) THEN false
+               ELSE true
+               END AS has_biological_treatment_monitorings,
+             CASE
+               WHEN (ds.max_bio_treatment_dates IS NULL) THEN false
+               ELSE true
+               END AS has_biological_treatments,
+             CASE
+               WHEN (ds.min_bio_dispersal_dates IS NULL) THEN false
+               ELSE true
+               END AS has_biological_dispersals,
+             CASE
+               WHEN (ds.max_chemical_treatment_monitoring_dates IS NULL) THEN false
+               ELSE true
+               END AS has_chemical_treatment_monitorings,
+             CASE
+               WHEN (ds.min_chemical_treatment_dates IS NULL) THEN false
+               ELSE true
+               END AS has_chemical_treatments,
+             CASE
+               WHEN (ds.max_mechanical_treatment_dates IS NULL) THEN false
+               ELSE true
+               END AS has_mechanical_treatments,
+             CASE
+               WHEN (ds.max_mechanical_treatment_monitoring_dates IS NULL) THEN false
+               ELSE true
+               END AS has_mechanical_treatment_monitorings,
+               sse.protected
+      FROM (sites_grouped sse
+        JOIN date_summary ds ON ((ds.site_id = sse.site_id)));
+    `
+  );
+
+  // Recreate Materialized View with reference to 'Protected'
+  await knex.raw(
+    //language=PostgreSQL
+    `
+    CREATE MATERIALIZED VIEW invasivesbc.iapp_site_summary AS
+      WITH jurisdiction_data AS (SELECT DISTINCT regexp_split_to_array((survey_extract.jurisdictions)::text,
+                                                                       '($1<=)(, )'::text) AS jurisdictions,
+                                                 survey_extract.site_id
+                                 FROM invasivesbc.survey_extract),
+           paper_file_list AS (SELECT DISTINCT se.site_paper_file_id,
+                                               se.site_id
+                               FROM invasivesbc.survey_extract se
+                               GROUP BY se.site_id, se.site_paper_file_id),
+           agencies AS (SELECT sea.site_id,
+                               string_agg(DISTINCT (sea.survey_agency)::text, ', '::text) AS agency_agg
+                        FROM invasivesbc.survey_extract sea
+                        GROUP BY sea.site_id),
+           areas AS (SELECT DISTINCT ON (z_1.site_id) z_1.site_id,
+                                                      z_1.estimated_area_hectares,
+                                                      z_1.survey_date
+                     FROM invasivesbc.survey_extract z_1
+                     ORDER BY z_1.site_id, z_1.survey_date DESC),
+           rd_riso AS (SELECT DISTINCT s.site_id,
+                                       s.regional_district,
+                                       s.regional_invasive_species_organization,
+                                       s.invasive_plant_management_area
+                       FROM invasivesbc.site_selection_extract s
+                       GROUP BY s.site_id, s.regional_district, s.regional_invasive_species_organization,
+                                s.invasive_plant_management_area)
+      SELECT i.site_id,
+             i.all_species_on_site,
+             i.map_symbol,
+             i.biological_agent,
+             i.decimal_longitude,
+             i.decimal_latitude,
+             i.min_survey,
+             i.max_survey,
+             i.min_chemical_treatment_dates,
+             i.max_chemical_treatment_dates,
+             i.min_chemical_treatment_monitoring_dates,
+             i.max_chemical_treatment_monitoring_dates,
+             i.min_bio_dispersal_dates,
+             i.max_bio_dispersal_dates,
+             i.min_bio_treatment_dates,
+             i.max_bio_treatment_dates,
+             i.min_bio_treatment_monitoring_dates,
+             i.max_bio_treatment_monitoring_dates,
+             i.min_mechanical_treatment_dates,
+             i.max_mechanical_treatment_dates,
+             i.min_mechanical_treatment_monitoring_dates,
+             i.max_mechanical_treatment_monitoring_dates,
+             i.has_surveys,
+             i.has_biological_treatment_monitorings,
+             i.has_biological_treatments,
+             i.has_biological_dispersals,
+             i.has_chemical_treatment_monitorings,
+             i.has_chemical_treatments,
+             i.has_mechanical_treatments,
+             i.has_mechanical_treatment_monitorings,
+             jd.jurisdictions,
+             z.estimated_area_hectares                                  AS reported_area,
+             string_to_array((i.all_species_on_site)::text, ', '::text) AS all_species_on_site_as_array,
+             p.site_paper_file_id,
+             a.agency_agg                                               AS agencies,
+             r.regional_district,
+             r.regional_invasive_species_organization,
+             r.invasive_plant_management_area,
+             i.protected
+      FROM (((((invasivesbc.iapp_site_summary_slow i
+        JOIN jurisdiction_data jd ON ((i.site_id = jd.site_id)))
+        JOIN paper_file_list p ON ((jd.site_id = p.site_id)))
+        JOIN agencies a ON ((p.site_id = a.site_id)))
+        JOIN areas z ON ((a.site_id = z.site_id)))
+        JOIN rd_riso r ON ((a.site_id = r.site_id)));
+
+      CREATE MATERIALIZED VIEW invasivesbc.iapp_site_summary_and_geojson AS
+      SELECT i.site_id,
+             i.all_species_on_site,
+             i.map_symbol,
+             i.biological_agent,
+             i.decimal_longitude,
+             i.decimal_latitude,
+             i.min_survey,
+             i.max_survey,
+             i.min_chemical_treatment_dates,
+             i.max_chemical_treatment_dates,
+             i.min_chemical_treatment_monitoring_dates,
+             i.max_chemical_treatment_monitoring_dates,
+             i.min_bio_dispersal_dates,
+             i.max_bio_dispersal_dates,
+             i.min_bio_treatment_dates,
+             i.max_bio_treatment_dates,
+             i.min_bio_treatment_monitoring_dates,
+             i.max_bio_treatment_monitoring_dates,
+             i.min_mechanical_treatment_dates,
+             i.max_mechanical_treatment_dates,
+             i.min_mechanical_treatment_monitoring_dates,
+             i.max_mechanical_treatment_monitoring_dates,
+             i.has_surveys,
+             i.has_biological_treatment_monitorings,
+             i.has_biological_treatments,
+             i.has_biological_dispersals,
+             i.has_chemical_treatment_monitorings,
+             i.has_chemical_treatments,
+             i.has_mechanical_treatments,
+             i.has_mechanical_treatment_monitorings,
+             i.jurisdictions,
+             i.reported_area,
+             i.all_species_on_site_as_array,
+             i.site_paper_file_id,
+             i.agencies,
+             i.regional_district,
+             i.regional_invasive_species_organization,
+             i.invasive_plant_management_area,
+             s.geog,
+             CASE
+               WHEN (i.has_biological_treatment_monitorings OR i.has_chemical_treatment_monitorings OR
+                     i.has_mechanical_treatment_monitorings) THEN 'Yes'::text
+               ELSE 'No'::text
+               END                                                   AS monitored,
+             json_build_object('type', 'Feature', 'properties',
+                               json_build_object('site_id', i.site_id, 'species', i.all_species_on_site,
+                                                 'map_symbol', i.map_symbol,
+                                                 'has_surveys',
+                                                 i.has_surveys, 'has_biological_treatments',
+                                                 i.has_biological_treatments,
+                                                 'has_biological_monitorings', i.has_biological_treatment_monitorings,
+                                                 'has_biological_dispersals', i.has_biological_dispersals,
+                                                 'has_chemical_treatments', i.has_chemical_treatments,
+                                                 'has_chemical_monitorings', i.has_chemical_treatment_monitorings,
+                                                 'has_mechanical_treatments', i.has_mechanical_treatments,
+                                                 'has_mechanical_monitorings', i.has_mechanical_treatment_monitorings,
+                                                 'earliest_survey', i.min_survey, 'latest_survey', i.max_survey,
+                                                 'earliest_chemical_treatment', i.min_chemical_treatment_dates,
+                                                 'latest_chemical_treatment', i.max_chemical_treatment_dates,
+                                                 'earliest_chemical_monitoring',
+                                                 i.min_chemical_treatment_monitoring_dates,
+                                                 'latest_chemical_monitoring',
+                                                 i.max_chemical_treatment_monitoring_dates,
+                                                 'earliest_bio_dispersal', i.min_bio_dispersal_dates,
+                                                 'latest_bio_dispersal',
+                                                 i.max_bio_dispersal_dates, 'earliest_bio_treatment',
+                                                 i.min_bio_treatment_dates, 'latest_bio_treatment',
+                                                 i.max_bio_treatment_dates,
+                                                 'earliest_bio_monitoring', i.min_bio_treatment_monitoring_dates,
+                                                 'latest_bio_monitoring', i.max_bio_treatment_monitoring_dates,
+                                                 'earliest_mechanical_treatment', i.min_mechanical_treatment_dates,
+                                                 'latest_mechanical_treatment', i.max_mechanical_treatment_dates,
+                                                 'earliest_mechanical_monitoring',
+                                                 i.min_mechanical_treatment_monitoring_dates,
+                                                 'latest_mechanical_monitoring',
+                                                 i.max_mechanical_treatment_monitoring_dates, 'reported_area',
+                                                 i.reported_area, 'jurisdictions', i.jurisdictions,
+                                                 'regional_district',
+                                                 i.regional_district, 'regional_invasive_species_organization',
+                                                 i.regional_invasive_species_organization), 'geometry',
+                               (public.st_asgeojson(s.geog))::jsonb) AS geojson,
+                               i.protected
+      FROM (invasivesbc.iapp_site_summary i
+        JOIN invasivesbc.iapp_spatial s ON ((i.site_id = s.site_id)));
+    `
+  );
+
+  // Add Indexes
+  await knex.raw(
+    //language=PostgreSQL
+    `
+    CREATE INDEX iapp_site_summary_and_geojson_geom_idx ON invasivesbc.iapp_site_summary_and_geojson USING gist (geog);    
+      CREATE INDEX iapp_site_summary_and_geojson_site_id_idx ON invasivesbc.iapp_site_summary_and_geojson USING btree (site_id,
+                                                                                                                       site_paper_file_id,
+                                                                                                                       jurisdictions,
+                                                                                                                       all_species_on_site,
+                                                                                                                       max_survey,
+                                                                                                                       agencies,
+                                                                                                                       has_biological_treatments,
+                                                                                                                       biological_agent,
+                                                                                                                       has_chemical_treatments,
+                                                                                                                       has_mechanical_treatments,
+                                                                                                                       has_biological_dispersals,
+                                                                                                                       monitored,
+                                                                                                                       all_species_on_site_as_array,
+                                                                                                                       regional_district,
+                                                                                                                       regional_invasive_species_organization,
+                                                                                                                       invasive_plant_management_area,
+                                                                                                                       map_symbol);
+      CREATE INDEX iapp_site_summary_and_geojson_site_id_only_idx ON invasivesbc.iapp_site_summary_and_geojson USING btree (site_id);
+      CREATE INDEX iapp_vector_tile_transform_index ON invasivesbc.iapp_site_summary_and_geojson USING gist (st_transform((geog)::geometry, 3857));
+      CREATE INDEX iapp_site_summary_and_geojson_protected_idx ON invasivesbc.iapp_site_summary_and_geojson USING btree (protected);
+    `
+  );
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(
+    //language=PostgreSQL
+    `set search_path to invasivesbc, public;`
+  );
+}

--- a/database/src/migrations/0035_add_iapp_column.ts
+++ b/database/src/migrations/0035_add_iapp_column.ts
@@ -1,5 +1,6 @@
 /**
- * @desc recreates the IAPP table views adding a new column to the site extracts table
+ * @desc recreates the IAPP table views adding a new column 'Protected' to the site extracts table and subsequent views
+ * used for adding site level filtering for biocontrol agents
  * @author brennanwebster
  */
 


### PR DESCRIPTION
# Overview

> [!NOTE]
> Migration Live in Dev

This PR includes the following proposed change(s):

Apply similar logic to IAPP Sites as we do to protected biocontrol sites

@brennanwebster 
- Add Migration to add `protected` column to IAPP sites. Rebuild Views to have column

@LocalNewsTV 
- Add role check to IAPP SQL to check for permission on protected entries

- Closes #4129 