### PR TITLE
Delete two unused actions

### DIFF
--- a/app/src/state/actions/activity/Photos.ts
+++ b/app/src/state/actions/activity/Photos.ts
@@ -16,7 +16,6 @@ class Photos {
 
   static readonly edit = createAction(`${this.PREFIX}/edit`);
   static readonly editSuccess = createAction<UploadedPhoto[]>(`${this.PREFIX}/editSuccess`);
-  static readonly editFailure = createAction(`${this.PREFIX}/editFailure`);
 
   static readonly delete = createAction<UploadedPhoto>(`${this.PREFIX}/delete`);
   static readonly deleteSuccess = createAction<DeleteSuccess>(`${this.PREFIX}/deleteSuccess`);

--- a/app/src/state/actions/userSettings/UserSettings.ts
+++ b/app/src/state/actions/userSettings/UserSettings.ts
@@ -102,7 +102,7 @@ class Map {
   }>(`${this.PREFIX}/togglePreferredOverlayLayer`);
   static readonly setCenter = createAction<number[]>(`${this.PREFIX}/setCenter`);
   static readonly setCenterSuccess = createAction<number[]>(`${this.PREFIX}/setCenterSuccess`);
-  static readonly setCenterFailure = createAction(`${this.PREFIX}/setCenterFailure`);
+
   static readonly setHoveredRecordset = createAction<IHoverRecordset>(`${this.PREFIX}/setHoveredRecordset`);
   static readonly markCoordinate = createAction<IMarkLocation>(`${this.PREFIX}/markCoordinate`);
 }

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -678,7 +678,6 @@ export function* handle_ACTIVITY_EDIT_PHOTO_REQUEST(action) {
     yield put(Activity.Photo.editSuccess(beforeActivityMedia));
   } catch (e) {
     console.error(e);
-    yield put(Activity.Photo.editFailure);
   }
 }
 

--- a/app/src/state/sagas/userSettings.ts
+++ b/app/src/state/sagas/userSettings.ts
@@ -117,7 +117,6 @@ function* handle_USER_SETTINGS_SET_MAP_CENTER_REQUEST(action) {
     yield put(UserSettings.Map.setCenterSuccess(action.payload));
   } catch (e) {
     console.error(e);
-    yield put(UserSettings.Map.setCenterFailure);
   }
 }
 


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

Found two actions not being called properly (missing `()`). Looking into it, neither of the two actions actually went anywhere, and so they were removed entirely.