### PR TITLE
[INV-4154] Add Details to Hover Marker

### DIFF
--- a/app/src/UI/Features/LegacyMap/helpers/components/AddressLookup/AddressLookup.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/AddressLookup/AddressLookup.tsx
@@ -57,14 +57,16 @@ const AddressLookup = () => {
     }
   };
 
-  const markLocationOnMap = (feature: Feature) => {
-    dispatch(UserSettings.Map.markCoordinate(feature));
+  const markLocationOnMap = (feature: Feature, suggestedAddress?: string) => {
+    dispatch(UserSettings.Map.markCoordinate({ feature, readableIdentifier: suggestedAddress }));
   };
 
   const handleGoToCoordinates = () => {
     if (disabled) return;
     try {
-      markLocationOnMap(point([parseFloat(long), parseFloat(lat)]));
+      const shape = point([parseFloat(long), parseFloat(lat)]);
+      const label = `[${lat}, ${long}]`;
+      markLocationOnMap(shape, label);
     } catch (e) {
       console.error(e);
     }
@@ -114,11 +116,11 @@ const AddressLookup = () => {
               </div>
               {showSuggestions && suggestions.length > 0 && (
                 <ul className="address-suggestions">
-                  {suggestions.map((suggestion) => (
-                    <li key={suggestion.suggestedAddress}>
-                      <button onClick={markLocationOnMap.bind(this, suggestion.feature)}>
+                  {suggestions.map(({ feature, suggestedAddress }) => (
+                    <li key={suggestedAddress}>
+                      <button onClick={markLocationOnMap.bind(this, feature, suggestedAddress)}>
                         <Place />
-                        <span>{suggestion.suggestedAddress}</span>
+                        <span>{suggestedAddress}</span>
                       </button>
                     </li>
                   ))}

--- a/app/src/UI/Features/LegacyMap/helpers/components/AddressLookup/AddressLookup.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/AddressLookup/AddressLookup.tsx
@@ -65,7 +65,7 @@ const AddressLookup = () => {
     if (disabled) return;
     try {
       const shape = point([parseFloat(long), parseFloat(lat)]);
-      const label = `[${lat}, ${long}]`;
+      const label = `Lat: ${lat},<br/>Long: ${long}`;
       markLocationOnMap(shape, label);
     } catch (e) {
       console.error(e);

--- a/app/src/UI/Features/LegacyMap/helpers/components/PositionMarkers.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/PositionMarkers.tsx
@@ -48,6 +48,7 @@ const PositionMarkers = ({ mapReady }) => {
   const userRecordOnHoverRecordGeometry = useSelector((state) => state.Map.userRecordOnHoverRecordGeometry);
   const userRecordOnHoverRecordType = useSelector((state) => state.Map.userRecordOnHoverRecordType);
   const userRecordOnHoverRecordID = useSelector((state) => state.Map.userRecordOnHoverRecordID);
+  const readableIdentifier = useSelector((state) => state.Map?.readableIdentifier);
 
   // Map Marker Refs
   const activityMarker = useRef<maplibregl.Marker>();
@@ -72,14 +73,14 @@ const PositionMarkers = ({ mapReady }) => {
         closeButton: false,
         closeOnMove: true,
         className: 'map-marker-popup'
-      }).setDOMContent(markerPopoverContents(hoveredFeatureMarker))
+      }).setDOMContent(markerPopoverContents(hoveredFeatureMarker, readableIdentifier, userRecordOnHoverRecordType))
     );
     refreshCurrentRecMakers(map, {
       userRecordOnHoverRecordGeometry,
       whatsHereMarker: hoveredFeatureMarker.current,
       whatsHereFeature: hoveredFeature
     });
-  }, [hoveredFeature, userRecordOnHoverRecordID]);
+  }, [hoveredFeature, userRecordOnHoverRecordID, readableIdentifier]);
 
   // Sets Map Marker for Active IAPP
   useEffect(() => {

--- a/app/src/UI/Features/Records/RecordSet/OfflineRecordSet.tsx
+++ b/app/src/UI/Features/Records/RecordSet/OfflineRecordSet.tsx
@@ -25,7 +25,8 @@ export const OfflineRecordSet = ({ setID }: PropTypes) => {
       UserSettings.Map.setHoveredRecordset({
         id: row.activity_id,
         geom: row.geometry?.[0] as Polygon | Point,
-        recordType: RecordSetType.Activity
+        recordType: RecordSetType.Activity,
+        readableIdentifier: row.short_id
       })
     );
   };

--- a/app/src/UI/Features/Records/RecordSet/RecordTable.tsx
+++ b/app/src/UI/Features/Records/RecordSet/RecordTable.tsx
@@ -26,16 +26,18 @@ type PropTypes = {
 
 export const RecordTable = ({ setID }: PropTypes) => {
   const onUserHoveredRecord = (row: IActivityTableRow | IIappTableRow) => {
-    const { id, geom } = (() => {
+    const { id, geom, identifier } = (() => {
       if ('activity_id' in row) {
         return {
           id: row.activity_id,
-          geom: row?.geometry?.[0]
+          geom: row?.geometry?.[0],
+          identifier: row.short_id
         };
       } else if ('site_id' in row) {
         return {
           id: row.site_id,
-          geom: row?.geometry
+          geom: row?.geometry,
+          identifier: row.site_id.toString()
         };
       }
       return { id: '', geom: undefined };
@@ -44,7 +46,8 @@ export const RecordTable = ({ setID }: PropTypes) => {
       UserSettings.Map.setHoveredRecordset({
         recordType: recordSetType,
         id: id,
-        geom: geom
+        geom: geom,
+        readableIdentifier: identifier
       })
     );
   };

--- a/app/src/UI/Features/Records/RecordSet/RecordTablePopoverContent/RecordTablePopoverContent.tsx
+++ b/app/src/UI/Features/Records/RecordSet/RecordTablePopoverContent/RecordTablePopoverContent.tsx
@@ -33,7 +33,8 @@ const RecordTablePopoverContent = ({ recordDisplayId: id, recordLookupId, record
         recordType: RecordSetType.Activity,
         id: recordLookupId,
         geom: geom,
-        quickPan: !!quickPan
+        quickPan: !!quickPan,
+        readableIdentifier: id
       })
     );
   };

--- a/app/src/UI/Features/Records/RecordSet/RecordTablePopoverContent/RecordTablePopoverContent.tsx
+++ b/app/src/UI/Features/Records/RecordSet/RecordTablePopoverContent/RecordTablePopoverContent.tsx
@@ -30,7 +30,7 @@ const RecordTablePopoverContent = ({ recordDisplayId: id, recordLookupId, record
   const handleMarkGeometryOnMap = (quickPan: boolean) => {
     dispatch(
       UserSettings.Map.setHoveredRecordset({
-        recordType: RecordSetType.Activity,
+        recordType: recordType,
         id: recordLookupId,
         geom: geom,
         quickPan: !!quickPan,

--- a/app/src/UI/Features/WhatsHere/Subcomponents/RenderTableActivity.tsx
+++ b/app/src/UI/Features/WhatsHere/Subcomponents/RenderTableActivity.tsx
@@ -18,11 +18,13 @@ const RenderTableActivity = ({ setAnchorEl }: PropTypes) => {
   const whatsHere = useSelector((state) => state.Map?.whatsHere);
 
   const dispatchUpdatedID = (params) => {
+    console.log(params);
     dispatch(
       UserSettings.Map.setHoveredRecordset({
         id: params.row.id,
         geom: params.row.geometry,
-        recordType: RecordSetType.Activity
+        recordType: RecordSetType.Activity,
+        readableIdentifier: params.row.short_id
       })
     );
   };

--- a/app/src/UI/Features/WhatsHere/Subcomponents/RenderTablePOI.tsx
+++ b/app/src/UI/Features/WhatsHere/Subcomponents/RenderTablePOI.tsx
@@ -21,7 +21,8 @@ const RenderTablePOI = ({ setAnchorEl }: PropTypes) => {
       UserSettings.Map.setHoveredRecordset({
         id: params.row.id,
         geom: params.row.geometry,
-        recordType: RecordSetType.IAPP
+        recordType: RecordSetType.IAPP,
+        readableIdentifier: params.row.id.toString()
       })
     );
   };

--- a/app/src/state/actions/userSettings/UserSettings.ts
+++ b/app/src/state/actions/userSettings/UserSettings.ts
@@ -8,7 +8,12 @@ interface IHoverRecordset {
   recordType: RecordSetType;
   id: string | number;
   geom: Point | Polygon | undefined;
-  quickPan?: boolean;
+  quickPan?: boolean; // Map should pan to this site when update occurs
+  readableIdentifier?: string; // Readable ID Format. e.g. Short ID or Site ID
+}
+interface IMarkLocation {
+  feature: Feature;
+  readableIdentifier?: string;
 }
 class Boundaries {
   private static readonly PREFIX = `UserSettings/Boundaries`;
@@ -73,7 +78,7 @@ class Map {
   static readonly setCenterSuccess = createAction<number[]>(`${this.PREFIX}/setCenterSuccess`);
   static readonly setCenterFailure = createAction(`${this.PREFIX}/setCenterFailure`);
   static readonly setHoveredRecordset = createAction<IHoverRecordset>(`${this.PREFIX}/setHoveredRecordset`);
-  static readonly markCoordinate = createAction<Feature>(`${this.PREFIX}/markCoordinate`);
+  static readonly markCoordinate = createAction<IMarkLocation>(`${this.PREFIX}/markCoordinate`);
 }
 
 class UserSettings {

--- a/app/src/state/reducers/map.ts
+++ b/app/src/state/reducers/map.ts
@@ -218,6 +218,7 @@ interface MapState {
     drawingShape: boolean;
   };
   quickPanToRecord: boolean;
+  readableIdentifier?: string;
   recordSetForCSV: number | null;
   recordTables: Record<PropertyKey, IRecordTable>;
   serverBoundaries: any[];
@@ -305,7 +306,6 @@ const initialState: MapState = {
     drawingShape: false
   },
   quickPanToRecord: false,
-
   recordSetForCSV: 0,
   recordTables: {},
 
@@ -677,11 +677,13 @@ function createMapReducer(): (MapState, AnyAction) => MapState {
         draftState.userRecordOnHoverRecordID = action.payload.id;
         draftState.userRecordOnHoverRecordGeometry = action.payload.geom;
         draftState.quickPanToRecord = !!action.payload?.quickPan;
+        draftState.readableIdentifier = action.payload?.readableIdentifier;
       } else if (UserSettings.Map.markCoordinate.match(action)) {
         draftState.userRecordOnHoverRecordType = undefined;
         draftState.userRecordOnHoverRecordID = undefined;
-        draftState.userRecordOnHoverRecordGeometry = action.payload;
+        draftState.userRecordOnHoverRecordGeometry = action.payload.feature;
         draftState.quickPanToRecord = true;
+        draftState.readableIdentifier = action.payload?.readableIdentifier;
       } else {
         switch (action.type) {
           case TOGGLE_WMS_LAYER: {
@@ -742,9 +744,9 @@ function createMapReducer(): (MapState, AnyAction) => MapState {
             draftState.serverBoundaries =
               action.payload.data?.map((incomingItem) => {
                 const returnVal = { ...incomingItem };
-                const existingToggleVal = draftState.serverBoundaries.find((oldItem) => {
-                  oldItem.id === incomingItem;
-                })?.toggle;
+                const existingToggleVal = draftState.serverBoundaries.find(
+                  (oldItem) => oldItem.id === incomingItem
+                )?.toggle;
                 returnVal.toggle =
                   existingToggleVal !== null && existingToggleVal !== undefined ? existingToggleVal : false;
                 return returnVal;

--- a/app/src/utils/makeMapMarker.tsx
+++ b/app/src/utils/makeMapMarker.tsx
@@ -38,8 +38,16 @@ const markerPopoverContents = (
   const main = document.createElement('div');
   if (id) {
     const p = document.createElement('p');
-    p.innerHTML =
-      recordType === RecordSetType.Activity ? `<span>Record ID</span>: ${id}` : `<span>Site ID</span>: ${id}`;
+    p.innerHTML = (() => {
+      switch (recordType) {
+        case RecordSetType.Activity:
+          return `<span>Record ID</span>: ${id}`;
+        case RecordSetType.IAPP:
+          return `<span>Site ID</span>: ${id}`;
+        default:
+          return id.toString();
+      }
+    })();
     main.appendChild(p);
   }
   const button = document.createElement('button');


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Add `readableIdentifier` to map State
- use `readableIdentifier` to display hovered recordsets / Addresses / Coordinates in Application
- Update Hovered/Marked actions to include this new key
- Closes #4154

## Screenshots

### Hovered IAPP

![image](https://github.com/user-attachments/assets/473b5803-91e5-42be-b23b-47fde2e982b7)


### Hovered Activity

![image](https://github.com/user-attachments/assets/212a9968-da23-45d4-9874-8e4eb034aa80)

### Address Marker

![image](https://github.com/user-attachments/assets/6391417d-3cc6-46e2-aeb2-cb02986fdffe)

### Coordinate Hover

![image](https://github.com/user-attachments/assets/d08e82a7-9271-4b3a-88ef-dc48d6249112)
