### PR TITLE
Restrict dropdown selection to assigned values for non-admins

### DIFF
--- a/app/src/state/sagas/activity.ts
+++ b/app/src/state/sagas/activity.ts
@@ -148,7 +148,7 @@ function* handle_ACTIVITY_BUILD_SCHEMA_FOR_FORM_REQUEST(action) {
   const activity_subtype = activityState?.activity?.activity_subtype;
   const uiSchema = RootUISchemas[activity_subtype];
   const isAdmin = ((yield select(selectAuth))?.accessRoles ?? []).some(
-    (role) => role.role_name === Role.MASTER_ADMINISTRATOR
+    (role) => role.role_name === Role.MASTER_ADMINISTRATOR || role.role_name === Role.ADMIN_PLANTS
   );
   let apiSpec;
   let userSettings = yield select(selectUserSettings);
@@ -156,12 +156,14 @@ function* handle_ACTIVITY_BUILD_SCHEMA_FOR_FORM_REQUEST(action) {
     yield take(UserSettings.InitState.getSuccess);
     userSettings = yield select(selectUserSettings);
   }
+
   if (isViewing || isAdmin) {
     // Admins get all codes as they fill out data on behalf of other users
     apiSpec = userSettings.apiDocsWithViewOptions;
   } else {
     apiSpec = userSettings.apiDocsWithSelectOptions;
   }
+
   const components = apiSpec.components;
   const subtypeSchema = components?.schemas?.[activity_subtype];
 

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -378,6 +378,7 @@ export function* handle_ACTIVITY_ON_FORM_CHANGE_REQUEST(action) {
       let linked_geo;
       if (connected) {
         const networkReturn = yield InvasivesAPI_Call('GET', `/api/activity/${linked_id}`);
+
         if (networkReturn?.ok) {
           linked_geo = networkReturn.data.geometry;
         }
@@ -594,7 +595,7 @@ export function* handle_ACTIVITY_GET_SUCCESS(action: PayloadAction<Record<string
     const created_by = action.payload.created_by;
     const createdByUser = userName === created_by;
 
-    const isViewing = !createdByUser;
+    const isViewing = !activityState.activeActivityPermissions.can_edit;
 
     // Don't fetch suggestions if the record doesn't belong to the user
     if (createdByUser) {


### PR DESCRIPTION
This update ensures that only users with admin roles can select from all available values in the dropdown. Users with other roles are restricted to selecting only the values assigned to them. They can, however, view it through other (non-editable) records.