### PR TITLE
[INV-4161] Add try catch to Network call, elvis the returns

### DIFF
--- a/app/src/state/sagas/activity/offline.ts
+++ b/app/src/state/sagas/activity/offline.ts
@@ -121,7 +121,7 @@ function* handle_ACTIVITY_RUN_OFFLINE_SYNC() {
               ...hydrated,
               sync_status: sync_status
             });
-      if (networkReturn.status >= 200 && networkReturn.status < 300) {
+      if (networkReturn?.ok) {
         yield put({
           type: ACTIVITY_UPDATE_SYNC_STATE,
           payload: {

--- a/app/src/state/sagas/activity/online.ts
+++ b/app/src/state/sagas/activity/online.ts
@@ -71,32 +71,33 @@ export function* handle_ACTIVITY_GET_NETWORK_REQUEST(action) {
 
 export function* handle_ACTIVITY_SAVE_NETWORK_REQUEST(action) {
   //save to server
+  try {
+    const oldActivity = yield select(selectActivity);
 
-  const oldActivity = yield select(selectActivity);
+    const newActivity = {
+      ...oldActivity.activity,
+      species_positive:
+        oldActivity.activity?.species_positive[0] !== null ? oldActivity.activity?.species_positive : [],
+      species_negative:
+        oldActivity.activity?.species_negative[0] !== null ? oldActivity.activity?.species_negative : [],
+      species_treated: oldActivity.activity?.species_treated[0] !== null ? oldActivity.activity?.species_treated : [],
+      form_data: action.payload?.updatedFormData ?? oldActivity.activity.form_data,
+      form_status: [ActivityStatus.DRAFT, ActivityStatus.IN_REVIEW, ActivityStatus.SUBMITTED].includes(
+        action.payload.form_status
+      )
+        ? action.payload.form_status
+        : ActivityStatus.DRAFT,
+      sync_status:
+        action.payload.form_status === ActivityStatus.SUBMITTED
+          ? ActivitySyncStatus.SAVE_SUCCESSFUL
+          : ActivitySyncStatus.SAVE_SUCCESSFUL_PRIVATE
+    };
 
-  const newActivity = {
-    ...oldActivity.activity,
-    species_positive: oldActivity.activity?.species_positive[0] !== null ? oldActivity.activity?.species_positive : [],
-    species_negative: oldActivity.activity?.species_negative[0] !== null ? oldActivity.activity?.species_negative : [],
-    species_treated: oldActivity.activity?.species_treated[0] !== null ? oldActivity.activity?.species_treated : [],
-    form_data: action.payload.updatedFormData ? action.payload.updatedFormData : oldActivity.activity.form_data,
-    form_status: [ActivityStatus.DRAFT, ActivityStatus.IN_REVIEW, ActivityStatus.SUBMITTED].includes(
-      action.payload.form_status
-    )
-      ? action.payload.form_status
-      : ActivityStatus.DRAFT,
-    sync_status:
-      action.payload.form_status === ActivityStatus.SUBMITTED
-        ? ActivitySyncStatus.SAVE_SUCCESSFUL
-        : ActivitySyncStatus.SAVE_SUCCESSFUL_PRIVATE
-  };
-
-  // handle delete photos if needed
-  const keys_to_delete: string[] = [];
-  const filtered_media_delete_keys: string[] = [];
-  if (newActivity.media_delete_keys) {
-    if (newActivity.media_delete_keys.length > 0) {
-      {
+    // handle delete photos if needed
+    const keys_to_delete: string[] = [];
+    const filtered_media_delete_keys: string[] = [];
+    if (newActivity.media_delete_keys) {
+      if (newActivity.media_delete_keys.length > 0) {
         const keys = newActivity.media_delete_keys;
         for (const key of keys) {
           const deleteReturn = yield InvasivesAPI_Call('DELETE', `/api/media/delete/${key}`);
@@ -105,32 +106,40 @@ export function* handle_ACTIVITY_SAVE_NETWORK_REQUEST(action) {
           }
         }
       }
+      filtered_media_delete_keys.push(
+        ...newActivity.media_delete_keys.filter((key: string) => !keys_to_delete.includes(key))
+      );
     }
-    filtered_media_delete_keys.push(
-      ...newActivity.media_delete_keys.filter((key: string) => !keys_to_delete.includes(key))
-    );
-  }
 
-  const networkReturn = yield InvasivesAPI_Call('PUT', `/api/activity/`, {
-    ...newActivity,
-    activity_id: oldActivity.activity.activity_id
-  });
-  //const validatedReturn = yield checkForErrors(networkReturn)
+    const networkReturn = yield InvasivesAPI_Call('PUT', `/api/activity/`, {
+      ...newActivity,
+      activity_id: oldActivity.activity.activity_id
+    });
 
-  //        const remappedBlob = yield mapDBActivityToDoc(networkReturn.data)
-  if (networkReturn.status < 200 || networkReturn.status > 299) {
+    if (networkReturn?.ok) {
+      yield put(
+        Activity.saveSuccess({
+          ...newActivity,
+          media_delete_keys: filtered_media_delete_keys
+        })
+      );
+    } else {
+      yield put(
+        Alerts.create({
+          content: networkReturn.data.message,
+          severity: AlertSeverity.Error,
+          subject: AlertSubjects.Form
+        })
+      );
+    }
+  } catch (e) {
+    console.error(e);
     yield put(
       Alerts.create({
-        content: networkReturn.data.message,
+        content:
+          'An Error occured while attempting to upload your activity. Please check your internet connection and try again.',
         severity: AlertSeverity.Error,
         subject: AlertSubjects.Form
-      })
-    );
-  } else {
-    yield put(
-      Activity.saveSuccess({
-        ...newActivity,
-        media_delete_keys: filtered_media_delete_keys
       })
     );
   }


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Refactor checks on `networkReturn.status` to `networkReturn?.ok` to avoid crash on api call failure.
- Add separate alert when Network call fails (in catch) prompting users to try again.
- Solution based on:
    - Screenshot presents failed API call
    - Subsequent Attempt succeeded 
- Closes #4161 