### PR TITLE
[INV-4224] pmt improvements

### DIFF
--- a/app/src/UI/Features/ManageTripsPage/subcomponents/PmtCacheStatus.tsx
+++ b/app/src/UI/Features/ManageTripsPage/subcomponents/PmtCacheStatus.tsx
@@ -168,6 +168,7 @@ const PmtCacheStatus = ({ trip, onRemove, cacheKey }: PropTypes) => {
               </Button>
             ),
             [IPlanMyTripCacheStatus.IN_PROGRESS]: <p>In Progress...</p>,
+            [IPlanMyTripCacheStatus.NO_DATA]: <p>No data matches the area for this type.</p>,
             [IPlanMyTripCacheStatus.UNAVAILABLE]: <p>Unavailable for offline storage</p>,
             [IPlanMyTripCacheStatus.NOT_CACHED]: {
               mapTiles: <PmtDownloadMaps trip={trip} />,

--- a/app/src/state/actions/planMyTrip/PlanMyTrip.ts
+++ b/app/src/state/actions/planMyTrip/PlanMyTrip.ts
@@ -38,7 +38,7 @@ interface IModifySubCache {
 }
 
 class PmtRecordset {
-  private static readonly PREFIX = 'PlanMyTrip/PmtRecordset';
+  public static readonly PREFIX = 'PlanMyTrip/PmtRecordset';
   public static readonly IAPP_PRE = 'iapp-'; // Prefix for IAPP Recordsets
   public static readonly ACTIVITY_PRE = 'act-'; // Prefix for Activity Recordsets
 
@@ -93,9 +93,19 @@ class PmtRecordset {
   /**
    * @desc Starts Download for Recordset, updates Trips cache status at completion of thunk
    */
-  public static readonly download = createAsyncThunk(`${this.PREFIX}/download`, async (setId: string, { dispatch }) => {
-    await dispatch(RecordCache.requestCaching({ setId }));
-  });
+  public static readonly download = createAsyncThunk(
+    `${this.PREFIX}/download`,
+    async (setId: string, { dispatch, getState, rejectWithValue }) => {
+      const state = getState() as RootState;
+      const recordsetIds = state.UserSettings.recordSets?.[setId]?.idList?.length;
+      if (recordsetIds > 0) {
+        await dispatch(RecordCache.requestCaching({ setId }));
+      } else {
+        dispatch(UserSettings.RecordSet.requestRemoval({ setId }));
+        return rejectWithValue({ reason: IPlanMyTripCacheStatus.NO_DATA });
+      }
+    }
+  );
 
   /**
    * @desc Clears Cache for Recordset from storage, updates Trip data,

--- a/app/src/state/actions/planMyTrip/PlanMyTrip.ts
+++ b/app/src/state/actions/planMyTrip/PlanMyTrip.ts
@@ -218,7 +218,7 @@ class PlanMyTrip {
     async (spec: IModifySubCache, { dispatch }) => {
       const service = await PlanMyTripCacheServiceFactory.getPlatformInstance();
       const repo = await service.getRepository(spec.id);
-      if (!repo || repo?.cacheStatuses[spec.cache] === IPlanMyTripCacheStatus.NOT_CACHED) return;
+      if (!repo) return;
       switch (spec.cache) {
         case 'mapTiles':
           await dispatch(TileCache.deleteRepository(spec.id));

--- a/app/src/state/sagas/activity.ts
+++ b/app/src/state/sagas/activity.ts
@@ -411,7 +411,7 @@ function* handle_MAP_SET_COORDS(action) {
       yield put({ type: ACTIVITY_UPDATE_GEO_REQUEST, payload: { geometry: [newGeo] } });
     }
   } catch (err) {
-    console.log(err);
+    console.error(err);
   }
 }
 

--- a/app/src/state/sagas/planMyTrip.ts
+++ b/app/src/state/sagas/planMyTrip.ts
@@ -7,10 +7,10 @@ import PlanMyTrip from 'state/actions/planMyTrip/PlanMyTrip';
 import { IPlanMyTripCacheStatus, IPlanMyTripCacheStatuses, PlanMyTripCacheService } from 'utils/plan-my-trip-cache';
 import { PlanMyTripCacheServiceFactory } from 'utils/plan-my-trip-cache/context';
 
-function* createQueueWorker(channel, workerFn) {
+function* createQueueWorker(channel) {
   while (true) {
     const action = yield take(channel);
-    yield call(workerFn, action);
+    yield call(processCombinedCacheAction, action);
   }
 }
 
@@ -19,7 +19,10 @@ const actionToCacheKey = (action: string, setId?: string): keyof IPlanMyTripCach
     return 'wellData';
   } else if (action.startsWith(TileCache.PREFIX)) {
     return 'mapTiles';
-  } else if (action.startsWith(RecordCache.PREFIX) && setId?.startsWith(PlanMyTrip.Recordset.ACTIVITY_PRE)) {
+  } else if (
+    (action.startsWith(RecordCache.PREFIX) || action.startsWith(PlanMyTrip.Recordset.PREFIX)) &&
+    setId?.startsWith(PlanMyTrip.Recordset.ACTIVITY_PRE)
+  ) {
     return 'activityRecordset';
   }
   return 'iappRecordset';
@@ -52,7 +55,11 @@ function* handleTripSubcacheDownloadSuccess(action) {
   yield handleUpdateSubcacheStatus(action, IPlanMyTripCacheStatus.CACHED);
 }
 function* handleTripSubcacheFailure(action) {
-  yield handleUpdateSubcacheStatus(action, IPlanMyTripCacheStatus.FAILED);
+  if (action.payload?.reason === IPlanMyTripCacheStatus.NO_DATA) {
+    yield handleUpdateSubcacheStatus(action, IPlanMyTripCacheStatus.NO_DATA);
+  } else {
+    yield handleUpdateSubcacheStatus(action, IPlanMyTripCacheStatus.FAILED);
+  }
 }
 function* handleTripSubcacheDeleteSuccess(action) {
   yield handleUpdateSubcacheStatus(action, IPlanMyTripCacheStatus.NOT_CACHED);
@@ -61,41 +68,84 @@ function* handleTripSubcacheDownloadPending(action) {
   yield handleUpdateSubcacheStatus(action, IPlanMyTripCacheStatus.IN_PROGRESS);
 }
 
+function* processCombinedCacheAction(action) {
+  try {
+    switch (action.type) {
+      // Download starts.
+      case TileCache.requestCaching.pending.type:
+      case WellCache.requestCaching.pending.type:
+      case RecordCache.requestCaching.pending.type:
+        yield call(handleTripSubcacheDownloadPending, action);
+        break;
+
+      // Success Actions
+      case TileCache.requestCaching.fulfilled.type:
+      case WellCache.requestCaching.fulfilled.type:
+      case RecordCache.requestCaching.fulfilled.type:
+        yield call(handleTripSubcacheDownloadSuccess, action);
+        break;
+
+      // All Rejected actions
+      case TileCache.requestCaching.rejected.type:
+      case TileCache.deleteRepository.rejected.type:
+      case WellCache.requestCaching.rejected.type:
+      case WellCache.deleteRepository.rejected.type:
+      case RecordCache.requestCaching.rejected.type:
+      case RecordCache.deleteCache.rejected.type:
+      case PlanMyTrip.Recordset.download.rejected.type:
+        yield call(handleTripSubcacheFailure, action);
+        break;
+
+      // Successful Deletion
+      case TileCache.deleteRepository.fulfilled.type:
+      case WellCache.deleteRepository.fulfilled.type:
+      case RecordCache.deleteCache.fulfilled.type:
+        yield call(handleTripSubcacheDeleteSuccess, action);
+        break;
+
+      default:
+        console.warn(`unhandled action type in queue: ${action.type}`);
+        break;
+    }
+  } catch (error) {
+    console.error(`Error in queue for action ${action.type}:`, error);
+  }
+}
+
 /**
- * @desc Saga for PlanMyTrip. Runs channels to avoid race conditions when updating (affects LocalForage)
+ * @desc Saga for PlanMyTrip. Runs single channel to avoid race conditions in updating (affects LocalForage)
  */
 function* planMyTripSaga() {
-  const pendingChannel = yield actionChannel(
-    [TileCache.requestCaching.pending, WellCache.requestCaching.pending, RecordCache.requestCaching.pending],
-    buffers.expanding()
-  );
-  const fulfilledChannel = yield actionChannel(
-    [TileCache.requestCaching.fulfilled, WellCache.requestCaching.fulfilled, RecordCache.requestCaching.fulfilled],
-    buffers.expanding()
-  );
-  const rejectedChannel = yield actionChannel(
+  const combinedCacheChannel = yield actionChannel(
     [
+      // Pending Actions
+      TileCache.requestCaching.pending,
+      WellCache.requestCaching.pending,
+      RecordCache.requestCaching.pending,
+
+      // Fulfilled Actions
+      TileCache.requestCaching.fulfilled,
+      WellCache.requestCaching.fulfilled,
+      RecordCache.requestCaching.fulfilled,
+
+      // Rejected Actions (various)
       TileCache.requestCaching.rejected,
       TileCache.deleteRepository.rejected,
       WellCache.requestCaching.rejected,
       WellCache.deleteRepository.rejected,
       RecordCache.requestCaching.rejected,
-      RecordCache.deleteCache.rejected
+      RecordCache.deleteCache.rejected,
+      PlanMyTrip.Recordset.download.rejected,
+
+      // Delete Fulfilled Actions
+      TileCache.deleteRepository.fulfilled,
+      WellCache.deleteRepository.fulfilled,
+      RecordCache.deleteCache.fulfilled
     ],
     buffers.expanding()
   );
 
-  const deleteFulfilledChannel = yield actionChannel(
-    [TileCache.deleteRepository.fulfilled, WellCache.deleteRepository.fulfilled, RecordCache.deleteCache.fulfilled],
-    buffers.expanding()
-  );
-
-  yield all([
-    fork(createQueueWorker, pendingChannel, handleTripSubcacheDownloadPending),
-    fork(createQueueWorker, fulfilledChannel, handleTripSubcacheDownloadSuccess),
-    fork(createQueueWorker, rejectedChannel, handleTripSubcacheFailure),
-    fork(createQueueWorker, deleteFulfilledChannel, handleTripSubcacheDeleteSuccess)
-  ]);
+  yield all([fork(createQueueWorker, combinedCacheChannel)]);
 }
 
 export default planMyTripSaga;

--- a/app/src/utils/plan-my-trip-cache/index.ts
+++ b/app/src/utils/plan-my-trip-cache/index.ts
@@ -43,7 +43,8 @@ enum IPlanMyTripCacheStatus {
   DELETING = 'DELETING',
   NOT_CACHED = 'NOT CACHED',
   UNAVAILABLE = 'UNAVAILABLE',
-  FAILED = 'FAILED'
+  FAILED = 'FAILED',
+  NO_DATA = 'NO DATA'
 }
 /**
  * @desc Plan My Trip is the umbrella category representing a set of different caches.


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Implement 'NO DATA' status for PMT Recordsets if no data was available for that area
    - If this is the case, do not create a recordset that would otherwise be empty
- Fix issue where deleting a trip that contains an `uncached` recordset causes the recordset to `not` be deleted 
- Consolidate PMT actionChannels into one unified saga handler ensuring a proper queue.
- Convert an errant `console.log` to `console.error` 
- Closes #4224 