### PR TITLE
[INV-3893] Add Layer to show Cached Map tile areas

### DIFF
--- a/app/src/UI/Features/LegacyMap/Map.tsx
+++ b/app/src/UI/Features/LegacyMap/Map.tsx
@@ -49,6 +49,8 @@ import {
 } from './helpers/functional/handleBoundaries';
 import { ButtonContainer } from 'UI/Features/LegacyMap/Controls/ButtonContainer';
 import { LayerPicker } from 'UI/Features/LegacyMap/LayerPicker/LayerPicker';
+import { MobileOnly } from 'UI/Reusable/Predicates/MobileOnly';
+import CachedMapLayer from './helpers/components/CachedMapLayer';
 /*
 
   MW: For every state obj, property, or array that the map cares about, there is a hook that listens for changes and handler functions to deal with them.
@@ -394,6 +396,9 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
           <PositionMarkers mapReady={mapReady} />
           <CurrentActivityLayer mapReady={mapReady} />
           {loggedInOrWorkingOffline && <LayerPicker />}
+          <MobileOnly>
+            <CachedMapLayer mapReady={mapReady} />
+          </MobileOnly>
         </MapContext.Provider>
         {children}
       </div>

--- a/app/src/UI/Features/LegacyMap/helpers/components/CachedMapLayer.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/CachedMapLayer.tsx
@@ -1,6 +1,6 @@
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useState, Fragment } from 'react';
 import { MapContext } from './MapContext';
-import { FillLayerSpecification, GeoJSONSourceSpecification, SymbolLayerSpecification } from 'maplibre-gl';
+import { FillLayerSpecification, SymbolLayerSpecification } from 'maplibre-gl';
 import VECTOR_MAP_FONT_FACE from 'constants/vectorMapFontFace';
 import { useSelector } from 'utils/use_selector';
 import bboxToPolygon from 'utils/bboxToPolygon';
@@ -10,11 +10,12 @@ import { LAYER_Z_FOREGROUND, LAYER_Z_MID } from '../functional/layer-definitions
 type PropTypes = {
   mapReady: boolean;
 };
+
 const CachedMapLayer = ({ mapReady }: PropTypes) => {
-  const MAP_ID = 'cached-tiles-source';
   const map = useContext(MapContext);
 
-  const createShapeLayerDefinition = (): FillLayerSpecification => ({
+  const MAP_ID = 'cached-tiles-source';
+  const LAYER_DEFINITION: FillLayerSpecification = {
     id: `fill-${MAP_ID}`,
     type: 'fill',
     source: MAP_ID,
@@ -22,9 +23,8 @@ const CachedMapLayer = ({ mapReady }: PropTypes) => {
       'fill-color': 'orange',
       'fill-opacity': 0.4
     }
-  });
-
-  const createLabelLayerDefinition = (): SymbolLayerSpecification => ({
+  };
+  const LABEL_DEFINITION: SymbolLayerSpecification = {
     id: `label-${MAP_ID}`,
     source: MAP_ID,
     type: 'symbol',
@@ -41,68 +41,74 @@ const CachedMapLayer = ({ mapReady }: PropTypes) => {
       'text-halo-width': 1,
       'text-halo-blur': 1
     }
-  });
+  };
 
   const setup = () => {
-    if (!map) return;
-    map.addSource(MAP_ID, createSourceDefinition());
-    map.addLayer(createLabelLayerDefinition(), LAYER_Z_FOREGROUND);
-    map.addLayer(createShapeLayerDefinition(), LAYER_Z_MID);
-  };
-  const tearDown = () => {
-    if (!map) return;
-    const allLayersOnMap = map.getLayersOrder();
-    const cachedMapLayers = allLayersOnMap.filter((layer) => layer.includes(MAP_ID));
-    cachedMapLayers.forEach((layer) => {
-      try {
-        map.removeLayer(layer);
-      } catch (e) {
-        console.error(e);
+    map?.addSource(MAP_ID, {
+      type: 'geojson',
+      data: {
+        type: 'FeatureCollection',
+        features: data
       }
     });
+    map?.addLayer(LABEL_DEFINITION, LAYER_Z_FOREGROUND);
+    map?.addLayer(LAYER_DEFINITION, LAYER_Z_MID);
+  };
+
+  const teardown = () => {
+    if (!map?.getSource(MAP_ID) || !mapReady) return;
     try {
+      const allLayersOnMap = map.getLayersOrder();
+      const cachedMapLayers = allLayersOnMap.filter((layer) => layer.includes(MAP_ID));
+      cachedMapLayers.forEach((layer) => {
+        try {
+          map.removeLayer(layer);
+        } catch (e) {
+          console.error('Failed to remove Offline Tile layer', e);
+        }
+      });
       map.removeSource(MAP_ID);
     } catch (e) {
-      console.error(e);
+      console.error('Failed to remove Offline Tile Source', e);
     }
   };
-  const createSourceDefinition = (): GeoJSONSourceSpecification => ({
-    type: 'geojson',
-    data: {
-      type: 'FeatureCollection',
-      features: data
-    }
-  });
 
   const repositories = useSelector((state) => state.TileCache?.repositories);
   const url = useSelector((state) => state.AppMode.url);
-  const [data, setData] = useState<Array<Feature<Polygon>>>([]);
-  const [onTilePage, setOnTilePage] = useState<boolean>(false);
-  useEffect(() => {
-    setOnTilePage(!!url?.includes('/OfflineTiles'));
-  }, [url]);
-  useEffect(() => {
-    if (!mapReady || !map || !repositories) return;
-    tearDown();
-    setup();
-  }, [data, mapReady]);
 
-  useEffect(() => {
-    if (!map) return;
-    const visibility = onTilePage ? 'visible' : 'none';
-    map.setLayoutProperty(`label-${MAP_ID}`, 'visibility', visibility);
-    map.setLayoutProperty(`fill-${MAP_ID}`, 'visibility', visibility);
-  }, [onTilePage]);
+  const [data, setData] = useState<Array<Feature<Polygon>>>([]);
+  const [userOnOfflineTilePage, setUserOnOfflineTilePage] = useState<boolean>(false);
+
+  // Rebuild Dataset when repository state updates
   useEffect(() => {
     const features =
-      repositories?.map((repo) => {
-        const shape = bboxToPolygon(repo.bounds);
-        shape.properties = { description: repo.description };
+      repositories?.map(({ bounds, description }) => {
+        const shape = bboxToPolygon(bounds);
+        shape.properties = { description };
         return shape;
       }) ?? [];
     setData(features);
   }, [repositories]);
 
-  return null;
+  // Rebuild layers when Data changes
+  useEffect(() => {
+    if (!map || !mapReady || !repositories) return;
+    teardown();
+    setup();
+  }, [data, mapReady]);
+
+  useEffect(() => {
+    setUserOnOfflineTilePage(!!url?.includes('/OfflineTiles'));
+  }, [url]);
+
+  // Toggle Layer Visibility
+  useEffect(() => {
+    if (!map || !mapReady) return;
+    const visibility = userOnOfflineTilePage ? 'visible' : 'none';
+    map.setLayoutProperty(`label-${MAP_ID}`, 'visibility', visibility);
+    map.setLayoutProperty(`fill-${MAP_ID}`, 'visibility', visibility);
+  }, [userOnOfflineTilePage]);
+
+  return Fragment;
 };
 export default CachedMapLayer;

--- a/app/src/UI/Features/LegacyMap/helpers/components/CachedMapLayer.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/CachedMapLayer.tsx
@@ -1,0 +1,108 @@
+import { useContext, useEffect, useState } from 'react';
+import { MapContext } from './MapContext';
+import { FillLayerSpecification, GeoJSONSourceSpecification, SymbolLayerSpecification } from 'maplibre-gl';
+import VECTOR_MAP_FONT_FACE from 'constants/vectorMapFontFace';
+import { useSelector } from 'utils/use_selector';
+import bboxToPolygon from 'utils/bboxToPolygon';
+import { Feature, Polygon } from 'geojson';
+import { LAYER_Z_FOREGROUND, LAYER_Z_MID } from '../functional/layer-definitions';
+
+type PropTypes = {
+  mapReady: boolean;
+};
+const CachedMapLayer = ({ mapReady }: PropTypes) => {
+  const MAP_ID = 'cached-tiles-source';
+  const map = useContext(MapContext);
+
+  const createShapeLayerDefinition = (): FillLayerSpecification => ({
+    id: `fill-${MAP_ID}`,
+    type: 'fill',
+    source: MAP_ID,
+    paint: {
+      'fill-color': 'orange',
+      'fill-opacity': 0.4
+    }
+  });
+
+  const createLabelLayerDefinition = (): SymbolLayerSpecification => ({
+    id: `label-${MAP_ID}`,
+    source: MAP_ID,
+    type: 'symbol',
+    layout: {
+      'text-field': ['format', ['get', 'description']],
+      'text-font': ['literal', [VECTOR_MAP_FONT_FACE]],
+      'text-offset': [0, 0.6],
+      'text-anchor': 'top',
+      visibility: 'visible'
+    },
+    paint: {
+      'text-color': 'black',
+      'text-halo-color': 'white',
+      'text-halo-width': 1,
+      'text-halo-blur': 1
+    }
+  });
+
+  const setup = () => {
+    if (!map) return;
+    map.addSource(MAP_ID, createSourceDefinition());
+    map.addLayer(createLabelLayerDefinition(), LAYER_Z_FOREGROUND);
+    map.addLayer(createShapeLayerDefinition(), LAYER_Z_MID);
+  };
+  const tearDown = () => {
+    if (!map) return;
+    const allLayersOnMap = map.getLayersOrder();
+    const cachedMapLayers = allLayersOnMap.filter((layer) => layer.includes(MAP_ID));
+    cachedMapLayers.forEach((layer) => {
+      try {
+        map.removeLayer(layer);
+      } catch (e) {
+        console.error(e);
+      }
+    });
+    try {
+      map.removeSource(MAP_ID);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+  const createSourceDefinition = (): GeoJSONSourceSpecification => ({
+    type: 'geojson',
+    data: {
+      type: 'FeatureCollection',
+      features: data
+    }
+  });
+
+  const repositories = useSelector((state) => state.TileCache?.repositories);
+  const url = useSelector((state) => state.AppMode.url);
+  const [data, setData] = useState<Array<Feature<Polygon>>>([]);
+  const [onTilePage, setOnTilePage] = useState<boolean>(false);
+  useEffect(() => {
+    setOnTilePage(!!url?.includes('/OfflineTiles'));
+  }, [url]);
+  useEffect(() => {
+    if (!mapReady || !map || !repositories) return;
+    tearDown();
+    setup();
+  }, [data, mapReady]);
+
+  useEffect(() => {
+    if (!map) return;
+    const visibility = onTilePage ? 'visible' : 'none';
+    map.setLayoutProperty(`label-${MAP_ID}`, 'visibility', visibility);
+    map.setLayoutProperty(`fill-${MAP_ID}`, 'visibility', visibility);
+  }, [onTilePage]);
+  useEffect(() => {
+    const features =
+      repositories?.map((repo) => {
+        const shape = bboxToPolygon(repo.bounds);
+        shape.properties = { description: repo.description };
+        return shape;
+      }) ?? [];
+    setData(features);
+  }, [repositories]);
+
+  return null;
+};
+export default CachedMapLayer;

--- a/app/src/UI/Features/LegacyMap/helpers/components/CachedMapLayer.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/CachedMapLayer.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useState, Fragment } from 'react';
 import { MapContext } from './MapContext';
-import { FillLayerSpecification, SymbolLayerSpecification } from 'maplibre-gl';
+import { FillLayerSpecification, GeoJSONSource, SymbolLayerSpecification } from 'maplibre-gl';
 import VECTOR_MAP_FONT_FACE from 'constants/vectorMapFontFace';
 import { useSelector } from 'utils/use_selector';
 import bboxToPolygon from 'utils/bboxToPolygon';
@@ -90,12 +90,22 @@ const CachedMapLayer = ({ mapReady }: PropTypes) => {
     setData(features);
   }, [repositories]);
 
-  // Rebuild layers when Data changes
+  // Update layer data on change instead of destroying/recreating each time there's an update
   useEffect(() => {
-    if (!map || !mapReady || !repositories) return;
-    teardown();
+    if (!map || !mapReady) return;
+    const source = map.getSource(MAP_ID) as GeoJSONSource;
+    if (!source) return;
+    source.setData({
+      type: 'FeatureCollection',
+      features: data
+    });
+  }, [data]);
+
+  useEffect(() => {
+    if (!map || !mapReady) return;
     setup();
-  }, [data, mapReady]);
+    return () => teardown();
+  }, [mapReady]);
 
   useEffect(() => {
     setUserOnOfflineTilePage(!!url?.includes('/OfflineTiles'));

--- a/app/src/constants/defaultRecordSets.ts
+++ b/app/src/constants/defaultRecordSets.ts
@@ -1,17 +1,17 @@
 import { ActivityStatus } from 'sharedAPI';
-import { RecordSetType, UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
+import { RecordSetId, RecordSetType, UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
 import { buildTimeConfig } from 'state/configuration/build-time-config';
 
 const defaultRecordSets: Record<PropertyKey, Partial<UserRecordSet>> = {
-  '1': {
-    id: '1',
+  [RecordSetId.Drafts]: {
+    id: RecordSetId.Drafts,
     idList: [],
     recordSetType: RecordSetType.Activity,
     recordSetName: 'My Drafts',
     // add draft key
     tableFilters: [
       {
-        id: '1',
+        id: RecordSetId.Drafts,
         field: 'form_status',
         filterType: 'tableFilter',
         filter: ActivityStatus.DRAFT,
@@ -36,8 +36,8 @@ const defaultRecordSets: Record<PropertyKey, Partial<UserRecordSet>> = {
     cacheMetadataStatus: UserRecordCacheStatus.NOT_ELIGIBLE,
     drawOrder: 1
   },
-  '2': {
-    id: '2',
+  [RecordSetId.Activity]: {
+    id: RecordSetId.Activity,
     idList: [],
     recordSetType: RecordSetType.Activity,
     recordSetName: 'All InvasivesBC Activities',
@@ -58,9 +58,9 @@ const defaultRecordSets: Record<PropertyKey, Partial<UserRecordSet>> = {
     cacheMetadataStatus: UserRecordCacheStatus.NOT_ELIGIBLE,
     drawOrder: 2
   },
-  '3': {
+  [RecordSetId.IAPP]: {
     recordSetType: RecordSetType.IAPP,
-    id: '3',
+    id: RecordSetId.IAPP,
     idList: [],
     recordSetName: 'All IAPP Records',
     color: '#21f34f',
@@ -70,9 +70,9 @@ const defaultRecordSets: Record<PropertyKey, Partial<UserRecordSet>> = {
 };
 
 if (buildTimeConfig.MOBILE) {
-  defaultRecordSets['4'] = {
+  defaultRecordSets[RecordSetId.OfflineActivities] = {
     recordSetType: RecordSetType.Activity,
-    id: '4',
+    id: RecordSetId.OfflineActivities,
     idList: [],
     recordSetName: 'All Unsynced Offline Activities',
     cacheMetadataStatus: UserRecordCacheStatus.NOT_ELIGIBLE,


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Add Map Layer for rendering the existing currently Cached areas on the map 
    - Only Shows layers when actively on the OfflineTiles page.
    - Labels display the description tag that the user assigned at time of cache.
- Closes #3893 

![image](https://github.com/user-attachments/assets/55beeaa4-3744-4377-be97-5cd28f0c4c3c)
