### PR TITLE
[INV-4256] Display Features on map click

### DIFF
--- a/app/src/UI/App.css
+++ b/app/src/UI/App.css
@@ -96,8 +96,14 @@ body {
   --success-green: #357a38;
   --warning-orange: #ffc107;
   --bc-yellow: #fcba19;
-  --blue-primary: #2196f3;
+  --blue-primary: #1976d2;
   --eigengrau: #16161d;
+  --popover-list-bg-color: #1e5189;
+
+  /* List Item Colors */
+  --even-list-item-bg-color: #eceae8;
+  --odd-list-item-bg-color: #fff;
+  --hovered-list-item-bg-color: #d1cfcd;
 }
 
 /* Color Classes */

--- a/app/src/UI/Features/LegacyMap/Map.tsx
+++ b/app/src/UI/Features/LegacyMap/Map.tsx
@@ -42,6 +42,7 @@ import { LayerComponent } from 'UI/Features/LegacyMap/helpers/components/LayerCo
 import { SourceCleanupComponent } from 'UI/Features/LegacyMap/helpers/components/SourceCleanupComponent';
 import { POSITIONING_LAYERS } from 'UI/Features/LegacyMap/helpers/functional/layer-definitions/positioning-layers';
 import { useInvasivesMapLayers } from 'UI/Features/LegacyMap/helpers/functional/layers-hook';
+import LayerDataMarker from './helpers/components/LayerDataMarker/LayerDataMarker';
 
 export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
   const { tileService: tileCache } = useContext(StartupContext);
@@ -395,6 +396,7 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
           ))}
 
           <PositionMarkers mapReady={mapReady} />
+          <LayerDataMarker />
           <CurrentActivityLayer mapReady={mapReady} />
           {loggedInOrWorkingOffline && (
             <LayerPicker layers={availableLayerDefinitions} setOverlayState={setOverlayState} />

--- a/app/src/UI/Features/LegacyMap/helpers/components/DrawControls.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/DrawControls.tsx
@@ -82,6 +82,7 @@ const DrawControls = () => {
     if (!features || features.length === 0 || features[0].geometry.type === GeoShapes.Point) return;
 
     isEditing.current = true;
+    map?.fire('draw.editshape', { active: isEditing.current });
     drawInstance?.current?.changeMode('direct_select', { featureId: features[0].id });
     dispatch(Alerts.create(mappingAlertMessages.saveActivityShape));
 
@@ -96,6 +97,7 @@ const DrawControls = () => {
     drawInstance.current?.changeMode('simple_select');
 
     const updatedFeature = drawInstance.current?.getAll().features[0];
+    map?.fire('draw.editshape', { active: isEditing.current });
     if (!updatedFeature || updatedFeature.geometry.type === GeoShapes.Point) return;
     dispatch(DrawToolActions.updateShape(updatedFeature));
 

--- a/app/src/UI/Features/LegacyMap/helpers/components/DrawControls.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/DrawControls.tsx
@@ -76,13 +76,19 @@ const DrawControls = () => {
 
   const isEditDisabled = ![TargetMode.ACTIVITY].includes(mode);
 
+  /**
+   * @desc Dispatch Custom event for when the Edit Button is used. Listened to by `LayerDataMarker.tsx`
+   */
+  const emitEdit = () => {
+    map?.fire('draw.editshape', { active: isEditing.current });
+  };
   const handleEdit = () => {
     const features = drawInstance.current?.getAll().features;
 
     if (!features || features.length === 0 || features[0].geometry.type === GeoShapes.Point) return;
 
     isEditing.current = true;
-    map?.fire('draw.editshape', { active: isEditing.current });
+    emitEdit();
     drawInstance?.current?.changeMode('direct_select', { featureId: features[0].id });
     dispatch(Alerts.create(mappingAlertMessages.saveActivityShape));
 
@@ -97,7 +103,7 @@ const DrawControls = () => {
     drawInstance.current?.changeMode('simple_select');
 
     const updatedFeature = drawInstance.current?.getAll().features[0];
-    map?.fire('draw.editshape', { active: isEditing.current });
+    emitEdit();
     if (!updatedFeature || updatedFeature.geometry.type === GeoShapes.Point) return;
     dispatch(DrawToolActions.updateShape(updatedFeature));
 

--- a/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarker.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarker.tsx
@@ -13,10 +13,11 @@ const LayerDataMarker = () => {
   const history = useHistory();
 
   const whatsHereEnabled = useSelector((state) => state.Map.whatsHere.toggle);
+  const connected = useSelector((state) => state.Network.connected);
 
-  const drawToolsActive = useRef<boolean>(false); //
+  const drawToolsActive = useRef<boolean>(false);
   const popupRef = useRef<Popup>();
-  const timeOfTouchStart = useRef<number>(0); //
+  const timeOfTouchStart = useRef<number>(0);
 
   const recordsetLayers = useMemo(() => {
     if (!map) return [];
@@ -45,7 +46,7 @@ const LayerDataMarker = () => {
   //
   const queryFeaturesAtTarget = useCallback(
     (e: MapMouseEvent | MapTouchEvent) => {
-      if (!map || drawToolsActive.current || map.getZoom() < MINIMUM_ZOOM || whatsHereEnabled) return;
+      if (!map || !connected || drawToolsActive.current || whatsHereEnabled || map.getZoom() < MINIMUM_ZOOM) return;
 
       const uniqueFormattedFeaturesAtClickTarget = Array.from(
         new Map(
@@ -90,7 +91,7 @@ const LayerDataMarker = () => {
       const root = ReactDOM.createRoot(el);
       root.render(<LayerDataMarkerContent history={history} features={uniqueFormattedFeaturesAtClickTarget} />);
     },
-    [map, recordsetLayers, popupRef, whatsHereEnabled]
+    [map, recordsetLayers, popupRef, whatsHereEnabled, connected]
   );
   /**
    * @desc Sets time touch event started at
@@ -131,7 +132,7 @@ const LayerDataMarker = () => {
       map.off('touchend', handleTouchEnd);
       popupRef?.current?.remove();
     };
-  }, [map?.isStyleLoaded(), whatsHereEnabled, recordsetLayers]);
+  }, [map?.isStyleLoaded(), whatsHereEnabled, recordsetLayers, connected]);
 
   return null;
 };

--- a/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarker.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarker.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
 import { MapContext } from '../MapContext';
-import { MapMouseEvent, MapTouchEvent, Popup } from 'maplibre-gl';
+import { MapMouseEvent, MapTouchEvent, Point, PointLike, Popup } from 'maplibre-gl';
 import ReactDOM from 'react-dom/client';
 import LayerDataMarkerContent from './LayerDataMarkerContent';
 import { useHistory } from 'react-router';
@@ -8,6 +8,7 @@ import { useSelector } from 'utils/use_selector';
 
 const LayerDataMarker = () => {
   const MINIMUM_ZOOM = 12;
+  const BUFFER_IN_PX = 5;
 
   const map = useContext(MapContext);
   const history = useHistory();
@@ -47,11 +48,15 @@ const LayerDataMarker = () => {
   const queryFeaturesAtTarget = useCallback(
     (e: MapMouseEvent | MapTouchEvent) => {
       if (!map || !connected || drawToolsActive.current || whatsHereEnabled || map.getZoom() < MINIMUM_ZOOM) return;
-
+      // Buffer target to avoid needing pinpoint accuracy
+      const bbox: [PointLike, PointLike] = [
+        new Point(e.point.x - BUFFER_IN_PX, e.point.y - BUFFER_IN_PX),
+        new Point(e.point.x + BUFFER_IN_PX, e.point.y + BUFFER_IN_PX)
+      ];
       const uniqueFormattedFeaturesAtClickTarget = Array.from(
         new Map(
           map
-            .queryRenderedFeatures(e.point, { layers: recordsetLayers })
+            .queryRenderedFeatures(bbox, { layers: recordsetLayers })
             .map((feature) => {
               const isInvasivesRecord = 'short_id' in feature.properties;
               return isInvasivesRecord

--- a/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarker.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarker.tsx
@@ -4,12 +4,20 @@ import { MapMouseEvent, MapTouchEvent, Popup } from 'maplibre-gl';
 import ReactDOM from 'react-dom/client';
 import LayerDataMarkerContent from './LayerDataMarkerContent';
 import { useHistory } from 'react-router';
+import { useSelector } from 'utils/use_selector';
 
 const LayerDataMarker = () => {
+  const MINIMUM_ZOOM = 12;
+
   const map = useContext(MapContext);
-  const popupRef = useRef<Popup>(); // Hold ref to prevent multiple appearing at once on Mobile
-  const touchTime = useRef<number>(0);
   const history = useHistory();
+
+  const whatsHereEnabled = useSelector((state) => state.Map.whatsHere.toggle);
+
+  const drawToolsActive = useRef<boolean>(false); //
+  const popupRef = useRef<Popup>();
+  const timeOfTouchStart = useRef<number>(0); //
+
   const recordsetLayers = useMemo(() => {
     if (!map) return [];
     return map
@@ -17,9 +25,27 @@ const LayerDataMarker = () => {
       .filter((layer) => layer.includes('recordset-layer-') || layer.includes('offline-activity'));
   }, [map?.getLayersOrder()]);
 
-  const queryFeaturesAtEpicenter = useCallback(
+  const createPopupDiv = (numFeatures: number): HTMLDivElement => {
+    /* 
+      Maplibre needs a static element for its popup so it can calculate the anchor position. Because we're injecting React in it can't calculate the size.
+      To make the anchoring work as expected, provide defaults based on its smallest size, else maplibre will calculate HxW at 0, and will frequently render outside the viewport
+    */
+    const BASE_CONTAINER_SIZE = 125; //in px
+    const SIZE_OF_ROW = 35; //in px
+    const BASE_CONTAINER_WIDTH = 210; //in px, Approximate width of smallest container size
+    const estPixelHeightOfPopover = BASE_CONTAINER_SIZE + Math.min(numFeatures, 3) * SIZE_OF_ROW;
+
+    const el = document.createElement('div');
+    el.style.minHeight = `${estPixelHeightOfPopover}px`;
+    el.style.minWidth = `${BASE_CONTAINER_WIDTH}px`;
+    el.className = 'map-features-root';
+    return el;
+  };
+
+  //
+  const queryFeaturesAtTarget = useCallback(
     (e: MapMouseEvent | MapTouchEvent) => {
-      if (!map) return;
+      if (!map || drawToolsActive.current || map.getZoom() < MINIMUM_ZOOM || whatsHereEnabled) return;
 
       const uniqueFormattedFeaturesAtClickTarget = Array.from(
         new Map(
@@ -47,14 +73,7 @@ const LayerDataMarker = () => {
 
       if (!uniqueFormattedFeaturesAtClickTarget?.length) return;
 
-      // Maplibre needs a static element for its markers. Because we're injecting React in. Estimate the size of the rendered container
-      // So the anchoring works as expected, else maplibre will calculate 0 for both, forcing items to render off screen.
-      const el = document.createElement('div');
-      const estPixelHeightOfPopover = 125 + Math.min(uniqueFormattedFeaturesAtClickTarget.length, 4) * 35;
-      el.style.minHeight = `${estPixelHeightOfPopover}px`;
-      el.style.minWidth = '220px';
-      el.style.backgroundColor = 'transparent';
-      el.className = 'map-features-root';
+      const el = createPopupDiv(uniqueFormattedFeaturesAtClickTarget.length);
 
       popupRef?.current?.remove(); // enforce singleton behaviour
       popupRef.current = new Popup({
@@ -70,40 +89,49 @@ const LayerDataMarker = () => {
       // Inject React into the new static container
       const root = ReactDOM.createRoot(el);
       root.render(<LayerDataMarkerContent history={history} features={uniqueFormattedFeaturesAtClickTarget} />);
-      popupRef.current.setDOMContent(el);
     },
-    [map, recordsetLayers, popupRef] // dependencies
+    [map, recordsetLayers, popupRef, whatsHereEnabled]
   );
   /**
    * @desc Sets time touch event started at
    */
   const handleTouchStart = useCallback((e: MapTouchEvent) => {
-    touchTime.current = e.originalEvent.timeStamp;
+    timeOfTouchStart.current = e.originalEvent.timeStamp;
   }, []);
 
   const handleTouchEnd = useCallback(
     (e: MapTouchEvent) => {
       const MAXIMUM_TOUCH_TIME = 125; // ms
-      if (e.originalEvent.timeStamp - touchTime.current < MAXIMUM_TOUCH_TIME) {
-        queryFeaturesAtEpicenter(e);
+      if (e.originalEvent.timeStamp - timeOfTouchStart.current < MAXIMUM_TOUCH_TIME) {
+        queryFeaturesAtTarget(e);
       }
     },
-    [queryFeaturesAtEpicenter]
+    [queryFeaturesAtTarget]
   );
+
+  /**
+   * @desc Updates with state of draw tools to prevent opening popup while user is attempting to draw.
+   *       uses Timeout to so event doesn't occur in the same tick as 'queryFeaturesAtEpicenter'
+   */
+  const handleDrawModeChanged = (e) => {
+    setTimeout(() => (drawToolsActive.current = e.mode !== 'simple_select'), 0);
+  };
 
   // Setup/teardown of react hooks. remove lingering popupRef if applicable.
   useEffect(() => {
     if (!map) return;
-    map.on('click', queryFeaturesAtEpicenter);
+    map.on('draw.modechange', handleDrawModeChanged);
+    map.on('click', queryFeaturesAtTarget);
     map.on('touchstart', handleTouchStart);
     map.on('touchend', handleTouchEnd);
     return () => {
-      map.off('click', queryFeaturesAtEpicenter);
+      map.off('draw.modechange', handleDrawModeChanged);
+      map.off('click', queryFeaturesAtTarget);
       map.off('touchstart', handleTouchStart);
       map.off('touchend', handleTouchEnd);
       popupRef?.current?.remove();
     };
-  }, [map?.isStyleLoaded()]);
+  }, [map?.isStyleLoaded(), whatsHereEnabled, recordsetLayers]);
 
   return null;
 };

--- a/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarker.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarker.tsx
@@ -1,0 +1,111 @@
+import { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import { MapContext } from '../MapContext';
+import { MapMouseEvent, MapTouchEvent, Popup } from 'maplibre-gl';
+import ReactDOM from 'react-dom/client';
+import LayerDataMarkerContent from './LayerDataMarkerContent';
+import { useHistory } from 'react-router';
+
+const LayerDataMarker = () => {
+  const map = useContext(MapContext);
+  const popupRef = useRef<Popup>(); // Hold ref to prevent multiple appearing at once on Mobile
+  const touchTime = useRef<number>(0);
+  const history = useHistory();
+  const recordsetLayers = useMemo(() => {
+    if (!map) return [];
+    return map
+      .getLayersOrder()
+      .filter((layer) => layer.includes('recordset-layer-') || layer.includes('offline-activity'));
+  }, [map?.getLayersOrder()]);
+
+  const queryFeaturesAtEpicenter = useCallback(
+    (e: MapMouseEvent | MapTouchEvent) => {
+      if (!map) return;
+
+      const uniqueFormattedFeaturesAtClickTarget = Array.from(
+        new Map(
+          map
+            .queryRenderedFeatures(e.point, { layers: recordsetLayers })
+            .map((feature) => {
+              const isInvasivesRecord = 'short_id' in feature.properties;
+              return isInvasivesRecord
+                ? {
+                    label: feature.properties.type,
+                    value: feature.properties.short_id,
+                    map_symbol: feature.properties.map_symbol,
+                    url: '/Records/Activity:' + feature.properties.activity_id + '/form'
+                  }
+                : {
+                    label: 'Site ID',
+                    value: feature.properties.site_id,
+                    map_symbol: feature.properties.map_symbol,
+                    url: '/Records/IAPP/' + feature.properties.site_id + '/summary'
+                  };
+            })
+            .map((obj) => [obj.value, obj])
+        ).values()
+      );
+
+      if (!uniqueFormattedFeaturesAtClickTarget?.length) return;
+
+      // Maplibre needs a static element for its markers. Because we're injecting React in. Estimate the size of the rendered container
+      // So the anchoring works as expected, else maplibre will calculate 0 for both, forcing items to render off screen.
+      const el = document.createElement('div');
+      const estPixelHeightOfPopover = 125 + Math.min(uniqueFormattedFeaturesAtClickTarget.length, 4) * 35;
+      el.style.minHeight = `${estPixelHeightOfPopover}px`;
+      el.style.minWidth = '220px';
+      el.style.backgroundColor = 'transparent';
+      el.className = 'map-features-root';
+
+      popupRef?.current?.remove(); // enforce singleton behaviour
+      popupRef.current = new Popup({
+        className: 'map-features-at-point',
+        maxWidth: 'none',
+        closeButton: true,
+        closeOnMove: true
+      })
+        .setLngLat(e.lngLat)
+        .setDOMContent(el)
+        .addTo(map);
+
+      // Inject React into the new static container
+      const root = ReactDOM.createRoot(el);
+      root.render(<LayerDataMarkerContent history={history} features={uniqueFormattedFeaturesAtClickTarget} />);
+      popupRef.current.setDOMContent(el);
+    },
+    [map, recordsetLayers, popupRef] // dependencies
+  );
+  /**
+   * @desc Sets time touch event started at
+   */
+  const handleTouchStart = useCallback((e: MapTouchEvent) => {
+    touchTime.current = e.originalEvent.timeStamp;
+  }, []);
+
+  const handleTouchEnd = useCallback(
+    (e: MapTouchEvent) => {
+      const MAXIMUM_TOUCH_TIME = 125; // ms
+      if (e.originalEvent.timeStamp - touchTime.current < MAXIMUM_TOUCH_TIME) {
+        queryFeaturesAtEpicenter(e);
+      }
+    },
+    [queryFeaturesAtEpicenter]
+  );
+
+  // Setup/teardown of react hooks. remove lingering popupRef if applicable.
+  useEffect(() => {
+    if (!map) return;
+    map.on('click', queryFeaturesAtEpicenter);
+    map.on('touchstart', handleTouchStart);
+    map.on('touchend', handleTouchEnd);
+    return () => {
+      map.off('click', queryFeaturesAtEpicenter);
+      map.off('touchstart', handleTouchStart);
+      map.off('touchend', handleTouchEnd);
+      popupRef?.current?.remove();
+    };
+  }, [map?.isStyleLoaded()]);
+
+  return null;
+};
+
+export default LayerDataMarker;

--- a/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarker.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarker.tsx
@@ -17,6 +17,8 @@ const LayerDataMarker = () => {
   const connected = useSelector((state) => state.Network.connected);
 
   const drawToolsActive = useRef<boolean>(false);
+  const editModeActive = useRef<boolean>(false);
+
   const popupRef = useRef<Popup>();
   const timeOfTouchStart = useRef<number>(0);
 
@@ -47,7 +49,8 @@ const LayerDataMarker = () => {
   //
   const queryFeaturesAtTarget = useCallback(
     (e: MapMouseEvent | MapTouchEvent) => {
-      if (!map || !connected || drawToolsActive.current || whatsHereEnabled || map.getZoom() < MINIMUM_ZOOM) return;
+      const isUserUtilizingDraw = drawToolsActive.current || whatsHereEnabled || editModeActive.current;
+      if (!map || !connected || isUserUtilizingDraw || map.getZoom() < MINIMUM_ZOOM) return;
       // Buffer target to avoid needing pinpoint accuracy
       const bbox: [PointLike, PointLike] = [
         new Point(e.point.x - BUFFER_IN_PX, e.point.y - BUFFER_IN_PX),
@@ -116,6 +119,11 @@ const LayerDataMarker = () => {
   );
 
   /**
+   * @desc Listen for custom 'draw.editshape' event to prevent displaying popover while user is actively editing
+   */
+  const handleEditShape = (e) => (editModeActive.current = e?.active);
+
+  /**
    * @desc Updates with state of draw tools to prevent opening popup while user is attempting to draw.
    *       uses Timeout to so event doesn't occur in the same tick as 'queryFeaturesAtEpicenter'
    */
@@ -126,11 +134,13 @@ const LayerDataMarker = () => {
   // Setup/teardown of react hooks. remove lingering popupRef if applicable.
   useEffect(() => {
     if (!map) return;
+    map.on('draw.editshape', handleEditShape);
     map.on('draw.modechange', handleDrawModeChanged);
     map.on('click', queryFeaturesAtTarget);
     map.on('touchstart', handleTouchStart);
     map.on('touchend', handleTouchEnd);
     return () => {
+      map.off('draw.editshape', handleEditShape);
       map.off('draw.modechange', handleDrawModeChanged);
       map.off('click', queryFeaturesAtTarget);
       map.off('touchstart', handleTouchStart);

--- a/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarkerContent.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarkerContent.tsx
@@ -1,0 +1,71 @@
+import LaunchIcon from '@mui/icons-material/Launch';
+import { IconButton } from '@mui/material';
+import './layerDataMarkerContent.css';
+import { Fragment } from 'react/jsx-runtime';
+import { ArrowCircleLeftOutlined, ArrowCircleRightOutlined, ArrowCircleRightRounded } from '@mui/icons-material';
+import { useState } from 'react';
+import { History } from 'history';
+
+type PropTypes = {
+  features: Array<{
+    label: string;
+    url: string;
+    value: string;
+    map_symbol: string;
+  }>;
+  history: History;
+};
+
+const LayerDataMarkerContent = ({ features, history }: PropTypes) => {
+  const STEP = 4;
+  const handleGoTo = (url: string) => history.push(url);
+  const inc = () => setFirstPos((oldPos) => Math.min(oldPos + STEP, features.length));
+  const dec = () => setFirstPos((oldPos) => Math.max(oldPos - STEP, 0));
+  const [firstPos, setFirstPos] = useState<number>(0);
+  const slicedFeatures = features.slice(firstPos, firstPos + STEP);
+  return (
+    <>
+      <div className="title">Records in Area</div>
+      <div className="content">
+        <table>
+          <thead>
+            <tr>
+              <th>Type</th>
+              <th>Record ID</th>
+              <th colSpan={2}>Map Symbol</th>
+              <th>
+                <Fragment />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {slicedFeatures.map(({ label, map_symbol, value, url }) => (
+              <tr key={value + map_symbol + label}>
+                <td>{label}</td>
+                <td>{value}</td>
+                <td>{map_symbol}</td>
+                <td>
+                  <IconButton onClick={handleGoTo.bind(this, url)}>
+                    <LaunchIcon />
+                  </IconButton>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="control">
+        <IconButton onClick={dec} disabled={firstPos <= 0}>
+          <ArrowCircleLeftOutlined />
+        </IconButton>
+        <p>
+          {firstPos + 1} to {Math.min(firstPos + STEP, features.length)} of {features.length} Records
+        </p>
+        <IconButton onClick={inc} disabled={firstPos + STEP >= features.length}>
+          <ArrowCircleRightOutlined />
+        </IconButton>
+      </div>
+    </>
+  );
+};
+export default LayerDataMarkerContent;

--- a/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarkerContent.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarkerContent.tsx
@@ -1,8 +1,7 @@
 import LaunchIcon from '@mui/icons-material/Launch';
 import { IconButton } from '@mui/material';
 import './layerDataMarkerContent.css';
-import { Fragment } from 'react/jsx-runtime';
-import { ArrowCircleLeftOutlined, ArrowCircleRightOutlined, ArrowCircleRightRounded } from '@mui/icons-material';
+import { ArrowCircleLeftOutlined, ArrowCircleRightOutlined } from '@mui/icons-material';
 import { useState } from 'react';
 import { History } from 'history';
 
@@ -17,7 +16,7 @@ type PropTypes = {
 };
 
 const LayerDataMarkerContent = ({ features, history }: PropTypes) => {
-  const STEP = 4;
+  const STEP = 3;
   const handleGoTo = (url: string) => history.push(url);
   const inc = () => setFirstPos((oldPos) => Math.min(oldPos + STEP, features.length));
   const dec = () => setFirstPos((oldPos) => Math.max(oldPos - STEP, 0));
@@ -33,9 +32,6 @@ const LayerDataMarkerContent = ({ features, history }: PropTypes) => {
               <th>Type</th>
               <th>Record ID</th>
               <th colSpan={2}>Map Symbol</th>
-              <th>
-                <Fragment />
-              </th>
             </tr>
           </thead>
           <tbody>

--- a/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/layerDataMarkerContent.css
+++ b/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/layerDataMarkerContent.css
@@ -20,6 +20,11 @@
     width: 100%;
     max-width: 100vw;
     box-sizing: border-box;
+
+    .map-features-root {
+      display: flex;
+      flex-direction: column;
+    }
   }
 
   .title {
@@ -37,6 +42,7 @@
   }
 
   .content {
+    display: flex;
     table {
       box-sizing: border-box;
       width: 100%;

--- a/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/layerDataMarkerContent.css
+++ b/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/layerDataMarkerContent.css
@@ -1,0 +1,109 @@
+.map-features-at-point {
+  .map-features-root {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-width: 100%;
+  }
+  /* max-width: 400px !important; */
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  .maplibregl-popup-close-button {
+    color: white;
+    font-size: 14pt;
+    &:focus {
+      outline: none;
+    }
+  }
+  .maplibregl-popup-tip {
+    display: none;
+  }
+
+  /* override default popup content settings */
+  .maplibregl-popup-content {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-width: 100vw;
+    box-sizing: border-box;
+  }
+
+  .title {
+    display: flex;
+    box-sizing: border-box;
+    width: 100%;
+    height: 45px;
+    align-items: center;
+    font-size: 1.2rem;
+    color: white;
+    border-bottom: 2pt solid var(--bc-yellow);
+    text-align: left;
+    padding: 0 0.75rem 0 0.5rem;
+    background-color: var(--popover-list-bg-color);
+  }
+
+  .content {
+    display: flex;
+    height: 100%;
+    flex-direction: column;
+    width: 100%;
+
+    table {
+      min-width: 245px;
+      font-size: 1rem;
+
+      border-collapse: collapse;
+      thead tr {
+        height: 35px;
+      }
+      tbody tr {
+        height: 40px;
+      }
+      /* Apply padding to first cell in each row */
+      th:first-of-type,
+      td:first-of-type {
+        padding-left: 8px;
+      }
+
+      /* Align all Cells text to left */
+      thead tr th,
+      tbody tr td {
+        text-align: left;
+      }
+      tr {
+        font-size: 0.85rem;
+      }
+      /* Style for First Cell per row (Type) */
+      tbody tr td:nth-child(1) {
+        font-size: 0.95rem;
+        font-weight: 500;
+      }
+
+      /* Align IconButtons to Right, maximize space */
+      thead tr th:last-child,
+      tbody tr td:last-child {
+        text-align: right;
+      }
+      /* Alternate Background colours */
+      tbody tr {
+        background-color: var(--even-list-item-bg-color);
+      }
+      tbody tr:nth-of-type(even) {
+        background-color: var(--odd-list-item-bg-color);
+      }
+      tbody tr:hover {
+        background-color: var(--hovered-list-item-bg-color);
+      }
+    }
+  }
+  .control {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    margin-top: auto;
+  }
+}

--- a/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/layerDataMarkerContent.css
+++ b/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/layerDataMarkerContent.css
@@ -1,14 +1,5 @@
 .map-features-at-point {
-  .map-features-root {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    max-width: 100%;
-  }
-  /* max-width: 400px !important; */
-  display: flex;
-  flex-direction: column;
-  box-sizing: border-box;
+  z-index: 3; /* Position over map buttons and under overlay pane*/
   .maplibregl-popup-close-button {
     color: white;
     font-size: 14pt;
@@ -17,7 +8,7 @@
     }
   }
   .maplibregl-popup-tip {
-    display: none;
+    display: none; /* Don't display popup tail. */
   }
 
   /* override default popup content settings */
@@ -46,15 +37,11 @@
   }
 
   .content {
-    display: flex;
-    height: 100%;
-    flex-direction: column;
-    width: 100%;
-
     table {
-      min-width: 245px;
-      font-size: 1rem;
-
+      box-sizing: border-box;
+      width: 100%;
+      max-width: 375px; /* Set max-size so large sets of map-Symbols will be forced to collapse */
+      border-bottom: 1pt solid #dedede;
       border-collapse: collapse;
       thead tr {
         height: 35px;
@@ -66,6 +53,11 @@
       th:first-of-type,
       td:first-of-type {
         padding-left: 8px;
+      }
+      /* And to last header cell */
+      thead tr th:last-child {
+        padding-right: 8pt;
+        box-sizing: border-box;
       }
 
       /* Align all Cells text to left */
@@ -83,19 +75,19 @@
       }
 
       /* Align IconButtons to Right, maximize space */
-      thead tr th:last-child,
       tbody tr td:last-child {
         text-align: right;
       }
+
       /* Alternate Background colours */
       tbody tr {
         background-color: var(--even-list-item-bg-color);
-      }
-      tbody tr:nth-of-type(even) {
-        background-color: var(--odd-list-item-bg-color);
-      }
-      tbody tr:hover {
-        background-color: var(--hovered-list-item-bg-color);
+        &:nth-of-type(even) {
+          background-color: var(--odd-list-item-bg-color);
+        }
+        &:hover {
+          background-color: var(--hovered-list-item-bg-color);
+        }
       }
     }
   }

--- a/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/layerDataMarkerContent.css
+++ b/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/layerDataMarkerContent.css
@@ -46,9 +46,6 @@
       thead tr {
         height: 35px;
       }
-      tbody tr {
-        height: 40px;
-      }
       /* Apply padding to first cell in each row */
       th:first-of-type,
       td:first-of-type {
@@ -79,8 +76,9 @@
         text-align: right;
       }
 
-      /* Alternate Background colours */
       tbody tr {
+        height: 40px;
+        /* Alternate Background colours */
         background-color: var(--even-list-item-bg-color);
         &:nth-of-type(even) {
           background-color: var(--odd-list-item-bg-color);

--- a/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
@@ -298,7 +298,9 @@ const createOfflineActivitiesLayer = async (
             ...parsedData.geometry[0],
             properties: {
               short_id: parsedData.short_id,
-              map_symbol: plantCodes
+              map_symbol: plantCodes,
+              activity_id: parsedData.activity_id,
+              type: parsedData.activity_type
             }
           };
         }

--- a/app/src/UI/Layout/OverlayLayout/Header/Mobile/MobileHeader.css
+++ b/app/src/UI/Layout/OverlayLayout/Header/Mobile/MobileHeader.css
@@ -1,5 +1,4 @@
 :root:has(#app.overlay-layout) {
-
   #nav-header {
     align-items: center;
     box-sizing: border-box;
@@ -12,7 +11,6 @@
     left: 0;
     top: 0;
     right: 0;
-
 
     .invasives-bc-logo {
       height: calc(var(--header-bar-height) - 5pt);
@@ -105,11 +103,11 @@
       }
 
       li:nth-child(even) {
-        background-color: #eceae8;
+        background-color: var(--even-list-item-bg-color);
       }
 
       li:nth-child(odd) {
-        background-color: #fff;
+        background-color: var(--odd-list-item-bg-color);
       }
 
       li > button {
@@ -134,7 +132,7 @@
 
         &:hover {
           cursor: pointer;
-          background-color: #d1cfcd;
+          background-color: var(--hovered-list-item-bg-color);
         }
       }
 
@@ -150,5 +148,4 @@
       font-size: 1rem;
     }
   }
-
 }


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Create two new Components
    - *LayerDataMarker.tsx* `Controller` for the Popover. holds event listeners
    - *LayerDataMarkerContent.tsx* `View` for Popover.
- Modify Offline Activities layers to imitate tiles in vector layer. 
- Move some CSS colour values into app.css, refactor accordingly.
- Emit custom event from Edit Button

Add new feature that shows metadata for Recordset vectors with a single click. Users will be able to see the type of record, ID, and Map Symbols (pulled from current vector data). Users can also open a record quickly this way.

The Popover will not interrupt active map work, such as using `Whats Here` or drawing any shapes with the draw tools.
The Popover appears when at zoom level 12 or greater

> [!IMPORTANT]
> Currently this feature only works while online. Since the geojson work is being replaced very soon with PMTiles, it will be revisited for feasability after that is implemented 

Since maplibre doesn't have a native 'touch' event, and instead has start/end ones. the events mock a touch by using a `time between` on the two events. ensuring regular device usage doesn't get interrupted by popups.

- Closes #4256

## Screenshots

<img width="368" height="319" alt="image" src="https://github.com/user-attachments/assets/126db423-5591-4f52-a427-9aeef90c89ae" />

[Feature highlighting ]

<img width="342" height="299" alt="image" src="https://github.com/user-attachments/assets/697b67db-5ee9-4a56-ac4b-4e8cc09cc1ae" />

[Many features in result]