### PR TITLE
[INV-4262] Refactor Sync Status UI Changes

### DIFF
--- a/app/src/UI/Features/OfflineDataSync/OfflineDataSync.css
+++ b/app/src/UI/Features/OfflineDataSync/OfflineDataSync.css
@@ -55,7 +55,6 @@
       text-align: center;
       button {
         height: 50px;
-        width: 100%;
         border-radius: 0;
         width: 200pt;
       }

--- a/app/src/UI/Features/OfflineDataSync/OfflineDataSync.css
+++ b/app/src/UI/Features/OfflineDataSync/OfflineDataSync.css
@@ -1,32 +1,80 @@
-#offline-data-sync-dialog {
-  .dialog-content {
+.offline-data-sync-dialog {
+  .content {
     padding: 1rem 10pt;
   }
 
-  .dialog-header {
-    align-items: center;
-    background-color: var(--bc-blue);
-    border-bottom: 3pt solid var(--bc-yellow);
-    display: flex;
-    height: 40pt;
-    justify-content: space-between;
-    padding-left: 10pt;
+  .content {
+    .dialog-table {
+      height: auto;
+      margin: 10pt;
+      max-height: 375px;
+      overflow: auto;
 
-    button {
-      color: white;
+      .offline-data-sync-table {
+        border-collapse: collapse;
+
+        th {
+          background-color: white;
+          position: sticky;
+          text-align: left;
+          top: 0;
+          z-index: 2;
+        }
+
+        tbody > tr:nth-child(odd):not(:hover) {
+          background-color: #eee;
+        }
+        tbody tr td {
+          vertical-align: top;
+          font-size: 0.95rem;
+          &:first-child {
+            padding-left: 8px;
+          }
+        }
+        tbody tr .modified-time {
+          font-weight: 600;
+          font-size: 0.85rem;
+        }
+        tbody tr .record-type {
+          font-size: 0.85rem;
+        }
+        tbody > tr > td:last-child {
+          text-align: right;
+        }
+
+        tbody > tr:hover {
+          background-color: #c9f2ef95;
+        }
+      }
     }
-  }
+    .progress-bar {
+      margin-bottom: 10px;
+      margin-top: 10px;
+    }
 
-  .dialog-table {
-    height: auto;
-    margin: 10pt;
-    max-height: 375pt;
-    overflow: auto;
-  }
-
-  h2 {
-    color: white;
-    padding: 0;
+    .popover-menu {
+      display: flex;
+      flex-direction: column;
+      color: white;
+      background-color: var(--bc-blue);
+      text-align: center;
+      button {
+        height: 50px;
+        width: 100%;
+        border-radius: 0;
+        width: 200pt;
+      }
+    }
+    .status-info {
+      margin: 1rem;
+      p {
+        font-size: 1rem;
+        margin: 0 0 8px 0;
+        span {
+          font-size: 0.9rem;
+        }
+      }
+    }
   }
 
   .control {
@@ -39,36 +87,10 @@
   }
 }
 
-.offlineDataSyncTable {
-  border-collapse: collapse;
-
-  th {
-    background-color: white;
-    position: sticky;
-    text-align: left;
-    top: 0;
-    z-index: 2;
+@media screen and (width < 600px) {
+  .offline-data-sync-dialog {
+    .content .dialog-table {
+      margin: 0;
+    }
   }
-
-  tbody > tr:nth-child(odd):not(:hover) {
-    background-color: #eee;
-  }
-
-  tbody > tr > td:last-child {
-    text-align: right;
-  }
-
-  tbody > tr:hover {
-    background-color: #c9f2ef95;
-  }
-}
-
-.progressBar {
-  margin-bottom: 10px;
-  margin-top: 10px;
-}
-
-.syncDisabledMessage {
-  color: var(--deep-red);
-  padding: 0 1rem;
 }

--- a/app/src/UI/Features/OfflineDataSync/OfflineDataSync.css
+++ b/app/src/UI/Features/OfflineDataSync/OfflineDataSync.css
@@ -1,12 +1,7 @@
 .offline-data-sync-dialog {
   .content {
-    padding: 1rem 10pt;
-  }
-
-  .content {
     .dialog-table {
       height: auto;
-      margin: 10pt;
       max-height: 375px;
       overflow: auto;
 

--- a/app/src/UI/Features/OfflineDataSync/OfflineDataSyncDialog.tsx
+++ b/app/src/UI/Features/OfflineDataSync/OfflineDataSyncDialog.tsx
@@ -1,13 +1,12 @@
-import { Dialog, DialogTitle, IconButton } from '@mui/material';
 import { selectOfflineActivity } from 'state/reducers/offlineActivity';
 import { useSelector } from 'utils/use_selector';
 import { useDispatch } from 'react-redux';
 import { OfflineDataSyncTable } from 'UI/Features/OfflineDataSync/OfflineDataSyncTable';
-import { Close } from '@mui/icons-material';
 import 'UI/Features/OfflineDataSync/OfflineDataSync.css';
 import { useEffect } from 'react';
 import { AuthActions } from 'state/actions/auth/Auth';
 import Activity from 'state/actions/activity/Activity';
+import StyledModal from 'UI/Reusable/StyledModal/StyledModal';
 
 export const OfflineDataSyncDialog = () => {
   const { statusDialogOpen } = useSelector(selectOfflineActivity);
@@ -22,16 +21,9 @@ export const OfflineDataSyncDialog = () => {
   }, [statusDialogOpen]);
 
   return (
-    <Dialog open={statusDialogOpen} id="offline-data-sync-dialog" maxWidth={'xl'} onClose={handleClose}>
-      <div className="dialog-header">
-        <DialogTitle>Offline Sync Status</DialogTitle>
-        <IconButton color="inherit" onClick={handleClose}>
-          <Close />
-        </IconButton>
-      </div>
-      <div className="dialog-content">
-        <OfflineDataSyncTable />
-      </div>
-    </Dialog>
+    <StyledModal open={statusDialogOpen} className="offline-data-sync-dialog" onClose={handleClose}>
+      <div className="header">Offline Sync Status</div>
+      <OfflineDataSyncTable handleClose={handleClose} />
+    </StyledModal>
   );
 };

--- a/app/src/UI/Features/OfflineDataSync/OfflineDataSyncTable.tsx
+++ b/app/src/UI/Features/OfflineDataSync/OfflineDataSyncTable.tsx
@@ -18,7 +18,9 @@ export const OfflineDataSyncTable = ({ handleClose }: PropTypes) => {
   const working = useSelector((state) => state.OfflineActivity.working);
   const { authenticated, workingOffline } = useSelector((state) => state.Auth);
   const connected = useSelector((state) => state.Network.connected);
-  const [syncDisabled, setSyncDisabled] = useState(false);
+
+  const [syncDisabled, setSyncDisabled] = useState<boolean>(false);
+  const [confirmDelete, setConfirmDelete] = useState<boolean>(false);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [contextRecord, setContextRecord] = useState<string>();
 
@@ -53,7 +55,12 @@ export const OfflineDataSyncTable = ({ handleClose }: PropTypes) => {
   }
   const handleDelete = () => {
     if (!contextRecord) return;
-    dispatch(Activity.Offline.delete(contextRecord));
+    if (confirmDelete) {
+      dispatch(Activity.Offline.delete(contextRecord));
+      setConfirmDelete(false);
+    } else {
+      setConfirmDelete(true);
+    }
   };
   const handleLoad = () => {
     if (!contextRecord) return;
@@ -63,6 +70,7 @@ export const OfflineDataSyncTable = ({ handleClose }: PropTypes) => {
   const handleOpenMenu = (evt: MouseEvent<any> | TouchEvent<any>, key: string) => {
     setAnchorEl(evt.currentTarget);
     setContextRecord(key);
+    setConfirmDelete(false);
   };
   return (
     <>
@@ -74,8 +82,8 @@ export const OfflineDataSyncTable = ({ handleClose }: PropTypes) => {
               <Button variant="contained" disabled={!(workingOffline || authenticated)} onClick={handleLoad}>
                 Open
               </Button>
-              <Button variant="contained" onClick={handleDelete} color="primary">
-                Delete Locally
+              <Button variant="contained" onClick={handleDelete} color={confirmDelete ? 'error' : 'primary'}>
+                {confirmDelete ? 'Are you sure?' : 'Delete Locally'}
               </Button>
             </div>
           </CustomPopover>

--- a/app/src/UI/Features/OfflineDataSync/OfflineDataSyncTable.tsx
+++ b/app/src/UI/Features/OfflineDataSync/OfflineDataSyncTable.tsx
@@ -1,21 +1,26 @@
-import React, { Fragment, useEffect, useMemo, useState } from 'react';
+import { Fragment, MouseEvent, TouchEvent, useEffect, useMemo, useState } from 'react';
 import { Button, IconButton, LinearProgress } from '@mui/material';
 import { OfflineActivityRecord, OfflineActivitySyncState, selectOfflineActivity } from 'state/reducers/offlineActivity';
 import { useSelector } from 'utils/use_selector';
 import { useDispatch } from 'react-redux';
-import Delete from '@mui/icons-material/Delete';
 import 'UI/Features/OfflineDataSync/OfflineDataSync.css';
 import moment from 'moment';
-import { FileOpen } from '@mui/icons-material';
+import { MoreVert } from '@mui/icons-material';
 import { ActivitySubtypeShortLabels } from 'sharedAPI';
 import { useHistory } from 'react-router-dom';
 import Activity from 'state/actions/activity/Activity';
+import CustomPopover from 'UI/Reusable/CustomPopover/CustomPopover';
 
-export const OfflineDataSyncTable = () => {
+type PropTypes = {
+  handleClose: () => void;
+};
+export const OfflineDataSyncTable = ({ handleClose }: PropTypes) => {
   const { working, serializedActivities } = useSelector(selectOfflineActivity);
   const { authenticated, workingOffline } = useSelector((state) => state.Auth);
   const connected = useSelector((state) => state.Network.connected);
   const [syncDisabled, setSyncDisabled] = useState(false);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [contextRecord, setContextRecord] = useState<string>();
 
   const numUnsynchronizedRecords = useMemo(
     () =>
@@ -46,88 +51,99 @@ export const OfflineDataSyncTable = () => {
   if (Object.values(serializedActivities).length === 0) {
     return <p>There are no locally-stored activities to synchronize.</p>;
   }
-
+  const handleDelete = () => {
+    if (!contextRecord) return;
+    dispatch(Activity.Offline.delete(contextRecord));
+  };
+  const handleLoad = () => {
+    if (!contextRecord) return;
+    history.push(`/Records/Activity:${contextRecord}/form`);
+    dispatch(Activity.Offline.setSyncDialogueWindow({ open: false }));
+  };
+  const handleOpenMenu = (evt: MouseEvent<any> | TouchEvent<any>, key: string) => {
+    setAnchorEl(evt.currentTarget);
+    setContextRecord(key);
+  };
   return (
     <>
-      <div className="dialog-table">
-        <table className={'offlineDataSyncTable'}>
-          <thead>
-            <tr>
-              <th>Load</th>
-              <th>Activity</th>
-              <th>Record Type</th>
-              <th>Locally Modified</th>
-              <th>Status</th>
-              <th>Delete Local</th>
-            </tr>
-          </thead>
-          <tbody>
-            {Object.entries(serializedActivities).map(([key, value]) => {
-              return (
-                <React.Fragment key={key}>
-                  <tr>
-                    <td>
-                      <IconButton
-                        disabled={!(workingOffline || authenticated)}
-                        color="primary"
-                        onClick={() => {
-                          history.push(`/Records/Activity:${key}/form`);
-                          dispatch(Activity.Offline.setSyncDialogueWindow({ open: false }));
-                        }}
-                      >
-                        <FileOpen />
-                      </IconButton>
-                    </td>
-                    <td>{`${(value as OfflineActivityRecord).short_id}`}</td>
-                    <td>{`${ActivitySubtypeShortLabels[(value as OfflineActivityRecord).record_type] || 'Unknown'}`}</td>
-                    <td>{`${moment((value as OfflineActivityRecord).saved_at)}`}</td>
-                    <td>{`${(value as OfflineActivityRecord).sync_state}`}</td>
-                    <td>
-                      <IconButton
-                        onClick={() => {
-                          dispatch(Activity.Offline.delete(key));
-                        }}
-                        color="primary"
-                      >
-                        <Delete />
-                      </IconButton>
-                    </td>
-                  </tr>
-                  {(value as OfflineActivityRecord).sync_state == 'Error' && (
+      <div className="content">
+        {contextRecord && (
+          <CustomPopover buttonOverrideOptions={{ anchorEl, setAnchorEl }} disablePortal>
+            <div className="popover-menu">
+              <p>Activity: {serializedActivities?.[contextRecord]?.short_id}</p>
+              <Button variant="contained" disabled={!(workingOffline || authenticated)} onClick={handleLoad}>
+                Open
+              </Button>
+              <Button variant="contained" onClick={handleDelete} color="primary">
+                Delete Locally
+              </Button>
+            </div>
+          </CustomPopover>
+        )}
+        <div className="dialog-table">
+          <table className={'offline-data-sync-table'}>
+            <thead>
+              <tr>
+                <th>Activity</th>
+                <th>Record Type</th>
+                <th>Last Modified</th>
+                <th colSpan={2}>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Object.entries(serializedActivities).map(([key, value]) => {
+                return (
+                  <Fragment key={key}>
                     <tr>
-                      <td>
-                        <Fragment />
+                      <td>{`${(value as OfflineActivityRecord).short_id}`}</td>
+                      <td className="record-type">{`${ActivitySubtypeShortLabels[(value as OfflineActivityRecord).record_type] || 'Unknown'}`}</td>
+                      <td className="modified-time">
+                        {`${moment((value as OfflineActivityRecord).saved_at)
+                          .startOf('hour')
+                          .fromNow()}`}
                       </td>
+                      <td className="sync-status">{`${(value as OfflineActivityRecord).sync_state}`}</td>
                       <td>
-                        {(value as OfflineActivityRecord).error_detail
-                          ? (value as OfflineActivityRecord).error_detail
-                          : 'Error'}
-                      </td>
-                      <td colSpan={4}>
-                        <pre>
-                          {(value as OfflineActivityRecord).error_object?.hasOwnProperty('message')
-                            ? JSON.stringify((value as OfflineActivityRecord).error_object?.message)
-                            : JSON.stringify((value as OfflineActivityRecord).error_object)}
-                        </pre>
+                        <IconButton onClick={(e) => handleOpenMenu(e, key)}>
+                          <MoreVert />
+                        </IconButton>
                       </td>
                     </tr>
-                  )}
-                </React.Fragment>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-      <div className="status-info">
-        {syncDisabled && numUnsynchronizedRecords > 0 && (
-          <p>Synchronization requires that you be online and authenticated.</p>
-        )}
-        <p>
-          Unsynced Records: <span>{numUnsynchronizedRecords}</span>
-        </p>
-        {working && <LinearProgress className={'progressBar'} />}
+                    {(value as OfflineActivityRecord).sync_state == 'Error' && (
+                      <tr>
+                        <td>
+                          <Fragment />
+                        </td>
+                        <td>
+                          {(value as OfflineActivityRecord).error_detail
+                            ? (value as OfflineActivityRecord).error_detail
+                            : 'Error'}
+                        </td>
+                        <td colSpan={4}>
+                          <pre>
+                            {(value as OfflineActivityRecord).error_object?.hasOwnProperty('message')
+                              ? JSON.stringify((value as OfflineActivityRecord).error_object?.message)
+                              : JSON.stringify((value as OfflineActivityRecord).error_object)}
+                          </pre>
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+        <div className="status-info">
+          <p>
+            Unsynced Records: <span>{numUnsynchronizedRecords}</span>
+          </p>
+          {!connected && <p className="deep-red">Synchronization requires that you be online and authenticated.</p>}
+          {working && <LinearProgress className={'progress-bar'} />}
+        </div>
       </div>
       <div className="control">
+        <Button onClick={handleClose}>Close</Button>
         <Button
           disabled={syncDisabled}
           variant={'contained'}

--- a/app/src/UI/Features/OfflineDataSync/OfflineDataSyncTable.tsx
+++ b/app/src/UI/Features/OfflineDataSync/OfflineDataSyncTable.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Button, IconButton, LinearProgress } from '@mui/material';
-import { OfflineActivityRecord, selectOfflineActivity } from 'state/reducers/offlineActivity';
+import { OfflineActivityRecord, OfflineActivitySyncState, selectOfflineActivity } from 'state/reducers/offlineActivity';
 import { useSelector } from 'utils/use_selector';
 import { useDispatch } from 'react-redux';
 import Delete from '@mui/icons-material/Delete';
@@ -17,12 +17,22 @@ export const OfflineDataSyncTable = () => {
   const connected = useSelector((state) => state.Network.connected);
   const [syncDisabled, setSyncDisabled] = useState(false);
 
+  const isThereUnsynchronizedRecords = useMemo(
+    () =>
+      Object.keys(serializedActivities).some(
+        (key: PropertyKey) => serializedActivities[key]?.sync_state !== OfflineActivitySyncState.SYNCHRONIZED
+      ),
+    [serializedActivities]
+  );
+
   const history = useHistory();
 
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if (working) {
+    if (!isThereUnsynchronizedRecords) {
+      setSyncDisabled(true); // We have nothing to sync!
+    } else if (working) {
       setSyncDisabled(true);
     } else if (workingOffline || !authenticated) {
       setSyncDisabled(true);
@@ -31,7 +41,7 @@ export const OfflineDataSyncTable = () => {
     } else {
       setSyncDisabled(false);
     }
-  }, [working, workingOffline, authenticated, connected]);
+  }, [working, workingOffline, authenticated, connected, isThereUnsynchronizedRecords]);
 
   if (Object.values(serializedActivities).length === 0) {
     return <p>There are no locally-stored activities to synchronize.</p>;

--- a/app/src/UI/Features/OfflineDataSync/OfflineDataSyncTable.tsx
+++ b/app/src/UI/Features/OfflineDataSync/OfflineDataSyncTable.tsx
@@ -1,8 +1,7 @@
 import { Fragment, MouseEvent, TouchEvent, useEffect, useMemo, useState } from 'react';
 import { Button, IconButton, LinearProgress } from '@mui/material';
-import { OfflineActivityRecord, OfflineActivitySyncState, selectOfflineActivity } from 'state/reducers/offlineActivity';
-import { useSelector } from 'utils/use_selector';
-import { useDispatch } from 'react-redux';
+import { OfflineActivityRecord, OfflineActivitySyncState } from 'state/reducers/offlineActivity';
+import { useDispatch, useSelector } from 'utils/use_selector';
 import 'UI/Features/OfflineDataSync/OfflineDataSync.css';
 import moment from 'moment';
 import { MoreVert } from '@mui/icons-material';
@@ -15,7 +14,8 @@ type PropTypes = {
   handleClose: () => void;
 };
 export const OfflineDataSyncTable = ({ handleClose }: PropTypes) => {
-  const { working, serializedActivities } = useSelector(selectOfflineActivity);
+  const serializedActivities = useSelector((state) => state.OfflineActivity.serializedActivities);
+  const working = useSelector((state) => state.OfflineActivity.working);
   const { authenticated, workingOffline } = useSelector((state) => state.Auth);
   const connected = useSelector((state) => state.Network.connected);
   const [syncDisabled, setSyncDisabled] = useState(false);
@@ -98,9 +98,7 @@ export const OfflineDataSyncTable = ({ handleClose }: PropTypes) => {
                       <td>{`${(value as OfflineActivityRecord).short_id}`}</td>
                       <td className="record-type">{`${ActivitySubtypeShortLabels[(value as OfflineActivityRecord).record_type] || 'Unknown'}`}</td>
                       <td className="modified-time">
-                        {`${moment((value as OfflineActivityRecord).saved_at)
-                          .startOf('hour')
-                          .fromNow()}`}
+                        {`${moment((value as OfflineActivityRecord).saved_at).fromNow()}`}
                       </td>
                       <td className="sync-status">{`${(value as OfflineActivityRecord).sync_state}`}</td>
                       <td>

--- a/app/src/UI/Features/OfflineDataSync/OfflineDataSyncTable.tsx
+++ b/app/src/UI/Features/OfflineDataSync/OfflineDataSyncTable.tsx
@@ -109,9 +109,7 @@ export const OfflineDataSyncTable = ({ handleClose }: PropTypes) => {
                     </tr>
                     {(value as OfflineActivityRecord).sync_state == 'Error' && (
                       <tr>
-                        <td>
-                          <Fragment />
-                        </td>
+                        <td></td>
                         <td>
                           {(value as OfflineActivityRecord).error_detail
                             ? (value as OfflineActivityRecord).error_detail

--- a/app/src/UI/Features/OfflineDataSync/OfflineDataSyncTable.tsx
+++ b/app/src/UI/Features/OfflineDataSync/OfflineDataSyncTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { Fragment, useEffect, useMemo, useState } from 'react';
 import { Button, IconButton, LinearProgress } from '@mui/material';
 import { OfflineActivityRecord, OfflineActivitySyncState, selectOfflineActivity } from 'state/reducers/offlineActivity';
 import { useSelector } from 'utils/use_selector';
@@ -17,11 +17,11 @@ export const OfflineDataSyncTable = () => {
   const connected = useSelector((state) => state.Network.connected);
   const [syncDisabled, setSyncDisabled] = useState(false);
 
-  const isThereUnsynchronizedRecords = useMemo(
+  const numUnsynchronizedRecords = useMemo(
     () =>
-      Object.keys(serializedActivities).some(
+      Object.keys(serializedActivities).filter(
         (key: PropertyKey) => serializedActivities[key]?.sync_state !== OfflineActivitySyncState.SYNCHRONIZED
-      ),
+      ).length,
     [serializedActivities]
   );
 
@@ -30,7 +30,7 @@ export const OfflineDataSyncTable = () => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if (!isThereUnsynchronizedRecords) {
+    if (numUnsynchronizedRecords === 0) {
       setSyncDisabled(true); // We have nothing to sync!
     } else if (working) {
       setSyncDisabled(true);
@@ -41,7 +41,7 @@ export const OfflineDataSyncTable = () => {
     } else {
       setSyncDisabled(false);
     }
-  }, [working, workingOffline, authenticated, connected, isThereUnsynchronizedRecords]);
+  }, [working, workingOffline, authenticated, connected, numUnsynchronizedRecords]);
 
   if (Object.values(serializedActivities).length === 0) {
     return <p>There are no locally-stored activities to synchronize.</p>;
@@ -95,13 +95,15 @@ export const OfflineDataSyncTable = () => {
                   </tr>
                   {(value as OfflineActivityRecord).sync_state == 'Error' && (
                     <tr>
-                      <td></td>
+                      <td>
+                        <Fragment />
+                      </td>
                       <td>
                         {(value as OfflineActivityRecord).error_detail
                           ? (value as OfflineActivityRecord).error_detail
                           : 'Error'}
                       </td>
-                      <td colSpan={3}>
+                      <td colSpan={4}>
                         <pre>
                           {(value as OfflineActivityRecord).error_object?.hasOwnProperty('message')
                             ? JSON.stringify((value as OfflineActivityRecord).error_object?.message)
@@ -116,10 +118,15 @@ export const OfflineDataSyncTable = () => {
           </tbody>
         </table>
       </div>
-      {syncDisabled && (
-        <span className="syncDisabledMessage">Synchronization requires that you be online and authenticated.</span>
-      )}
-      {working && <LinearProgress className={'progressBar'} />}
+      <div className="status-info">
+        {syncDisabled && numUnsynchronizedRecords > 0 && (
+          <p>Synchronization requires that you be online and authenticated.</p>
+        )}
+        <p>
+          Unsynced Records: <span>{numUnsynchronizedRecords}</span>
+        </p>
+        {working && <LinearProgress className={'progressBar'} />}
+      </div>
       <div className="control">
         <Button
           disabled={syncDisabled}

--- a/app/src/UI/Reusable/CustomPopover/CustomPopover.tsx
+++ b/app/src/UI/Reusable/CustomPopover/CustomPopover.tsx
@@ -23,6 +23,7 @@ type PropTypes = {
   children: ReactNode;
   horizontal?: number | 'left' | 'center' | 'right';
   vertical?: number | 'top' | 'center' | 'bottom';
+  disablePortal?: boolean;
 };
 
 /**
@@ -35,7 +36,8 @@ const CustomPopover = ({
   children,
   closeAfterPress = false,
   horizontal = 'center',
-  vertical = 'center'
+  vertical = 'center',
+  disablePortal = false
 }: PropTypes) => {
   const handleClick = (event: MouseEvent<HTMLButtonElement> | TouchEvent<HTMLButtonElement>) => {
     if (!buttonOverrideOptions) {
@@ -76,6 +78,7 @@ const CustomPopover = ({
         anchorOrigin={{ vertical, horizontal }}
         onClick={handleCloseAfterClick}
         onClose={handleClose}
+        disablePortal={disablePortal}
       >
         {children}
       </Popover>

--- a/app/src/state/reducers/offlineActivity.ts
+++ b/app/src/state/reducers/offlineActivity.ts
@@ -18,7 +18,7 @@ interface OfflineActivityRecord {
   record_type: string;
   sync_state: OfflineActivitySyncState;
   error_detail?: string;
-  error_object?: unknown;
+  error_object?: Record<PropertyKey, unknown>;
 }
 
 interface OfflineActivityState {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

Refactors the SyncStatus UI to be more friendly on smaller screens, and more readable in general.

## Visual Changes
- Change `Dialog` to `StyledModal` for edge-to-edge display on smaller viewports
- Modify font-weights and text sizes for easier to parse information
- Change modified time to last modified, reducing cognitive load of data.
- Vertically align items for consistency

## Functional Changes
- Reduce number of columns in Sync table, introduce popover menu for action items
- Disable Sync Button when no records require sync
- add MUI prop `disablePortal` to CustomPopover 
- Two click delete action for offline records. 
- Closes #4262




## Screenshots

> [!NOTE]
> No production data used for the displaying of this data 

<img width="297" height="176" alt="image" src="https://github.com/user-attachments/assets/cbfc1438-c145-41bf-8921-5b3f3ea71815" />

[*Popover*]

<img width="298" height="177" alt="image" src="https://github.com/user-attachments/assets/3a79044d-02a3-4cef-ac76-0f9994b1d2df" />

[*Popover Confirmation*]

<img width="609" height="504" alt="image" src="https://github.com/user-attachments/assets/ce369931-7ca2-49ce-b784-2e46c6855017" />

[*Full Width Offline Sync Status Window* ]

<img width="419" height="741" alt="image" src="https://github.com/user-attachments/assets/49962001-f4bc-4183-b722-20238b155494" />

[*iPhone SE Viewport size*]

<img width="665" height="950" alt="image" src="https://github.com/user-attachments/assets/3026d150-8ee0-4268-9d30-88053ffebfa5" />

[*Screenshot from iPad*]

<img width="439" height="892" alt="image" src="https://github.com/user-attachments/assets/c77007fc-dfd3-4f2c-9bee-2dffc33c40d8" />

[*Screenshot from iPhone 16e*]

<img width="1145" height="497" alt="image" src="https://github.com/user-attachments/assets/5bc1d69a-2d3b-429a-8c48-5e7af98b731b" />

[*Original Full Width*]

<img width="434" height="751" alt="image" src="https://github.com/user-attachments/assets/5b1f3247-674d-4482-9419-82aaeec85e2e" />

[*Original iPhone SE display*]
