### PR TITLE
Add Platform Tag for New Records

### DIFF
--- a/api/src/models/activity.ts
+++ b/api/src/models/activity.ts
@@ -44,6 +44,7 @@ export class ActivityPostRequestBody {
   species_treated: string[];
 
   jurisdiction: string[];
+  platform_src: string;
 
   /**
    * Creates an instance of ActivityPostRequestBody.
@@ -99,6 +100,7 @@ export class ActivityPostRequestBody {
     this.species_treated = obj?.species_treated || [];
 
     this.jurisdiction = obj?.jurisdiction || [];
+    this.platform_src = obj?.platform_src || '';
   }
 }
 

--- a/api/src/queries/activity-queries.ts
+++ b/api/src/queries/activity-queries.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/exports-last */
 import { SQL, SQLStatement } from 'sql-template-strings';
 import { getLogger } from 'utils/logger';
 import { ActivityPostRequestBody, ActivitySearchCriteria } from 'models/activity';
@@ -30,6 +31,7 @@ export const postActivitySQL = (
                                         updated_by_with_guid,
                                         sync_status,
                                         form_status,
+                                        platform_src,
                                         review_status,
                                         reviewed_by,
                                         reviewed_at,
@@ -51,6 +53,7 @@ export const postActivitySQL = (
             ${activity.updated_by_with_guid.replace('bceidbusiness', 'bceid-business')},
             ${activity.sync_status},
             ${activity.form_status},
+            ${activity.platform_src},
             ${activity.review_status},
             ${activity.reviewed_by},
             ${activity.reviewed_at},

--- a/api/src/queries/activity-queries.ts
+++ b/api/src/queries/activity-queries.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/exports-last */
 import { SQL, SQLStatement } from 'sql-template-strings';
 import { getLogger } from 'utils/logger';
 import { ActivityPostRequestBody, ActivitySearchCriteria } from 'models/activity';

--- a/database/src/migrations/0038_add_platform_column.ts
+++ b/database/src/migrations/0038_add_platform_column.ts
@@ -1,0 +1,28 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  try {
+    await knex.raw(`
+      ALTER TABLE invasivesbc.activity_incoming_data
+      ADD COLUMN platform_src TEXT;
+  `);
+    await knex.raw(`
+      COMMENT ON COLUMN invasivesbc.activity_incoming_data.platform_src IS 'Indicates whether the record was created via web or mobile';
+  `);
+  } catch (e) {
+    console.error('Failed to add platform_src column:', e);
+    throw e;
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  try {
+    await knex.raw(`
+      ALTER TABLE invasivesbc.activity_incoming_data
+      DROP COLUMN platform_src;
+    `);
+  } catch (e) {
+    console.error('Failed to rollback invasivesbc.activity_incoming_data table:', e);
+    throw e;
+  }
+}

--- a/sharedAPI/src/index.ts
+++ b/sharedAPI/src/index.ts
@@ -174,7 +174,8 @@ export function generateDBActivityPayload(
     form_status: ActivityStatus.DRAFT,
     review_status: 'Not Reviewed',
     reviewed_by: undefined,
-    reviewed_at: undefined
+    reviewed_at: undefined,
+    platform_src: import.meta.env.VITE_TARGET_PLATFORM
   };
   if (returnVal.activity_subtype === ActivitySubtype.Treatment_ChemicalPlant) {
     returnVal.form_data.activity_subtype_data.chemical_treatment_details = {


### PR DESCRIPTION
# Overview

- This PR adds a new column `platform_src` to the activity table to track the platform used when creating an activity.
- Verified data insertion from both Web and iPad platforms.
- Closes #4216 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

To test:
- Run database migrations.
- Create and submit a new activity.
- Verify that the platform_src column is correctly populated in the activity table.