### PR TITLE
[N/A] Convert JumpTo -> Ease To and set Offset value

### DIFF
--- a/app/src/UI/Features/LegacyMap/Map.tsx
+++ b/app/src/UI/Features/LegacyMap/Map.tsx
@@ -103,8 +103,8 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
     }
 
     maplibregl.addProtocol('api', async (request) => {
-      const fetchRequest = new Request(request.url.replace("api://", API_BASE));
-      fetchRequest.headers.set("Authorization", await getCurrentJWT())
+      const fetchRequest = new Request(request.url.replace('api://', API_BASE));
+      fetchRequest.headers.set('Authorization', await getCurrentJWT());
       const result = await fetch(fetchRequest);
       if (result.ok) {
         return {
@@ -329,7 +329,11 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
 
     try {
       if (map_center && map_zoom) {
-        map.jumpTo({ center: map_center, zoom: map_zoom });
+        map.easeTo({
+          center: map_center,
+          zoom: map_zoom,
+          offset: [0, map.getContainer().clientHeight * -0.2]
+        });
       }
     } catch (e) {
       console.error(e);

--- a/app/src/UI/Features/LegacyMap/helpers/components/PositionMarkers.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/PositionMarkers.tsx
@@ -15,8 +15,6 @@ import { RecordSetType } from 'interfaces/UserRecordSet';
 import { makeMapMarker, makeMarkerElement } from 'utils/makeMapMarker';
 
 const PositionMarkers = ({ mapReady }) => {
-  const LATITUDE = 1;
-  const LAT_OFFSET = -0.00325;
   const map = useContext(MapContext);
 
   // User tracking coords jump and markers/indicators
@@ -130,10 +128,10 @@ const PositionMarkers = ({ mapReady }) => {
     if (quickPanToRecord && userRecordOnHoverRecordGeometry) {
       const c = centroid(userRecordOnHoverRecordGeometry).geometry.coordinates as LngLatLike;
       if (c) {
-        c[LATITUDE] += LAT_OFFSET;
-        map.jumpTo({
+        map.easeTo({
           center: c,
-          zoom: 15
+          zoom: 15,
+          offset: [0, map.getContainer().clientHeight * -0.2]
         });
       }
     }

--- a/app/src/UI/Features/LegacyMap/helpers/functional/position-tracking.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/position-tracking.ts
@@ -12,7 +12,10 @@ export const handlePositionTracking = (
 ) => {
   if (userCoords && positionTracking) {
     if (panToUser) {
-      map.jumpTo({ center: [userCoords.long, userCoords.lat] });
+      map.easeTo({
+        center: [userCoords.long, userCoords.lat],
+        offset: [0, map.getContainer().clientHeight * -0.2]
+      });
     }
     positionMarker.setLngLat([userCoords.long, userCoords.lat]);
     positionMarker.addTo(map);


### PR DESCRIPTION
# Overview

Replace `jumpTo` functions with `easeTo` and supply an offset value to the map (jumpTo does not support offset).

- points on the map will appear 30% from the top of the map window instead of the dead center, decreasing likely hood that center will be covered by the map overlay. 

 

