### PR TITLE
[INV-4194][INV-4186] Offline Maps modifications

### DIFF
--- a/app/src/UI/Features/LegacyMap/LayerPicker/LpOfflineMaps/LpOfflineMaps.tsx
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LpOfflineMaps/LpOfflineMaps.tsx
@@ -46,10 +46,10 @@ const LpOfflineMaps = ({ closePicker }: PropTypes) => {
       )}
       <div className="guide">
         <p>
-          You can modify or create new Map Caches from the <b>Tile Cache Status</b> page.
+          You can modify or create new Map Caches from the <b>Offline Maps</b> page.
         </p>
-        <Link to="/OfflineTiles" onClick={closePicker}>
-          Go to Tile Cache Status page
+        <Link to="/OfflineMaps" onClick={closePicker}>
+          Go to offline maps page
         </Link>
       </div>
     </div>

--- a/app/src/UI/Features/LegacyMap/helpers/components/CachedMapLayer.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/CachedMapLayer.tsx
@@ -108,7 +108,7 @@ const CachedMapLayer = ({ mapReady }: PropTypes) => {
   }, [mapReady]);
 
   useEffect(() => {
-    setUserOnOfflineTilePage(!!url?.includes('/OfflineTiles'));
+    setUserOnOfflineTilePage(!!url?.includes('/OfflineMaps'));
   }, [url]);
 
   // Toggle Layer Visibility

--- a/app/src/UI/Features/TileCache/TileCacheCreationPanel.tsx
+++ b/app/src/UI/Features/TileCache/TileCacheCreationPanel.tsx
@@ -68,7 +68,7 @@ const TileCacheCreationPanel = () => {
 
   return (
     <section>
-      <form>
+      <form className="tile-cache-creation-panel">
         <p>
           Choose the zoom level you want to use for saving map tiles. A higher zoom level allows you to see more detail
           when you zoom in, but it will also take up more space on your device.
@@ -83,7 +83,13 @@ const TileCacheCreationPanel = () => {
           value={zoom}
           step={null}
           aria-label={'Zoom Level'}
-          marks={AVAILABLE_ZOOMS}
+          marks={AVAILABLE_ZOOMS.map((item) => {
+            // don't display label for odd entries.
+            if (item.value % 2 === 1) {
+              item.label = '';
+            }
+            return item;
+          })}
           sx={{ width: '80%' }}
           min={AVAILABLE_ZOOMS[0].value}
           max={AVAILABLE_ZOOMS[AVAILABLE_ZOOMS.length - 1].value}

--- a/app/src/UI/Features/TileCache/TileCacheDownloadProgress.tsx
+++ b/app/src/UI/Features/TileCache/TileCacheDownloadProgress.tsx
@@ -22,7 +22,7 @@ const TileCacheDownloadProgress = () => {
   const dispatch = useDispatch();
   const downloadProgress = useSelector((state) => state.TileCache?.downloadProgress, shallowEqual);
   const failedDownloads = useSelector((state) => state.TileCache?.repositories ?? []).filter(
-    (r) => [RepositoryStatus.FAILED].includes(r.status) && !downloadProgress?.[r.id]
+    (r) => ![RepositoryStatus.READY].includes(r.status) && !downloadProgress?.[r.id]
   );
 
   const activeDownloads = Object.keys(downloadProgress ?? {}).length + failedDownloads.length > 0;

--- a/app/src/UI/Features/TileCache/TileCacheDownloadProgress.tsx
+++ b/app/src/UI/Features/TileCache/TileCacheDownloadProgress.tsx
@@ -21,32 +21,34 @@ const TileCacheDownloadProgress = () => {
   }
   return (
     <section>
-      <table>
-        <thead>
-          <tr>
-            <th>Cache Name</th>
-            <th>Download Status</th>
-            <th>Progress</th>
-            <th>Cancel</th>
-          </tr>
-        </thead>
-        <tbody>
-          {Object.keys(downloadProgress).map((k) => (
-            <tr key={k}>
-              <td>{downloadProgress[k].description ?? downloadProgress[k].repository}</td>
-              <td>{downloadProgress[k].message}</td>
-              <td>
-                <LinearProgress variant={'determinate'} value={downloadProgress[k].normalizedProgress * 100} />
-              </td>
-              <td>
-                <IconButton color="error" onClick={() => handleStopDownload(downloadProgress[k].repository)}>
-                  <StopCircleOutlined />
-                </IconButton>
-              </td>
+      <div className="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Cache Name</th>
+              <th>Download Status</th>
+              <th>Progress</th>
+              <th>Cancel</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {Object.keys(downloadProgress).map((k) => (
+              <tr key={k}>
+                <td>{downloadProgress[k].description ?? downloadProgress[k].repository}</td>
+                <td>{downloadProgress[k].message}</td>
+                <td>
+                  <LinearProgress variant={'determinate'} value={downloadProgress[k].normalizedProgress * 100} />
+                </td>
+                <td>
+                  <IconButton color="error" onClick={() => handleStopDownload(downloadProgress[k].repository)}>
+                    <StopCircleOutlined />
+                  </IconButton>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </section>
   );
 };

--- a/app/src/UI/Features/TileCache/TileCacheDownloadProgress.tsx
+++ b/app/src/UI/Features/TileCache/TileCacheDownloadProgress.tsx
@@ -1,16 +1,31 @@
 import { IconButton, LinearProgress } from '@mui/material';
 import { useDispatch, useSelector } from 'utils/use_selector';
 import { shallowEqual } from 'react-redux';
-import { StopCircleOutlined } from '@mui/icons-material';
+import { Delete, Refresh, StopCircleOutlined } from '@mui/icons-material';
 import TileCache from 'state/actions/cache/TileCache';
+import { RepositoryStatus } from 'utils/tile-cache';
+import PlanMyTrip from 'state/actions/planMyTrip/PlanMyTrip';
 
 const TileCacheDownloadProgress = () => {
   const handleStopDownload = (repository: string) => {
     dispatch(TileCache.deleteRepository(repository));
   };
+
+  const handleRestartDownload = ({ description, id, bounds, maxZoom }) => {
+    dispatch(TileCache.requestCaching({ description, id, bounds, maxZoom }));
+  };
+
+  const handleDeleteDownload = (repository: string) => {
+    dispatch(PlanMyTrip.delete(repository));
+  };
+
   const dispatch = useDispatch();
   const downloadProgress = useSelector((state) => state.TileCache?.downloadProgress, shallowEqual);
-  const activeDownloads = Object.keys(downloadProgress ?? {}).length > 0;
+  const failedDownloads = useSelector((state) => state.TileCache?.repositories ?? []).filter(
+    (r) => [RepositoryStatus.FAILED].includes(r.status) && !downloadProgress?.[r.id]
+  );
+
+  const activeDownloads = Object.keys(downloadProgress ?? {}).length + failedDownloads.length > 0;
 
   if (!downloadProgress || !activeDownloads) {
     return (
@@ -28,7 +43,7 @@ const TileCacheDownloadProgress = () => {
               <th>Cache Name</th>
               <th>Download Status</th>
               <th>Progress</th>
-              <th>Cancel</th>
+              <th>Restart/Cancel</th>
             </tr>
           </thead>
           <tbody>
@@ -42,6 +57,21 @@ const TileCacheDownloadProgress = () => {
                 <td>
                   <IconButton color="error" onClick={() => handleStopDownload(downloadProgress[k].repository)}>
                     <StopCircleOutlined />
+                  </IconButton>
+                </td>
+              </tr>
+            ))}
+            {failedDownloads.map((r) => (
+              <tr key={r.id}>
+                <td>{r.description || r.id}</td>
+                <td className="deep-red">{r.status}</td>
+                <td></td>
+                <td>
+                  <IconButton onClick={() => handleRestartDownload(r)}>
+                    <Refresh />
+                  </IconButton>
+                  <IconButton onClick={() => handleDeleteDownload(r.id)}>
+                    <Delete color={'error'} />
                   </IconButton>
                 </td>
               </tr>

--- a/app/src/UI/Features/TileCache/TileCacheDownloadProgress.tsx
+++ b/app/src/UI/Features/TileCache/TileCacheDownloadProgress.tsx
@@ -64,7 +64,7 @@ const TileCacheDownloadProgress = () => {
             {failedDownloads.map((r) => (
               <tr key={r.id}>
                 <td>{r.description || r.id}</td>
-                <td className="deep-red">{r.status}</td>
+                <td className="deep-red">ERROR</td>
                 <td></td>
                 <td>
                   <IconButton onClick={() => handleRestartDownload(r)}>

--- a/app/src/UI/Features/TileCache/TileCacheList.tsx
+++ b/app/src/UI/Features/TileCache/TileCacheList.tsx
@@ -15,23 +15,25 @@ const TileCacheList = () => {
   }
   return (
     <section>
-      <table>
-        <thead>
-          <tr>
-            <th>Show</th>
-            <th>Name</th>
-            <th>Status</th>
-            <th>Tile Count</th>
-            <th>Cache Size</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {repositories.map((r) => (
-            <TileCacheListRow key={r.id} metadata={r} visible={visibleLayers.includes(r?.id)} />
-          ))}
-        </tbody>
-      </table>
+      <div className="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Show</th>
+              <th>Name</th>
+              <th>Status</th>
+              <th>Tile Count</th>
+              <th>Cache Size</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {repositories.map((r) => (
+              <TileCacheListRow key={r.id} metadata={r} visible={visibleLayers.includes(r?.id)} />
+            ))}
+          </tbody>
+        </table>
+      </div>
       <p>
         You can toggle the visibility of cached map tiles here, or from the <b>Layer Picker</b>
       </p>

--- a/app/src/UI/Features/TileCache/TileCacheList.tsx
+++ b/app/src/UI/Features/TileCache/TileCacheList.tsx
@@ -1,10 +1,14 @@
 import TileCache from 'state/actions/cache/TileCache';
 import { useDispatch, useSelector } from 'utils/use_selector';
 import TileCacheListRow from 'UI/Features/TileCache/TileCacheListRow';
+import { RepositoryStatus } from 'utils/tile-cache';
 
 const TileCacheList = () => {
-  const repositories = useSelector((state) => state.TileCache?.repositories);
+  const repositories = useSelector((state) => state.TileCache?.repositories ?? []).filter(
+    (r) => r.status === RepositoryStatus.READY
+  );
   const visibleLayers = useSelector((state) => state.Map.enabledOverlayLayers) ?? [];
+
   const dispatch = useDispatch();
   if (!repositories || repositories.length === 0) {
     return (

--- a/app/src/UI/Features/TileCache/TileCacheListRow.tsx
+++ b/app/src/UI/Features/TileCache/TileCacheListRow.tsx
@@ -11,7 +11,13 @@ import MapActions from 'state/actions/map';
 import PlanMyTrip from 'state/actions/planMyTrip/PlanMyTrip';
 
 const TileCacheListRow = ({ metadata, visible }) => {
+  const updateStatistics = async () => {
+    if (!serviceRef.current) return;
+    serviceRef.current.getRepositoryStatistics(metadata.id).then((value) => setStats(value));
+  };
+
   const handleToggleVisibility = (id: string) => dispatch(MapActions.toggleOverlay(id));
+
   const handleEditCacheDescription = () => {
     const callback = (newName: string) => {
       dispatch(TileCache.updateDescription({ repository: metadata.id, newDescription: newName }));
@@ -28,6 +34,7 @@ const TileCacheListRow = ({ metadata, visible }) => {
       })
     );
   };
+
   const handleDelete = () => {
     const callback = (confirmation: boolean) => {
       if (confirmation) {
@@ -48,23 +55,19 @@ const TileCacheListRow = ({ metadata, visible }) => {
   };
 
   const dispatch = useDispatch();
-  const serviceRef = useRef<TileCacheService | null>(null);
-  const [stats, setStats] = useState<RepositoryStatistics | null>(null);
+  const serviceRef = useRef<TileCacheService>();
+  const [stats, setStats] = useState<RepositoryStatistics>();
 
   useEffect(() => {
-    if (!serviceRef.current) {
-      return;
-    }
-    serviceRef.current.getRepositoryStatistics(metadata.id).then((value) => {
-      setStats(value);
-    });
-  }, [metadata.id, serviceRef.current]);
-
-  useEffect(() => {
-    TileCacheServiceFactory.getPlatformInstance().then((value) => {
-      serviceRef.current = value;
-    });
+    (async () => {
+      serviceRef.current = await TileCacheServiceFactory.getPlatformInstance();
+      updateStatistics();
+    })();
   }, []);
+
+  useEffect(() => {
+    updateStatistics();
+  }, [metadata]);
 
   return (
     <tr>

--- a/app/src/UI/Features/TileCache/TileCachePanel.tsx
+++ b/app/src/UI/Features/TileCache/TileCachePanel.tsx
@@ -5,6 +5,8 @@ import { TileCacheCreationPanel } from 'UI/Features/TileCache/TileCacheCreationP
 import { TileCacheList } from 'UI/Features/TileCache/TileCacheList';
 import { TileCacheDownloadProgress } from 'UI/Features/TileCache/TileCacheDownloadProgress';
 import 'UI/Features/TileCache/tileCache.css';
+import Accordion from 'UI/Reusable/Accordion/Accordion';
+import { Create, Downloading, SdStorage } from '@mui/icons-material';
 
 const TileCachePanel = () => {
   const dispatch = useDispatch();
@@ -25,14 +27,22 @@ const TileCachePanel = () => {
     <div id={`offline-map-overlay`}>
       <h2>Offline Maps</h2>
       <p className="subheader">Manage your map data for offline access</p>
-      <h3>Create Cached Maps</h3>
-      <TileCacheCreationPanel />
-      <h3>Download Progress</h3>
-      <p className="subheader">Check the status of caches being downloaded for offline access.</p>
-      <TileCacheDownloadProgress />
-      <h3>Downloaded Maps</h3>
-      <p className="subheader">These caches are currently saved on your device</p>
-      <TileCacheList />
+      <div className="content">
+        <Accordion title="Create Cached Maps" icon={<Create />}>
+          <h3>Create Cached Maps</h3>
+          <TileCacheCreationPanel />
+        </Accordion>
+        <Accordion title="Download Progress" icon={<Downloading />}>
+          <h3>Download Progress</h3>
+          <p className="subheader">Check the status of caches being downloaded for offline access.</p>
+          <TileCacheDownloadProgress />
+        </Accordion>
+        <Accordion title="Downloaded Maps" icon={<SdStorage />}>
+          <h3>Downloaded Maps</h3>
+          <p className="subheader">These caches are currently saved on your device</p>
+          <TileCacheList />
+        </Accordion>
+      </div>
     </div>
   );
 };

--- a/app/src/UI/Features/TileCache/constants.ts
+++ b/app/src/UI/Features/TileCache/constants.ts
@@ -10,9 +10,19 @@ export const AVAILABLE_ZOOMS = [
     scale: '1:150,000'
   },
   {
+    value: 13,
+    label: 'Zoom 13',
+    scale: '1:75,000'
+  },
+  {
     value: 14,
     label: 'Zoom 14',
     scale: '1:35,000'
+  },
+  {
+    value: 15,
+    label: 'Zoom 15',
+    scale: '1:16,000'
   },
   {
     value: 16,
@@ -20,9 +30,19 @@ export const AVAILABLE_ZOOMS = [
     scale: '1:8,000'
   },
   {
+    value: 17,
+    label: 'Zoom 17',
+    scale: '1:4,000'
+  },
+  {
     value: 18,
     label: 'Zoom 18',
     scale: '1:2,000'
+  },
+  {
+    value: 19,
+    label: 'Zoom 19',
+    scale: '1:1,000'
   },
   {
     value: 20,

--- a/app/src/UI/Features/TileCache/tileCache.css
+++ b/app/src/UI/Features/TileCache/tileCache.css
@@ -5,7 +5,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: 0;
+  padding: 0 0 1rem 0;
   width: 100%;
 
   h2 {
@@ -50,13 +50,16 @@
   width: 100%;
   max-width: 860px;
   min-height: 100pt;
-  width: 100%;
   padding: 0;
-
-  table {
+  .table-wrapper {
+    width: 100%;
+    overflow-x: auto;
+    border: 1pt solid lightgray;
+  }
+  .table-wrapper table {
+    min-width: 550px;
     width: 100%;
     border-collapse: collapse;
-    border: 1pt solid lightgray;
     border-radius: 5pt;
     word-wrap: break-word;
 
@@ -119,6 +122,7 @@
   button {
     width: 110pt;
     border: 1pt solid var(--blue-primary);
+    font-size: 14px;
     color: var(--blue-primary);
     background-color: transparent;
     transition:
@@ -140,12 +144,10 @@
     padding: 0 0 0 10pt;
     border: 1pt solid black;
   }
-
-  & > *:not(:first-child) {
-    margin: 10pt 0 0 0;
-  }
 }
-
+#offline-map-overlay section form {
+  width: 100%;
+}
 .too-large-warning {
   color: var(--error-red);
   font-weight: bold;

--- a/app/src/UI/Features/TileCache/tileCache.css
+++ b/app/src/UI/Features/TileCache/tileCache.css
@@ -30,6 +30,12 @@
   .subheader {
     margin-top: 0;
   }
+  .content {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-width: 860px;
+  }
 }
 
 /* Generic for each sub-section in Offline Maps */

--- a/app/src/UI/Features/TileCache/tileCache.css
+++ b/app/src/UI/Features/TileCache/tileCache.css
@@ -47,7 +47,8 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  max-width: 768px;
+  width: 100%;
+  max-width: 860px;
   min-height: 100pt;
   width: 100%;
   padding: 0;

--- a/app/src/UI/Layout/OverlayLayout/Header/Mobile/HeaderPopover.tsx
+++ b/app/src/UI/Layout/OverlayLayout/Header/Mobile/HeaderPopover.tsx
@@ -104,9 +104,9 @@ const HeaderPopover = () => {
           <ul>
             {loggedInOrWorkingOffline && (
               <li>
-                <button onClick={() => history.push('/OfflineTiles')}>
+                <button onClick={() => history.push('/OfflineMaps')}>
                   <OfflineBolt />
-                  Tile Cache Status
+                  Offline Maps
                 </button>
               </li>
             )}

--- a/app/src/UI/Layout/Routes/AppRoutes.tsx
+++ b/app/src/UI/Layout/Routes/AppRoutes.tsx
@@ -148,7 +148,7 @@ const AppRoutes = () => {
       />
 
       <Route
-        path="/OfflineTiles"
+        path="/OfflineMaps"
         render={() => (
           <Suspense fallback={<Spinner />}>
             <TileCachePanel />

--- a/app/src/UI/Reusable/Accordion/Accordion.css
+++ b/app/src/UI/Reusable/Accordion/Accordion.css
@@ -1,4 +1,5 @@
 .accordion-control {
+  color: black;
   min-height: 48px;
   width: 100%;
   font-size: 16pt;
@@ -12,6 +13,7 @@
   padding: 10pt;
 
   span {
+    color: black;
     margin-right: 1rem;
   }
 

--- a/app/src/UI/Reusable/Accordion/Accordion.tsx
+++ b/app/src/UI/Reusable/Accordion/Accordion.tsx
@@ -22,7 +22,7 @@ const Accordion = ({ title, children, icon }: PropTypes) => {
   return (
     <>
       <button className={`accordion-control ${open && 'active'}`} onClick={() => setOpen((prev) => !prev)}>
-        {icon !== undefined && icon}
+        {icon !== undefined && <span>{icon}</span>}
         {title}
         {open ? <ExpandLess color="disabled" /> : <ExpandMore color="disabled" />}
       </button>

--- a/app/src/constants/LpModules.ts
+++ b/app/src/constants/LpModules.ts
@@ -2,7 +2,7 @@ enum LpModules {
   Init = 'Init',
   DataBcLayers = 'Map Layers',
   Recordsets = 'Recordset Layers',
-  MapTiles = 'Offline Map Tiles'
+  MapTiles = 'Offline Maps'
 }
 
 export default LpModules;

--- a/app/src/state/reducers/tile_cache.ts
+++ b/app/src/state/reducers/tile_cache.ts
@@ -110,7 +110,7 @@ function createTileCacheReducer() {
   return (state = initialState, action: unknown) => {
     return createNextState(state, (draft: Draft<TileCacheState>): void => {
       if (TileCache.downloadProgressEvent.match(action)) {
-        if (action.payload.normalizedProgress == 1 || action.payload.aborted) {
+        if (action.payload.normalizedProgress >= 1 || action.payload.aborted) {
           // completed or aborted
           if (Object.prototype.hasOwnProperty.call(draft.downloadProgress, action.payload.repository)) {
             delete draft.downloadProgress[action.payload.repository];

--- a/app/src/utils/tile-cache/index.ts
+++ b/app/src/utils/tile-cache/index.ts
@@ -141,6 +141,18 @@ abstract class TileCacheService extends BaseCacheService<
     const executing = new Set<Promise<void>>();
 
     try {
+      const repositoryDoesExist = !!(await this.getRepository(spec.id));
+      let currentTilesForRepo = 0;
+      if (repositoryDoesExist) {
+        // Pull information about the last tile, and total sum of all tiles if the cache previously had a download attempt
+        const tilesAlreadyCached = await this.fetchSumTilesFromRepository(spec.id);
+        if (tilesAlreadyCached > 0) {
+          // due to concurrency, a tile might get downloaded out of sequence during termination, so duplicate the last few tiles, in order to fill any gaps
+          currentTilesForRepo += Math.max(tilesAlreadyCached - this.CONCURRENCY_LIMIT, 0);
+          processedTiles += currentTilesForRepo;
+        }
+      }
+
       await this.addOrUpdateRepository({
         id: spec.id,
         status: RepositoryStatus.DOWNLOADING,
@@ -163,7 +175,7 @@ abstract class TileCacheService extends BaseCacheService<
       }
       const promises = tileUrls.map((config) => () => this.downloadTile(config));
 
-      for (let i = 0; i < promises.length && !abort; i++) {
+      for (let i = currentTilesForRepo; i < promises.length && !abort; i++) {
         if (executing.size >= this.CONCURRENCY_LIMIT) {
           await Promise.race(executing);
         }
@@ -233,6 +245,12 @@ abstract class TileCacheService extends BaseCacheService<
     const responseData = await fetch(url).then(async (r) => await r.arrayBuffer());
     await this.setTile(id, z, x, y, new Uint8Array(responseData));
   }
+
+  /**
+   * @desc Helper method to fetch current sum of tiles from repository. Used for restarting a download
+   * @param {string} repository  ID of Repository
+   */
+  protected abstract fetchSumTilesFromRepository(repository: string): Promise<number>;
 
   public abstract waitForStore(): Promise<void>;
 }

--- a/app/src/utils/tile-cache/localforage-cache.ts
+++ b/app/src/utils/tile-cache/localforage-cache.ts
@@ -37,6 +37,19 @@ class LocalForageCacheService extends TileCacheService {
     return LocalForageCacheService._instance;
   }
 
+  protected async fetchSumTilesFromRepository(repository: string): Promise<number> {
+    if (this.store == null) throw new Error('Cache not available');
+    let count = 0;
+
+    await this.store.iterate((_: TileKey, val: string) => {
+      if (val === LocalForageCacheService.REPOSITORY_METADATA_KEY) return;
+      const value = JSON.parse(val);
+      if (value?.repository === repository) {
+        count++;
+      }
+    });
+    return count;
+  }
   private static serializeTileKey(key: TileKey) {
     // serialize the object so we can deserialize later for (inefficient) index-like operations
     // in utility method in case we want to change the mechanism
@@ -251,7 +264,7 @@ class LocalForageCacheService extends TileCacheService {
       return this.store.ready();
     }
     throw new Error('store is not ready');
-  };
+  }
 }
 
 export { LocalForageCacheService };

--- a/app/src/utils/tile-cache/sqlite-cache.ts
+++ b/app/src/utils/tile-cache/sqlite-cache.ts
@@ -278,6 +278,20 @@ class SQLiteTileCacheService extends TileCacheService {
       return TileCacheService.generateStripedFallbackTile();
     }
   }
+  protected async fetchSumTilesFromRepository(repository: string): Promise<number> {
+    if (this.cacheDB == null) {
+      throw new Error('Cache not available');
+    }
+    const result = await this.cacheDB.query(
+      //Language=SQLite
+      `SELECT COUNT(*) AS COUNT
+       FROM CACHED_TILES
+       WHERE TILESET = ?`,
+      [repository]
+    );
+    console.dir(result.values);
+    return result.values?.[0]['COUNT'] ?? 0;
+  }
 
   private async getCachedTile(repository: string, z: number, x: number, y: number) {
     if (this.cacheDB == null) {
@@ -367,7 +381,7 @@ class SQLiteTileCacheService extends TileCacheService {
       return;
     }
     throw new Error('store is not ready');
-  };
+  }
 }
 
 export { SQLiteTileCacheService };


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

# #4194
- Change `Cache Tile Status` and `Map Tiles` verbiage to `Offline Maps` for end user clarity
- Wrap Offline Maps sections into Accordions to reduce screen size
- Re Add the Removed `span` from the Accordion Headers
- modify CSS to handle Accordions, and make sections more friendly on cellphone widths (tested with SE Viewport)
- Allow user to select `odd` zoom levels. Previously only even values were allowed. 
- Fix CSS for Accordion colours that was being overridden by Safari defaults. 
- Closes #4194 

# #4186 
- Only display `Ready` cached in the `Downloaded Maps section`
    - Show all Failed downloads in the `Download Progress` section.
- Add option to restart a download that has failed
- Use count of cache tiles in repo to determine start index of promise array. 
    - Add minor backtracking to cover possibly missed tiles due to concurrency. duplicate tiles just update old tiles. 
- Closes #4186 

## Displaying Error Recovery. Options to Toss or restart
<img width="988" height="298" alt="image" src="https://github.com/user-attachments/assets/20aee19e-f43f-446a-a3a0-3593f6c52191" />

## Offline Maps condensed into Accordions, Iconography added
<img width="1002" height="390" alt="image" src="https://github.com/user-attachments/assets/ce250665-48a4-4054-aaef-624455b11bb1" />

