### PR TITLE
[INV-4202] PlanMyTrip Form

### DIFF
--- a/app/src/UI/Features/ManageTripsPage/ManageTripsPage.tsx
+++ b/app/src/UI/Features/ManageTripsPage/ManageTripsPage.tsx
@@ -1,66 +1,20 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import TileCache from 'state/actions/cache/TileCache';
-import PlanMyTrip from 'state/actions/planMyTrip/PlanMyTrip';
-import {
-  IPlanMyTripCacheStatuses,
-  IPlanMyTripRepositoryMetadata,
-  PlanMyTripCacheService
-} from 'utils/plan-my-trip-cache';
-import { PlanMyTripCacheServiceFactory } from 'utils/plan-my-trip-cache/context';
-import { useDispatch, useSelector } from 'utils/use_selector';
-import PmtCacheStatus from './subcomponents/PmtCacheStatus';
+import './manageTripsPage.css';
+import { useDispatch } from 'utils/use_selector';
 import { Button } from '@mui/material';
-import { Delete } from '@mui/icons-material';
-import Accordion from 'UI/Reusable/Accordion/Accordion';
+import { ArrowBackIos } from '@mui/icons-material';
+import PlanMyTripForm from './subcomponents/PlanMyTripForm/PlanMyTripForm';
+import ManageTrips from './subcomponents/ManageTrips/ManageTrips';
 
 const ManageTripsPage = () => {
-  const service = useRef<PlanMyTripCacheService>();
+  enum Mode {
+    CREATE,
+    MAIN,
+    MANAGE
+  }
+  const [mode, setMode] = useState<Mode>(Mode.MAIN);
   const dispatch = useDispatch();
-
-  const bounds = useSelector((state) => state.TileCache?.drawnShapeBounds);
-  const drawnShape = useSelector((state) => state.PlanMyTrip?.drawnShape);
-  const [trips, setTrips] = useState<IPlanMyTripRepositoryMetadata[]>([]);
-  const [tripName, setTripName] = useState<string>('');
-  const lastUpdate = useSelector((state) => state.PlanMyTrip?.lastUpdate);
-
-  const addTrip = () => {
-    (async () => {
-      const name = tripName;
-      setTripName('');
-      await dispatch(
-        PlanMyTrip.create({
-          name: name,
-          wellData: true,
-          zoom: 5,
-          iapp: true,
-          activities: true
-        })
-      );
-    })();
-  };
-
-  const removeSubCache = (id: string, cache: keyof IPlanMyTripCacheStatuses) => {
-    dispatch(PlanMyTrip.removeSubCache({ id, cache }));
-  };
-
-  useEffect(() => {
-    (async () => {
-      if (!service.current) return;
-      await service.current.listRepositories().then((trips) => {
-        setTrips([...trips]);
-      });
-    })();
-  }, [lastUpdate, service.current]);
-
-  const deleteTrip = (id: string) => {
-    dispatch(PlanMyTrip.delete(id));
-  };
-  useEffect(() => {
-    if (service.current) return;
-    (async () => {
-      service.current = await PlanMyTripCacheServiceFactory.getPlatformInstance();
-    })();
-  }, []);
 
   useEffect(() => {
     dispatch(TileCache.setMapTileCacheMode(true));
@@ -70,60 +24,50 @@ const ManageTripsPage = () => {
   }, []);
 
   return (
-    <div>
-      <div style={{ display: 'flex', flexDirection: 'column' }}>
-        <div>
-          <p>Add a Repo</p>
-          <input type="text" placeholder="Name" value={tripName} onChange={(e) => setTripName(e.target.value)} />
-          <button onClick={addTrip} disabled={tripName.length === 0}>
-            Add One
-          </button>
+    <div id="manage-trips">
+      {mode !== Mode.MAIN && (
+        <div className="trip-header">
+          <Button onClick={setMode.bind(this, Mode.MAIN)}>
+            <ArrowBackIos /> Back
+          </Button>
         </div>
-        <h2>Shape</h2>
-        <div
-          style={{
-            display: 'flex',
-            width: '100vw',
-            boxSizing: 'border-box',
-            alignItems: 'center',
-            justifyContent: 'center'
-          }}
-        >
-          <div style={{ width: '400px', textWrap: 'wrap', wordBreak: 'break-word' }}>
-            <Accordion title="shapes">
-              <p>
-                <b>Bounds:</b> {JSON.stringify(bounds)}
-              </p>
-              <p>
-                <b>Original Shape:</b> {JSON.stringify(drawnShape) ?? 'null'}
-              </p>
-            </Accordion>
-          </div>
-        </div>
-        <h2>Repos</h2>
-        <div style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap' }}>
-          {trips.length === 0 && <p>No Trips available</p>}
-          {trips.map((trip) => (
-            <div key={trip.id} style={{ border: '1pt solid black', margin: 5, padding: 5, width: 450 }}>
-              <p>Trip Name: {trip.name}</p>
-              <div>
-                Offline Storage Status:
-                {Object.keys(trip.cacheStatuses).map((key) => (
-                  <PmtCacheStatus
-                    trip={trip}
-                    onRemove={removeSubCache}
-                    cacheKey={key as keyof IPlanMyTripCacheStatuses}
-                    key={key}
-                  />
-                ))}
-                <Button sx={{ mt: 3, mb: 1 }} color="error" onClick={() => deleteTrip(trip.id)}>
-                  Delete
-                  <Delete />
+      )}
+      <div className="content">
+        {
+          {
+            [Mode.MAIN]: (
+              <div className="main">
+                <p>I'm Looking to...</p>
+                <Button variant="contained" size="large" onClick={setMode.bind(this, Mode.CREATE)}>
+                  Plan A New Trip
+                </Button>
+                <Button variant="contained" size="large" onClick={setMode.bind(this, Mode.MANAGE)}>
+                  Manage My Trips
                 </Button>
               </div>
-            </div>
-          ))}
-        </div>
+            ),
+            [Mode.CREATE]: (
+              <div>
+                <PlanMyTripForm />
+                <div className="redirect">
+                  <p>Looking for an existing trip?</p>
+                  <Button onClick={setMode.bind(this, Mode.MANAGE)}>Manage My Trips</Button>
+                </div>
+              </div>
+            ),
+            [Mode.MANAGE]: (
+              <div>
+                <ManageTrips />
+                <div className="redirect">
+                  <p>Not seeing what you're looking for?</p>
+                  <Button size="small" onClick={setMode.bind(this, Mode.CREATE)}>
+                    Plan a New Trip
+                  </Button>
+                </div>
+              </div>
+            )
+          }[mode]
+        }
       </div>
     </div>
   );

--- a/app/src/UI/Features/ManageTripsPage/ManageTripsPage.tsx
+++ b/app/src/UI/Features/ManageTripsPage/ManageTripsPage.tsx
@@ -37,9 +37,9 @@ const ManageTripsPage = () => {
           {
             [Mode.MAIN]: (
               <div className="main">
-                <p>I'm Looking to...</p>
+                <p>I'm Looking To...</p>
                 <Button variant="contained" size="large" onClick={setMode.bind(this, Mode.CREATE)}>
-                  Plan A New Trip
+                  Plan a New Trip
                 </Button>
                 <Button variant="contained" size="large" onClick={setMode.bind(this, Mode.MANAGE)}>
                   Manage My Trips

--- a/app/src/UI/Features/ManageTripsPage/manageTripsPage.css
+++ b/app/src/UI/Features/ManageTripsPage/manageTripsPage.css
@@ -1,0 +1,46 @@
+#manage-trips {
+  box-sizing: border-box;
+  margin-bottom: 2rem;
+
+  .trip-header {
+    background-color: white;
+    display: flex;
+    justify-content: flex-start;
+    left: 0;
+    margin-bottom: 2rem;
+    position: sticky;
+    top: 0;
+    width: 100%;
+  }
+
+  .content {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+  }
+  .redirect {
+    display: flex;
+    margin-top: 1rem;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    button {
+      text-decoration: underline;
+    }
+  }
+  .main {
+    display: flex;
+    flex-direction: column;
+    p {
+      font-size: 24px;
+    }
+    & > * {
+      margin-bottom: 1.5rem;
+    }
+    button:not(.redirect) {
+      background-color: var(--bc-blue);
+      height: 60pt;
+      width: 165pt;
+    }
+  }
+}

--- a/app/src/UI/Features/ManageTripsPage/subcomponents/ManageTrips/ManageTrips.tsx
+++ b/app/src/UI/Features/ManageTripsPage/subcomponents/ManageTrips/ManageTrips.tsx
@@ -1,0 +1,81 @@
+import {
+  IPlanMyTripCacheStatuses,
+  IPlanMyTripRepositoryMetadata,
+  PlanMyTripCacheService
+} from 'utils/plan-my-trip-cache';
+import PmtCacheStatus from '../PmtCacheStatus';
+import { Button } from '@mui/material';
+import { Delete } from '@mui/icons-material';
+import { PlanMyTripCacheServiceFactory } from 'utils/plan-my-trip-cache/context';
+import { useEffect, useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'utils/use_selector';
+import PlanMyTrip from 'state/actions/planMyTrip/PlanMyTrip';
+import TileCache from 'state/actions/cache/TileCache';
+
+const ManageTrips = () => {
+  const [trips, setTrips] = useState<IPlanMyTripRepositoryMetadata[]>([]);
+  const [ready, setReady] = useState<boolean>(false);
+  const lastUpdate = useSelector((state) => state.PlanMyTrip?.lastUpdate);
+  const service = useRef<PlanMyTripCacheService>();
+  const removeSubCache = (id: string, cache: keyof IPlanMyTripCacheStatuses) => {
+    dispatch(PlanMyTrip.removeSubCache({ id, cache }));
+  };
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    (async () => {
+      if (!service.current) return;
+      await service.current.listRepositories().then((trips) => {
+        setTrips([...trips]);
+      });
+    })();
+  }, [lastUpdate, ready]);
+
+  const deleteTrip = (id: string) => {
+    dispatch(PlanMyTrip.delete(id));
+  };
+
+  useEffect(() => {
+    dispatch(TileCache.clearTileCacheShape());
+    dispatch(PlanMyTrip.clearShape());
+  }, []);
+
+  useEffect(() => {
+    if (service?.current) return;
+    (async () => {
+      service.current = await PlanMyTripCacheServiceFactory.getPlatformInstance();
+      setReady(service.current != undefined);
+    })();
+  }, []);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <h2>Repos</h2>
+      <div style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap' }}>
+        {trips.length === 0 && <p>No Trips available</p>}
+        {trips.map((trip) => (
+          <div key={trip.id} style={{ border: '1pt solid black', margin: 5, padding: 5, width: 450 }}>
+            <p>Trip Name: {trip.name}</p>
+            <div>
+              Offline Storage Status:
+              {Object.keys(trip.cacheStatuses).map((key) => (
+                <PmtCacheStatus
+                  trip={trip}
+                  onRemove={removeSubCache}
+                  cacheKey={key as keyof IPlanMyTripCacheStatuses}
+                  key={key}
+                />
+              ))}
+              <Button sx={{ mt: 3, mb: 1 }} color="error" onClick={() => deleteTrip(trip.id)}>
+                Delete
+                <Delete />
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ManageTrips;

--- a/app/src/UI/Features/ManageTripsPage/subcomponents/PlanMyTripForm/PlanMyTripForm.tsx
+++ b/app/src/UI/Features/ManageTripsPage/subcomponents/PlanMyTripForm/PlanMyTripForm.tsx
@@ -1,0 +1,181 @@
+import { Button } from '@mui/material';
+import './planMyTripForm.css';
+import { Check, Draw } from '@mui/icons-material';
+import TooltipWithIcon from 'UI/Reusable/TooltipWithIcon/TooltipWithIcon';
+import { IPlanMyTripCacheStatuses } from 'utils/plan-my-trip-cache';
+import MapSlider from 'UI/Features/TileCache/MapSlider';
+import { useDispatch, useSelector } from 'utils/use_selector';
+import { ChangeEvent, useEffect, useRef, useState } from 'react';
+import PlanMyTrip, { ICreateMyTrip } from 'state/actions/planMyTrip/PlanMyTrip';
+import { AVAILABLE_ZOOMS } from 'UI/Features/TileCache/constants';
+
+interface CacheOption {
+  tooltip: string;
+  name: keyof IPlanMyTripCacheStatuses | 'all';
+  labelText: string;
+}
+
+const PlanMyTripForm = () => {
+  const CACHE_OPTIONS: Array<CacheOption> = [
+    {
+      tooltip: 'Creates an IAPP Recordset with your drawn region as the primary filter',
+      name: 'iappRecordset',
+      labelText: 'IAPP Records'
+    },
+    {
+      tooltip: 'Creates an InvasivesBC Recordset with your drawn region as the primary filter',
+      name: 'activityRecordset',
+      labelText: 'InvasivesBC Records'
+    },
+    {
+      tooltip: 'Get locations of recorded groundwater wells in your region for use with Chemical Treatment forms',
+      name: 'wellData',
+      labelText: 'Well Data'
+    },
+    {
+      tooltip: 'Download Maps available offline for your drawn region',
+      name: 'mapTiles',
+      labelText: 'Offline Maps'
+    }
+  ];
+
+  // Clear current shape and set draw tools to Polygon.
+  const handleDrawRegion = () => {
+    deleteRef.current?.click();
+    drawPolygonRef?.current?.click();
+  };
+
+  const handleNameChange = (e: ChangeEvent<HTMLInputElement>) => setTripName(e.target.value);
+
+  const handleSelectionChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setUserSelectedCaches((prev) => ({
+      ...prev,
+      [e.target.name]: !prev[e.target.name]
+    }));
+  };
+
+  const handleSubmit = () => {
+    const request: ICreateMyTrip = {
+      name: tripName,
+      iapp: userSelectedCaches.iappRecordset,
+      activities: userSelectedCaches.activityRecordset,
+      wellData: userSelectedCaches.wellData,
+      wmsLayers: userSelectedCaches.wmsLayer
+    };
+    if (userSelectedCaches.mapTiles) {
+      request.zoom = mapZoomLevel;
+    }
+    dispatch(PlanMyTrip.create(request));
+  };
+
+  const dispatch = useDispatch();
+
+  const deleteRef = useRef<HTMLButtonElement>(
+    document.getElementsByClassName('mapbox-gl-draw_trash')?.[0] as HTMLButtonElement
+  );
+  const drawPolygonRef = useRef<HTMLButtonElement>(
+    document.getElementsByClassName('mapbox-gl-draw_polygon')?.[0] as HTMLButtonElement
+  );
+
+  const planMyTripRegion = useSelector((state) => state.PlanMyTrip?.drawnShape);
+
+  const [tripName, setTripName] = useState<string>('');
+  const [formValid, setFormValid] = useState<boolean>(false);
+  const [mapZoomLevel, setMapZoomLevel] = useState<number>(AVAILABLE_ZOOMS[0].value);
+  const [isOversizedTileDownload, setIsOversizedTileDownload] = useState<boolean>(false);
+  const [userSelectedCaches, setUserSelectedCaches] = useState<Record<keyof IPlanMyTripCacheStatuses, boolean>>({
+    wellData: false,
+    iappRecordset: false,
+    activityRecordset: false,
+    mapTiles: false,
+    wmsLayer: false
+  });
+
+  // Check form validity on changes
+  useEffect(() => {
+    const isNameSet = !!tripName;
+    const isRegionDefined = planMyTripRegion != undefined;
+    const isAnyCacheTypeSelected = Object.values(userSelectedCaches).some(Boolean);
+    const isTileRequestOversized = isOversizedTileDownload && userSelectedCaches.mapTiles;
+    setFormValid(isNameSet && isRegionDefined && isAnyCacheTypeSelected && !isTileRequestOversized);
+  }, [tripName, planMyTripRegion, userSelectedCaches, isOversizedTileDownload]);
+
+  return (
+    <div id="trip-planning-form">
+      <form>
+        <h2>Planning Your Trip</h2>
+        <p className="overview">
+          Draw a region on the map and download detailed information for that area, including maps, records, and well
+          data.
+        </p>
+        <section className="details-section">
+          <div className="input-label">
+            <label htmlFor="trip-planning-form-name">Name of Trip:</label>
+            <input type="text" id="trip-planning-form-name" value={tripName} onChange={handleNameChange} />
+          </div>
+          <div className="drawn-field">
+            {drawPolygonRef?.current && (
+              <Button
+                variant="contained"
+                onClick={handleDrawRegion}
+                className={'trip-planning-button'}
+                color="success"
+                id="trip-draw-button"
+              >
+                {planMyTripRegion ? <Check /> : <Draw />}
+                Draw Region
+              </Button>
+            )}
+          </div>
+        </section>
+        <section className="contents-section">
+          <fieldset>
+            <legend>What are you bringing with you?</legend>
+            {CACHE_OPTIONS.map(({ tooltip, name, labelText }) => (
+              <div className="input-label" key={name}>
+                <input
+                  type="checkbox"
+                  name={name}
+                  checked={userSelectedCaches[name]}
+                  onChange={handleSelectionChange}
+                />
+                <label htmlFor="IAPP Records">
+                  {labelText} <TooltipWithIcon tooltipText={tooltip} />
+                </label>
+              </div>
+            ))}
+          </fieldset>
+        </section>
+        {userSelectedCaches.mapTiles && (
+          <fieldset>
+            <legend>Offline Map Detail</legend>
+            {planMyTripRegion ? (
+              <MapSlider
+                drawnShape={planMyTripRegion}
+                zoom={mapZoomLevel}
+                setZoom={setMapZoomLevel}
+                setOversizedTileDownload={setIsOversizedTileDownload}
+              />
+            ) : (
+              <p>Please draw a region on the map to see offline map details</p>
+            )}
+          </fieldset>
+        )}
+        <div className="control">
+          <Button
+            variant="contained"
+            className={formValid ? 'trip-planning-button' : ''}
+            color="primary"
+            onClick={handleSubmit}
+            disabled={!formValid}
+            size="large"
+          >
+            Plan my Trip!
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default PlanMyTripForm;

--- a/app/src/UI/Features/ManageTripsPage/subcomponents/PlanMyTripForm/PlanMyTripForm.tsx
+++ b/app/src/UI/Features/ManageTripsPage/subcomponents/PlanMyTripForm/PlanMyTripForm.tsx
@@ -110,7 +110,9 @@ const PlanMyTripForm = () => {
         </p>
         <section className="details-section">
           <div className="input-label">
-            <label htmlFor="trip-planning-form-name">Name of Trip:</label>
+            <label htmlFor="trip-planning-form-name">
+              Name of Trip:<span className="required">*</span>
+            </label>
             <input type="text" id="trip-planning-form-name" value={tripName} onChange={handleNameChange} />
           </div>
           <div className="drawn-field">
@@ -123,14 +125,16 @@ const PlanMyTripForm = () => {
                 id="trip-draw-button"
               >
                 {planMyTripRegion ? <Check /> : <Draw />}
-                Draw Region
+                Draw Region<span className="required">*</span>
               </Button>
             )}
           </div>
         </section>
         <section className="contents-section">
           <fieldset>
-            <legend>What are you bringing with you?</legend>
+            <legend>
+              What are you bringing with you?<span className="required">*</span>
+            </legend>
             {CACHE_OPTIONS.map(({ tooltip, name, labelText }) => (
               <div className="input-label" key={name}>
                 <input
@@ -148,7 +152,9 @@ const PlanMyTripForm = () => {
         </section>
         {userSelectedCaches.mapTiles && (
           <fieldset>
-            <legend>Offline Map Detail</legend>
+            <legend>
+              Offline Map Detail<span className="required">*</span>
+            </legend>
             {planMyTripRegion ? (
               <MapSlider
                 drawnShape={planMyTripRegion}

--- a/app/src/UI/Features/ManageTripsPage/subcomponents/PlanMyTripForm/PlanMyTripForm.tsx
+++ b/app/src/UI/Features/ManageTripsPage/subcomponents/PlanMyTripForm/PlanMyTripForm.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@mui/material';
 import './planMyTripForm.css';
-import { Check, Draw } from '@mui/icons-material';
+import { Draw } from '@mui/icons-material';
 import TooltipWithIcon from 'UI/Reusable/TooltipWithIcon/TooltipWithIcon';
 import { IPlanMyTripCacheStatuses } from 'utils/plan-my-trip-cache';
 import MapSlider from 'UI/Features/TileCache/MapSlider';
@@ -124,8 +124,9 @@ const PlanMyTripForm = () => {
                 color="success"
                 id="trip-draw-button"
               >
-                {planMyTripRegion ? <Check /> : <Draw />}
-                Draw Region<span className="required">*</span>
+                <Draw />
+                {planMyTripRegion ? 'Redraw Region' : 'Draw Region'}
+                <span className="required">*</span>
               </Button>
             )}
           </div>

--- a/app/src/UI/Features/ManageTripsPage/subcomponents/PlanMyTripForm/PlanMyTripForm.tsx
+++ b/app/src/UI/Features/ManageTripsPage/subcomponents/PlanMyTripForm/PlanMyTripForm.tsx
@@ -133,7 +133,7 @@ const PlanMyTripForm = () => {
         <section className="contents-section">
           <fieldset>
             <legend>
-              What are you bringing with you?<span className="required">*</span>
+              What info should come with you?<span className="required">*</span>
             </legend>
             {CACHE_OPTIONS.map(({ tooltip, name, labelText }) => (
               <div className="input-label" key={name}>

--- a/app/src/UI/Features/ManageTripsPage/subcomponents/PlanMyTripForm/planMyTripForm.css
+++ b/app/src/UI/Features/ManageTripsPage/subcomponents/PlanMyTripForm/planMyTripForm.css
@@ -1,0 +1,101 @@
+#trip-planning-form {
+  --blanket-margin: 1rem;
+
+  border-radius: 4pt;
+  box-sizing: border-box;
+  max-width: 700px;
+  padding: 1rem;
+
+  .overview {
+    text-align: left;
+  }
+
+  h2 {
+    font-size: 1.75rem;
+    margin-top: var(--blanket-margin);
+    text-align: left;
+  }
+
+  #trip-planning-form-name {
+    font-size: 14px;
+    height: 32px;
+    padding-left: 0.5rem;
+    width: 200px;
+  }
+
+  .trip-planning-button {
+    background-color: var(--bc-blue);
+  }
+
+  .control {
+    box-sizing: border-box;
+    display: flex;
+    justify-content: flex-end;
+    margin-top: var(--blanket-margin);
+    padding: 0 1rem;
+    width: 100%;
+  }
+
+  legend {
+    font-size: 14pt;
+    margin-top: var(--blanket-margin);
+  }
+
+  fieldset {
+    border-color: #ccc;
+    border-width: 1px;
+    margin-top: 1rem;
+    padding: 0.5rem 1rem;
+  }
+
+  .details-section {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+
+    & > * {
+      margin-right: auto;
+      margin-top: var(--blanket-margin);
+    }
+  }
+
+  .input-label {
+    align-items: center;
+    display: flex;
+    justify-content: flex-start;
+
+    & > :first-child {
+      margin-right: 8pt;
+    }
+  }
+
+  form fieldset {
+    align-items: flex;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+
+    input[type='checkbox'] {
+      width: 25px;
+      height: 25px;
+    }
+  }
+}
+
+@media only screen and (width >700px) {
+  #trip-planning-form {
+    border: 1pt solid black;
+    fieldset {
+      margin: var(--blanket-margin);
+    }
+    legend {
+      font-size: 16pt;
+    }
+  }
+  .details-section {
+    justify-content: space-between;
+    & > * {
+      margin-right: auto;
+    }
+  }
+}

--- a/app/src/UI/Features/ManageTripsPage/subcomponents/PlanMyTripForm/planMyTripForm.css
+++ b/app/src/UI/Features/ManageTripsPage/subcomponents/PlanMyTripForm/planMyTripForm.css
@@ -5,7 +5,9 @@
   box-sizing: border-box;
   max-width: 700px;
   padding: 1rem;
-
+  .required {
+    color: var(--error-red);
+  }
   .overview {
     text-align: left;
   }

--- a/app/src/UI/Features/TileCache/MapSlider.tsx
+++ b/app/src/UI/Features/TileCache/MapSlider.tsx
@@ -8,11 +8,12 @@ import { RepositoryBoundingBoxSpec, TileCacheService } from 'utils/tile-cache';
 import bbox from '@turf/bbox';
 
 type PropTypes = {
-  handleDownload: (zoom: number, shape: RepositoryBoundingBoxSpec) => void;
   drawnShape: GeoJSON;
+  zoom: number;
+  setZoom: (newVal: number) => void;
+  setOversizedTileDownload?: (bool: boolean) => void;
 };
-const MapSlider = ({ handleDownload, drawnShape }: PropTypes) => {
-  const [zoom, setZoom] = useState<number>(AVAILABLE_ZOOMS[0].value);
+const MapSlider = ({ drawnShape, setZoom, zoom, setOversizedTileDownload }: PropTypes) => {
   const [scale, setScale] = useState<string>(AVAILABLE_ZOOMS[0].scale);
   const boundary = useRef<RepositoryBoundingBoxSpec>(
     (() => {
@@ -27,17 +28,11 @@ const MapSlider = ({ handleDownload, drawnShape }: PropTypes) => {
   );
   const [tileCount, setTileCount] = useState<number | null>(null);
   const [approximateDownloadSize, setApproximateDownloadSize] = useState<number | null>(null);
-  const [downloadDisabled, setDownloadDisabled] = useState<boolean>(false);
   const { overDownloadLimit } = useTileSizeThresholds(approximateDownloadSize);
 
   useEffect(() => {
-    if (!boundary.current || approximateDownloadSize == null) {
-      setDownloadDisabled(true);
-      return;
-    }
-
-    setDownloadDisabled(overDownloadLimit);
-  }, [boundary, approximateDownloadSize, overDownloadLimit]);
+    setOversizedTileDownload?.(overDownloadLimit);
+  }, [overDownloadLimit]);
 
   useEffect(() => {
     if (!boundary.current) {
@@ -67,7 +62,7 @@ const MapSlider = ({ handleDownload, drawnShape }: PropTypes) => {
         sx={{ width: '80%' }}
         min={AVAILABLE_ZOOMS[0].value}
         max={AVAILABLE_ZOOMS[AVAILABLE_ZOOMS.length - 1].value}
-        onChange={(e, value) => {
+        onChange={(_e, value) => {
           if (typeof value === 'number') {
             setZoom(value);
             setScale(AVAILABLE_ZOOMS.find((item) => item.value === value)?.scale ?? '');
@@ -85,9 +80,6 @@ const MapSlider = ({ handleDownload, drawnShape }: PropTypes) => {
           )}
         </p>
       </div>
-      <button onClick={() => handleDownload(zoom, boundary.current)} disabled={downloadDisabled}>
-        Download Offline Maps
-      </button>
     </div>
   );
 };

--- a/app/src/UI/Layout/AlertsContainer/AlertsContainer.tsx
+++ b/app/src/UI/Layout/AlertsContainer/AlertsContainer.tsx
@@ -3,7 +3,7 @@
  * @external {@link https://github.com/bcgov/invasivesbc/wiki/User-Alert-System }
  */
 import { Alert, AlertTitle, Button, Icon } from '@mui/material';
-import { Assignment, InsertPhoto, Lock, MapOutlined, Save, Wifi } from '@mui/icons-material';
+import { Assignment, InsertPhoto, Lock, Luggage, MapOutlined, Save, Wifi } from '@mui/icons-material';
 import { useDispatch } from 'react-redux';
 import 'UI/Layout/AlertsContainer/AlertsContainer.css';
 import AlertMessage from 'interfaces/AlertMessage';
@@ -34,6 +34,8 @@ const AlertsContainer = () => {
         return <Save />;
       case AlertSubjects.Authentication:
         return <Lock />;
+      case AlertSubjects.PlanMyTrip:
+        return <Luggage />;
       default:
         break;
     }

--- a/app/src/constants/alertEnums.ts
+++ b/app/src/constants/alertEnums.ts
@@ -4,7 +4,8 @@ export enum AlertSubjects {
   Photo = 'photo',
   Network = 'network',
   Authentication = 'authentication',
-  Cache = 'cache'
+  Cache = 'cache',
+  PlanMyTrip = 'plan my trip'
 }
 
 export enum AlertSeverity {

--- a/app/src/constants/alerts/tripAlerts.ts
+++ b/app/src/constants/alerts/tripAlerts.ts
@@ -1,0 +1,13 @@
+import { AlertSeverity, AlertSubjects } from 'constants/alertEnums';
+import AlertMessage from 'interfaces/AlertMessage';
+
+const tripAlertMessages: Record<string, AlertMessage> = {
+  submitted: {
+    content: 'Your trip has been submitted.',
+    severity: AlertSeverity.Success,
+    subject: AlertSubjects.PlanMyTrip,
+    autoClose: 3
+  }
+};
+
+export default tripAlertMessages;

--- a/app/src/state/actions/planMyTrip/PlanMyTrip.ts
+++ b/app/src/state/actions/planMyTrip/PlanMyTrip.ts
@@ -9,6 +9,8 @@ import { RootState } from 'state/reducers/rootReducer';
 import { PlanMyTripCacheServiceFactory } from 'utils/plan-my-trip-cache/context';
 import { IPlanMyTripCacheStatus, IPlanMyTripCacheStatuses } from 'utils/plan-my-trip-cache';
 import { RecordSetType } from 'interfaces/UserRecordSet';
+import Alerts from 'state/actions/alerts/Alerts';
+import tripAlertMessages from 'constants/alerts/tripAlerts';
 
 /**
  * @desc Parameters for a user planning their trip
@@ -166,7 +168,7 @@ class PlanMyTrip {
           activityRecordset: getInitStatus(!!spec?.activities)
         }
       });
-
+      dispatch(Alerts.create(tripAlertMessages.submitted));
       if (spec?.iapp) {
         dispatch(
           PlanMyTrip.Recordset.create({


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

## Testing
- Will need to enable `PLAN_MY_TRIP` feature flag to see/use.

## Changes
- Create Form for Plan My Trip
    - Stub subsections for WMS details, but don't display in forms. 
- Create `Landing` type page to separate Managing Trips from planning them.
- Move `Manage Trips` details into separate component. Not final product, separate ticket to adjust this.
- Add `Alert` for Starting a trip, Reset name so user can't multi-submit accidentally. 

- Closes #4202

## Screenshots

<img width="765" height="583" alt="image" src="https://github.com/user-attachments/assets/d9946f97-bead-4bd7-b849-21b9e41a6ea5" />

[*Form Component, no Map tiles selected*]

<img width="1918" height="875" alt="image" src="https://github.com/user-attachments/assets/6541e737-6807-4a51-b404-c80e5ff68918" />

[*Form Component with Map Tiles Selected*]

<img width="411" height="376" alt="image" src="https://github.com/user-attachments/assets/b1f9f538-340f-4b48-b2ca-8628a9cb80b9" />

[*Landing page*]

<img width="414" height="668" alt="image" src="https://github.com/user-attachments/assets/6ddf2030-5b47-4323-b12d-bb78d11e6c91" />

[*Mobile*]