### PR TITLE
[INV-4286] Allow extending Redirect_URI path 

### DIFF
--- a/app/src/UI/Features/Landing/Landing.tsx
+++ b/app/src/UI/Features/Landing/Landing.tsx
@@ -40,7 +40,7 @@ const InformationalLinkBox = () => {
 export const LandingComponent = () => {
   const requestAccess = async () => {
     if (connected && !authenticated) {
-      dispatch(AuthActions.signinRequest({}));
+      dispatch(AuthActions.signinRequest({ extendedRedirectUri: '/AccessRequest' }));
     } else {
       navigate('/AccessRequest');
       dispatch(EventActions.setLayoutParameters({ viewLayout: LayoutMode.MAP_HIDDEN }));

--- a/app/src/UI/Layout/OverlayLayout/Header/Mobile/HeaderPopover.tsx
+++ b/app/src/UI/Layout/OverlayLayout/Header/Mobile/HeaderPopover.tsx
@@ -66,7 +66,7 @@ const HeaderPopover = () => {
 
   const requestAccess = async () => {
     if (!authenticated) {
-      dispatch(AuthActions.signinRequest({}));
+      dispatch(AuthActions.signinRequest({ extendedRedirectUri: '/AccessRequest' }));
     } else {
       navigate('/AccessRequest');
       dispatch(EventActions.setLayoutParameters({ viewLayout: LayoutMode.MAP_HIDDEN }));

--- a/app/src/UI/Layout/OverlayLayout/Header/Web/WebHeader.tsx
+++ b/app/src/UI/Layout/OverlayLayout/Header/Web/WebHeader.tsx
@@ -103,7 +103,7 @@ const LoginOrOutMemo = React.memo(() => {
 
   const requestAccess = async () => {
     if (!authenticated) {
-      dispatch(AuthActions.signinRequest({}));
+      dispatch(AuthActions.signinRequest({ extendedRedirectUri: '/AccessRequest' }));
     } else {
       navigate('/AccessRequest');
     }

--- a/app/src/state/actions/auth/Auth.ts
+++ b/app/src/state/actions/auth/Auth.ts
@@ -22,7 +22,9 @@ class AuthActions {
 
   static readonly tokenValidationRequest = createAction(`${this.PREFIX}/tokenValidationRequest`);
 
-  static readonly signinRequest = createAction<{ idpHint?: string }>(`${this.PREFIX}/signinRequest`);
+  static readonly signinRequest = createAction<{ idpHint?: string; extendedRedirectUri?: string }>(
+    `${this.PREFIX}/signinRequest`
+  );
   static readonly signoutRequest = createAction(`${this.PREFIX}/signoutRequest`);
   static readonly signoutComplete = createAction(`${this.PREFIX}/signoutComplete`);
   static readonly updateTokenState = createAction<{ idToken: string }>(`${this.PREFIX}/updateTokenState`);

--- a/app/src/state/sagas/auth/keycloak.ts
+++ b/app/src/state/sagas/auth/keycloak.ts
@@ -1,6 +1,5 @@
 import { call, cancelled, delay, fork, put, select, takeLatest } from 'redux-saga/effects';
 import Keycloak, { KeycloakLogoutOptions } from 'keycloak-js';
-import { useNavigate } from 'react-router';
 import { AppConfig } from 'state/configuration/runtime-config';
 import { selectConfiguration } from 'state/reducers/configuration';
 import { selectAuth } from 'state/reducers/auth';
@@ -23,7 +22,7 @@ function* handleSigninRequest(action) {
 
   try {
     yield call(keycloakInstance.login, {
-      redirectUri: config.REDIRECT_URI,
+      redirectUri: config.REDIRECT_URI + (action.payload?.extendedRedirectUri || ''),
       ...action.payload
     });
 


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Allow REDIRECT_URI Path to be extended from the base for sign-in requests.
   - Implementation is scalable if future examples needed to be implemented down the line.
- Does not affect Logging in on through mobile application
- Closes #4286
 
## Use Case

1. User enters the application for the first time
2. User selects 'Request Access'
3. User is prompted to Login
4. User Successfully Logs in and is redirected to the `Access Request` page

In the current version, the user would be redirected back to the home page, as if the click onto `Access Request` never happened.

If a user logs in normally, they'll be redirected to the base url as normal.