### PR TITLE
[INV-4258] Get IDs Dynamically for Recordset Caching

### DIFF
--- a/app/src/state/actions/cache/RecordCache.ts
+++ b/app/src/state/actions/cache/RecordCache.ts
@@ -6,6 +6,7 @@ import { getRecordFilterObjectFromStateForAPI } from 'state/sagas/map/dataAccess
 import getBoundingBoxFromRecordsetFilters from 'utils/getBoundingBoxFromRecordsetFilters';
 import { CacheDownloadMode, RecordCacheProgressCallbackParameters } from 'utils/record-cache';
 import { RecordCacheServiceFactory } from 'utils/record-cache/context';
+import getIdsForRecordset from 'utils/getIdsForRecordset';
 
 class RecordCache {
   static readonly PREFIX = 'RecordCache';
@@ -55,12 +56,15 @@ class RecordCache {
 
       const service = await RecordCacheServiceFactory.getPlatformInstance();
       const recordSet = JSON.parse(JSON.stringify(state.UserSettings.recordSets[spec.setId]));
-      const idsToCache: string[] = recordSet.idList.map((id) => id.toString());
+      const idsMatchingFilterSet = await getIdsForRecordset({
+        recordSetType: recordSet.recordSetType,
+        tableFilters: recordSet.tableFilters
+      });
+      const idsToCache = idsMatchingFilterSet.map((id) => id.toString());
 
       recordSet.tableFilters = getRecordFilterObjectFromStateForAPI(spec.setId, state.UserSettings);
 
       const bbox = await getBoundingBoxFromRecordsetFilters(recordSet);
-
       const downloadMode: CacheDownloadMode = await service.download(
         {
           API_BASE: state.Configuration.current.runtime.API_BASE,

--- a/app/src/utils/getIdsForRecordset.ts
+++ b/app/src/utils/getIdsForRecordset.ts
@@ -1,0 +1,46 @@
+import { RecordSetType } from 'interfaces/UserRecordSet';
+import { IFilter } from 'state/actions/userSettings/RecordSet';
+import { getCurrentJWT } from 'state/sagas/auth/auth';
+
+type Options = {
+  recordSetType: RecordSetType;
+  tableFilters: Array<IFilter>;
+};
+/**
+ * @desc Get list of all IDs from a recordset using current filters.
+ * @returns {Array<string | number>} Ids for all records matching params for a user with read permissions.
+ */
+const getIdsForRecordset = async (options: Options): Promise<Array<string | number>> => {
+  const { recordSetType, tableFilters } = options;
+  const config = (() => {
+    switch (recordSetType) {
+      case RecordSetType.IAPP:
+        return {
+          url: `${CONFIGURATION_API_BASE}/api/v2/IAPP`,
+          col: 'site_id'
+        };
+      case RecordSetType.Activity:
+        return {
+          url: `${CONFIGURATION_API_BASE}/api/v2/activities/`,
+          col: 'activity_id'
+        };
+    }
+  })();
+
+  const filterObjects = { selectColumns: [config.col], tableFilters, limit: 999999 };
+  const res = await fetch(config.url, {
+    method: 'POST',
+    headers: { Authorization: await getCurrentJWT(), 'Content-Type': 'application/json' },
+    body: JSON.stringify({ filterObjects: [filterObjects] })
+  });
+
+  if (res?.ok) {
+    const data = await res.json();
+    const ids = data.result.map((id) => id[config.col]);
+    console.log(ids);
+    return ids;
+  }
+  return [];
+};
+
+export default getIdsForRecordset;


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

Fetch Recordset IDs dynamically

- Create Recordset agnostic Util for getting Recordset Ids (Previously linked between two separate functions and flows)
- When caching a recordset, dynamically get the list of Ids that will be cached (don't rely on potentially stale state).
- Closes #4258 


When a Recordset is being cached, the IDs to be cached will be generated at request time instead of relying on the state of the recordset. This helps close a loop where a user will Update a filter and request caching before the ID list is updated, and so the original IDList is used. This issue is expected to have primarily affected users with Lagging devices or slow internet speeds. 
