### PR TITLE
[INV-4178] Persist shapes in recordset caches after app deletion

### DIFF
--- a/app/src/UI/Features/LegacyMap/LayerPicker/LayerPicker.css
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LayerPicker.css
@@ -52,7 +52,7 @@ li > hr {
   width: 100%;
   max-width: 400px;
   height: 100%;
-  z-index: 2000;
+  z-index: 500;
   box-sizing: border-box;
   border-left: 1pt solid var(--eigengrau);
 

--- a/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
@@ -20,7 +20,6 @@ import VECTOR_MAP_FONT_FACE from 'constants/vectorMapFontFace';
 import { RecordCacheServiceFactory } from 'utils/record-cache/context';
 import { OfflineActivityRecord } from 'state/reducers/offlineActivity';
 import { getConcatenatedCodes, findSpeciesCodes } from 'utils/addActivity';
-import { EFilterType, IFilter } from 'state/actions/userSettings/RecordSet';
 
 const LAYER_ID_PREFIX = 'recordset-layer-';
 const OFFLINE_ACTIVITIES_LAYER_ID = 'offline-activity';

--- a/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
@@ -15,11 +15,12 @@ import {
 import { FALLBACK_COLOR } from 'UI/Features/LegacyMap/helpers/functional/constants';
 import { safelySetPaintProperty } from 'UI/Features/LegacyMap/helpers/functional/utility-functions';
 import { buildTimeConfig } from 'state/configuration/build-time-config';
-import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
+import { RecordSetId, RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import VECTOR_MAP_FONT_FACE from 'constants/vectorMapFontFace';
 import { RecordCacheServiceFactory } from 'utils/record-cache/context';
 import { OfflineActivityRecord } from 'state/reducers/offlineActivity';
 import { getConcatenatedCodes, findSpeciesCodes } from 'utils/addActivity';
+import { EFilterType, IFilter } from 'state/actions/userSettings/RecordSet';
 
 const LAYER_ID_PREFIX = 'recordset-layer-';
 const OFFLINE_ACTIVITIES_LAYER_ID = 'offline-activity';
@@ -58,9 +59,16 @@ const createCachedIappLayer = async (map: maplibregl.Map, layer: any) => {
 
 const createOnlineIappLayer = (map: any, layer: any) => {
   const layerID = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
+  const filterObject = structuredClone(layer.filterObject);
+
+  filterObject?.tableFilters?.forEach((filter: IFilter, i: number) => {
+    if (filter.filterType === EFilterType.Uploaded) {
+      delete filterObject?.tableFilters?.[i]?.geojson;
+    }
+  });
   const source: SourceSpecification = {
     type: 'vector',
-    tiles: [`api:///api/vectors/iapp/{z}/{x}/{y}?filterObject=${encodeURI(JSON.stringify(layer.filterObject))}`],
+    tiles: [`api:///api/vectors/iapp/{z}/{x}/{y}?filterObject=${encodeURI(JSON.stringify(filterObject))}`],
     minzoom: 0,
     maxzoom: 24
   };
@@ -251,14 +259,21 @@ const createCachedActivityLayer = async (map: maplibregl.Map, layer: any) => {
 const createOnlineActivityLayer = (map: maplibregl.Map, layer: any) => {
   const layerID = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
 
-  if (['1', '2'].includes(layer.recordSetID) && !layer.layerState.colorScheme) {
+  if ([RecordSetId.Drafts, RecordSetId.Activity].includes(layer.recordSetID) && !layer.layerState.colorScheme) {
     return;
   }
+  const filterObject = structuredClone(layer.filterObject);
+
+  filterObject?.tableFilters?.forEach((filter: IFilter, i: number) => {
+    if (filter.filterType === EFilterType.Uploaded) {
+      delete filterObject?.tableFilters?.[i]?.geojson;
+    }
+  });
 
   // color the feature depending on the property 'Activity Type' matching the keys in the layer colorScheme:
   const source: SourceSpecification = {
     type: 'vector',
-    tiles: [`api:///api/vectors/activities/{z}/{x}/{y}?filterObject=${encodeURI(JSON.stringify(layer.filterObject))}`],
+    tiles: [`api:///api/vectors/activities/{z}/{x}/{y}?filterObject=${encodeURI(JSON.stringify(filterObject))}`],
     minzoom: 0,
     maxzoom: 24
   };

--- a/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
@@ -28,7 +28,7 @@ const OFFLINE_ACTIVITIES_LAYER_ID = 'offline-activity';
 const formatLayerID = (recordSetID: string, tableFiltersHash: string): string =>
   `${LAYER_ID_PREFIX}${recordSetID}-hash-${tableFiltersHash}`;
 
-export const createCachedIappLayer = async (map: maplibregl.Map, layer: any) => {
+const createCachedIappLayer = async (map: maplibregl.Map, layer: any) => {
   if (layer?.layerState?.cacheMetadataStatus !== UserRecordCacheStatus.CACHED || !layer.layerState.mapToggle) {
     return;
   }
@@ -56,7 +56,7 @@ export const createCachedIappLayer = async (map: maplibregl.Map, layer: any) => 
   map.addLayer(labelLayer, LAYER_Z_FOREGROUND);
 };
 
-export const createOnlineIappLayer = (map: any, layer: any) => {
+const createOnlineIappLayer = (map: any, layer: any) => {
   const layerID = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
   const source: SourceSpecification = {
     type: 'vector',
@@ -197,7 +197,7 @@ const getLabelLayer = (layerID: string, options: LayerOptions): SymbolLayerSpeci
  * @desc Uses the device's recordset Cache data to display geoJson Layers on the map when offline
  *       Displays two layers: Points at high levels, and shapes at lower
  */
-export const createCachedActivityLayer = async (map: maplibregl.Map, layer: any) => {
+const createCachedActivityLayer = async (map: maplibregl.Map, layer: any) => {
   if (layer?.layerState?.cacheMetadataStatus !== UserRecordCacheStatus.CACHED || !layer.layerState.mapToggle) {
     return;
   }
@@ -248,7 +248,7 @@ export const createCachedActivityLayer = async (map: maplibregl.Map, layer: any)
   map.addLayer(circleMarkerZoomedOutLayerCentroid, LAYER_Z_FOREGROUND);
 };
 
-export const createOnlineActivityLayer = (map: maplibregl.Map, layer: any) => {
+const createOnlineActivityLayer = (map: maplibregl.Map, layer: any) => {
   const layerID = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
 
   if (['1', '2'].includes(layer.recordSetID) && !layer.layerState.colorScheme) {
@@ -258,9 +258,7 @@ export const createOnlineActivityLayer = (map: maplibregl.Map, layer: any) => {
   // color the feature depending on the property 'Activity Type' matching the keys in the layer colorScheme:
   const source: SourceSpecification = {
     type: 'vector',
-    tiles: [
-      `api:///api/vectors/activities/{z}/{x}/{y}?filterObject=${encodeURI(JSON.stringify(layer.filterObject))}`
-    ],
+    tiles: [`api:///api/vectors/activities/{z}/{x}/{y}?filterObject=${encodeURI(JSON.stringify(layer.filterObject))}`],
     minzoom: 0,
     maxzoom: 24
   };
@@ -342,7 +340,7 @@ const createOfflineActivitiesLayer = async (
     }
   }
 };
-export const removeOfflineActivitiesLayer = async (map: maplibregl.Map) => {
+const removeOfflineActivitiesLayer = async (map: maplibregl.Map) => {
   const allLayersOnMap = map.getLayersOrder();
   const recordSetOfflineLayers = allLayersOnMap.filter((layer) => layer.includes(OFFLINE_ACTIVITIES_LAYER_ID));
 
@@ -358,7 +356,7 @@ export const removeOfflineActivitiesLayer = async (map: maplibregl.Map) => {
   }
 };
 
-export const refreshOfflineActivitiesLayer = async (
+const refreshOfflineActivitiesLayer = async (
   map: maplibregl.Map,
   visibility: boolean,
   labelVisibility: boolean,
@@ -372,7 +370,7 @@ export const refreshOfflineActivitiesLayer = async (
   await createOfflineActivitiesLayer(map, locallyStoredActivities, labelVisibility);
 };
 
-export const toggleOfflineActivityLabels = async (map: maplibregl.Map, labelVisibility: boolean) => {
+const toggleOfflineActivityLabels = async (map: maplibregl.Map, labelVisibility: boolean) => {
   const allLayersOnMap = map.getLayersOrder();
   const recordSetOfflineLabelLayer = allLayersOnMap.filter((layer) =>
     layer.includes('label-' + OFFLINE_ACTIVITIES_LAYER_ID)
@@ -420,7 +418,7 @@ const purgeRecordsetLayersNotInStore = (
   });
 };
 
-export const deleteStaleRecordsetLayer = (map: maplibregl.Map, layer: Record<PropertyKey, any>) => {
+const deleteStaleRecordsetLayer = (map: maplibregl.Map, layer: Record<PropertyKey, any>) => {
   if (!map) {
     return;
   }
@@ -462,7 +460,7 @@ export const deleteStaleRecordsetLayer = (map: maplibregl.Map, layer: Record<Pro
  * @desc Delete all recordset layers on the map in response to major app events (connectivity change, or cache update)
  * @param map Current map
  */
-export const removeRecordsetLayersOnForcedRedraw = (map: maplibregl.Map) => {
+const removeRecordsetLayersOnForcedRedraw = (map: maplibregl.Map) => {
   const allLayersOnMap = map.getLayersOrder();
   const allSourcesOnMap = Object.keys(map.style.sourceCaches);
 
@@ -485,8 +483,11 @@ export const removeRecordsetLayersOnForcedRedraw = (map: maplibregl.Map) => {
   });
 };
 
-export const rebuildLayersOnTableHashUpdate = async (
-  storeLayers: Record<PropertyKey, any>, map: maplibregl.Map, connectedToNetwork: boolean) => {
+const rebuildLayersOnTableHashUpdate = async (
+  storeLayers: Record<PropertyKey, any>,
+  map: maplibregl.Map,
+  connectedToNetwork: boolean
+) => {
   const MOBILE_OFFLINE = buildTimeConfig.MOBILE && !connectedToNetwork;
   /* First need to delete the layers who's record set was deleted altogether: */
   const storeLayersIds = storeLayers.map((layer) => formatLayerID(layer.recordSetID, layer.tableFiltersHash));
@@ -532,7 +533,7 @@ const createMapLayer = async (
   }
 };
 
-export const refreshColoursOnColourUpdate = (storeLayers, map: maplibregl.Map) => {
+const refreshColoursOnColourUpdate = (storeLayers, map: maplibregl.Map) => {
   /** Get color value for a given paint property */
   const currentColor = (paint, property: string) => paint[property] ?? '';
 
@@ -562,7 +563,7 @@ export const refreshColoursOnColourUpdate = (storeLayers, map: maplibregl.Map) =
   }
 };
 
-export const refreshVisibilityOnToggleUpdate = (storeLayers, map: maplibregl.Map) => {
+const refreshVisibilityOnToggleUpdate = (storeLayers, map: maplibregl.Map) => {
   storeLayers.map((layer) => {
     const layerSearchString = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
     const mapLayers = map.getLayersOrder();
@@ -594,4 +595,19 @@ export const refreshVisibilityOnToggleUpdate = (storeLayers, map: maplibregl.Map
       }
     });
   });
+};
+
+export {
+  createCachedIappLayer,
+  createOnlineActivityLayer,
+  refreshVisibilityOnToggleUpdate,
+  refreshColoursOnColourUpdate,
+  rebuildLayersOnTableHashUpdate,
+  removeRecordsetLayersOnForcedRedraw,
+  deleteStaleRecordsetLayer,
+  toggleOfflineActivityLabels,
+  removeOfflineActivitiesLayer,
+  refreshOfflineActivitiesLayer,
+  createCachedActivityLayer,
+  createOnlineIappLayer
 };

--- a/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
@@ -59,16 +59,9 @@ const createCachedIappLayer = async (map: maplibregl.Map, layer: any) => {
 
 const createOnlineIappLayer = (map: any, layer: any) => {
   const layerID = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
-  const filterObject = structuredClone(layer.filterObject);
-
-  filterObject?.tableFilters?.forEach((filter: IFilter, i: number) => {
-    if (filter.filterType === EFilterType.Uploaded) {
-      delete filterObject?.tableFilters?.[i]?.geojson;
-    }
-  });
   const source: SourceSpecification = {
     type: 'vector',
-    tiles: [`api:///api/vectors/iapp/{z}/{x}/{y}?filterObject=${encodeURI(JSON.stringify(filterObject))}`],
+    tiles: [`api:///api/vectors/iapp/{z}/{x}/{y}?filterObject=${encodeURI(JSON.stringify(layer.filterObject))}`],
     minzoom: 0,
     maxzoom: 24
   };
@@ -262,18 +255,11 @@ const createOnlineActivityLayer = (map: maplibregl.Map, layer: any) => {
   if ([RecordSetId.Drafts, RecordSetId.Activity].includes(layer.recordSetID) && !layer.layerState.colorScheme) {
     return;
   }
-  const filterObject = structuredClone(layer.filterObject);
-
-  filterObject?.tableFilters?.forEach((filter: IFilter, i: number) => {
-    if (filter.filterType === EFilterType.Uploaded) {
-      delete filterObject?.tableFilters?.[i]?.geojson;
-    }
-  });
 
   // color the feature depending on the property 'Activity Type' matching the keys in the layer colorScheme:
   const source: SourceSpecification = {
     type: 'vector',
-    tiles: [`api:///api/vectors/activities/{z}/{x}/{y}?filterObject=${encodeURI(JSON.stringify(filterObject))}`],
+    tiles: [`api:///api/vectors/activities/{z}/{x}/{y}?filterObject=${encodeURI(JSON.stringify(layer.filterObject))}`],
     minzoom: 0,
     maxzoom: 24
   };

--- a/app/src/UI/Features/Records/RecordSet/Filter.tsx
+++ b/app/src/UI/Features/Records/RecordSet/Filter.tsx
@@ -40,6 +40,13 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
     []
   );
 
+  const updateSpatialFilter = (id: string, filterType: string) => {
+    const shape =
+      filterType === 'spatialFilterUploaded'
+        ? serverBoundariesToDisplay.find((boundary) => boundary.value === id)
+        : clientBoundariesToDisplay.find((boundary) => boundary.value === id);
+    updateFilter({ filter: shape.id, geojson: shape.geojson, filterType: filterType });
+  };
   /**
    * Update the Recordsets filters
    * @param newVal additional object keys
@@ -84,7 +91,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
           <select
             className="filterSelect"
             disabled={disabled}
-            onChange={(e) => updateFilter({ filter: e.target.value })}
+            onChange={(e) => updateSpatialFilter(e.target.value, 'spatialFilterUploaded')}
             value={filterSet.filter}
           >
             {serverBoundariesToDisplay?.map((option) => (
@@ -99,7 +106,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
           <select
             className="filterSelect"
             disabled={disabled}
-            onChange={(e) => updateFilter({ filter: e.target.value })}
+            onChange={(e) => updateSpatialFilter(e.target.value, 'spatialFilterDrawn')}
             value={filterSet.filter}
           >
             {clientBoundariesToDisplay?.map((option) => (
@@ -118,11 +125,13 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
 
   const serverBoundariesToDisplay = useSelector((state) => state.Map.serverBoundaries)?.map((boundary) => ({
     label: boundary.title,
-    value: boundary.id
+    value: boundary.id,
+    ...boundary
   }));
   const clientBoundariesToDisplay = useSelector((state) => state.Map.clientBoundaries)?.map((boundary) => ({
     label: boundary.title,
-    value: boundary.id
+    value: boundary.id,
+    ...boundary
   }));
   const filterColumns = recordSetType === RecordSetType.Activity ? activityColumnsToDisplay : iappColumnsToDisplay;
   const filterOptions = filterColumns.map((option) => ({ label: option.name, value: option.key }));

--- a/app/src/UI/Features/Records/RecordSet/Filter.tsx
+++ b/app/src/UI/Features/Records/RecordSet/Filter.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from 'utils/use_selector';
 import { RecordSetType } from 'interfaces/UserRecordSet';
 import UserSettings from 'state/actions/userSettings/UserSettings';
 import debounce from 'lodash.debounce';
-import { IFilter, IUpdateFilter } from 'state/actions/userSettings/RecordSet';
+import { EFilterType, IFilter, IUpdateFilter } from 'state/actions/userSettings/RecordSet';
 
 type PropTypes = {
   setID: string;
@@ -15,11 +15,6 @@ type PropTypes = {
 };
 
 const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
-  enum FilterType {
-    Drawn = 'spatialFilterDrawn',
-    Uploaded = 'spatialFilterUploaded',
-    Table = 'tableFilter'
-  }
   const TIME_TO_AUTO_UPDATE_IN_SECONDS = 0.75;
 
   /**
@@ -35,7 +30,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
     debounce((value: string) => {
       dispatch(
         UserSettings.RecordSet.updateFilter({
-          filterType: FilterType.Table,
+          filterType: EFilterType.Table,
           setID: setID,
           filterID: filterSet.id,
           filter: value
@@ -47,11 +42,11 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
 
   const updateSpatialFilter = (id: string, filterType: string) => {
     let payload;
-    if (filterType === FilterType.Uploaded) {
-      const shape = serverBoundariesToDisplay.find(({ value }) => value == id);
-      payload = { filter: shape.id };
-    } else {
-      const shape = clientBoundariesToDisplay.find(({ value }) => value === id);
+    if (filterType !== EFilterType.Table) {
+      const shape =
+        filterType === EFilterType.Drawn
+          ? clientBoundariesToDisplay.find(({ value }) => value === id)
+          : serverBoundariesToDisplay.find(({ value }) => value == id);
       payload = { filter: shape.id, geojson: shape?.geojson };
     }
     updateFilter({ filterType: filterType, ...payload });
@@ -85,7 +80,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
 
   const getFilterType = (filterType: string) => {
     switch (filterType) {
-      case FilterType.Table:
+      case EFilterType.Table:
         return (
           <input
             className="filterSelect"
@@ -95,12 +90,12 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
             value={inputValue}
           />
         );
-      case FilterType.Uploaded:
+      case EFilterType.Uploaded:
         return (
           <select
             className="filterSelect"
             disabled={disabled}
-            onChange={(e) => updateSpatialFilter(e.target.value, FilterType.Uploaded)}
+            onChange={(e) => updateSpatialFilter(e.target.value, EFilterType.Uploaded)}
             value={filterSet.filter}
           >
             {serverBoundariesToDisplay.length > 0 ? (
@@ -116,12 +111,12 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
             )}
           </select>
         );
-      case FilterType.Drawn:
+      case EFilterType.Drawn:
         return (
           <select
             className="filterSelect"
             disabled={disabled}
-            onChange={(e) => updateSpatialFilter(e.target.value, FilterType.Drawn)}
+            onChange={(e) => updateSpatialFilter(e.target.value, EFilterType.Drawn)}
             value={filterSet.filter}
           >
             {clientBoundariesToDisplay.length > 0 ? (
@@ -170,7 +165,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
         >
           {
             {
-              [FilterType.Table]: (
+              [EFilterType.Table]: (
                 <>
                   <option value={'AND'} label={'AND'}>
                     AND
@@ -180,7 +175,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
                   </option>
                 </>
               ),
-              [FilterType.Drawn]: (
+              [EFilterType.Drawn]: (
                 <>
                   <option value={'AND'} label={'AND'}>
                     AND
@@ -190,7 +185,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
                   </option>
                 </>
               ),
-              [FilterType.Uploaded]: (
+              [EFilterType.Uploaded]: (
                 <>
                   <option value={'AND'} label={'AND'}>
                     AND
@@ -213,7 +208,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
         >
           {
             {
-              [FilterType.Table]: (
+              [EFilterType.Table]: (
                 <>
                   <option value={'CONTAINS'} label={'CONTAINS'}>
                     CONTAINS
@@ -223,7 +218,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
                   </option>
                 </>
               ),
-              [FilterType.Drawn]: (
+              [EFilterType.Drawn]: (
                 <>
                   <option value={'CONTAINED IN'} label={'CONTAINED IN'}>
                     CONTAINED IN
@@ -233,7 +228,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
                   </option>
                 </>
               ),
-              [FilterType.Uploaded]: (
+              [EFilterType.Uploaded]: (
                 <>
                   <option value={'CONTAINED IN'} label={'CONTAINED IN'}>
                     CONTAINED IN
@@ -252,10 +247,10 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
           className="filterTypeSelect"
           disabled={disabled}
           onChange={(e) => {
-            if (e.target.value === FilterType.Uploaded) {
-              updateSpatialFilter(serverBoundariesToDisplay[0].value, FilterType.Uploaded);
-            } else if (e.target.value === FilterType.Drawn) {
-              updateSpatialFilter(clientBoundariesToDisplay[0].value, FilterType.Drawn);
+            if (e.target.value === EFilterType.Uploaded) {
+              updateSpatialFilter(serverBoundariesToDisplay[0].value, EFilterType.Uploaded);
+            } else if (e.target.value === EFilterType.Drawn) {
+              updateSpatialFilter(clientBoundariesToDisplay[0].value, EFilterType.Drawn);
             } else {
               updateFilter({
                 filterType: e.target.value,
@@ -266,15 +261,15 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
           }}
           value={filterSet.filterType}
         >
-          <option value={FilterType.Table} label={'Field/Column'}>
+          <option value={EFilterType.Table} label={'Field/Column'}>
             Field/Column
           </option>
-          <option disabled={clientBoundariesToDisplay.length < 1} value={FilterType.Drawn} label={'Spatial - Drawn'}>
+          <option disabled={clientBoundariesToDisplay.length < 1} value={EFilterType.Drawn} label={'Spatial - Drawn'}>
             Spatial - Drawn
           </option>
           <option
             disabled={serverBoundariesToDisplay.length < 1}
-            value={FilterType.Uploaded}
+            value={EFilterType.Uploaded}
             label={'Spatial - Uploaded'}
           >
             Spatial - Uploaded
@@ -287,10 +282,10 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
           disabled={disabled}
           value={filterSet.field}
           onChange={(e) =>
-            updateFilter({ filterID: filterSet.id, field: e.target.value, filterType: FilterType.Table })
+            updateFilter({ filterID: filterSet.id, field: e.target.value, filterType: EFilterType.Table })
           }
         >
-          {filterSet.filterType === FilterType.Table ? (
+          {filterSet.filterType === EFilterType.Table ? (
             filterOptions.map((option) => (
               <option key={option.value + option.label} value={option.value}>
                 {option.label}
@@ -310,7 +305,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
             <Button
               className={'deleteButton'}
               disabled={disabled}
-              onClick={() => removeFilter(FilterType.Table)}
+              onClick={() => removeFilter(EFilterType.Table)}
               variant="contained"
             >
               Delete

--- a/app/src/UI/Features/Records/RecordSet/Filter.tsx
+++ b/app/src/UI/Features/Records/RecordSet/Filter.tsx
@@ -2,7 +2,7 @@ import { Button, Tooltip } from '@mui/material';
 import { useCallback, useState } from 'react';
 import { activityColumnsToDisplay, iappColumnsToDisplay } from 'UI/Features/Records/RecordSet/RecordTableHelpers';
 import { useDispatch, useSelector } from 'utils/use_selector';
-import { RecordSetType } from 'interfaces/UserRecordSet';
+import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import UserSettings from 'state/actions/userSettings/UserSettings';
 import debounce from 'lodash.debounce';
 import { EFilterType, IFilter, IUpdateFilter } from 'state/actions/userSettings/RecordSet';
@@ -42,11 +42,8 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
 
   const updateSpatialFilter = (id: string, filterType: string) => {
     let payload;
-    if (filterType !== EFilterType.Table) {
-      const shape =
-        filterType === EFilterType.Drawn
-          ? clientBoundariesToDisplay.find(({ value }) => value === id)
-          : serverBoundariesToDisplay.find(({ value }) => value == id);
+    if (filterType === EFilterType.Drawn) {
+      const shape = clientBoundariesToDisplay.find(({ value }) => value === id);
       payload = { filter: shape.id, geojson: shape?.geojson };
     }
     updateFilter({ filterType: filterType, ...payload });
@@ -95,7 +92,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
           <select
             className="filterSelect"
             disabled={disabled}
-            onChange={(e) => updateSpatialFilter(e.target.value, EFilterType.Uploaded)}
+            onChange={(e) => updateFilter({ filter: e.target.value })}
             value={filterSet.filter}
           >
             {serverBoundariesToDisplay.length > 0 ? (
@@ -141,19 +138,22 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
 
   const serverBoundariesToDisplay = useSelector((state) => state.Map.serverBoundaries)?.map((boundary) => ({
     label: boundary.title,
-    value: boundary.id,
-    ...boundary
+    value: boundary.id
   }));
   const clientBoundariesToDisplay = useSelector((state) => state.Map.clientBoundaries)?.map((boundary) => ({
     label: boundary.title,
     value: boundary.id,
     ...boundary
   }));
+  const serverSpatialFiltersDisabled = useSelector(
+    (state) => state.UserSettings.recordSets[setID].cacheMetadataStatus === UserRecordCacheStatus.CACHED
+  );
   const filterColumns = recordSetType === RecordSetType.Activity ? activityColumnsToDisplay : iappColumnsToDisplay;
   const filterOptions = filterColumns.map((option) => ({ label: option.name, value: option.key }));
 
   const [inputValue, setInputValue] = useState<string>(filterSet.filter);
   const input = getFilterType(filterSet.filterType);
+
   return (
     <tr>
       <td>
@@ -248,15 +248,16 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
           disabled={disabled}
           onChange={(e) => {
             if (e.target.value === EFilterType.Uploaded) {
-              updateSpatialFilter(serverBoundariesToDisplay[0].value, EFilterType.Uploaded);
+              updateFilter({
+                filterType: EFilterType.Uploaded,
+                setID: setID,
+                filterID: filterSet.id,
+                filter: serverBoundariesToDisplay[0].value
+              });
             } else if (e.target.value === EFilterType.Drawn) {
               updateSpatialFilter(clientBoundariesToDisplay[0].value, EFilterType.Drawn);
             } else {
-              updateFilter({
-                filterType: e.target.value,
-                setID: setID,
-                filterID: filterSet.id
-              });
+              updateFilter({ filterType: EFilterType.Table, setID: setID, filterID: filterSet.id });
             }
           }}
           value={filterSet.filterType}
@@ -268,7 +269,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
             Spatial - Drawn
           </option>
           <option
-            disabled={serverBoundariesToDisplay.length < 1}
+            disabled={serverBoundariesToDisplay.length < 1 || serverSpatialFiltersDisabled}
             value={EFilterType.Uploaded}
             label={'Spatial - Uploaded'}
           >

--- a/app/src/UI/Features/Records/RecordSet/Filter.tsx
+++ b/app/src/UI/Features/Records/RecordSet/Filter.tsx
@@ -15,6 +15,11 @@ type PropTypes = {
 };
 
 const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
+  enum FilterType {
+    Drawn = 'spatialFilterDrawn',
+    Uploaded = 'spatialFilterUploaded',
+    Table = 'tableFilter'
+  }
   const TIME_TO_AUTO_UPDATE_IN_SECONDS = 0.75;
 
   /**
@@ -30,7 +35,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
     debounce((value: string) => {
       dispatch(
         UserSettings.RecordSet.updateFilter({
-          filterType: 'tableFilter',
+          filterType: FilterType.Table,
           setID: setID,
           filterID: filterSet.id,
           filter: value
@@ -41,11 +46,15 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
   );
 
   const updateSpatialFilter = (id: string, filterType: string) => {
-    const shape =
-      filterType === 'spatialFilterUploaded'
-        ? serverBoundariesToDisplay.find((boundary) => boundary.value === id)
-        : clientBoundariesToDisplay.find((boundary) => boundary.value === id);
-    updateFilter({ filter: shape.id, geojson: shape.geojson, filterType: filterType });
+    let payload;
+    if (filterType === FilterType.Uploaded) {
+      const shape = serverBoundariesToDisplay.find(({ value }) => value == id);
+      payload = { filter: shape.id };
+    } else {
+      const shape = clientBoundariesToDisplay.find(({ value }) => value === id);
+      payload = { filter: shape.id, geojson: shape?.geojson };
+    }
+    updateFilter({ filterType: filterType, ...payload });
   };
   /**
    * Update the Recordsets filters
@@ -76,7 +85,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
 
   const getFilterType = (filterType: string) => {
     switch (filterType) {
-      case 'tableFilter':
+      case FilterType.Table:
         return (
           <input
             className="filterSelect"
@@ -86,12 +95,12 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
             value={inputValue}
           />
         );
-      case 'spatialFilterUploaded':
+      case FilterType.Uploaded:
         return (
           <select
             className="filterSelect"
             disabled={disabled}
-            onChange={(e) => updateSpatialFilter(e.target.value, 'spatialFilterUploaded')}
+            onChange={(e) => updateSpatialFilter(e.target.value, FilterType.Uploaded)}
             value={filterSet.filter}
           >
             {serverBoundariesToDisplay?.map((option) => (
@@ -101,12 +110,12 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
             ))}
           </select>
         );
-      case 'spatialFilterDrawn':
+      case FilterType.Drawn:
         return (
           <select
             className="filterSelect"
             disabled={disabled}
-            onChange={(e) => updateSpatialFilter(e.target.value, 'spatialFilterDrawn')}
+            onChange={(e) => updateSpatialFilter(e.target.value, FilterType.Drawn)}
             value={filterSet.filter}
           >
             {clientBoundariesToDisplay?.map((option) => (
@@ -149,7 +158,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
         >
           {
             {
-              tableFilter: (
+              [FilterType.Table]: (
                 <>
                   <option value={'AND'} label={'AND'}>
                     AND
@@ -159,7 +168,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
                   </option>
                 </>
               ),
-              spatialFilterDrawn: (
+              [FilterType.Drawn]: (
                 <>
                   <option value={'AND'} label={'AND'}>
                     AND
@@ -169,7 +178,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
                   </option>
                 </>
               ),
-              spatialFilterUploaded: (
+              [FilterType.Uploaded]: (
                 <>
                   <option value={'AND'} label={'AND'}>
                     AND
@@ -192,7 +201,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
         >
           {
             {
-              tableFilter: (
+              [FilterType.Table]: (
                 <>
                   <option value={'CONTAINS'} label={'CONTAINS'}>
                     CONTAINS
@@ -202,7 +211,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
                   </option>
                 </>
               ),
-              spatialFilterDrawn: (
+              [FilterType.Drawn]: (
                 <>
                   <option value={'CONTAINED IN'} label={'CONTAINED IN'}>
                     CONTAINED IN
@@ -212,7 +221,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
                   </option>
                 </>
               ),
-              spatialFilterUploaded: (
+              [FilterType.Uploaded]: (
                 <>
                   <option value={'CONTAINED IN'} label={'CONTAINED IN'}>
                     CONTAINED IN
@@ -237,28 +246,25 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
               filterID: filterSet.id
             };
 
-            if (e.target.value === 'spatialFilterUploaded') {
-              payload.filter = serverBoundariesToDisplay[0].value;
-            } else if (e.target.value === 'spatialFilterDrawn') {
-              payload.filter = clientBoundariesToDisplay[0].value;
+            if (e.target.value === FilterType.Uploaded) {
+              updateSpatialFilter(serverBoundariesToDisplay[0].value, FilterType.Uploaded);
+            } else if (e.target.value === FilterType.Drawn) {
+              updateSpatialFilter(clientBoundariesToDisplay[0].value, FilterType.Drawn);
+            } else {
+              updateFilter(payload);
             }
-            updateFilter(payload);
           }}
           value={filterSet.filterType}
         >
-          <option value={'tableFilter'} label={'Field/Column'}>
+          <option value={FilterType.Table} label={'Field/Column'}>
             Field/Column
           </option>
-          <option
-            disabled={clientBoundariesToDisplay.length < 1}
-            value={'spatialFilterDrawn'}
-            label={'Spatial - Drawn'}
-          >
+          <option disabled={clientBoundariesToDisplay.length < 1} value={FilterType.Drawn} label={'Spatial - Drawn'}>
             Spatial - Drawn
           </option>
           <option
             disabled={serverBoundariesToDisplay.length < 1}
-            value={'spatialFilterUploaded'}
+            value={FilterType.Uploaded}
             label={'Spatial - Uploaded'}
           >
             Spatial - Uploaded
@@ -270,9 +276,11 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
           className="filterSelect"
           disabled={disabled}
           value={filterSet.field}
-          onChange={(e) => updateFilter({ filterID: filterSet.id, field: e.target.value, filterType: 'tableFilter' })}
+          onChange={(e) =>
+            updateFilter({ filterID: filterSet.id, field: e.target.value, filterType: FilterType.Table })
+          }
         >
-          {filterSet.filterType === 'tableFilter' ? (
+          {filterSet.filterType === FilterType.Table ? (
             filterOptions.map((option) => (
               <option key={option.value + option.label} value={option.value}>
                 {option.label}
@@ -292,7 +300,7 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
             <Button
               className={'deleteButton'}
               disabled={disabled}
-              onClick={() => removeFilter('tableFilter')}
+              onClick={() => removeFilter(FilterType.Table)}
               variant="contained"
             >
               Delete

--- a/app/src/UI/Features/Records/RecordSet/Filter.tsx
+++ b/app/src/UI/Features/Records/RecordSet/Filter.tsx
@@ -103,11 +103,17 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
             onChange={(e) => updateSpatialFilter(e.target.value, FilterType.Uploaded)}
             value={filterSet.filter}
           >
-            {serverBoundariesToDisplay?.map((option) => (
-              <option key={option.value + option.label} value={option.value}>
-                {option.label}
+            {serverBoundariesToDisplay.length > 0 ? (
+              serverBoundariesToDisplay?.map((option) => (
+                <option key={option.value + option.label} value={option.value}>
+                  {option.label}
+                </option>
+              ))
+            ) : (
+              <option selected disabled value="">
+                Original source removed
               </option>
-            ))}
+            )}
           </select>
         );
       case FilterType.Drawn:
@@ -118,11 +124,17 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
             onChange={(e) => updateSpatialFilter(e.target.value, FilterType.Drawn)}
             value={filterSet.filter}
           >
-            {clientBoundariesToDisplay?.map((option) => (
-              <option key={option.value + option.label} value={option.value}>
-                {option.label}
+            {clientBoundariesToDisplay.length > 0 ? (
+              clientBoundariesToDisplay?.map((option) => (
+                <option key={option.value + option.label} value={option.value}>
+                  {option.label}
+                </option>
+              ))
+            ) : (
+              <option selected disabled value="">
+                Original source removed
               </option>
-            ))}
+            )}
           </select>
         );
       default:
@@ -240,18 +252,16 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
           className="filterTypeSelect"
           disabled={disabled}
           onChange={(e) => {
-            const payload: Partial<IUpdateFilter> = {
-              filterType: e.target.value,
-              setID: setID,
-              filterID: filterSet.id
-            };
-
             if (e.target.value === FilterType.Uploaded) {
               updateSpatialFilter(serverBoundariesToDisplay[0].value, FilterType.Uploaded);
             } else if (e.target.value === FilterType.Drawn) {
               updateSpatialFilter(clientBoundariesToDisplay[0].value, FilterType.Drawn);
             } else {
-              updateFilter(payload);
+              updateFilter({
+                filterType: e.target.value,
+                setID: setID,
+                filterID: filterSet.id
+              });
             }
           }}
           value={filterSet.filterType}

--- a/app/src/UI/Layout/DebugMenu/ClearAppCache.tsx
+++ b/app/src/UI/Layout/DebugMenu/ClearAppCache.tsx
@@ -1,0 +1,23 @@
+import { PersistorContext } from 'utils/PersistorContext';
+
+const ClearAppCache = () => (
+  <PersistorContext.Consumer>
+    {(persistor) => (
+      <button
+        onClick={() => {
+          if (persistor) {
+            persistor.purge().then(() => {
+              window.location.reload();
+            });
+          } else {
+            window.location.reload();
+          }
+        }}
+      >
+        Clear App Cache
+      </button>
+    )}
+  </PersistorContext.Consumer>
+);
+
+export default ClearAppCache;

--- a/app/src/UI/Layout/DebugMenu/DebugMenu.css
+++ b/app/src/UI/Layout/DebugMenu/DebugMenu.css
@@ -13,5 +13,9 @@
     width: 100%;
     text-align: justify;
     line-height: 1.5;
+    min-height: 35px;
+  }
+  button:not(last-child) {
+    margin-top: 5pt;
   }
 }

--- a/app/src/UI/Layout/DebugMenu/DebugMenu.tsx
+++ b/app/src/UI/Layout/DebugMenu/DebugMenu.tsx
@@ -9,6 +9,7 @@ import './DebugMenu.css';
 import { Platform } from 'state/configuration/build-time-config';
 import { AndroidMemoryReport } from 'UI/Layout/DebugMenu/AndroidMemoryReport';
 import { PlatformGated } from 'UI/Reusable/Predicates/PlatformGated';
+import ClearAppCache from './ClearAppCache';
 
 const DebugMenu = () => {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
@@ -25,6 +26,7 @@ const DebugMenu = () => {
           <PlatformGated requires={Platform.ANDROID}>
             <AndroidMemoryReport />
           </PlatformGated>
+          <ClearAppCache />
         </div>
       </CustomPopover>
     </Debug>

--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -57,11 +57,7 @@ class RecordCache {
       const recordSet = JSON.parse(JSON.stringify(state.UserSettings.recordSets[spec.setId]));
       const idsToCache: string[] = recordSet.idList.map((id) => id.toString());
 
-      recordSet.tableFilters = getRecordFilterObjectFromStateForAPI(
-        spec.setId,
-        state.UserSettings,
-        state.Map.clientBoundaries
-      );
+      recordSet.tableFilters = getRecordFilterObjectFromStateForAPI(spec.setId, state.UserSettings);
 
       const bbox = await getBoundingBoxFromRecordsetFilters(recordSet);
 

--- a/app/src/state/actions/userSettings/RecordSet.ts
+++ b/app/src/state/actions/userSettings/RecordSet.ts
@@ -27,7 +27,7 @@ enum EFilterType {
 interface IFilter {
   id: string;
   field: string;
-  filterType: string;
+  filterType: EFilterType;
   filter: string;
   operator: string;
   operator2: string;

--- a/app/src/state/actions/userSettings/RecordSet.ts
+++ b/app/src/state/actions/userSettings/RecordSet.ts
@@ -1,12 +1,12 @@
 import { createAction, createAsyncThunk, nanoid } from '@reduxjs/toolkit';
 import { Feature } from 'geojson';
+import { buildTimeConfig } from '../../configuration/build-time-config';
 import { RECORD_COLOURS } from 'constants/colors';
 import { RecordSetType, UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
 import { RootState } from 'state/reducers/rootReducer';
 import { RecordCacheServiceFactory } from 'utils/record-cache/context';
 import { CacheDownloadMode } from 'utils/record-cache';
 import RecordCache from 'state/actions/cache/RecordCache';
-import { buildTimeConfig } from '../../configuration/build-time-config';
 
 interface IUpdateFilter extends Partial<IFilter> {
   setID: string | number;
@@ -19,6 +19,11 @@ interface IRemoveFilter {
   filterID: string | number;
 }
 
+enum EFilterType {
+  Drawn = 'spatialFilterDrawn',
+  Uploaded = 'spatialFilterUploaded',
+  Table = 'tableFilter'
+}
 interface IFilter {
   id: string;
   field: string;
@@ -137,4 +142,5 @@ class RecordSet {
 }
 
 export default RecordSet;
+export { EFilterType };
 export type { IUpdateFilter, IRemoveFilter, IFilter, IAddFilter };

--- a/app/src/state/reducers/userSettings.ts
+++ b/app/src/state/reducers/userSettings.ts
@@ -134,7 +134,7 @@ function createUserSettingsReducer(_configuration: AppConfig) {
             tableFilter[key] = action.payload[key];
           }
         });
-        if (filterType && [EFilterType.Drawn, EFilterType.Uploaded].includes(filterType)) {
+        if (filterType === EFilterType.Drawn) {
           tableFilter.field = '';
           tableFilter.operator ??= 'CONTAINED IN';
           tableFilter.filter ??= '';

--- a/app/src/state/reducers/userSettings.ts
+++ b/app/src/state/reducers/userSettings.ts
@@ -123,7 +123,7 @@ function createUserSettingsReducer(_configuration: AppConfig) {
           draftState.recordSets[action.payload.setName][key] = action.payload.updatedSet[key];
         });
       } else if (UserSettings.RecordSet.updateFilter.match(action)) {
-        const { setID, filterType, filterID } = action.payload;
+        const { setID, filterType, filterID, geojson } = action.payload;
         const recordSet = draftState.recordSets[setID];
         const tableFilter = recordSet?.tableFilters.find((filter) => filter.id === filterID);
         if (!tableFilter) return;
@@ -133,11 +133,11 @@ function createUserSettingsReducer(_configuration: AppConfig) {
             tableFilter[key] = action.payload[key];
           }
         });
-
         if (action.payload?.filterType === 'spatialFilterDrawn' || filterType === 'spatialFilterUploaded') {
           tableFilter.field = '';
           tableFilter.operator ??= 'CONTAINED IN';
           tableFilter.filter ??= '';
+          tableFilter.geojson = geojson;
         }
 
         const tableFiltersNotBlank = recordSet?.tableFilters.filter((filter) => !!filter.filter);

--- a/app/src/state/reducers/userSettings.ts
+++ b/app/src/state/reducers/userSettings.ts
@@ -15,6 +15,7 @@ import { CacheDownloadMode } from 'utils/record-cache';
 import { APIDocs } from 'state/actions/userSettings/APIDocs';
 import { activityColumnsToDisplay, iappColumnsToDisplay } from 'UI/Features/Records/RecordSet/RecordTableHelpers';
 import defaultRecordSets from 'constants/defaultRecordSets';
+import { EFilterType } from 'state/actions/userSettings/RecordSet';
 
 interface UserSettingsState {
   [MIGRATION_VERSION_KEY]: number;
@@ -133,7 +134,7 @@ function createUserSettingsReducer(_configuration: AppConfig) {
             tableFilter[key] = action.payload[key];
           }
         });
-        if (action.payload?.filterType === 'spatialFilterDrawn' || filterType === 'spatialFilterUploaded') {
+        if (filterType && [EFilterType.Drawn, EFilterType.Uploaded].includes(filterType)) {
           tableFilter.field = '';
           tableFilter.operator ??= 'CONTAINED IN';
           tableFilter.filter ??= '';

--- a/app/src/state/sagas/activity/online.ts
+++ b/app/src/state/sagas/activity/online.ts
@@ -12,6 +12,7 @@ import SuggestedTreatmentId from 'interfaces/SuggestedTreatmentId';
 import { AuthActions } from 'state/actions/auth/Auth';
 import { buildTimeConfig } from 'state/configuration/build-time-config';
 import parseActivityForPermissions from 'utils/parseActivityForPermissions';
+import { EFilterType } from 'state/actions/userSettings/RecordSet';
 
 export function* handle_ACTIVITY_CREATE_NETWORK(action: PayloadAction<Record<string, any>>) {
   const response = yield InvasivesAPI_Call('POST', `/api/activity/`, action.payload);
@@ -220,7 +221,7 @@ export function* handle_ACTIVITY_GET_SUGGESTED_TREATMENT_IDS_REQUEST_ONLINE(acti
 
     if (action.payload.search_feature?.features?.[0]) {
       filterObject.tableFilters.push({
-        filterType: 'spatialFilterDrawn',
+        filterType: EFilterType.Drawn,
         operator: 'CONTAINED IN',
         operator2: 'AND',
         filter: '0.113619259813296791712616073543',

--- a/app/src/state/sagas/map.ts
+++ b/app/src/state/sagas/map.ts
@@ -304,13 +304,12 @@ function* handle_WHATS_HERE_PAGE_ACTIVITY() {
 function* handle_RECORD_SET_TO_EXCEL_REQUEST(action) {
   const userSettings = yield select(selectUserSettings);
   const set = userSettings?.recordSets?.[action.payload.id];
-  const clientBoundaries = yield select((state) => state.Map.clientBoundaries);
   try {
     let conditionallyUnnestedURL;
     if (set.recordSetType === 'IAPP') {
       const currentState = yield select((state) => state.UserSettings);
 
-      const filterObject = getRecordFilterObjectFromStateForAPI(action.payload.id, currentState, clientBoundaries);
+      const filterObject = getRecordFilterObjectFromStateForAPI(action.payload.id, currentState);
       if (filterObject == null) {
         yield put({
           type: RECORD_SET_TO_EXCEL_FAILURE
@@ -335,7 +334,7 @@ function* handle_RECORD_SET_TO_EXCEL_REQUEST(action) {
     } else {
       const currentState = yield select((state) => state.UserSettings);
 
-      const filterObject = getRecordFilterObjectFromStateForAPI(action.payload.id, currentState, clientBoundaries);
+      const filterObject = getRecordFilterObjectFromStateForAPI(action.payload.id, currentState);
       if (filterObject == null) {
         yield put({
           type: RECORD_SET_TO_EXCEL_FAILURE

--- a/app/src/state/sagas/map.ts
+++ b/app/src/state/sagas/map.ts
@@ -54,7 +54,7 @@ import { RootState } from 'state/reducers/rootReducer';
 import TileCache from 'state/actions/cache/TileCache';
 import { LAYER_ELIGIBILITY_UPDATE } from 'state/sagas/map/layer-eligibility';
 import { RECORD_COLOURS } from 'constants/colors';
-import { IRemoveFilter, IUpdateFilter } from 'state/actions/userSettings/RecordSet';
+import { EFilterType, IRemoveFilter, IUpdateFilter } from 'state/actions/userSettings/RecordSet';
 import { selectNetworkConnected, selectNetworkState } from 'state/reducers/network';
 import UserRecord from 'interfaces/UserRecord';
 import { buildTimeConfig } from 'state/configuration/build-time-config';
@@ -92,7 +92,7 @@ function* handle_WHATS_HERE_FEATURE(whatsHereFeature: PayloadAction<Feature>) {
     const tableFilters = [
       {
         id: '0.81778552637744651712083357942',
-        filterType: 'spatialFilterDrawn',
+        filterType: EFilterType.Drawn,
         operator: 'CONTAINED IN',
         filter: '0.652479498272151712093656568',
         geojson: whatsHereFeature.payload

--- a/app/src/state/sagas/map/dataAccess.ts
+++ b/app/src/state/sagas/map/dataAccess.ts
@@ -16,13 +16,8 @@ import { IQueryParams } from 'utils/record-cache';
 export function* handle_PREP_FILTERS_FOR_VECTOR_ENDPOINT(action) {
   try {
     const currentState = yield select((state) => state?.UserSettings);
-    const clientBoundaries = yield select((state) => state.Map?.clientBoundaries);
     const recordset: UserRecordSet = currentState.recordSets[action.payload.recordSetID];
-    const filterObject = getRecordFilterObjectFromStateForAPI(
-      action.payload.recordSetID,
-      currentState,
-      clientBoundaries
-    );
+    const filterObject = getRecordFilterObjectFromStateForAPI(action.payload.recordSetID, currentState);
     if (filterObject == null) {
       console.warn('filterObject returned by getRecordFilterObjectFromStateForAPI is null, probable data error');
     }
@@ -53,8 +48,7 @@ export function* handle_PREP_FILTERS_FOR_VECTOR_ENDPOINT(action) {
 
 export function* handle_ACTIVITIES_GET_IDS_FOR_RECORDSET_REQUEST(action: PayloadAction<IGetIdsForRecordset>) {
   const currentState = yield select((state) => state.UserSettings);
-  const clientBoundaries = yield select((state) => state.Map?.clientBoundaries);
-  const filterObject = getRecordFilterObjectFromStateForAPI(action.payload.recordSetID, currentState, clientBoundaries);
+  const filterObject = getRecordFilterObjectFromStateForAPI(action.payload.recordSetID, currentState);
   const workingOffline = yield select((state) => state.Auth.workingOffline);
   const connected = yield select((state) => state.Network.connected);
   if (filterObject == null) {
@@ -100,8 +94,7 @@ export function* getIdsForRecordsetFromCache(action: IGetIdsForRecordset) {
     const service = yield RecordCacheServiceFactory.getPlatformInstance();
     if (yield service.isCached(action.recordSetID)) {
       const userSettingsState = yield select(selectUserSettings);
-      const clientBoundaries = yield select((state) => state.Map.clientBoundaries);
-      const filters = getRecordFilterObjectFromStateForAPI(action.recordSetID, userSettingsState, clientBoundaries);
+      const filters = getRecordFilterObjectFromStateForAPI(action.recordSetID, userSettingsState);
 
       if (filters == null) {
         console.warn('null filterObject returned by getRecordFilterObjectFromStateForAPI, probable data error');
@@ -131,14 +124,9 @@ export function* getIdsForRecordsetFromCache(action: IGetIdsForRecordset) {
 export function* handle_IAPP_GET_IDS_FOR_RECORDSET_REQUEST(action) {
   try {
     const currentState = yield select((state) => state.UserSettings);
-    const clientBoundaries = yield select((state) => state.Map?.clientBoundaries);
     const workingOffline = yield select((state) => state.Auth.workingOffline);
     const connected = yield select((state) => state.Network.connected);
-    const filterObject = getRecordFilterObjectFromStateForAPI(
-      action.payload.recordSetID,
-      currentState,
-      clientBoundaries
-    );
+    const filterObject = getRecordFilterObjectFromStateForAPI(action.payload.recordSetID, currentState);
     if (filterObject == null) {
       yield put({ type: ACTIVITY_GET_INITIAL_STATE_FAILURE });
       return;
@@ -163,28 +151,13 @@ export function* handle_IAPP_GET_IDS_FOR_RECORDSET_REQUEST(action) {
   }
 }
 
-export const getRecordFilterObjectFromStateForAPI = (recordSetID, recordSetsState, clientBoundaries) => {
-  const getFilterWithDrawnShape = (filterID) => {
-    return clientBoundaries.filter((filter) => {
-      return filter.id === filterID;
-    })?.[0]?.geojson;
-  };
+export const getRecordFilterObjectFromStateForAPI = (recordSetID, recordSetsState) => {
   try {
     const recordSet = JSON.parse(JSON.stringify(recordSetsState.recordSets?.[recordSetID]));
     const recordSetType = JSON.parse(JSON.stringify(recordSetsState?.recordSets?.[recordSetID]?.recordSetType));
     const sortColumn = recordSet?.sortColumn;
     const sortOrder = recordSet?.sortOrder;
     const tableFilters = recordSet?.tableFilters;
-    let modifiedTableFilters = tableFilters?.map((filter) =>
-      filter.filterType !== 'spatialFilterDrawn'
-        ? filter
-        : {
-            ...filter,
-            geojson: getFilterWithDrawnShape(filter.filter)
-          }
-    );
-
-    modifiedTableFilters ??= [];
     const selectColumns = recordSet?.selectColumns ?? getSelectColumnsByRecordSetType(recordSetType);
 
     return {
@@ -192,7 +165,7 @@ export const getRecordFilterObjectFromStateForAPI = (recordSetID, recordSetsStat
       ids_to_filter: recordSet?.ids_to_filter,
       sortColumn: sortColumn,
       sortOrder: sortOrder,
-      tableFilters: modifiedTableFilters,
+      tableFilters: tableFilters,
       selectColumns: selectColumns
     } as any;
   } catch (_e) {
@@ -208,7 +181,7 @@ export function* handle_ACTIVITIES_TABLE_GET_ROWS(action: PayloadAction<Activity
     const { recordSetID, page, limit, tableFiltersHash } = action.payload;
     const userMobileOffline = buildTimeConfig.MOBILE && !connected;
 
-    const filterObject = getRecordFilterObjectFromStateForAPI(recordSetID, currentState, mapState?.clientBoundaries);
+    const filterObject = getRecordFilterObjectFromStateForAPI(recordSetID, currentState);
     if (filterObject == null) {
       console.warn('filterObject returned by getRecordFilterObjectFromStateForAPI is null, probable data error');
     } else {
@@ -251,8 +224,7 @@ export function* getRowsFromCachedRecordset(req: ActivityTableRowGetRequest) {
   try {
     const { recordSetID, page, limit, tableFiltersHash } = req;
     const userSettingsState = yield select(selectUserSettings);
-    const clientBoundaries = yield select((state) => state.Map.clientBoundaries);
-    const filters = getRecordFilterObjectFromStateForAPI(recordSetID, userSettingsState, clientBoundaries);
+    const filters = getRecordFilterObjectFromStateForAPI(recordSetID, userSettingsState);
     const service = yield RecordCacheServiceFactory.getPlatformInstance();
 
     if (filters == null) {
@@ -291,7 +263,7 @@ export function* handle_IAPP_TABLE_ROWS_GET_REQUEST(action: PayloadAction<IappTa
     const { recordSetID, page, limit, tableFiltersHash } = action.payload;
     const userMobileOffline = buildTimeConfig.MOBILE && !connected;
 
-    const filterObject = getRecordFilterObjectFromStateForAPI(recordSetID, currentState, mapState?.clientBoundaries);
+    const filterObject = getRecordFilterObjectFromStateForAPI(recordSetID, currentState);
     if (filterObject == null) {
       console.warn('filterObject returned by getRecordFilterObjectFromStateForAPI is null, probable data error');
     } else {
@@ -333,8 +305,7 @@ export function* getIappRowsFromCache(payload: IappTableRowRequest) {
   try {
     const { recordSetID, page, limit, tableFiltersHash } = payload;
     const userSettingsState = yield select(selectUserSettings);
-    const clientBoundaries = yield select((state) => state.Map.clientBoundaries);
-    const filters = getRecordFilterObjectFromStateForAPI(recordSetID, userSettingsState, clientBoundaries);
+    const filters = getRecordFilterObjectFromStateForAPI(recordSetID, userSettingsState);
     if (filters == null) {
       console.warn('filterObject returned by getRecordFilterObjectFromStateForAPI is null, probable data error');
     }

--- a/app/src/state/sagas/map/offline.ts
+++ b/app/src/state/sagas/map/offline.ts
@@ -27,8 +27,7 @@ export function* handle_ACTIVITIES_TABLE_ROWS_GET_OFFLINE(action) {
   const { serializedActivities } = yield select(selectOfflineActivity);
   const mapState = yield select((state) => state.Map);
   const currentState = yield select((state) => state.UserSettings);
-  const clientBoundaries = yield select((state) => state.Map?.clientBoundaries);
-  const filterObject = getRecordFilterObjectFromStateForAPI(action.payload.recordSetID, currentState, clientBoundaries);
+  const filterObject = getRecordFilterObjectFromStateForAPI(action.payload.recordSetID, currentState);
   if (filterObject == null) {
     console.warn('null filterObject returned by getRecordFilterObjectFromStateForAPI, probable data issue');
   } else {

--- a/app/src/state/sagas/userSettings.ts
+++ b/app/src/state/sagas/userSettings.ts
@@ -84,7 +84,7 @@ function* handle_USER_SETTINGS_GET_INITIAL_STATE_REQUEST(action) {
 
   const defaultRecordSet = defaultRecordSets;
   // add offline activities for mobile
-  if (buildTimeConfig.MOBILE && (!recordSets || Object.keys(recordSets).length === 0)) {
+  if (buildTimeConfig.MOBILE) {
     // RecordSets are empty, try to recover whats in the local database
     const service = yield RecordCacheServiceFactory.getPlatformInstance();
     const repos = yield service.listRepositories(['filter_objects', 'status', 'record_set_type', 'set_id']);
@@ -96,7 +96,7 @@ function* handle_USER_SETTINGS_GET_INITIAL_STATE_REQUEST(action) {
         backedUpRecordSet.id = repo?.set_id;
         backedUpRecordSet.cacheMetadataStatus = repo.status;
         backedUpRecordSet.recordSetName = repo.set_name ?? '';
-        defaultRecordSet[repo.set_id] = backedUpRecordSet;
+        defaultRecordSet[repo.set_id] ??= backedUpRecordSet;
       }
     });
   }

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -162,7 +162,12 @@ abstract class RecordCacheService extends BaseCacheService<
       cachedGeoJSON: null,
       cachedCentroid: null
     };
-
+    const containsServerFilterShape = spec.filterObjects?.tableFilters.some(
+      (shape) => shape.filterType === EFilterType.Uploaded
+    );
+    if (containsServerFilterShape) {
+      spec.ids_to_filter ??= spec.idsToCache;
+    }
     await this.addOrUpdateRepository({
       set_id: spec.setId,
       cache_time: new Date(),

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -8,6 +8,7 @@ import { getCurrentJWT } from 'state/sagas/auth/auth';
 import BaseCacheService from 'utils/base-classes/BaseCacheService';
 import { RepositoryBoundingBoxSpec } from 'utils/tile-cache';
 import FilterObjects from 'interfaces/FilterObjects';
+import { EFilterType } from 'state/actions/userSettings/RecordSet';
 
 enum IappRecordMode {
   Record = 'record',
@@ -386,8 +387,14 @@ abstract class RecordCacheService extends BaseCacheService<
    * @returns { string[] } new Records or IDs updated since provided date.
    */
   private async getListOfNewIds(filterObjects: FilterObjects, cacheTime: Date): Promise<string[]> {
+    const filterObjs = structuredClone(filterObjects);
+    filterObjs.tableFilters.forEach((filter, i) => {
+      if (filter.filterType === EFilterType.Uploaded) {
+        delete filterObjs?.tableFilters?.[i]?.geojson;
+      }
+    });
     const rez = await fetch(
-      `${CONFIGURATION_API_BASE}/api/v2/activities/cache-update-ids?filterObjects=${JSON.stringify([filterObjects])}&lastUpdated=${cacheTime.toISOString()}`,
+      `${CONFIGURATION_API_BASE}/api/v2/activities/cache-update-ids?filterObjects=${JSON.stringify([filterObjs])}&lastUpdated=${cacheTime.toISOString()}`,
       { headers: { Authorization: await getCurrentJWT(), 'Content-Type': 'application/json' } }
     );
     return (await rez.json()) ?? [];

--- a/app/src/utils/record-cache/index.ts
+++ b/app/src/utils/record-cache/index.ts
@@ -37,6 +37,18 @@ interface RecordCacheDownloadRequestSpec {
  * @property { GeoJSONSourceSpecification } cachedGeoJSON  Cached Features for low map layers
  * @property { GeoJSONSourceSpecification } cachedCentroid Cached Points for high map layers
  * @property { UserRecordCacheStatus } status Cache Status.
+ *
+ * cached_ids VS ids_to_filter
+ *
+ *  cached_ids:
+ *    Cached IDs are all the IDS applied to a recordset during time of caching
+ *    Their focus is maintenance of the client database by removing duplicates / not losing cached records between recordsets
+ *    Cached ids are created based on the results of a recordset. If two recordsets have the same id, it won't get deleted.
+ *  ids_to_filter:
+ *    Binding constraint used when creating a cached recordset. Lets us set specific records to a recordset with(out) the use of filters.
+ *     - Locks in Server side shape boundaries
+ *     - Lets us create a recordset using a Sitelist
+ *     - In majority of use cases, ids_to_filter is undefined.
  */
 interface RepositoryMetadata {
   bbox?: RepositoryBoundingBoxSpec;

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -17,6 +17,7 @@ import IappTableRow from 'interfaces/IappTableRecord';
 import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import bboxToPolygon from 'utils/bboxToPolygon';
 import { getUnnestedFieldsForActivity } from 'UI/Features/Records/RecordSet/RecordTableHelpers';
+import { EFilterType } from 'state/actions/userSettings/RecordSet';
 
 class LocalForageRecordCacheService extends RecordCacheService {
   private static _instance: LocalForageRecordCacheService;
@@ -59,25 +60,29 @@ class LocalForageRecordCacheService extends RecordCacheService {
       if (keyIsCacheKey || idsNotInIdsToFilter || incorrectKeyType) return;
       if (
         params.tableFilters.every((filter) => {
-          if (filter?.geojson) {
+          if (filter.filterType === EFilterType.Drawn && filter?.geojson) {
             const shape = value?.record?.geom?.geometry ?? value?.geometry ?? null;
             if (Array.isArray(shape)) {
               return shape.some((cachedFeature: Feature) => booleanIntersects(cachedFeature, filter.geojson));
             } else if (shape) {
               return booleanIntersects(shape, filter.geojson);
             }
+          } else if (filter.filterType === EFilterType.Uploaded) {
+            // Server filters are bound in the ids_to_filter due to accuracy loss of WKB -> GeoJSON. They can safely be ignored
+            return true;
+          } else {
+            const pattern = new RegExp(filter.filter, 'i');
+            const columnVal = (() => {
+              if (value?.[filter.field]) {
+                return value[filter.field];
+              } else if (value?.row?.[filter.field]) {
+                return value.row[filter.field];
+              } else {
+                return '';
+              }
+            })();
+            return filter.operator === 'CONTAINS' ? pattern.test(columnVal) : !pattern.test(columnVal);
           }
-          const pattern = new RegExp(filter.filter, 'i');
-          const columnVal = (() => {
-            if (value?.[filter.field]) {
-              return value[filter.field];
-            } else if (value?.row?.[filter.field]) {
-              return value.row[filter.field];
-            } else {
-              return '';
-            }
-          })();
-          return filter.operator === 'CONTAINS' ? pattern.test(columnVal) : !pattern.test(columnVal);
         })
       ) {
         records.push(value);

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -17,7 +17,6 @@ import IappTableRow from 'interfaces/IappTableRecord';
 import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import bboxToPolygon from 'utils/bboxToPolygon';
 import { getUnnestedFieldsForActivity } from 'UI/Features/Records/RecordSet/RecordTableHelpers';
-import { EFilterType } from 'state/actions/userSettings/RecordSet';
 
 class LocalForageRecordCacheService extends RecordCacheService {
   private static _instance: LocalForageRecordCacheService;
@@ -60,7 +59,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
       if (keyIsCacheKey || idsNotInIdsToFilter || incorrectKeyType) return;
       if (
         params.tableFilters.every((filter) => {
-          if ([EFilterType.Drawn, EFilterType.Uploaded].includes(filter.filterType)) {
+          if (filter?.geojson) {
             const shape = value?.record?.geom?.geometry ?? value?.geometry ?? null;
             if (Object.hasOwn(shape, 'length')) {
               return shape.some((cachedFeature: Feature) => booleanIntersects(cachedFeature, filter.geojson));

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -17,6 +17,7 @@ import IappTableRow from 'interfaces/IappTableRecord';
 import { RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
 import bboxToPolygon from 'utils/bboxToPolygon';
 import { getUnnestedFieldsForActivity } from 'UI/Features/Records/RecordSet/RecordTableHelpers';
+import { EFilterType } from 'state/actions/userSettings/RecordSet';
 
 class LocalForageRecordCacheService extends RecordCacheService {
   private static _instance: LocalForageRecordCacheService;
@@ -59,7 +60,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
       if (keyIsCacheKey || idsNotInIdsToFilter || incorrectKeyType) return;
       if (
         params.tableFilters.every((filter) => {
-          if (['spatialFilterDrawn', 'spatialFilterUploaded'].includes(filter.filterType)) {
+          if ([EFilterType.Drawn, EFilterType.Uploaded].includes(filter.filterType)) {
             const shape = value?.record?.geom?.geometry ?? value?.geometry ?? null;
             if (Object.hasOwn(shape, 'length')) {
               return shape.some((cachedFeature: Feature) => booleanIntersects(cachedFeature, filter.geojson));

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -61,7 +61,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
         params.tableFilters.every((filter) => {
           if (filter?.geojson) {
             const shape = value?.record?.geom?.geometry ?? value?.geometry ?? null;
-            if (Object.hasOwn(shape, 'length')) {
+            if (Array.isArray(shape)) {
               return shape.some((cachedFeature: Feature) => booleanIntersects(cachedFeature, filter.geojson));
             } else if (shape) {
               return booleanIntersects(shape, filter.geojson);

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -59,7 +59,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
       if (keyIsCacheKey || idsNotInIdsToFilter || incorrectKeyType) return;
       if (
         params.tableFilters.every((filter) => {
-          if (filter.filterType === 'spatialFilterDrawn') {
+          if (['spatialFilterDrawn', 'spatialFilterUploaded'].includes(filter.filterType)) {
             const shape = value?.record?.geom?.geometry ?? value?.geometry ?? null;
             if (Object.hasOwn(shape, 'length')) {
               return shape.some((cachedFeature: Feature) => booleanIntersects(cachedFeature, filter.geojson));

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -23,7 +23,7 @@ import {
   getUnnestedFieldsForActivity,
   getUnnestedFieldsForIAPP
 } from 'UI/Features/Records/RecordSet/RecordTableHelpers';
-import { EFilterType, IFilter } from 'state/actions/userSettings/RecordSet';
+import { IFilter } from 'state/actions/userSettings/RecordSet';
 
 const CACHE_DB_NAME = 'record_cache.db';
 const CACHE_UNAVAILABLE = 'cache not available';
@@ -359,7 +359,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     (shapesInBufferedArea.values ?? []).forEach((entry) => {
       entry = JSON.parse(entry['GEOJSON']);
       // IAPP is Shape, but InvBC records are Array<Shape>
-      const recordIsActivity = Object.hasOwn(entry, 'length');
+      const recordIsActivity = Array.isArray(entry);
       if (recordIsActivity) {
         entry?.forEach((shape: Feature) => {
           if (booleanIntersects(geom, shape)) {
@@ -479,8 +479,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
-    const filteredFilterTypes = [EFilterType.Drawn, EFilterType.Uploaded];
-    const spatialQueries = params.tableFilters.filter((filter) => filteredFilterTypes.includes(filter.filterType));
+    const spatialQueries = params.tableFilters.filter((filter) => filter?.geojson);
     const values: Array<string | number> = [];
     const table = {
       [RecordSetType.Activity]: 'CACHED_RECORDS',
@@ -527,15 +526,16 @@ class SQLiteRecordCacheService extends RecordCacheService {
       `;
 
     let results = (await this.cacheDB.query(query, values))?.values ?? [];
+
     if (spatialQueries.length > 0) {
       results = results.filter((result) => {
-        const geojson = JSON.parse(result['GEOJSON']);
-        if (Object.hasOwn(geojson, 'length')) {
-          return geojson.every((shape: Feature) =>
-            spatialQueries.every((query) => booleanIntersects(shape, query.geojson))
-          );
-        }
-        return spatialQueries.every((spatialFilter) => booleanIntersects(spatialFilter.geojson, geojson));
+        return spatialQueries.every((query) => {
+          const geojson = JSON.parse(result['GEOJSON']);
+          if (Array.isArray(geojson)) {
+            return geojson.some((feature) => booleanIntersects(feature, query.geojson));
+          }
+          return booleanIntersects(geojson, query.geojson);
+        });
       });
     }
     return (

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -23,7 +23,7 @@ import {
   getUnnestedFieldsForActivity,
   getUnnestedFieldsForIAPP
 } from 'UI/Features/Records/RecordSet/RecordTableHelpers';
-import { IFilter } from 'state/actions/userSettings/RecordSet';
+import { EFilterType, IFilter } from 'state/actions/userSettings/RecordSet';
 
 const CACHE_DB_NAME = 'record_cache.db';
 const CACHE_UNAVAILABLE = 'cache not available';
@@ -479,7 +479,8 @@ class SQLiteRecordCacheService extends RecordCacheService {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
-    const spatialQueries = params.tableFilters.filter((filter) => filter.filterType === 'spatialFilterDrawn');
+    const filteredFilterTypes = [EFilterType.Drawn, EFilterType.Uploaded];
+    const spatialQueries = params.tableFilters.filter((filter) => filteredFilterTypes.includes(filter.filterType));
     const values: Array<string | number> = [];
     const table = {
       [RecordSetType.Activity]: 'CACHED_RECORDS',
@@ -494,7 +495,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
 
     params.tableFilters.forEach((filter: IFilter) => {
       where += '\n AND ';
-      if (filter.filterType === 'spatialFilterDrawn') {
+      if ([EFilterType.Drawn, EFilterType.Uploaded].includes(filter.filterType)) {
         const [minX, minY, maxX, maxY] = bbox(filter.geojson);
         where += `LATITUDE BETWEEN ${minY} AND ${maxY} AND LONGITUDE BETWEEN ${minX} AND ${maxX}`;
       } else {

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -495,7 +495,7 @@ class SQLiteRecordCacheService extends RecordCacheService {
 
     params.tableFilters.forEach((filter: IFilter) => {
       where += '\n AND ';
-      if ([EFilterType.Drawn, EFilterType.Uploaded].includes(filter.filterType)) {
+      if (filter?.geojson) {
         const [minX, minY, maxX, maxY] = bbox(filter.geojson);
         where += `LATITUDE BETWEEN ${minY} AND ${maxY} AND LONGITUDE BETWEEN ${minX} AND ${maxX}`;
       } else {

--- a/app/src/utils/record-cache/sqlite-cache.ts
+++ b/app/src/utils/record-cache/sqlite-cache.ts
@@ -23,7 +23,7 @@ import {
   getUnnestedFieldsForActivity,
   getUnnestedFieldsForIAPP
 } from 'UI/Features/Records/RecordSet/RecordTableHelpers';
-import { IFilter } from 'state/actions/userSettings/RecordSet';
+import { EFilterType, IFilter } from 'state/actions/userSettings/RecordSet';
 
 const CACHE_DB_NAME = 'record_cache.db';
 const CACHE_UNAVAILABLE = 'cache not available';
@@ -479,22 +479,28 @@ class SQLiteRecordCacheService extends RecordCacheService {
     if (this.cacheDB == null) {
       throw new Error(CACHE_UNAVAILABLE);
     }
-    const spatialQueries = params.tableFilters.filter((filter) => filter?.geojson);
+    const localSpatialQueries = params.tableFilters.filter((filter) => filter?.filterType === EFilterType.Drawn);
     const values: Array<string | number> = [];
     const table = {
       [RecordSetType.Activity]: 'CACHED_RECORDS',
       [RecordSetType.IAPP]: 'CACHED_IAPP_RECORDS'
     }[params.recordSetType];
 
-    if (spatialQueries.length > 0 && params.selectColumns.length > 0 && !params.selectColumns.includes('GEOJSON')) {
+    if (
+      localSpatialQueries.length > 0 &&
+      params.selectColumns.length > 0 &&
+      !params.selectColumns.includes('GEOJSON')
+    ) {
       params.selectColumns.push('GEOJSON');
     }
     const columns = params.selectColumns.length > 0 ? params.selectColumns.join(', ') : '*';
     let where = 'WHERE 1=1 ';
 
     params.tableFilters.forEach((filter: IFilter) => {
+      // Server filters are bound in the ids_to_filter due to accuracy loss of WKB -> GeoJSON. They can safely be ignored
+      if (filter?.filterType === EFilterType.Uploaded) return;
       where += '\n AND ';
-      if (filter?.geojson) {
+      if (filter?.filterType === EFilterType.Drawn && filter?.geojson) {
         const [minX, minY, maxX, maxY] = bbox(filter.geojson);
         where += `LATITUDE BETWEEN ${minY} AND ${maxY} AND LONGITUDE BETWEEN ${minX} AND ${maxX}`;
       } else {
@@ -527,9 +533,9 @@ class SQLiteRecordCacheService extends RecordCacheService {
 
     let results = (await this.cacheDB.query(query, values))?.values ?? [];
 
-    if (spatialQueries.length > 0) {
+    if (localSpatialQueries.length > 0) {
       results = results.filter((result) => {
-        return spatialQueries.every((query) => {
+        return localSpatialQueries.every((query) => {
           const geojson = JSON.parse(result['GEOJSON']);
           if (Array.isArray(geojson)) {
             return geojson.some((feature) => booleanIntersects(feature, query.geojson));


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Add Clear App Cache button to Debug Menu
- Drop Z-Index of Layer Picker to it doesn't appear over Modals
- Create Enum for tablefilter options
- Move some exports to bottom of file, fixing ESLint issues about export positioning. (recordset-layers.ts)
- Show `Original source removed` on drawn spatial filter if filter was removed via app data delete.
- Refactor `getRecordFilterObjectFromStateForAPI` to no longer care about clientBoundaries (as they are now part of the filters)

**Main Stuff**
- Create Duplicate of Client Drawn shape that is saved to the recordset
    - If app data is cleared, the shape can persist, preventing applicable recordsets from being useless.
- Lock cache to results generated from Server side shapes using `ids_to_filter`
    - Makes server shapes work offline consistently, and eliminates the projection error that WKB -> GeoJSON create when comparing online/offline results
- Block users from applying additional server side filters to recordsets already cached. Must be applied before caching.
- Update query functions to ignore server filters, and to parse client filters.
- Closes #4178