### PR TITLE
Disable Draw Tools' buttons to prevent mode conflict when Geo-tracking is active

### DIFF
--- a/app/src/UI/Features/LegacyMap/helpers/components/DrawControls.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/DrawControls.tsx
@@ -20,6 +20,7 @@ import {
 import { WhatsHereBoxMode } from 'UI/Features/LegacyMap/helpers/functional/whats-here-box-mode';
 import GeoShapes from 'constants/geoShapes';
 import { GEO_TRACKING_FEATURE } from '../functional/constants';
+import GeoTracking from 'state/actions/geotracking/GeoTracking';
 
 // @ts-expect-error mapboxdraw compatibility with maplibre-gl issue
 MapboxDraw.constants.classes.CONTROL_BASE = 'maplibregl-ctrl';
@@ -194,6 +195,14 @@ const DrawControls = () => {
     }
   };
 
+  const disableDrawButtons = (disabled: boolean) => {
+    const buttons = document.querySelectorAll('.mapbox-gl-draw_ctrl-draw-btn');
+    buttons.forEach((btn) => {
+      (btn as HTMLButtonElement).disabled = disabled;
+      btn.classList.toggle('disabled', disabled);
+    });
+  };
+
   const drawCreate = useCallback((event) => {
     if (!drawInstance.current) return;
 
@@ -239,6 +248,15 @@ const DrawControls = () => {
     }
   }, []);
 
+  const handleModeChange = useCallback((e) => {
+    if (
+      modeRef.current === TargetMode.ACTIVITY_GEO_TRACK &&
+      ['draw_line_string', 'draw_polygon', 'draw_point'].includes(e.mode)
+    ) {
+      dispatch(GeoTracking.modeLocked());
+    }
+  }, []);
+
   // setup mode based on what's going on in the redux store / current url
   useEffect(() => {
     if (whatsHereToggle) {
@@ -253,8 +271,11 @@ const DrawControls = () => {
     } else if (appModeURL?.includes('Activity')) {
       if (currGeoTrackingMode || prevGeoTrackingMode) {
         setMode(TargetMode.ACTIVITY_GEO_TRACK);
+        disableDrawButtons(true);
+        dispatch(GeoTracking.modeLocked());
       } else {
         setMode(TargetMode.ACTIVITY);
+        disableDrawButtons(false);
       }
     } else {
       setMode(TargetMode.DISABLED);
@@ -415,6 +436,8 @@ const DrawControls = () => {
     map.on('draw.create', drawCreate);
     map.on('draw.selectionchange', (evt) => drawShapeUpdate(evt, map));
 
+    // map.on('draw.modechange', handleModeChange);
+
     map.addControl(drawInstance.current as unknown as IControl, 'top-left');
     map.addControl(drawModeDisplay.current, 'top-left');
 
@@ -426,7 +449,7 @@ const DrawControls = () => {
 
       map.off('draw.create', drawCreate);
       map.off('draw.selectionChange', (evt) => drawShapeUpdate(evt, map));
-
+      // map.off('draw.modechange', handleModeChange);
       if (drawInstance.current) {
         (map as unknown as mapboxgl.Map).removeControl(drawInstance.current);
         drawInstance.current = undefined;

--- a/app/src/UI/Features/LegacyMap/helpers/components/DrawControls.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/DrawControls.tsx
@@ -20,7 +20,6 @@ import {
 import { WhatsHereBoxMode } from 'UI/Features/LegacyMap/helpers/functional/whats-here-box-mode';
 import GeoShapes from 'constants/geoShapes';
 import { GEO_TRACKING_FEATURE } from '../functional/constants';
-import GeoTracking from 'state/actions/geotracking/GeoTracking';
 
 // @ts-expect-error mapboxdraw compatibility with maplibre-gl issue
 MapboxDraw.constants.classes.CONTROL_BASE = 'maplibregl-ctrl';
@@ -46,8 +45,8 @@ const DrawControls = () => {
   const tileCacheMode = useSelector((state) => state.Map.tileCacheMode);
   const drawingCustomLayer = useSelector((state) => state.Map.drawingCustomLayer);
   const appModeURL = useSelector((state) => state.AppMode.url);
-  const currGeoTrackingMode = useSelector((state) => state.Map.track_me_draw_geo.drawingShape);
-  const [prevGeoTrackingMode, setPrevGeoTrackingMode] = useState<boolean | undefined>(undefined);
+  const currGeoTrackingMode = useSelector((state) => state.Map.track_me_draw_geo.isTracking);
+  const [prevGeoTrackingMode, setPrevGeoTrackingMode] = useState<boolean>(false);
   const EMPTY_OBJECT = {}; //  a stable reference for the default value to avoid unnecessary re-renders
   const activityGeo = (useSelector((state) => state.ActivityPage.activity?.geometry) ?? [])[0] ?? EMPTY_OBJECT;
 
@@ -151,6 +150,9 @@ const DrawControls = () => {
       drawInstance?.current?.deleteAll();
       drawInstance?.current?.changeMode('geo_tracking_mode'); // force reset geo-tracking instance
     }
+
+    // early exit
+    if (!currGeoTrackingMode && prevGeoTrackingMode) setPrevGeoTrackingMode(false);
   }, [currGeoTrackingMode]);
 
   /**
@@ -248,15 +250,6 @@ const DrawControls = () => {
     }
   }, []);
 
-  const handleModeChange = useCallback((e) => {
-    if (
-      modeRef.current === TargetMode.ACTIVITY_GEO_TRACK &&
-      ['draw_line_string', 'draw_polygon', 'draw_point'].includes(e.mode)
-    ) {
-      dispatch(GeoTracking.modeLocked());
-    }
-  }, []);
-
   // setup mode based on what's going on in the redux store / current url
   useEffect(() => {
     if (whatsHereToggle) {
@@ -272,7 +265,6 @@ const DrawControls = () => {
       if (currGeoTrackingMode || prevGeoTrackingMode) {
         setMode(TargetMode.ACTIVITY_GEO_TRACK);
         disableDrawButtons(true);
-        dispatch(GeoTracking.modeLocked());
       } else {
         setMode(TargetMode.ACTIVITY);
         disableDrawButtons(false);
@@ -436,8 +428,6 @@ const DrawControls = () => {
     map.on('draw.create', drawCreate);
     map.on('draw.selectionchange', (evt) => drawShapeUpdate(evt, map));
 
-    // map.on('draw.modechange', handleModeChange);
-
     map.addControl(drawInstance.current as unknown as IControl, 'top-left');
     map.addControl(drawModeDisplay.current, 'top-left');
 
@@ -449,7 +439,7 @@ const DrawControls = () => {
 
       map.off('draw.create', drawCreate);
       map.off('draw.selectionChange', (evt) => drawShapeUpdate(evt, map));
-      // map.off('draw.modechange', handleModeChange);
+
       if (drawInstance.current) {
         (map as unknown as mapboxgl.Map).removeControl(drawInstance.current);
         drawInstance.current = undefined;

--- a/app/src/UI/Features/LegacyMap/map.css
+++ b/app/src/UI/Features/LegacyMap/map.css
@@ -117,3 +117,9 @@
 .map-containing-block {
   background: #999;
 }
+
+.mapbox-gl-draw_ctrl-draw-btn.disabled {
+  opacity: 0.5;
+  background-color: #c1c0c0 !important;
+  border-color: #a0a0a0 !important;
+}

--- a/app/src/constants/alerts/mappingAlerts.ts
+++ b/app/src/constants/alerts/mappingAlerts.ts
@@ -74,6 +74,12 @@ const mappingAlertMessages: Record<string, AlertMessage> = {
     subject: AlertSubjects.Map,
     autoClose: 3
   },
+  geoTrackingModeLocked: {
+    content: 'GeoTracking is in progress. To change modes, please stop GeoTracking first.',
+    severity: AlertSeverity.Warning,
+    subject: AlertSubjects.Map,
+    autoClose: 5
+  },
   // Success
   trackingStarted: {
     content: 'Start walking to draw a geometry. Click the button again to stop.',

--- a/app/src/constants/offline_state_version.ts
+++ b/app/src/constants/offline_state_version.ts
@@ -1,5 +1,5 @@
 /*
   handle purging the offline storage on app version upgrade
 */
-export const CURRENT_MIGRATION_VERSION = 20250617;
+export const CURRENT_MIGRATION_VERSION = 20250618;
 export const MIGRATION_VERSION_KEY = '_persistedMigrationVersion';

--- a/app/src/constants/offline_state_version.ts
+++ b/app/src/constants/offline_state_version.ts
@@ -1,5 +1,5 @@
 /*
   handle purging the offline storage on app version upgrade
 */
-export const CURRENT_MIGRATION_VERSION = 20250616;
+export const CURRENT_MIGRATION_VERSION = 20250617;
 export const MIGRATION_VERSION_KEY = '_persistedMigrationVersion';

--- a/app/src/state/actions/geotracking/GeoTracking.ts
+++ b/app/src/state/actions/geotracking/GeoTracking.ts
@@ -35,6 +35,11 @@ class GeoTracking {
    * @desc Action Creator for clearing Geotracking feature and nothing else
    */
   static readonly exitDrawing = createAction(`${this.PREFIX}/exitDrawing`);
+
+  /**
+   * @desc Action creator to notify users that the Geo-tracking feature must be stopped before using other draw tools
+   */
+  static readonly modeLocked = createAction(`${this.PREFIX}/modeLocked`);
 }
 
 export default GeoTracking;

--- a/app/src/state/sagas/activity.ts
+++ b/app/src/state/sagas/activity.ts
@@ -198,6 +198,7 @@ function* handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_START() {
     };
     yield put({ type: ACTIVITY_UPDATE_GEO_REQUEST, payload: { geometry: [initGeo] } });
     yield put(Alerts.create(message));
+    yield put(Alerts.create(mappingAlertMessages.geoTrackingModeLocked));
   } else {
     yield put(GeoTracking.stop());
     yield put(Alerts.create(mappingAlertMessages.cannotGetUsersCoordinates));
@@ -340,10 +341,6 @@ function* handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_PAUSE() {
   yield put(Alerts.create(mappingAlertMessages.trackingPaused));
 }
 
-function* handle_GEO_TRACKING_MODE_LOCKED() {
-  yield put(Alerts.create(mappingAlertMessages.geoTrackingModeLocked));
-}
-
 /**
  * @desc Handles new coordinates coming in from the TRACK_ME_GEO featureset.
  *       Evaluates distance between new and previous points to eliminate micro adjustments from GPS sway.
@@ -476,7 +473,6 @@ function* activityPageSaga() {
     takeEvery(GeoTracking.stop, handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_STOP),
     takeEvery(GeoTracking.pause, handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_PAUSE),
     takeEvery(GeoTracking.resume, handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_RESUME),
-    takeEvery(GeoTracking.modeLocked, handle_GEO_TRACKING_MODE_LOCKED),
     ...OFFLINE_ACTIVITY_SAGA_HANDLERS
   ]);
 }

--- a/app/src/state/sagas/activity.ts
+++ b/app/src/state/sagas/activity.ts
@@ -269,7 +269,6 @@ function* handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_STOP() {
     yield put(GeoTracking.earlyExit());
     yield put({ type: ACTIVITY_UPDATE_GEO_REQUEST, payload: { geometry: [newGeo] } });
     yield put(Alerts.create(mappingAlertMessages.trackMyPathStoppedEarly));
-    yield put(Alerts.create(mappingAlertMessages.willContainIntersections));
     return;
   }
   if (!geometryHasPositiveArea) {
@@ -341,6 +340,10 @@ function* handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_PAUSE() {
   yield put(Alerts.create(mappingAlertMessages.trackingPaused));
 }
 
+function* handle_GEO_TRACKING_MODE_LOCKED() {
+  yield put(Alerts.create(mappingAlertMessages.geoTrackingModeLocked));
+}
+
 /**
  * @desc Handles new coordinates coming in from the TRACK_ME_GEO featureset.
  *       Evaluates distance between new and previous points to eliminate micro adjustments from GPS sway.
@@ -351,43 +354,46 @@ function* handle_MAP_SET_COORDS(action) {
   const {
     track_me_draw_geo: { isTracking, drawingShape }
   } = activityState;
+  try {
+    if (isTracking && drawingShape) {
+      let currentGeo = activityState?.activity?.geometry?.[0];
+      if (!currentGeo) {
+        currentGeo = {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: GeoShapes.LineString,
+            coordinates: []
+          }
+        };
+      }
+      const nextCoords = [action.payload.position.coords.longitude, action.payload.position.coords.latitude];
+      const haveCoordinatesToCompare = currentGeo.geometry.coordinates.length > 0;
 
-  if (isTracking && drawingShape) {
-    let currentGeo = activityState?.activity?.geometry?.[0];
-    if (!currentGeo) {
-      currentGeo = {
+      if (haveCoordinatesToCompare) {
+        const distanceBetweenPoints = distance(
+          currentGeo.geometry.coordinates[currentGeo.geometry.coordinates.length - 1],
+          nextCoords,
+          { units: 'meters' }
+        );
+
+        if (distanceBetweenPoints <= MINIMUM_DISTANCE_BETWEEN_POINTS_IN_METERS) {
+          return;
+        }
+      }
+      const newGeo = {
         type: 'Feature',
         properties: {},
         geometry: {
-          type: GeoShapes.LineString,
-          coordinates: []
+          type: currentGeo?.geometry?.type || GeoShapes.LineString,
+          coordinates: [...currentGeo.geometry.coordinates, nextCoords]
         }
       };
+      //append to linestring
+      yield put({ type: ACTIVITY_UPDATE_GEO_REQUEST, payload: { geometry: [newGeo] } });
     }
-
-    const nextCoords = [action.payload.position.coords.longitude, action.payload.position.coords.latitude];
-    const haveCoordinatesToCompare = currentGeo.geometry.coordinates.length > 0;
-    if (haveCoordinatesToCompare) {
-      const distanceBetweenPoints = distance(
-        currentGeo.geometry.coordinates[currentGeo.geometry.coordinates.length - 1],
-        nextCoords,
-        { units: 'meters' }
-      );
-      if (distanceBetweenPoints <= MINIMUM_DISTANCE_BETWEEN_POINTS_IN_METERS) {
-        return;
-      }
-    }
-    const newGeo = {
-      type: 'Feature',
-      properties: {},
-      geometry: {
-        type: currentGeo?.geometry?.type || GeoShapes.LineString,
-        coordinates: [...currentGeo.geometry.coordinates, nextCoords]
-      }
-    };
-
-    //append to linestring
-    yield put({ type: ACTIVITY_UPDATE_GEO_REQUEST, payload: { geometry: [newGeo] } });
+  } catch (err) {
+    console.log(err);
   }
 }
 
@@ -470,6 +476,7 @@ function* activityPageSaga() {
     takeEvery(GeoTracking.stop, handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_STOP),
     takeEvery(GeoTracking.pause, handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_PAUSE),
     takeEvery(GeoTracking.resume, handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_RESUME),
+    takeEvery(GeoTracking.modeLocked, handle_GEO_TRACKING_MODE_LOCKED),
     ...OFFLINE_ACTIVITY_SAGA_HANDLERS
   ]);
 }

--- a/app/src/state/sagas/activity.ts
+++ b/app/src/state/sagas/activity.ts
@@ -266,10 +266,10 @@ function* handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_STOP() {
     console.error(err);
   }
   if (geographyWillContainIntersections) {
-    // validationErrors.push(mappingAlertMessages.willContainIntersections);
     yield put(GeoTracking.earlyExit());
-    yield put({ type: ACTIVITY_UPDATE_GEO_REQUEST, payload: { geometry: [] } });
+    yield put({ type: ACTIVITY_UPDATE_GEO_REQUEST, payload: { geometry: [newGeo] } });
     yield put(Alerts.create(mappingAlertMessages.trackMyPathStoppedEarly));
+    yield put(Alerts.create(mappingAlertMessages.willContainIntersections));
     return;
   }
   if (!geometryHasPositiveArea) {


### PR DESCRIPTION

Disable Draw Tools' buttons during active Geo-tracking to prevent mode conflicts. Buttons remain disabled in Pause mode and are re-enabled only when Geo-tracking is stopped.

Fixes #4168 