### PR TITLE
[INV-3703][Fix] Set render to Auth users only

### DIFF
--- a/app/src/UI/Features/LegacyMap/helpers/components/AddressLookup/AddressLookup.test.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/AddressLookup/AddressLookup.test.tsx
@@ -28,10 +28,12 @@ describe('AddressLookup.tsx', () => {
     namespace: 'address-search'
   };
 
-  const store = createMockStore({
-    Configuration: createMockConfigurationReducer(),
-    ...mockSliceReducer('Network', { connected: true })
-  });
+  const mockStore = () =>
+    createMockStore({
+      Configuration: createMockConfigurationReducer(),
+      ...mockSliceReducer('Network', { connected: true }),
+      ...mockSliceReducer('Auth', { loggedInOrWorkingOffline: true })
+    });
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -39,7 +41,7 @@ describe('AddressLookup.tsx', () => {
 
   it('should render', () => {
     render(
-      <Provider store={store}>
+      <Provider store={mockStore()}>
         <AddressLookup />
       </Provider>
     );
@@ -57,7 +59,7 @@ describe('AddressLookup.tsx', () => {
       )
     );
     const { queryAllByRole } = render(
-      <Provider store={store}>
+      <Provider store={mockStore()}>
         <AddressLookup />
       </Provider>
     );
@@ -82,7 +84,9 @@ describe('AddressLookup.tsx', () => {
 
   it('Should Fire event when clicking result', async () => {
     const dispatchTestStore = createMockStore({
-      Configuration: createMockConfigurationReducer()
+      Configuration: createMockConfigurationReducer(),
+      ...mockSliceReducer('Network', { connected: true }),
+      ...mockSliceReducer('Auth', { loggedInOrWorkingOffline: true })
     });
     const dispatchSpy = vi.spyOn(dispatchTestStore, 'dispatch');
     const { getByText } = render(
@@ -105,7 +109,7 @@ describe('AddressLookup.tsx', () => {
 
   it('Should toggle to Coordinates', async () => {
     const { getByTestId } = render(
-      <Provider store={store}>
+      <Provider store={mockStore()}>
         <AddressLookup />
       </Provider>
     );
@@ -119,7 +123,7 @@ describe('AddressLookup.tsx', () => {
   });
   it('Should enable when Lat/long are both populated', async () => {
     const { getByTestId } = render(
-      <Provider store={store}>
+      <Provider store={mockStore()}>
         <AddressLookup />
       </Provider>
     );
@@ -146,9 +150,7 @@ describe('AddressLookup.tsx', () => {
   });
 
   it('Should Fire Redux event with shape information', async () => {
-    const dispatchTestStore = createMockStore({
-      Configuration: createMockConfigurationReducer()
-    });
+    const dispatchTestStore = mockStore();
     const dispatchSpy = vi.spyOn(dispatchTestStore, 'dispatch');
     const { getByTestId } = render(
       <Provider store={dispatchTestStore}>
@@ -172,7 +174,7 @@ describe('AddressLookup.tsx', () => {
 
   it('Should not allow numbers out of bounds or letters', async () => {
     const { getByTestId } = render(
-      <Provider store={store}>
+      <Provider store={mockStore()}>
         <AddressLookup />
       </Provider>
     );

--- a/app/src/UI/Features/LegacyMap/helpers/components/AddressLookup/AddressLookup.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/AddressLookup/AddressLookup.tsx
@@ -74,6 +74,7 @@ const AddressLookup = () => {
 
   const base_url = useSelector((state) => state.Configuration.current.runtime.API_BASE);
   const connected = useSelector((state) => state.Network.connected);
+  const authorizedUser = useSelector((state) => state.Auth.loggedInOrWorkingOffline);
 
   const [address, setAddress] = useState<string>('');
   const [disabled, setDisabled] = useState<boolean>(true);
@@ -87,7 +88,7 @@ const AddressLookup = () => {
     setDisabled(!lat || !long);
   }, [lat, long]);
 
-  if (!connected) return;
+  if (!connected || !authorizedUser) return;
   return (
     <div id="address-lookup">
       {

--- a/app/src/UI/Features/LegacyMap/helpers/components/DisplayComposite/DisplayComposite.test.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/DisplayComposite/DisplayComposite.test.tsx
@@ -6,6 +6,8 @@ import { createMockConfigurationReducer, createMockStore, mockSliceReducer } fro
 describe('DisplayComposite.tsx', () => {
   const store = createMockStore({
     ...mockSliceReducer('Map', { accuracyToggle: false, positionTracking: true }),
+    ...mockSliceReducer('Auth', { loggedInOrWorkingOffline: true }),
+    ...mockSliceReducer('Network', { connected: true }),
     Configuration: createMockConfigurationReducer()
   });
 


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Don't render component when user not logged in (no public access) 
    - API was already protected, so this component would be visible and not working
- Adjust tests to include added state
    - DRY tests to just mock store function  