### PR TITLE
[Request] Add Preferred Browser prompt to Landing

### DIFF
--- a/app/src/UI/Features/Landing/Landing.tsx
+++ b/app/src/UI/Features/Landing/Landing.tsx
@@ -1,5 +1,5 @@
 import './Landing.css';
-import { Box, Button, Divider, Grid } from '@mui/material';
+import { Alert, Box, Button, Divider, Grid } from '@mui/material';
 import { selectNetworkConnected } from 'state/reducers/network';
 import { selectAuth } from 'state/reducers/auth';
 import { selectUserInfo } from 'state/reducers/userInfo';
@@ -37,10 +37,6 @@ const InformationalLinkBox = () => {
 };
 
 export const LandingComponent = () => {
-  const connected = useSelector(selectNetworkConnected);
-  const dispatch = useDispatch();
-  const history = useHistory();
-
   const requestAccess = async () => {
     if (connected && !authenticated) {
       dispatch(AuthActions.signinRequest({}));
@@ -53,9 +49,16 @@ export const LandingComponent = () => {
     }
   };
 
+  const dispatch = useDispatch();
+  const history = useHistory();
+
+  const connected = useSelector(selectNetworkConnected);
   const { authenticated, loggedInOrWorkingOffline, workingOffline, username, displayName, email, roles } =
     useSelector(selectAuth);
   const { loaded: userInfoLoaded, activated } = useSelector(selectUserInfo);
+
+  const isChromeUserAgent = navigator.userAgent.includes('Chrome');
+
   return (
     <section id="landing">
       <div className="content">
@@ -69,6 +72,16 @@ export const LandingComponent = () => {
             </p>
           </Box>
         </FeatureGated>
+        {!isChromeUserAgent && (
+          <WebOnly>
+            {/* Training Materials suggest using InvasivesBC, and some users using non-chromium browsers like Safari report bugs when using tools like /Reports (which uses iFrames) */}
+            <Box>
+              <Alert variant="outlined" severity="warning">
+                For optimal compatibility and performance, we recommend using Google Chrome.
+              </Alert>
+            </Box>
+          </WebOnly>
+        )}
         {(userInfoLoaded || loggedInOrWorkingOffline) && (
           <>
             <Box mt={2}>


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

As is part of the User Manual, Google Chrome is the preferred browser of the application for a consistent user experience.

- Adds messaging to the Landing page recommending Google Chrome as the choice browser when viewing in a non-chrome browser.
- Reorganizes hooks
 

![image](https://github.com/user-attachments/assets/70a59f70-331e-467f-841b-0fe612a686f3)
