### PR TITLE
[INV-4252] BUGFIX** use ArrayBuffer as fallback to .bytes()

### DIFF
--- a/app/src/UI/Features/LegacyMap/Map.tsx
+++ b/app/src/UI/Features/LegacyMap/Map.tsx
@@ -90,9 +90,18 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
       fetchRequest.headers.set('Authorization', await getCurrentJWT());
       const result = await fetch(fetchRequest);
       if (result.ok) {
-        return {
-          data: (await result?.bytes?.()) ?? (await result?.arrayBuffer?.()) ?? undefined
-        };
+        if (result.bytes) {
+          return {
+            data: await result.bytes()
+          };
+        } else if (result.arrayBuffer) {
+          return {
+            data: await result.arrayBuffer()
+          };
+        } else {
+          console.error('Unable to load response. Response object unreadable.');
+          return { data: undefined };
+        }
       }
       return {
         data: undefined
@@ -111,9 +120,18 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
 
         const result = await fetch(fetchRequest);
         if (result.ok) {
-          return {
-            data: (await result?.bytes?.()) ?? (await result?.arrayBuffer?.()) ?? undefined
-          };
+          if (result.bytes) {
+            return {
+              data: await result.bytes()
+            };
+          } else if (result.arrayBuffer) {
+            return {
+              data: await result.arrayBuffer()
+            };
+          } else {
+            console.error('Unable to load response. Response object unreadable.');
+            return { data: undefined };
+          }
         }
         return {
           data: undefined
@@ -125,9 +143,18 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
 
         const result = await fetch(fetchRequest);
         if (result.ok) {
-          return {
-            data: (await result?.bytes?.()) ?? (await result?.arrayBuffer?.()) ?? undefined
-          };
+          if (result.bytes) {
+            return {
+              data: await result.bytes()
+            };
+          } else if (result.arrayBuffer) {
+            return {
+              data: await result.arrayBuffer()
+            };
+          } else {
+            console.error('Unable to load response. Response object unreadable.');
+            return { data: undefined };
+          }
         }
         return {
           data: undefined

--- a/app/src/UI/Features/LegacyMap/Map.tsx
+++ b/app/src/UI/Features/LegacyMap/Map.tsx
@@ -91,7 +91,7 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
       const result = await fetch(fetchRequest);
       if (result.ok) {
         return {
-          data: await result.bytes()
+          data: (await result?.bytes?.()) ?? (await result?.arrayBuffer?.()) ?? undefined
         };
       }
       return {
@@ -112,7 +112,7 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
         const result = await fetch(fetchRequest);
         if (result.ok) {
           return {
-            data: await result.bytes()
+            data: (await result?.bytes?.()) ?? (await result?.arrayBuffer?.()) ?? undefined
           };
         }
         return {
@@ -126,7 +126,7 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
         const result = await fetch(fetchRequest);
         if (result.ok) {
           return {
-            data: await result.bytes()
+            data: (await result?.bytes?.()) ?? (await result?.arrayBuffer?.()) ?? undefined
           };
         }
         return {


### PR DESCRIPTION
> [!NOTE]
> For Consideration


# Overview

This PR includes the following proposed change(s):
- Use `.arrayBuffer()` as Fallback to `.bytes()` when not available.
- Closes #4252

## Background

Arraybuffer is long supported by many webviews and applications. bytes is an alternative with less support but better performance.

iOS 17.5 has an issue in its webview where `bytes()` is not supported, so attempts at handling our vector tiles and WMS layers fails and these never render on the page. in iOS 18 and above, this issue does not carry over to its WebView.

By adding `arrayBuffer`as a fallback, iOS 17.5 can properly handle these tile responses. 

This change is slightly moot if we continue to only support iOS 18 in the future. But its not impossible we see a resurgence of this issue.

## Why it Matters

- Given bytes having lower support, its possible we can run into this issue again in web, iOS, or Android. If that is the case, we will have already handled it with the wider supported ArrayBuffer. Since bytes is used first, this doesn't harm the current workings of using `bytes` as primary.