### PR TITLE
Fix crash when adding more than 4 custom recordsets

### DIFF
--- a/app/src/state/reducers/map.ts
+++ b/app/src/state/reducers/map.ts
@@ -565,8 +565,7 @@ function createMapReducer(): (MapState, AnyAction) => MapState {
             if (!draftState.layers[index]) {
               draftState.layers.push({
                 recordSetID: action.payload.recordSetID,
-                type: action.payload.recordSetType,
-                loading: false
+                type: action.payload.recordSetType
               });
             }
             index = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.recordSetID);

--- a/app/src/state/reducers/map.ts
+++ b/app/src/state/reducers/map.ts
@@ -565,7 +565,8 @@ function createMapReducer(): (MapState, AnyAction) => MapState {
             if (!draftState.layers[index]) {
               draftState.layers.push({
                 recordSetID: action.payload.recordSetID,
-                type: action.payload.recordSetType
+                type: action.payload.recordSetType,
+                loading: false
               });
             }
             index = draftState.layers.findIndex((layer) => layer.recordSetID === action.payload.recordSetID);

--- a/app/src/state/sagas/map.ts
+++ b/app/src/state/sagas/map.ts
@@ -547,12 +547,12 @@ function* handle_MAP_INIT_FOR_RECORDSETS() {
   const recordSets = Object.keys(userSettingsState.recordSets);
 
   // current layers
-  const layers = yield select((state) => state.Map.layers);
+  const mapState = yield select(selectMap);
+  const layers = mapState.layers;
   const layerIDs = layers.map((layer) => layer.recordSetID);
 
-  // current but unintialized:
   const currentUninitializedLayers = layers
-    .filter((layer) => !layer.loading)
+    .filter((layer) => !Object.prototype.hasOwnProperty.call(layer, 'loading'))
     .map((layer) => {
       return { recordSetID: layer.recordSetID, recordSetType: layer.type };
     });


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Fixes #4219 
- Tested on the browser, iPad and iPad simulator
- Noticed that the app is slow on initial load after creating 8+ recordsets.  [#4229](https://github.com/bcgov/invasivesbc/issues/4229)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change
