### PR TITLE
[INV-4261] records not  automatically syncing

### DIFF
--- a/app/src/state/sagas/activity/offline.ts
+++ b/app/src/state/sagas/activity/offline.ts
@@ -16,22 +16,28 @@ import { ISaveOffline } from 'state/actions/activity/Offline';
 import WhatsHere from 'state/actions/whatsHere/WhatsHere';
 
 function* handle_ACTIVITY_SAVE_OFFLINE(action: PayloadAction<ISaveOffline>) {
-  yield put(
-    Alerts.create({
-      content: 'Saved locally',
-      severity: AlertSeverity.Info,
-      subject: AlertSubjects.Form
-    })
-  );
+  const connected = yield select(selectNetworkConnected);
   // reload the activity in case the reducer modified it (create time, etc.)
   yield put(Activity.get(action.payload.id));
-
-  // trigger a sync if we're online
-  const connected = yield select(selectNetworkConnected);
-
   if (connected) {
+    // trigger a sync if we're online
+    yield put(
+      Alerts.create({
+        content: 'Synchronizing records with server.',
+        severity: AlertSeverity.Info,
+        subject: AlertSubjects.Form
+      })
+    );
     yield delay(500);
-    yield put(Activity.Offline.syncRun);
+    yield put(Activity.Offline.syncRun());
+  } else {
+    yield put(
+      Alerts.create({
+        content: 'Saved locally',
+        severity: AlertSeverity.Info,
+        subject: AlertSubjects.Form
+      })
+    );
   }
 }
 


### PR DESCRIPTION
# Overview

> [!NOTE]
> Merges into other PR to avoid Merge conflicts

This PR includes the following proposed change(s):

- Fix issue where sync was not being triggered due to missing `()` 
- Add alert when syncing with the server versus always saying `Saves Locally` as this confuses end users.
- Closes #4261