### PR TITLE
[INV-4177][INV-4092] Disable Layer Toggles when Layer not available

### DIFF
--- a/app/src/UI/Features/Records/RecordSetControl.tsx
+++ b/app/src/UI/Features/Records/RecordSetControl.tsx
@@ -1,9 +1,12 @@
 import { MobileOnly } from 'UI/Reusable/Predicates/MobileOnly';
 import { RecordSetCacheButtons } from 'UI/Features/Records/RecordSetCacheButtons';
 import { IconButton, Tooltip } from '@mui/material';
-import { UserRecordSet } from 'interfaces/UserRecordSet';
+import { RecordSetType, UserRecordSet } from 'interfaces/UserRecordSet';
 import { ColorLens, Delete, Label, LabelOff, Layers, LayersClear } from '@mui/icons-material';
 import { MouseEvent, useState } from 'react';
+import { useDispatch, useSelector } from 'utils/use_selector';
+import Activity from 'state/actions/activity/Activity';
+import IappActions from 'state/actions/activity/Iapp';
 
 type PropTypes = {
   isDefaultRecordset: boolean;
@@ -31,6 +34,22 @@ const RecordSetControl = ({
   const DELETE_TIP =
     'Delete this layer/list of records.  Does NOT delete the actual records, just the set of filters / layer configuration.';
 
+  const dispatch = useDispatch();
+  const hasLayerIndex = useSelector(
+    (state) => !!state.Map.layers.find((layer) => layer?.recordSetID === recordsetKey)?.layerState
+  );
+
+  if (!hasLayerIndex) {
+    const payload = {
+      recordSetID: recordsetKey,
+      tableFiltersHash: recordset?.tableFiltersHash ?? ''
+    };
+    if (recordset.recordSetType === RecordSetType.IAPP) {
+      dispatch(IappActions.getIdsForRecordset(payload));
+    } else if (recordset.recordSetType === RecordSetType.Activity) {
+      dispatch(Activity.getIdsForRecordset(payload));
+    }
+  }
   const [isProgressBar, setIsProgressBar] = useState(false);
 
   const handleProgressStateChange = (state: boolean) => {
@@ -55,7 +74,7 @@ const RecordSetControl = ({
         <Tooltip classes={{ tooltip: 'toolTip' }} title={LABEL_TOGGLE_TIP}>
           <span>
             <IconButton
-              disabled={!recordset?.mapToggle}
+              disabled={!recordset?.mapToggle || !hasLayerIndex}
               onClick={(e) => onClickToggleLabel(recordsetKey, e)}
               color="primary"
               data-testid="label-toggle"
@@ -66,7 +85,12 @@ const RecordSetControl = ({
         </Tooltip>
 
         <Tooltip classes={{ tooltip: 'toolTip' }} title={LAYER_TOGGLE_TIP}>
-          <IconButton data-testid="layer-toggle" onClick={(e) => onClickToggleLayer(recordsetKey, e)} color="primary">
+          <IconButton
+            data-testid="layer-toggle"
+            onClick={(e) => onClickToggleLayer(recordsetKey, e)}
+            color="primary"
+            disabled={!hasLayerIndex}
+          >
             {recordset?.mapToggle ? <Layers /> : <LayersClear />}
           </IconButton>
         </Tooltip>
@@ -78,6 +102,7 @@ const RecordSetControl = ({
                 data-testid="cycle-color"
                 onClick={(e) => onClickCycleColour(recordsetKey, e)}
                 color="primary"
+                disabled={!hasLayerIndex}
               >
                 <ColorLens />
               </IconButton>

--- a/app/src/state/reducers/map.ts
+++ b/app/src/state/reducers/map.ts
@@ -359,6 +359,7 @@ function createMapReducer(): (MapState, AnyAction) => MapState {
         }
       } else if (UserSettings.RecordSet.set.match(action)) {
         const layerIndex = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.setName);
+        if (layerIndex === -1) return;
         Object.keys(action.payload.updatedSet).forEach((key) => {
           if (['color', 'mapToggle', 'drawOrder', 'labelToggle'].includes(key)) {
             draftState.layers[layerIndex].layerState[key] = action.payload.updatedSet[key];
@@ -409,11 +410,11 @@ function createMapReducer(): (MapState, AnyAction) => MapState {
         Object.keys(action.payload.recordSets).forEach((setID) => {
           if (setID !== RecordSetId.OfflineActivities) {
             let layerIndex = draftState.layers.findIndex((layer) => layer.recordSetID === setID);
-            if (!draftState.layers[layerIndex]) {
+            if (layerIndex === -1) {
               draftState.layers.push({ recordSetID: setID, type: action.payload.recordSets[setID].recordSetType });
               layerIndex = draftState.layers.findIndex((layer) => layer.recordSetID === setID);
             }
-            draftState.layers[layerIndex].layerState = {};
+            draftState.layers[layerIndex].layerState ??= {};
             Object.assign(draftState.layers[layerIndex].layerState, action.payload.recordSets[setID]);
           }
         });


### PR DESCRIPTION

# Overview

- if map.layer[entry] does not exist:
    - disable layer-related recordset controls (preventing a crash)
    - Fire `getIdsForRecordset`so that map.layers[entry] is created if it did not already exist. 

- Closes #4177 
- Closes #4092