### PR TITLE
[INV-4214] Populate offline map options in layerpicker

### DIFF
--- a/app/src/UI/Features/LegacyMap/LayerPicker/LpOfflineMaps/LpOfflineMaps.tsx
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LpOfflineMaps/LpOfflineMaps.tsx
@@ -3,7 +3,7 @@ import 'UI/Features/LegacyMap/LayerPicker/LpOfflineMaps/LpOfflineMaps.css';
 import LpOfflineMapsOptions from 'UI/Features/LegacyMap/LayerPicker/LpOfflineMaps/LpOfflineMapsOption';
 import TooltipWithIcon from 'UI/Reusable/TooltipWithIcon/TooltipWithIcon';
 import { InvasivesMapLayerDefinitionWithState } from 'UI/Features/LegacyMap/helpers/functional/layers-hook';
-import { useDispatch, useSelector } from 'utils/use_selector';
+import { useDispatch } from 'utils/use_selector';
 import TileCache from 'state/actions/cache/TileCache';
 import { useEffect } from 'react';
 
@@ -19,15 +19,9 @@ const LpOfflineMaps = ({ closePicker, setOverlayState, layers }: PropTypes) => {
 
   const dispatch = useDispatch();
 
-  const cache_enabled = useSelector((state) => state.Configuration.current.features.CACHE_TILES.enabled);
-
   // Ensure TileCache repositoryList is up to date, if available.
   useEffect(() => {
-    if (cache_enabled) {
-      (async () => {
-        dispatch(TileCache.repositoryList());
-      })();
-    }
+    dispatch(TileCache.repositoryList());
   }, []);
 
   return (

--- a/app/src/UI/Features/LegacyMap/LayerPicker/LpOfflineMaps/LpOfflineMaps.tsx
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LpOfflineMaps/LpOfflineMaps.tsx
@@ -21,7 +21,9 @@ const LpOfflineMaps = ({ closePicker, setOverlayState, layers }: PropTypes) => {
 
   // Ensure TileCache repositoryList is up to date, if available.
   useEffect(() => {
-    dispatch(TileCache.repositoryList());
+    if (layers.filter((l) => l.mode === 'overlay' && l.selectionMode === 'offline-layers').length === 0) {
+      dispatch(TileCache.repositoryList());
+    }
   }, []);
 
   return (

--- a/app/src/UI/Features/LegacyMap/LayerPicker/LpOfflineMaps/LpOfflineMaps.tsx
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LpOfflineMaps/LpOfflineMaps.tsx
@@ -3,6 +3,9 @@ import 'UI/Features/LegacyMap/LayerPicker/LpOfflineMaps/LpOfflineMaps.css';
 import LpOfflineMapsOptions from 'UI/Features/LegacyMap/LayerPicker/LpOfflineMaps/LpOfflineMapsOption';
 import TooltipWithIcon from 'UI/Reusable/TooltipWithIcon/TooltipWithIcon';
 import { InvasivesMapLayerDefinitionWithState } from 'UI/Features/LegacyMap/helpers/functional/layers-hook';
+import { useDispatch, useSelector } from 'utils/use_selector';
+import TileCache from 'state/actions/cache/TileCache';
+import { useEffect } from 'react';
 
 type PropTypes = {
   closePicker: () => void;
@@ -13,6 +16,19 @@ type PropTypes = {
 const LpOfflineMaps = ({ closePicker, setOverlayState, layers }: PropTypes) => {
   const cachedToolTipText =
     'Use this option to show or hide the map tiles you’ve previously downloaded to your device.';
+
+  const dispatch = useDispatch();
+
+  const cache_enabled = useSelector((state) => state.Configuration.current.features.CACHE_TILES.enabled);
+
+  // Ensure TileCache repositoryList is up to date, if available.
+  useEffect(() => {
+    if (cache_enabled) {
+      (async () => {
+        dispatch(TileCache.repositoryList());
+      })();
+    }
+  }, []);
 
   return (
     <div id="lp-offline-maps">


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Add useEffect to LayerPicker to update the list of offline map repositories if currently none. 