### PR TITLE
[INV-3999] Filters Ignored at time of cache

### DIFF
--- a/app/src/UI/Features/Records/RecordSetCacheButtons.tsx
+++ b/app/src/UI/Features/Records/RecordSetCacheButtons.tsx
@@ -107,7 +107,7 @@ const RecordSetCacheButtons = ({ recordSet, setId, onCacheStateChange }: PropTyp
   const formatStatusKey = (cacheStatus: UserRecordCacheStatus): string => {
     if (!cacheStatus) {
       return 'Unknown';
-    } else if (isLoadingRecords) {
+    } else if (isLoadingRecords && connected) {
       return 'Updating...';
     } else if (cacheStatus === UserRecordCacheStatus.NOT_CACHED) {
       return 'Save';

--- a/app/src/UI/Features/Records/RecordSetCacheButtons.tsx
+++ b/app/src/UI/Features/Records/RecordSetCacheButtons.tsx
@@ -107,7 +107,7 @@ const RecordSetCacheButtons = ({ recordSet, setId, onCacheStateChange }: PropTyp
   const formatStatusKey = (cacheStatus: UserRecordCacheStatus): string => {
     if (!cacheStatus) {
       return 'Unknown';
-    } else if (isLoadingRecords && connected) {
+    } else if (isLoadingRecords && connected && cacheStatus === UserRecordCacheStatus.NOT_CACHED) {
       return 'Updating...';
     } else if (cacheStatus === UserRecordCacheStatus.NOT_CACHED) {
       return 'Save';

--- a/app/src/UI/Features/Records/RecordSetCacheButtons.tsx
+++ b/app/src/UI/Features/Records/RecordSetCacheButtons.tsx
@@ -21,7 +21,7 @@ const RecordSetCacheButtons = ({ recordSet, setId, onCacheStateChange }: PropTyp
     (state) => state.UserSettings?.recordSets[setId].cacheDownloadProgress,
     shallowEqual
   );
-
+  const isLoadingRecords = useSelector((state) => state.Map.recordTables?.[setId]?.loading);
   const activeDownloads = downloadProgress.normalizedProgress != 0;
 
   const [cacheActionEnabled, setCacheActionEnabled] = useState<boolean>(false);
@@ -68,19 +68,17 @@ const RecordSetCacheButtons = ({ recordSet, setId, onCacheStateChange }: PropTyp
   };
 
   const downloadCache = () => {
-    const callback = (confirmation: boolean) => {
-      if (confirmation) {
-        dispatch(RecordCache.requestCaching({ setId }));
-        setIsPaused(false);
-      }
-    };
-
     dispatch(
       Prompt.confirmation({
         title: 'Download Records',
         prompt: 'Would you like to download this cache? The record sets will be available for offline use.',
         confirmText: 'Download Records',
-        callback
+        callback: (confirmation: boolean) => {
+          if (confirmation) {
+            dispatch(RecordCache.requestCaching({ setId }));
+            setIsPaused(false);
+          }
+        }
       })
     );
   };
@@ -106,6 +104,8 @@ const RecordSetCacheButtons = ({ recordSet, setId, onCacheStateChange }: PropTyp
   const formatStatusKey = (cacheStatus: UserRecordCacheStatus): string => {
     if (!cacheStatus) {
       return 'Unknown';
+    } else if (isLoadingRecords) {
+      return 'Updating...';
     } else if (cacheStatus === UserRecordCacheStatus.NOT_CACHED) {
       return 'Save';
     }
@@ -124,6 +124,7 @@ const RecordSetCacheButtons = ({ recordSet, setId, onCacheStateChange }: PropTyp
   useEffect(() => {
     setCacheActionEnabled(
       connected &&
+        !isLoadingRecords &&
         [
           UserRecordCacheStatus.CACHED,
           UserRecordCacheStatus.NOT_CACHED,
@@ -133,7 +134,7 @@ const RecordSetCacheButtons = ({ recordSet, setId, onCacheStateChange }: PropTyp
           UserRecordCacheStatus.PAUSED
         ].includes(recordSet.cacheMetadataStatus)
     );
-  }, [recordSet.cacheMetadataStatus, connected]);
+  }, [recordSet.cacheMetadataStatus, connected, isLoadingRecords]);
 
   return (
     <Tooltip classes={{ tooltip: 'toolTip' }} title="Click to save this layer and it's records">

--- a/app/src/UI/Features/Records/RecordSetCacheButtons.tsx
+++ b/app/src/UI/Features/Records/RecordSetCacheButtons.tsx
@@ -71,7 +71,10 @@ const RecordSetCacheButtons = ({ recordSet, setId, onCacheStateChange }: PropTyp
     dispatch(
       Prompt.confirmation({
         title: 'Download Records',
-        prompt: 'Would you like to download this cache? The record sets will be available for offline use.',
+        prompt: [
+          'Would you like to download this cache? The record sets will be available for offline use.',
+          `You will download ${recordSet.idList.length ?? 0} record(s).`
+        ],
         confirmText: 'Download Records',
         callback: (confirmation: boolean) => {
           if (confirmation) {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Disable the cache button when applying filters to avoid race condition of `current` -> `next` recordSet.idLists used for caching.
    - Add `Updating...` text to cache button
- Display number of records being cached in prompt text. 
- Closes #3999

## Additional Details

This bug ticket has been sitting in the `cannot replicate` column for a while. The only replication I've had so far was when working with spatial filters, as they are slower to query. Given the workflows, it's assumed that the issue is caused by slow API Results when applying filters, resulting in a race condition. (or they used an `or` checkbox which is janky at best, but has also had some very minor iteration done on it) 


![image](https://github.com/user-attachments/assets/dc05d562-49d8-450c-bce3-2fcf78d5ad8d)
