### PR TITLE
[INV-4283] Toggle on persisted ServerBoundaries when offline user

### DIFF
--- a/app/src/UI/Features/LegacyMap/Map.tsx
+++ b/app/src/UI/Features/LegacyMap/Map.tsx
@@ -58,7 +58,6 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
   const mapContainer: React.MutableRefObject<HTMLDivElement | null> = useRef<HTMLDivElement>(null);
 
   // Auth + Network
-  const authenticated = useSelector((state) => state.Auth.authenticated);
   const loggedInOrWorkingOffline = useSelector((state) => state.Auth.loggedInOrWorkingOffline);
   const connectedToNetwork = useSelector((state) => state.Network.connected);
   const configuration = useSelector((state) => state.Configuration.current);

--- a/app/src/UI/Features/LegacyMap/Map.tsx
+++ b/app/src/UI/Features/LegacyMap/Map.tsx
@@ -321,11 +321,11 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
 
   useEffect(() => {
     if (!mapReady || !map) return;
-    if (authenticated && loggedInOrWorkingOffline) {
+    if (loggedInOrWorkingOffline) {
       addServerBoundariesIfNotExists(serverBoundaries, map);
       refreshServerBoundariesOnToggle(serverBoundaries, map);
     }
-  }, [serverBoundaries, authenticated, map, mapReady]);
+  }, [serverBoundaries, loggedInOrWorkingOffline, map, mapReady]);
 
   // Custom Layers:
   useEffect(() => {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Modify conditions that render serverboundaries so `offline user` can access them. Was blocked by an `authenticated` gate restricting offline Users. This likely predates a time where `loggedInOrWorkingOffline` didn't include offline Users

Additional information:

- Server boundaries were already being persisted
- Serve boundaries were being displayed in LayerPicker when offline
- Closes #4283
