### PR TITLE
Geo-tracking mode with Draw Tools

### DIFF
--- a/app/src/UI/Features/LegacyMap/Controls/GeoTrackingButton.tsx
+++ b/app/src/UI/Features/LegacyMap/Controls/GeoTrackingButton.tsx
@@ -7,7 +7,6 @@ import { useDispatch } from 'react-redux';
 import { useSelector } from 'utils/use_selector';
 import GeoTracking from 'state/actions/geotracking/GeoTracking';
 import Prompt from 'state/actions/prompts/Prompt';
-import { GEO_TRACKING_FEATURE } from '../helpers/functional/constants';
 
 /**
  * TrackMeButton

--- a/app/src/UI/Features/LegacyMap/Controls/GeoTrackingButton.tsx
+++ b/app/src/UI/Features/LegacyMap/Controls/GeoTrackingButton.tsx
@@ -7,6 +7,7 @@ import { useDispatch } from 'react-redux';
 import { useSelector } from 'utils/use_selector';
 import GeoTracking from 'state/actions/geotracking/GeoTracking';
 import Prompt from 'state/actions/prompts/Prompt';
+import { GEO_TRACKING_FEATURE } from '../helpers/functional/constants';
 
 /**
  * TrackMeButton
@@ -28,7 +29,7 @@ export const GeoTrackingButton = () => {
 
   useEffect(() => {
     if (activityGeo && activityGeo?.properties?.error == 'true') {
-      dispatch(GeoTracking.stop());
+      dispatch(GeoTracking.exitDrawing());
     }
   }, [activityGeo?.properties]);
 

--- a/app/src/UI/Features/LegacyMap/helpers/components/DrawControls.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/DrawControls.tsx
@@ -2,12 +2,7 @@ import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { MapContext } from 'UI/Features/LegacyMap/helpers/components/MapContext';
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
 import { useDispatch, useSelector } from 'utils/use_selector';
-import {
-  ACTIVITY_UPDATE_GEO_REQUEST,
-  ACTIVITY_UPDATE_GEO_SUCCESS,
-  MAP_ON_SHAPE_CREATE,
-  MAP_ON_SHAPE_UPDATE
-} from 'state/actions';
+import { ACTIVITY_UPDATE_GEO_SUCCESS, MAP_ON_SHAPE_CREATE, MAP_ON_SHAPE_UPDATE } from 'state/actions';
 import TileCache from 'state/actions/cache/TileCache';
 import WhatsHere from 'state/actions/whatsHere/WhatsHere';
 import { useHistory } from 'react-router-dom';
@@ -101,9 +96,10 @@ const DrawControls = () => {
 
   useEffect(() => {
     const feature = drawInstance?.current?.get(GEO_TRACKING_FEATURE);
+    const isActivityGeoEmpty = Object.keys(activityGeo).length === 0;
+    const isFeaturePresent = feature && Object.keys(feature).length > 0;
 
-    // activityGeo is empty and feature has some values
-    if (Object.keys(activityGeo).length === 0 && feature && Object.keys(feature).length > 0) {
+    if (isActivityGeoEmpty && isFeaturePresent) {
       drawInstance?.current?.deleteAll();
       return;
     }
@@ -112,26 +108,36 @@ const DrawControls = () => {
 
     const isPolygon = activityGeo.geometry.type === GeoShapes.Polygon;
     const coordinates = activityGeo.geometry.coordinates;
-    const hasError = String(activityGeo?.properties?.error || 'false') === 'true';
-
+    const hasError = String(activityGeo?.properties?.error ?? 'false') === 'true';
     const isInitialDraw = !feature || coordinates.length === 1;
+    const justExitedTracking = prevGeoTrackingMode && !currGeoTrackingMode;
+
+    const handleInitialDraw = () => {
+      setPrevGeoTrackingMode(currGeoTrackingMode);
+    };
+
+    const handleUpdate = () => {
+      updateGPSCoordinate(coordinates, hasError ? 'true' : 'false');
+      if (hasError) {
+        setPrevGeoTrackingMode(false); // allow user to adjust shape after error
+      }
+    };
+
+    const handlePolygonConversion = () => {
+      convertLineToPolygon(coordinates, hasError ? 'true' : 'false');
+      setPrevGeoTrackingMode(currGeoTrackingMode);
+    };
 
     if (mode === TargetMode.ACTIVITY_GEO_TRACK) {
       if (isInitialDraw) {
-        setPrevGeoTrackingMode(currGeoTrackingMode);
+        handleInitialDraw();
       } else {
-        updateGPSCoordinate(coordinates, hasError ? 'true' : 'false');
-        if (hasError) {
-          setPrevGeoTrackingMode(false); // allow user to adjust shape after error
-        }
+        handleUpdate();
       }
     }
 
-    const justExitedTracking = prevGeoTrackingMode && !currGeoTrackingMode;
-
     if (justExitedTracking && isPolygon) {
-      convertLineToPolygon(coordinates, hasError ? 'true' : 'false');
-      setPrevGeoTrackingMode(currGeoTrackingMode);
+      handlePolygonConversion();
     }
   }, [activityGeo?.geometry, currGeoTrackingMode]);
 

--- a/app/src/UI/Features/LegacyMap/helpers/components/DrawControls.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/DrawControls.tsx
@@ -2,18 +2,29 @@ import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { MapContext } from 'UI/Features/LegacyMap/helpers/components/MapContext';
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
 import { useDispatch, useSelector } from 'utils/use_selector';
-import { ACTIVITY_UPDATE_GEO_SUCCESS, MAP_ON_SHAPE_CREATE, MAP_ON_SHAPE_UPDATE } from 'state/actions';
+import {
+  ACTIVITY_UPDATE_GEO_REQUEST,
+  ACTIVITY_UPDATE_GEO_SUCCESS,
+  MAP_ON_SHAPE_CREATE,
+  MAP_ON_SHAPE_UPDATE
+} from 'state/actions';
 import TileCache from 'state/actions/cache/TileCache';
 import WhatsHere from 'state/actions/whatsHere/WhatsHere';
 import { useHistory } from 'react-router-dom';
 import { DoNothing } from 'UI/Features/LegacyMap/helpers/functional/do-nothing-mode';
 import maplibregl, { IControl } from 'maplibre-gl';
 import { createRoot, Root } from 'react-dom/client';
-
 import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css';
 import { InvasivesMap } from 'UI/Features/LegacyMap/InvasivesMap';
 import Prompt from 'state/actions/prompts/Prompt';
+import {
+  GeoTrackingMode,
+  convertLineToPolygon,
+  updateGPSCoordinate
+} from 'UI/Features/LegacyMap/helpers/functional/geo-tracking-mode';
 import { WhatsHereBoxMode } from 'UI/Features/LegacyMap/helpers/functional/whats-here-box-mode';
+import GeoShapes from 'constants/geoShapes';
+import { GEO_TRACKING_FEATURE } from '../functional/constants';
 
 // @ts-expect-error mapboxdraw compatibility with maplibre-gl issue
 MapboxDraw.constants.classes.CONTROL_BASE = 'maplibregl-ctrl';
@@ -28,6 +39,7 @@ enum TargetMode {
   WHATS_HERE = 'WHATS_HERE',
   CUSTOM_LAYER = 'CUSTOM_LAYER',
   ACTIVITY = 'ACTIVITY',
+  ACTIVITY_GEO_TRACK = 'ACTIVITY_GEO_TRACK',
   TILE_CACHE = 'TILE_CACHE'
 }
 
@@ -38,7 +50,8 @@ const DrawControls = () => {
   const tileCacheMode = useSelector((state) => state.Map.tileCacheMode);
   const drawingCustomLayer = useSelector((state) => state.Map.drawingCustomLayer);
   const appModeURL = useSelector((state) => state.AppMode.url);
-
+  const currGeoTrackingMode = useSelector((state) => state.Map.track_me_draw_geo.drawingShape);
+  const [prevGeoTrackingMode, setPrevGeoTrackingMode] = useState<boolean | undefined>(undefined);
   const EMPTY_OBJECT = {}; //  a stable reference for the default value to avoid unnecessary re-renders
   const activityGeo = (useSelector((state) => state.ActivityPage.activity?.geometry) ?? [])[0] ?? EMPTY_OBJECT;
 
@@ -57,19 +70,81 @@ const DrawControls = () => {
     modeRef.current = mode;
   }, [mode]);
 
-  // update the drawn LineString or Polygon to a red dotted line if an error occurs
+  // update drawn LineString or Polygon to a red dotted line if an error occurs
   useEffect(() => {
-    const feature = drawInstance?.current?.getAll().features[0];
-    if (feature) {
-      feature.properties = { error: activityGeo?.properties?.error ?? 'false' };
-      try {
-        drawInstance?.current?.deleteAll();
-        drawInstance?.current?.add(feature);
-      } catch (e) {
-        console.error(e);
-      }
+    if (!activityGeo?.properties?.error) return;
+    const feature = drawInstance?.current?.getAll()?.features?.[0];
+
+    if (!feature) return;
+
+    // Update feature properties to reflect error state
+    feature.properties = {
+      ...feature.properties,
+      error: activityGeo.properties.error,
+      user_error: activityGeo.properties.error
+    };
+
+    if (activityGeo.geometry?.type && activityGeo.geometry?.coordinates) {
+      feature.geometry = {
+        type: activityGeo.geometry.type,
+        coordinates: activityGeo.geometry.coordinates
+      };
+    }
+
+    try {
+      drawInstance?.current?.deleteAll();
+      drawInstance?.current?.add(feature);
+    } catch (error) {
+      console.error('Failed to update feature with error styling:', error);
     }
   }, [activityGeo?.properties?.error, activityGeo?.geometry]);
+
+  useEffect(() => {
+    const feature = drawInstance?.current?.get(GEO_TRACKING_FEATURE);
+
+    // activityGeo is empty and feature has some values
+    if (Object.keys(activityGeo).length === 0 && feature && Object.keys(feature).length > 0) {
+      drawInstance?.current?.deleteAll();
+      return;
+    }
+
+    if (!activityGeo?.geometry) return;
+
+    const isPolygon = activityGeo.geometry.type === GeoShapes.Polygon;
+    const coordinates = activityGeo.geometry.coordinates;
+    const hasError = String(activityGeo?.properties?.error || 'false') === 'true';
+
+    const isInitialDraw = !feature || coordinates.length === 1;
+
+    if (mode === TargetMode.ACTIVITY_GEO_TRACK) {
+      if (isInitialDraw) {
+        setPrevGeoTrackingMode(currGeoTrackingMode);
+      } else {
+        updateGPSCoordinate(coordinates, hasError ? 'true' : 'false');
+        if (hasError) {
+          setPrevGeoTrackingMode(false); // allow user to adjust shape after error
+        }
+      }
+    }
+
+    const justExitedTracking = prevGeoTrackingMode && !currGeoTrackingMode;
+
+    if (justExitedTracking && isPolygon) {
+      convertLineToPolygon(coordinates, hasError ? 'true' : 'false');
+      setPrevGeoTrackingMode(currGeoTrackingMode);
+    }
+  }, [activityGeo?.geometry, currGeoTrackingMode]);
+
+  useEffect(() => {
+    const feature = drawInstance?.current?.get(GEO_TRACKING_FEATURE);
+    const hasError = feature?.properties?.error === 'true';
+
+    // Either intersection occurs or activity is reset in the store due to another error
+    if (currGeoTrackingMode && hasError) {
+      drawInstance?.current?.deleteAll();
+      drawInstance?.current?.changeMode('geo_tracking_mode'); // force reset geo-tracking instance
+    }
+  }, [currGeoTrackingMode]);
 
   /**
    * @desc Override the delete button to clear all shapes from drawn tools and to update the Form activity with null shape.
@@ -91,6 +166,7 @@ const DrawControls = () => {
         });
       }
     };
+
     if (!drawInstance.current) return;
     if (mode === TargetMode.ACTIVITY) {
       dispatch(
@@ -107,6 +183,7 @@ const DrawControls = () => {
       } else if (mode === TargetMode.WHATS_HERE) {
         dispatch(WhatsHere.clear_whats_here());
       }
+
       drawInstance.current.deleteAll();
     }
   };
@@ -137,6 +214,10 @@ const DrawControls = () => {
         dispatch({ type: MAP_ON_SHAPE_CREATE, payload: feature });
         break;
       }
+      case TargetMode.ACTIVITY_GEO_TRACK: {
+        // don't do anything
+        break;
+      }
       case TargetMode.TILE_CACHE: {
         dispatch(TileCache.setTileCacheShape({ geometry: feature.geometry }));
         break;
@@ -164,11 +245,15 @@ const DrawControls = () => {
       setMode(TargetMode.CUSTOM_LAYER);
       return;
     } else if (appModeURL?.includes('Activity')) {
-      setMode(TargetMode.ACTIVITY);
+      if (currGeoTrackingMode || prevGeoTrackingMode) {
+        setMode(TargetMode.ACTIVITY_GEO_TRACK);
+      } else {
+        setMode(TargetMode.ACTIVITY);
+      }
     } else {
       setMode(TargetMode.DISABLED);
     }
-  }, [whatsHereToggle, tileCacheMode, drawingCustomLayer, appModeURL]);
+  }, [whatsHereToggle, tileCacheMode, drawingCustomLayer, appModeURL, currGeoTrackingMode, prevGeoTrackingMode]);
 
   /**
    * @desc Update the Drawn Shape.
@@ -211,8 +296,13 @@ const DrawControls = () => {
         case TargetMode.WHATS_HERE:
           drawInstance.current.changeMode('whats_here_box_mode');
           break;
-        case TargetMode.DISABLED:
+        case TargetMode.ACTIVITY_GEO_TRACK:
+          drawInstance.current.changeMode('geo_tracking_mode');
+          break;
         case TargetMode.ACTIVITY:
+          drawInstance.current.changeMode('simple_select');
+          break;
+        case TargetMode.DISABLED:
           drawInstance.current.changeMode('do_nothing');
           break;
         default:
@@ -237,7 +327,8 @@ const DrawControls = () => {
       modes: {
         ...MapboxDraw.modes,
         do_nothing: DoNothing,
-        whats_here_box_mode: WhatsHereBoxMode
+        whats_here_box_mode: WhatsHereBoxMode,
+        geo_tracking_mode: GeoTrackingMode
       },
       styles: [
         {
@@ -268,13 +359,22 @@ const DrawControls = () => {
           }
         },
         {
+          id: 'gl-drawn-fill',
+          type: 'fill',
+          layout: {},
+          filter: ['all', ['==', 'active', 'false'], ['!=', 'user_error', 'true']],
+          paint: {
+            'fill-color': 'white',
+            'fill-opacity': 0.5
+          }
+        },
+        {
           id: 'gl-error-line',
           type: 'line',
           layout: {
             'line-cap': 'round',
             'line-join': 'round'
           },
-          filter: ['all', ['==', 'active', 'false']],
           paint: {
             'line-color': ['match', ['get', 'user_error'], 'true', '#B00020', 'false', '#FCBA19', '#FCBA19'],
             'line-dasharray': [1, 2],

--- a/app/src/UI/Features/LegacyMap/helpers/functional/constants.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/constants.ts
@@ -1,1 +1,2 @@
 export const FALLBACK_COLOR = 'red';
+export const GEO_TRACKING_FEATURE = 'geo-tracking-feature';

--- a/app/src/UI/Features/LegacyMap/helpers/functional/geo-tracking-mode.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/geo-tracking-mode.ts
@@ -1,0 +1,142 @@
+import type { DrawCustomMode } from '@mapbox/mapbox-gl-draw';
+import type { Position, Feature, LineString, GeoJSON, Polygon } from 'geojson';
+import { GEO_TRACKING_FEATURE } from './constants';
+import GeoShapes from 'constants/geoShapes';
+
+type GeoTrackingFeature = Feature<LineString | Polygon>;
+
+type GeoTrackingState = {
+  shape: GeoTrackingFeature;
+};
+
+type SetupOptions = {
+  initialCoordinates?: Position;
+};
+
+const GeoTrackingContext = (() => {
+  let state: GeoTrackingState | null = null;
+
+  return {
+    getState: () => state,
+    setState: (newState: GeoTrackingState) => {
+      state = newState;
+    }
+  };
+})();
+
+function handleClick(this: any, state: GeoTrackingState) {
+  const featureId = state.shape.id;
+  if (state.shape.properties?.active === 'false') {
+    this.changeMode('direct_select', { featureId });
+  }
+}
+
+const GeoTrackingMode: DrawCustomMode<GeoTrackingState, SetupOptions> = {
+  onSetup(_opts: SetupOptions): GeoTrackingState {
+    const shape: Feature<LineString> = {
+      id: GEO_TRACKING_FEATURE,
+      type: 'Feature',
+      geometry: {
+        type: GeoShapes.LineString,
+        coordinates: []
+      },
+      properties: { _updated: Date.now() }
+    };
+
+    this.clearSelectedFeatures();
+    this.updateUIClasses({ mouse: 'add' });
+
+    const drawFeature = this.newFeature(shape);
+    this.addFeature(drawFeature);
+
+    return { shape };
+  },
+
+  onClick(state: GeoTrackingState) {
+    handleClick.call(this, state);
+  },
+
+  onTap(state: GeoTrackingState) {
+    handleClick.call(this, state);
+  },
+
+  toDisplayFeatures(state, _, display: (_: GeoJSON) => void) {
+    try {
+      GeoTrackingContext.setState(state);
+
+      const { shape } = state;
+      const { geometry, properties } = shape;
+
+      const baseProperties = {
+        ...properties,
+        active: properties.user_error === 'false' ? 'true' : 'false'
+      };
+
+      if (geometry.type === GeoShapes.LineString && geometry.coordinates.length > 1) {
+        display({ ...shape, properties: baseProperties });
+      } else if (geometry.type === GeoShapes.Polygon) {
+        display({ ...shape, properties: { ...baseProperties, active: 'false' } });
+      }
+    } catch (e) {
+      console.error('Error in toDisplayFeatures:', e);
+    }
+  },
+
+  onTrash(state: GeoTrackingState) {
+    this.deleteFeature('' + state.shape.id, { silent: true });
+    this.changeMode('simple_select');
+  },
+
+  onStop(state: GeoTrackingState) {
+    if (state.shape) {
+      this.map.fire('draw.create', {
+        features: [state.shape]
+      });
+    }
+  }
+};
+
+export { GeoTrackingMode };
+
+/**
+ * Updates the GPS coordinates of the current LineString feature.
+ * @param coord - New coordinates array.
+ * @param error - Error string used to trigger visual feedback
+ */
+export function updateGPSCoordinate(coord: Position[], error: string) {
+  const state = GeoTrackingContext.getState();
+  if (!state || state.shape.geometry.type !== GeoShapes.LineString) return;
+
+  state.shape.geometry.coordinates = coord;
+  state.shape.properties = {
+    ...state.shape.properties,
+    error,
+    user_error: error,
+    _updated: Date.now()
+  };
+}
+
+/**
+ * Converts the current LineString feature into a Polygon.
+ * @param coords - Polygon coordinates.
+ * @param error - Error string used to trigger visual feedback
+ */
+export function convertLineToPolygon(coords: Position[], error: string) {
+  const state = GeoTrackingContext.getState();
+  if (!state || !state.shape || !state.shape.geometry) return;
+
+  state.shape = {
+    ...state.shape,
+    geometry: {
+      type: GeoShapes.Polygon,
+      coordinates: coords
+    },
+    properties: {
+      ...state.shape.properties,
+      error,
+      user_error: error,
+      fromTracking: true,
+      _updated: Date.now()
+    }
+  };
+}

--- a/app/src/UI/Layout/OverlayLayout/OverlayHeader.css
+++ b/app/src/UI/Layout/OverlayLayout/OverlayHeader.css
@@ -1,9 +1,7 @@
 :root:has(#app.overlay-layout) {
-
   .overlay-header {
     pointer-events: all;
     height: var(--overlay-grip-height);
-    touch-action: none;
     width: 100%;
     top: -1px;
     position: sticky;
@@ -36,7 +34,6 @@
       justify-content: center;
       display: flex;
       flex-direction: row;
-
 
       .overlay-control {
         color: black;

--- a/app/src/UI/Layout/OverlayLayout/OverlayHeader.tsx
+++ b/app/src/UI/Layout/OverlayLayout/OverlayHeader.tsx
@@ -75,7 +75,6 @@ const onClickDragButton = (e) => {
   e.preventDefault();
   document.addEventListener('pointermove', drag, false);
   document.addEventListener('pointerup', cleanup, { once: true, passive: true });
-  document.addEventListener('pointercancel', cleanup, { once: true, passive: true }); //Android needs this
 };
 
 export const OverlayHeader = () => {

--- a/app/src/constants/offline_state_version.ts
+++ b/app/src/constants/offline_state_version.ts
@@ -1,5 +1,5 @@
 /*
   handle purging the offline storage on app version upgrade
 */
-export const CURRENT_MIGRATION_VERSION = 20250521;
+export const CURRENT_MIGRATION_VERSION = 20250616;
 export const MIGRATION_VERSION_KEY = '_persistedMigrationVersion';

--- a/app/src/state/actions/geotracking/GeoTracking.ts
+++ b/app/src/state/actions/geotracking/GeoTracking.ts
@@ -30,6 +30,11 @@ class GeoTracking {
    * @desc Action Creator for pausing Geotracking, stopping points from being plotted
    */
   static readonly pause = createAction(`${this.PREFIX}/pause`);
+
+  /**
+   * @desc Action Creator for clearing Geotracking feature and nothing else
+   */
+  static readonly exitDrawing = createAction(`${this.PREFIX}/exitDrawing`);
 }
 
 export default GeoTracking;

--- a/app/src/state/reducers/activity.ts
+++ b/app/src/state/reducers/activity.ts
@@ -91,6 +91,12 @@ function createActivityReducer() {
         draftState.track_me_draw_geo.drawingShape = false;
       } else if (GeoTracking.resume.match(action)) {
         draftState.track_me_draw_geo.drawingShape = true;
+      } else if (GeoTracking.exitDrawing.match(action)) {
+        draftState.track_me_draw_geo = {
+          isTracking: false,
+          type: draftState.track_me_draw_geo.type,
+          drawingShape: false
+        };
       } else if (Activity.Photo.addSuccess.match(action)) {
         if (draftState.activity.media == undefined) {
           draftState.activity.media = [];

--- a/app/src/state/reducers/map.ts
+++ b/app/src/state/reducers/map.ts
@@ -558,6 +558,12 @@ function createMapReducer(): (MapState, AnyAction) => MapState {
         draftState.track_me_draw_geo.drawingShape = false;
       } else if (GeoTracking.resume.match(action)) {
         draftState.track_me_draw_geo.drawingShape = true;
+      } else if (GeoTracking.exitDrawing.match(action)) {
+        draftState.track_me_draw_geo = {
+          isTracking: false,
+          type: draftState.track_me_draw_geo.type,
+          drawingShape: false
+        };
       } else if (IappActions.getRows.match(action) || Activity.getRows.match(action)) {
         const { recordSetID, page, limit, tableFiltersHash } = action.payload;
         draftState.recordTables[recordSetID] ??= {} as IRecordTable;

--- a/app/src/state/sagas/activity.ts
+++ b/app/src/state/sagas/activity.ts
@@ -69,6 +69,7 @@ import cacheAlertMessages from 'constants/alerts/cacheAlerts';
 import MapActions from 'state/actions/map';
 import { selectAuth } from 'state/reducers/auth';
 import { Role } from 'constants/roles';
+import { GEO_TRACKING_FEATURE } from 'UI/Features/LegacyMap/helpers/functional/constants';
 
 function* handle_ACTIVITY_DELETE_SUCCESS() {
   yield put(UserSettings.RecordSet.setSelected(null));
@@ -187,6 +188,7 @@ function* handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_START() {
   const userHasTrackingEnabled = coords?.hasOwnProperty('long');
   if (userHasTrackingEnabled) {
     const initGeo = {
+      id: GEO_TRACKING_FEATURE,
       type: 'Feature',
       properties: {},
       geometry: {

--- a/app/src/state/sagas/map.ts
+++ b/app/src/state/sagas/map.ts
@@ -66,6 +66,9 @@ import IappRecord from 'interfaces/IappRecord';
 import NetworkActions from 'state/actions/network/NetworkActions';
 import MapActions from 'state/actions/map';
 import GeoShapes from 'constants/geoShapes';
+import GeoTracking from 'state/actions/geotracking/GeoTracking';
+import { normalizeToPolygonCoordinates } from 'utils/geometryHelpers';
+import { GEO_TRACKING_FEATURE } from 'UI/Features/LegacyMap/helpers/functional/constants';
 
 function* handle_USER_SETTINGS_GET_INITIAL_STATE_SUCCESS() {
   yield put(MapActions.initRequest());
@@ -602,9 +605,18 @@ function* handle_MAP_ON_SHAPE_CREATE(action) {
       return [{ type: ACTIVITY_UPDATE_GEO_REQUEST, payload: { geometry: [newGeo] } }];
     }
   };
+
   const appModeUrl = yield select((state: any) => state.AppMode.url);
   const whatsHereToggle = yield select((state: any) => state.Map.whatsHere.toggle);
-  if (action?.payload?.geometry?.type === GeoShapes.LineString) {
+  const { isTracking, type } = yield select((state) => state.Map.track_me_draw_geo);
+
+  const isGeoTrackingLineString = isTracking && type === GeoShapes.LineString;
+  const isLineString = action?.payload?.geometry?.type === GeoShapes.LineString;
+  const hasCoordinates = action?.payload?.geometry?.coordinates?.length > 0;
+  const noUserError = action?.payload?.properties?.user_error !== 'true';
+
+  if (isLineString && hasCoordinates && noUserError) {
+    if (!isGeoTrackingLineString && action.payload.id === GEO_TRACKING_FEATURE) return; // no prompt for polygon
     yield put(
       Prompt.number({
         title: 'Buffer needed',
@@ -619,16 +631,58 @@ function* handle_MAP_ON_SHAPE_CREATE(action) {
 }
 
 function* handle_MAP_ON_SHAPE_UPDATE(action) {
-  const { url } = yield select((state) => state.AppMode);
-  const { drawingCustomLayer, whatsHere, tileCacheMode } = yield select((state: RootState) => state.Map);
+  try {
+    const { url } = yield select((state) => state.AppMode);
+    const { drawingCustomLayer, whatsHere, tileCacheMode } = yield select((state: RootState) => state.Map);
+    const { isTracking, type } = yield select((state) => state.Map.track_me_draw_geo);
+    const { id, geometry } = action.payload;
 
-  if (drawingCustomLayer) {
-    yield put({ type: CUSTOM_LAYER_DRAWN, payload: action.payload });
-  } else if (url && /Activity/.test(url) && !whatsHere.toggle) {
-    if (action.payload.geometry.type === GeoShapes.LineString) return; // prevent updating LineString on outside click
-    yield put({ type: ACTIVITY_UPDATE_GEO_REQUEST, payload: { geometry: [action.payload] } });
-  } else if (tileCacheMode) {
-    yield put(TileCache.setTileCacheShape({ geometry: action.payload.geometry }));
+    if (drawingCustomLayer) {
+      yield put({ type: CUSTOM_LAYER_DRAWN, payload: action.payload });
+      return;
+    }
+
+    const callback = (width: number) => {
+      const newGeo = buffer(action.payload.geometry, width / 10000) ?? action.payload;
+      if (isActivityPage && !whatsHere.toggle) {
+        return [{ type: ACTIVITY_UPDATE_GEO_REQUEST, payload: { geometry: [newGeo] } }];
+      }
+    };
+    const isActivityPage = url && /Activity/.test(url);
+    const isGeoTrackingFeature = id === GEO_TRACKING_FEATURE;
+
+    if (isActivityPage && !whatsHere.toggle) {
+      if (isGeoTrackingFeature && type === GeoShapes.Polygon) {
+        geometry.type = type;
+        geometry.coordinates = normalizeToPolygonCoordinates(geometry.coordinates);
+      } else if (type === GeoShapes.LineString && action?.payload?.geometry?.type === GeoShapes.LineString) {
+        yield put(
+          Prompt.number({
+            title: 'Buffer needed',
+            prompt: 'Enter width in meters for line to be buffered:',
+            min: 0.001,
+            acceptFloats: true,
+            callback,
+            label: 'Meters'
+          })
+        );
+        return;
+      } else if (isTracking) {
+        yield put(GeoTracking.exitDrawing());
+      }
+
+      yield put({
+        type: ACTIVITY_UPDATE_GEO_REQUEST,
+        payload: { geometry: [action.payload] }
+      });
+      return;
+    }
+
+    if (tileCacheMode) {
+      yield put(TileCache.setTileCacheShape({ geometry }));
+    }
+  } catch (error) {
+    console.error('Error in handle_MAP_ON_SHAPE_UPDATE:', error);
   }
 }
 

--- a/app/src/utils/geometryHelpers.ts
+++ b/app/src/utils/geometryHelpers.ts
@@ -1,7 +1,7 @@
 import area from '@turf/area';
 import centroid from '@turf/centroid';
 import * as turf from '@turf/helpers';
-import { Feature } from 'geojson';
+import { Feature, Position } from 'geojson';
 import GeoShapes from 'constants/geoShapes';
 
 /**
@@ -80,7 +80,7 @@ export function calculateLatLng(geom: Feature[]) {
     latitude = firstCoord[0][1];
     longitude = firstCoord[0][0];
   } else {
-    const centerPoint = centroid(geom[0] as any); //center(turf.polygon(geo['coordinates'])).geometry;
+    const centerPoint = centroid(geom[0] as any) || centroid(geom as any); //center(turf.polygon(geo['coordinates'])).geometry;
     latitude = centerPoint.geometry.coordinates[1];
     longitude = centerPoint.geometry.coordinates[0];
   }
@@ -92,4 +92,24 @@ export function calculateLatLng(geom: Feature[]) {
     latitude: parseFloat(latitude.toFixed(6)),
     longitude: parseFloat(longitude.toFixed(6))
   };
+}
+
+export function normalizeToPolygonCoordinates(coords: Position[] | Position[][]): Position[][] {
+  let normalized: Position[][];
+
+  if (!Array.isArray(coords[0][0])) {
+    normalized = [coords as Position[]];
+  } else {
+    normalized = coords as Position[][];
+  }
+
+  const ring = normalized[0];
+  const first = ring[0];
+  const last = ring[ring.length - 1];
+
+  if (first[0] !== last[0] || first[1] !== last[1]) {
+    ring.push(first);
+  }
+
+  return normalized;
 }


### PR DESCRIPTION
This PR integrates geo-tracking functionality with support for a variety of use cases (not all listed here).
- Geo-tracking happy path works as expected
- Smooth switching between different modes
- Provides user feedback for intersection-related errors
- Enables editing when intersection-related errors occur

The next iteration will focus on refactoring the draw controls further to improve maintainability

Tested on Web and iOS (physical device)

Closes #4008 #4132 