### PR TITLE
Eliminate blocking check, no longer needed

### DIFF
--- a/app/src/state/sagas/map/dataAccess.ts
+++ b/app/src/state/sagas/map/dataAccess.ts
@@ -23,16 +23,6 @@ export function* handle_PREP_FILTERS_FOR_VECTOR_ENDPOINT(action: PayloadAction<I
       console.warn('filterObject returned by getRecordFilterObjectFromStateForAPI is null, probable data error');
     }
 
-    // abort if already a stale hash
-    const mapState = yield select((state) => state.Map);
-    const tableHash = mapState?.layers?.filter((layer) => {
-      return layer?.recordSetID === recordSetID;
-    })?.[0]?.tableFiltersHash;
-
-    if (tableHash && tableHash !== tableFiltersHash) {
-      return;
-    }
-
     yield put(
       AppActions.vectorFiltersPrepped({
         filterObject: filterObject,


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

This removes a tableFiltersHash Check that is no longer necessary. It blocks the action preventing filters to ever update. The original caller, `handle_UserFilterChange` already performs this check before the action is even submitted.

This was blocking Vectors from updating when filters changed. 