### PR TITLE
[Fix] 'Hover' type position Markers work with Tap gesture

### DIFF
--- a/app/src/UI/Features/LegacyMap/helpers/components/PositionMarkers.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/PositionMarkers.tsx
@@ -5,14 +5,14 @@ import {
   refreshHighlightedRecord
 } from 'UI/Features/LegacyMap/helpers/functional/current-record';
 import centroid from '@turf/centroid';
-import maplibregl, { LngLatLike, Popup } from 'maplibre-gl';
+import maplibregl, { LngLatLike } from 'maplibre-gl';
 import { useSelector } from 'utils/use_selector';
 import circle from '@turf/circle';
 import { MapContext } from 'UI/Features/LegacyMap/helpers/components/MapContext';
 import { handlePositionTracking } from 'UI/Features/LegacyMap/helpers/functional/position-tracking';
 import { buildTimeConfig } from 'state/configuration/build-time-config';
 import { RecordSetType } from 'interfaces/UserRecordSet';
-import { makeMapMarker, makeMarkerElement, markerPopoverContents } from 'utils/makeMapMarker';
+import { makeMapMarker, makeMarkerElement } from 'utils/makeMapMarker';
 const PositionMarkers = ({ mapReady }) => {
   const LATITUDE = 1;
   const LAT_OFFSET = -0.00325;
@@ -68,13 +68,12 @@ const PositionMarkers = ({ mapReady }) => {
     if (!mapReady) return;
 
     hoveredFeatureMarker?.current?.remove();
-    hoveredFeatureMarker.current = new maplibregl.Marker().setPopup(
-      new Popup({
-        closeButton: false,
-        closeOnMove: true,
-        className: 'map-marker-popup'
-      }).setDOMContent(markerPopoverContents(hoveredFeatureMarker, readableIdentifier, userRecordOnHoverRecordType))
-    );
+    hoveredFeatureMarker.current = makeMapMarker({
+      marker: new maplibregl.Marker(),
+      ref: hoveredFeatureMarker,
+      id: readableIdentifier,
+      recordType: userRecordOnHoverRecordType
+    });
     refreshCurrentRecMakers(map, {
       userRecordOnHoverRecordGeometry,
       whatsHereMarker: hoveredFeatureMarker.current,

--- a/app/src/utils/makeMapMarker.tsx
+++ b/app/src/utils/makeMapMarker.tsx
@@ -59,25 +59,30 @@ const markerPopoverContents = (
 };
 
 interface IMarkerOptions {
-  marker?: maplibregl.Marker;
   ref: MutableRefObject<maplibregl.Marker | undefined>;
-  iconSrc: string;
-  classes: string;
+  classes?: string;
   id?: string | number;
   recordType?: RecordSetType;
+}
+interface IMarkerOptionsIcon extends IMarkerOptions {
+  iconSrc: string;
+}
+interface IMarkerSupplyMarker extends IMarkerOptions {
+  marker: maplibregl.Marker;
 }
 /**
  * Creates a Map Marker With removable Popup Menu using supplied options
  * @param options Configuration
  * @returns Maplibre Map Marker
  */
-const makeMapMarker = (options: IMarkerOptions) => {
-  const { ref, iconSrc, classes, id, recordType, marker } = options;
+const makeMapMarker = (options: IMarkerOptionsIcon | IMarkerSupplyMarker) => {
+  const { ref, classes = '', id, recordType } = options;
   const newMarker =
-    marker ??
-    new maplibregl.Marker({
-      element: makeMarkerElement(iconSrc, classes)
-    });
+    'marker' in options
+      ? options.marker
+      : new maplibregl.Marker({
+          element: makeMarkerElement(options.iconSrc, classes)
+        });
 
   newMarker.setPopup(
     new Popup({


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Refactor creation of Hover Markers for consistency
- Modify interface to include `either` a marker element, or a iconSrc (this allows for the default marker to use the creator)
    - Hover Marker now has the eventListener assigned to it that it was missing. 
