### PR TITLE
[INV-4274][INV-4267] Refactor Recordsets Layer Management | Global Layer Filter

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -9140,6 +9140,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/prettier-linter-helpers": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -9140,23 +9140,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/prettier-linter-helpers": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",

--- a/app/src/UI/Features/LegacyMap/LayerPicker/LayerPicker.css
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LayerPicker.css
@@ -8,21 +8,12 @@
   position: absolute;
   padding: 0;
   margin: 0;
-  right: 5pt;
-  top: 5pt;
-  border-radius: 50%;
-  height: 40pt;
-  width: 40pt;
-  border: 1pt solid var(--eigengrau);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: black;
-
-  svg {
-    height: 20pt;
-    width: 20pt;
-  }
+  right: 8px;
+  top: 8px;
+  height: 35px;
+  width: 35px;
+  background-color: white;
+  color: var(--bc-blue);
 
   &:hover {
     cursor: pointer;
@@ -50,7 +41,7 @@ ul > hr {
   top: 0;
   right: 0;
   width: 100%;
-  max-width: 400px;
+  max-width: 350px;
   height: 100%;
   z-index: 500;
   box-sizing: border-box;
@@ -76,7 +67,7 @@ ul > hr {
   margin: 0 5pt;
   box-sizing: border-box;
   background-color: var(--list-option);
-  border-radius: 18pt;
+  border-radius: 10pt;
   overflow: hidden;
 }
 

--- a/app/src/UI/Features/LegacyMap/LayerPicker/LayerPicker.css
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LayerPicker.css
@@ -94,6 +94,7 @@ ul > hr {
 
       & > svg {
         margin-right: 1rem;
+        color: var(--eigengrau);
       }
     }
 
@@ -108,7 +109,7 @@ ul > hr {
 }
 
 #layer-picker-container > div:first-child {
-  height: 50pt;
+  height: 50px;
   display: flex;
   justify-content: flex-end;
   align-items: center;
@@ -120,7 +121,7 @@ ul > hr {
 
   & > div:first-child {
     margin-right: auto;
-    font-size: 20pt;
+    font-size: 24px;
     display: flex;
     align-items: center;
   }

--- a/app/src/UI/Features/LegacyMap/LayerPicker/LayerPicker.tsx
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LayerPicker.tsx
@@ -36,14 +36,14 @@ export const LayerPicker = ({ layers, setOverlayState }: PropTypes) => {
 
   if (!showLayerPicker) {
     return (
-      <button
+      <IconButton
         data-testid="lp-open"
         id="layer-picker-closed-icon"
         className="layer-picker-pos"
         onClick={() => setShowLayerPicker(true)}
       >
         <LayersIcon />
-      </button>
+      </IconButton>
     );
   }
   return (

--- a/app/src/UI/Features/LegacyMap/LayerPicker/LpGlobalFilters/LpGlobalFilters.tsx
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LpGlobalFilters/LpGlobalFilters.tsx
@@ -1,0 +1,42 @@
+import { FilterAlt, FilterAltOff } from '@mui/icons-material';
+import { IconButton } from '@mui/material';
+import { MapRecordsetLayerFilterCategory } from '../../helpers/functional/layer-definitions/reusable-layer-specifications';
+import TooltipWithIcon from 'UI/Reusable/TooltipWithIcon/TooltipWithIcon';
+import { useDispatch, useSelector } from 'utils/use_selector';
+import UserSettings from 'state/actions/userSettings/UserSettings';
+import './lpGlobalFilters.css';
+
+const LpGlobalFilters = () => {
+  const MAP_FILTER_TOOLTIP_TEXT = 'Show or hide the record layers on the map. This setting applies to all record sets.';
+  const handleToggleGlobalMapFilter = (key: MapRecordsetLayerFilterCategory) => {
+    dispatch(UserSettings.Map.toggleGlobalMapFilter(key));
+  };
+
+  const dispatch = useDispatch();
+
+  const globalMapFilters = useSelector((state) => state.Map.globalMapFilters);
+  return (
+    <div id="lp-global-map-filters">
+      <h3>
+        Map Filters <TooltipWithIcon tooltipText={MAP_FILTER_TOOLTIP_TEXT} />
+      </h3>
+      <ul>
+        {Object.entries(globalMapFilters).map(([key, value], index) => (
+          <>
+            {index !== 0 && <hr />}
+            <li
+              key={key}
+              onClick={() => handleToggleGlobalMapFilter(key as MapRecordsetLayerFilterCategory)}
+              className="lp-global-map-filter-option"
+            >
+              <IconButton>{value ? <FilterAlt /> : <FilterAltOff />}</IconButton>
+              {key}
+            </li>
+          </>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default LpGlobalFilters;

--- a/app/src/UI/Features/LegacyMap/LayerPicker/LpGlobalFilters/LpGlobalFilters.tsx
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LpGlobalFilters/LpGlobalFilters.tsx
@@ -25,11 +25,10 @@ const LpGlobalFilters = () => {
         {Object.entries(globalMapFilters).map(([key, value], index) => (
           <Fragment key={key}>
             {index !== 0 && <hr />}
-            <li
-              onClick={() => handleToggleGlobalMapFilter(key as MapRecordsetLayerFilterCategory)}
-              className="lp-global-map-filter-option"
-            >
-              <IconButton>{value ? <FilterAlt /> : <FilterAltOff />}</IconButton>
+            <li className="lp-global-map-filter-option">
+              <IconButton onClick={() => handleToggleGlobalMapFilter(key as MapRecordsetLayerFilterCategory)}>
+                {value ? <FilterAlt /> : <FilterAltOff />}
+              </IconButton>
               {key}
             </li>
           </Fragment>

--- a/app/src/UI/Features/LegacyMap/LayerPicker/LpGlobalFilters/LpGlobalFilters.tsx
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LpGlobalFilters/LpGlobalFilters.tsx
@@ -1,11 +1,11 @@
 import { FilterAlt, FilterAltOff } from '@mui/icons-material';
 import { IconButton } from '@mui/material';
-import { MapRecordsetLayerFilterCategory } from '../../helpers/functional/layer-definitions/reusable-layer-specifications';
 import TooltipWithIcon from 'UI/Reusable/TooltipWithIcon/TooltipWithIcon';
 import { useDispatch, useSelector } from 'utils/use_selector';
 import UserSettings from 'state/actions/userSettings/UserSettings';
 import './lpGlobalFilters.css';
 import { Fragment } from 'react';
+import { MapRecordsetLayerFilterCategory } from 'state/reducers/map';
 
 const LpGlobalFilters = () => {
   const MAP_FILTER_TOOLTIP_TEXT = 'Show or hide the record layers on the map. This setting applies to all record sets.';

--- a/app/src/UI/Features/LegacyMap/LayerPicker/LpGlobalFilters/LpGlobalFilters.tsx
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LpGlobalFilters/LpGlobalFilters.tsx
@@ -5,6 +5,7 @@ import TooltipWithIcon from 'UI/Reusable/TooltipWithIcon/TooltipWithIcon';
 import { useDispatch, useSelector } from 'utils/use_selector';
 import UserSettings from 'state/actions/userSettings/UserSettings';
 import './lpGlobalFilters.css';
+import { Fragment } from 'react';
 
 const LpGlobalFilters = () => {
   const MAP_FILTER_TOOLTIP_TEXT = 'Show or hide the record layers on the map. This setting applies to all record sets.';
@@ -22,17 +23,16 @@ const LpGlobalFilters = () => {
       </h3>
       <ul>
         {Object.entries(globalMapFilters).map(([key, value], index) => (
-          <>
+          <Fragment key={key}>
             {index !== 0 && <hr />}
             <li
-              key={key}
               onClick={() => handleToggleGlobalMapFilter(key as MapRecordsetLayerFilterCategory)}
               className="lp-global-map-filter-option"
             >
               <IconButton>{value ? <FilterAlt /> : <FilterAltOff />}</IconButton>
               {key}
             </li>
-          </>
+          </Fragment>
         ))}
       </ul>
     </div>

--- a/app/src/UI/Features/LegacyMap/LayerPicker/LpGlobalFilters/lpGlobalFilters.css
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LpGlobalFilters/lpGlobalFilters.css
@@ -1,0 +1,48 @@
+#lp-global-map-filters {
+  h3 {
+    text-align: left;
+    margin: 1rem 8pt;
+  }
+  ul {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+    box-sizing: border-box;
+    background-color: var(--list-option);
+    border-radius: 8pt;
+    overflow-y: auto;
+    scrollbar-width: none;
+    &:hover,
+    *:hover {
+      scrollbar-width: thin;
+    }
+    .lp-global-map-filter-option {
+      display: flex;
+      align-items: center;
+      height: 48px;
+      box-sizing: border-box;
+      background-color: white;
+      button {
+        background-color: transparent;
+        border: none;
+        height: 100%;
+        padding: 10px;
+
+        &:not(:disabled) {
+          color: var(--bc-blue);
+        }
+      }
+      button:hover {
+        cursor: pointer;
+      }
+      div {
+        display: flex;
+        flex-direction: row;
+      }
+      p {
+        margin: 0;
+        word-wrap: wrap;
+      }
+    }
+  }
+}

--- a/app/src/UI/Features/LegacyMap/LayerPicker/LpGlobalFilters/lpGlobalFilters.css
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LpGlobalFilters/lpGlobalFilters.css
@@ -29,7 +29,7 @@
         padding: 10px;
 
         &:not(:disabled) {
-          color: var(--bc-blue);
+          color: var(--eigengrau);
         }
       }
       button:hover {

--- a/app/src/UI/Features/LegacyMap/LayerPicker/LpLayers/LpLayers.tsx
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LpLayers/LpLayers.tsx
@@ -67,7 +67,7 @@ const LpLayers = ({ layers, setOverlayState }: PropTypes) => {
 
       <div>
         {KmlLayers?.length > 0 ? (
-          <ul className="layerList">
+          <ul>
             {KmlLayers?.map((layer) => (
               <LpLayersOption key={layer.id ?? nanoid()} onClick={handleKmlClick} layer={layer} />
             ))}

--- a/app/src/UI/Features/LegacyMap/LayerPicker/LpPlanMyTrip/lpPlanMyTrip.css
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LpPlanMyTrip/lpPlanMyTrip.css
@@ -36,7 +36,7 @@
       padding: 5pt 5pt 5pt 1rem;
 
       button:not(:disabled) {
-        color: var(--bc-blue);
+        color: var(--eigengrau);
       }
 
       p {

--- a/app/src/UI/Features/LegacyMap/LayerPicker/LpRecordSet/LpRecordSet.css
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LpRecordSet/LpRecordSet.css
@@ -33,13 +33,14 @@
 #lp-record-set .lp-record-set-option {
   display: flex;
   align-items: center;
-  height: 48px;
+  min-height: 48px;
   box-sizing: border-box;
   button {
     background-color: transparent;
     border: none;
     height: 100%;
     padding: 10px;
+    color: var(--eigengrau);
   }
   button:hover {
     cursor: pointer;

--- a/app/src/UI/Features/LegacyMap/LayerPicker/LpRecordSet/LpRecordSet.tsx
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LpRecordSet/LpRecordSet.tsx
@@ -5,6 +5,7 @@ import LpRecordSetOption from './LpRecordSetOption';
 import { RecordSetId, UserRecordSet } from 'interfaces/UserRecordSet';
 import filterRecordsetsByNetworkState from 'utils/filterRecordsetsByNetworkState';
 import { useEffect, useState } from 'react';
+import LpGlobalFilters from '../LpGlobalFilters/LpGlobalFilters';
 
 type PropTypes = {
   closePicker: () => void;
@@ -52,6 +53,7 @@ const LpRecordSet = ({ closePicker }: PropTypes) => {
 
   return (
     <div id="lp-record-set">
+      <LpGlobalFilters />
       <h3>Default Recordsets</h3>
       <ul>
         {defaultRecordSets.map((recordSet, index) => (

--- a/app/src/UI/Features/LegacyMap/Map.tsx
+++ b/app/src/UI/Features/LegacyMap/Map.tsx
@@ -36,6 +36,7 @@ import { OfflineMapsPluginPMTilesSource } from 'utils/offline-protomaps/capacito
 import { DEMO_DOWNLOADED_FILENAME } from 'UI/Features/LegacyMap/helpers/functional/layer-definitions/demo-offline-vector';
 import LayerDataMarker from './helpers/components/LayerDataMarker/LayerDataMarker';
 import { useRecordSetControls } from 'utils/useRecordSetControls';
+import OfflineRecordsetLayer from './helpers/components/OfflineRecordsetLayer';
 
 const OfflineProtoMapsDebugModal = React.lazy(
   () => import('UI/Features/LegacyMap/helpers/components/OfflineProtomaps/Debug')
@@ -358,6 +359,7 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
           )}
           <MobileOnly>
             <CachedMapLayer mapReady={mapReady} />
+            <OfflineRecordsetLayer mapReady={mapReady} />
           </MobileOnly>
         </MapContext.Provider>
         {children}

--- a/app/src/UI/Features/LegacyMap/Map.tsx
+++ b/app/src/UI/Features/LegacyMap/Map.tsx
@@ -4,15 +4,6 @@ import './map.css';
 
 import { useSelector } from 'utils/use_selector';
 import { getCurrentJWT } from 'state/sagas/auth/auth';
-import {
-  rebuildLayersOnTableHashUpdate,
-  refreshColoursOnColourUpdate,
-  refreshOfflineActivitiesLayer,
-  refreshVisibilityOnToggleUpdate,
-  removeOfflineActivitiesLayer,
-  removeRecordsetLayersOnForcedRedraw,
-  toggleOfflineActivityLabels
-} from 'UI/Features/LegacyMap/helpers/functional/recordset-layers';
 import { MapContext } from 'UI/Features/LegacyMap/helpers/components/MapContext';
 import { InvasivesMap } from 'UI/Features/LegacyMap/InvasivesMap';
 import { PositionMarkers } from 'UI/Features/LegacyMap/helpers/components/PositionMarkers';
@@ -21,9 +12,7 @@ import { PMTiles, Protocol } from 'pmtiles';
 import { TileCacheService } from 'utils/tile-cache';
 import { CurrentActivityLayer } from 'UI/Features/LegacyMap/helpers/components/CurrentActivityLayer';
 import { DrawControls } from 'UI/Features/LegacyMap/helpers/components/DrawControls';
-import { OfflineActivityRecord, OfflineActivitySyncState } from 'state/reducers/offlineActivity';
 import DisplayComposite from './helpers/components/DisplayComposite/DisplayComposite';
-import { sha1 } from 'utils/sha1';
 import { StartupContext } from 'UI/StartupCoordinator/StartupCoordinator';
 import {
   addClientBoundariesIfNotExists,
@@ -46,7 +35,7 @@ import Spinner from 'UI/Reusable/Spinner/Spinner';
 import { OfflineMapsPluginPMTilesSource } from 'utils/offline-protomaps/capacitor';
 import { DEMO_DOWNLOADED_FILENAME } from 'UI/Features/LegacyMap/helpers/functional/layer-definitions/demo-offline-vector';
 import LayerDataMarker from './helpers/components/LayerDataMarker/LayerDataMarker';
-import { RecordSetId } from 'interfaces/UserRecordSet';
+import { useRecordSetControls } from 'utils/useRecordSetControls';
 
 const OfflineProtoMapsDebugModal = React.lazy(
   () => import('UI/Features/LegacyMap/helpers/components/OfflineProtomaps/Debug')
@@ -59,15 +48,15 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
 
   // Auth + Network
   const loggedInOrWorkingOffline = useSelector((state) => state.Auth.loggedInOrWorkingOffline);
-  const connectedToNetwork = useSelector((state) => state.Network.connected);
+  // const connectedToNetwork = useSelector((state) => state.Network.connected);
   const configuration = useSelector((state) => state.Configuration.current);
 
   // RecordSet Layers
   const storeLayers = useSelector((state) => state.Map.layers);
 
   // Offline Activities layer
-  const { serializedActivities } = useSelector((state) => state.OfflineActivity);
-  const offlineActivities = useSelector((state) => state.UserSettings.recordSets?.[RecordSetId.OfflineActivities]);
+  // const { serializedActivities } = useSelector((state) => state.OfflineActivity);
+  // const offlineActivities = useSelector((state) => state.UserSettings.recordSets?.[RecordSetId.OfflineActivities]);
 
   //KML
   const serverBoundaries = useSelector((state) => state.Map.serverBoundaries);
@@ -79,7 +68,6 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
   const map_center = useSelector((state) => state.Map.map_center);
   const map_zoom = useSelector((state) => state.Map.map_zoom);
 
-  const [cacheStatusHash, setCacheStatusHash] = useState<string>('init');
   const [map, setMap] = useState<InvasivesMap>();
   const [mapLoaded, setMapLoaded] = useState<boolean>(false);
   const [mapReady, setMapReady] = useState<boolean>(false);
@@ -87,7 +75,7 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
   const API_BASE = useSelector((state) => state.Configuration.current.runtime.API_BASE);
 
   const { sources, layers, availableLayerDefinitions, setActiveBaseMap, setOverlayState } = useInvasivesMapLayers();
-
+  const { recordsetLayers, recordsetSources } = useRecordSetControls();
   useEffect(() => {
     if (!mapContainer.current) {
       console.error('Mapinit invoked with invalid reference');
@@ -268,55 +256,7 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
     for (const layer of storeLayers) {
       cacheStatusTuples += `${layer.recordSetID}-${layer.layerState?.cacheMetadataStatus}`;
     }
-    sha1(cacheStatusTuples).then((hash) => {
-      setCacheStatusHash(hash);
-    });
   }, [storeLayers]);
-
-  useEffect(() => {
-    if (!mapReady) return;
-    if (!map) return;
-    removeRecordsetLayersOnForcedRedraw(map);
-  }, [connectedToNetwork, cacheStatusHash]);
-
-  // RecordSet Layers:
-  useEffect(() => {
-    if (!mapReady) return;
-    if (!map) return;
-    (async () => {
-      await rebuildLayersOnTableHashUpdate(storeLayers, map, connectedToNetwork);
-      refreshColoursOnColourUpdate(storeLayers, map);
-      refreshVisibilityOnToggleUpdate(storeLayers, map);
-    })();
-  }, [storeLayers, map, mapReady, connectedToNetwork, loggedInOrWorkingOffline, cacheStatusHash]);
-
-  // Offline Activities Layer:
-  useEffect(() => {
-    if (!map || !mapReady || !configuration.build.MOBILE) return;
-    if (!offlineActivities?.mapToggle || !loggedInOrWorkingOffline) {
-      removeOfflineActivitiesLayer(map);
-    } else {
-      const unsyncedOfflineActivities = Object.fromEntries(
-        Object.entries(serializedActivities).filter(
-          ([, value]) => (value as OfflineActivityRecord).sync_state !== OfflineActivitySyncState.SYNCHRONIZED
-        )
-      );
-      refreshOfflineActivitiesLayer(
-        map,
-        offlineActivities?.mapToggle,
-        offlineActivities?.labelToggle,
-        unsyncedOfflineActivities as Record<PropertyKey, OfflineActivityRecord>
-      );
-    }
-  }, [serializedActivities, map, mapReady, loggedInOrWorkingOffline, offlineActivities?.mapToggle]);
-
-  // Offline Activities Label:
-  useEffect(() => {
-    if (!map || !mapReady || !configuration.build.MOBILE) return;
-    (async () => {
-      await toggleOfflineActivityLabels(map, offlineActivities?.labelToggle);
-    })();
-  }, [serializedActivities, map, mapReady, loggedInOrWorkingOffline, offlineActivities?.labelToggle]);
 
   useEffect(() => {
     if (!mapReady || !map) return;
@@ -398,15 +338,15 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
 
           <ButtonContainer selectLayer={buttonContainerLayerSelect} layers={availableLayerDefinitions} />
 
-          {Object.entries(sources).map(([key, source]) => (
+          {[...Object.entries(recordsetSources), ...Object.entries(sources)].map(([key, source]) => (
             <SourceComponent mapReady={mapReady} key={key} id={key} source={source} />
           ))}
 
-          {layers.map((layer) => (
+          {[...layers, ...recordsetLayers].map((layer) => (
             <LayerComponent mapReady={mapReady} key={layer.id} id={layer.id} layer={layer} />
           ))}
 
-          {Object.keys(sources).map((key) => (
+          {[...Object.keys(sources), ...Object.keys(recordsetSources)].map((key) => (
             <SourceCleanupComponent mapReady={mapReady} key={key} id={key} />
           ))}
 

--- a/app/src/UI/Features/LegacyMap/Map.tsx
+++ b/app/src/UI/Features/LegacyMap/Map.tsx
@@ -49,15 +49,7 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
 
   // Auth + Network
   const loggedInOrWorkingOffline = useSelector((state) => state.Auth.loggedInOrWorkingOffline);
-  // const connectedToNetwork = useSelector((state) => state.Network.connected);
   const configuration = useSelector((state) => state.Configuration.current);
-
-  // RecordSet Layers
-  const storeLayers = useSelector((state) => state.Map.layers);
-
-  // Offline Activities layer
-  // const { serializedActivities } = useSelector((state) => state.OfflineActivity);
-  // const offlineActivities = useSelector((state) => state.UserSettings.recordSets?.[RecordSetId.OfflineActivities]);
 
   //KML
   const serverBoundaries = useSelector((state) => state.Map.serverBoundaries);
@@ -247,17 +239,6 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
       setMapReady(true);
     }
   }, [map?.isStyleLoaded()]);
-
-  useEffect(() => {
-    // update cacheStatusHash when any recordset is added/removed or has a cache status change. this will force a redraw.
-    if (!configuration.build.MOBILE) {
-      return;
-    }
-    let cacheStatusTuples = '';
-    for (const layer of storeLayers) {
-      cacheStatusTuples += `${layer.recordSetID}-${layer.layerState?.cacheMetadataStatus}`;
-    }
-  }, [storeLayers]);
 
   useEffect(() => {
     if (!mapReady || !map) return;

--- a/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarker.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarker.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { MapContext } from '../MapContext';
 import { MapMouseEvent, MapTouchEvent, Point, PointLike, Popup } from 'maplibre-gl';
 import ReactDOM from 'react-dom/client';
@@ -16,19 +16,21 @@ const LayerDataMarker = () => {
   const whatsHereEnabled = useSelector((state) => state.Map.whatsHere.toggle);
   const connected = useSelector((state) => state.Network.connected);
   const globalMapFilters = useSelector((state) => state.Map.globalMapFilters);
-
   const drawToolsActive = useRef<boolean>(false);
   const editModeActive = useRef<boolean>(false);
 
   const popupRef = useRef<Popup>();
   const timeOfTouchStart = useRef<number>(0);
 
-  const recordsetLayers = useMemo(() => {
+  const [recordsetLayers, setRecordsetLayers] = useState<string[]>([]);
+
+  const updateLayers = () => {
     if (!map) return [];
-    return map
+    const newLayers = map
       .getLayersOrder()
       .filter((layer) => layer.includes('recordset-layer-') || layer.includes('offline-activity'));
-  }, [map?.getLayersOrder(), globalMapFilters]);
+    setRecordsetLayers(newLayers);
+  };
 
   const createPopupDiv = (numFeatures: number): HTMLDivElement => {
     /*
@@ -47,7 +49,6 @@ const LayerDataMarker = () => {
     return el;
   };
 
-  //
   const queryFeaturesAtTarget = useCallback(
     (e: MapMouseEvent | MapTouchEvent) => {
       const isUserUtilizingDraw = drawToolsActive.current || whatsHereEnabled || editModeActive.current;
@@ -140,14 +141,16 @@ const LayerDataMarker = () => {
     map.on('click', queryFeaturesAtTarget);
     map.on('touchstart', handleTouchStart);
     map.on('touchend', handleTouchEnd);
+    map.on('styledata', updateLayers);
     return () => {
       map.off('draw.editshape', handleEditShape);
       map.off('draw.modechange', handleDrawModeChanged);
       map.off('click', queryFeaturesAtTarget);
       map.off('touchstart', handleTouchStart);
       map.off('touchend', handleTouchEnd);
+      map.off('styledata', updateLayers);
     };
-  }, [map?.isStyleLoaded(), whatsHereEnabled, recordsetLayers, connected]);
+  }, [map, whatsHereEnabled, recordsetLayers, connected]);
 
   return null;
 };

--- a/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarker.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarker.tsx
@@ -15,6 +15,7 @@ const LayerDataMarker = () => {
 
   const whatsHereEnabled = useSelector((state) => state.Map.whatsHere.toggle);
   const connected = useSelector((state) => state.Network.connected);
+  const globalMapFilters = useSelector((state) => state.Map.globalMapFilters);
 
   const drawToolsActive = useRef<boolean>(false);
   const editModeActive = useRef<boolean>(false);
@@ -27,7 +28,7 @@ const LayerDataMarker = () => {
     return map
       .getLayersOrder()
       .filter((layer) => layer.includes('recordset-layer-') || layer.includes('offline-activity'));
-  }, [map?.getLayersOrder()]);
+  }, [map?.getLayersOrder(), globalMapFilters]);
 
   const createPopupDiv = (numFeatures: number): HTMLDivElement => {
     /*
@@ -99,7 +100,7 @@ const LayerDataMarker = () => {
       const root = ReactDOM.createRoot(el);
       root.render(<LayerDataMarkerContent navigate={navigate} features={uniqueFormattedFeaturesAtClickTarget} />);
     },
-    [map, recordsetLayers, popupRef, whatsHereEnabled, connected]
+    [map, recordsetLayers, popupRef, whatsHereEnabled, connected, globalMapFilters]
   );
   /**
    * @desc Sets time touch event started at

--- a/app/src/UI/Features/LegacyMap/helpers/components/OfflineRecordsetLayer.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/OfflineRecordsetLayer.tsx
@@ -78,7 +78,6 @@ const OfflineRecordsetLayer = ({ mapReady }: PropTypes) => {
             'fill-outline-color': 'blue',
             'fill-opacity': 0.5
           },
-          maxzoom: 24,
           minzoom: 0,
           layout: {
             visibility: 'visible'
@@ -94,7 +93,6 @@ const OfflineRecordsetLayer = ({ mapReady }: PropTypes) => {
             'line-opacity': 1,
             'line-width': 3
           },
-          maxzoom: 24,
           minzoom: 0,
           layout: {
             visibility: 'visible'
@@ -109,7 +107,6 @@ const OfflineRecordsetLayer = ({ mapReady }: PropTypes) => {
             'circle-color': 'blue',
             'circle-radius': 4
           },
-          maxzoom: 24,
           minzoom: 0,
           layout: {
             visibility: 'visible'
@@ -142,7 +139,6 @@ const OfflineRecordsetLayer = ({ mapReady }: PropTypes) => {
             'text-halo-blur': 1
           },
           minzoom: 12,
-          maxzoom: 24,
           stackLayer: LAYER_Z_FOREGROUND
         }
       );

--- a/app/src/UI/Features/LegacyMap/helpers/components/OfflineRecordsetLayer.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/OfflineRecordsetLayer.tsx
@@ -9,26 +9,33 @@ import { OfflineActivityRecord, OfflineActivitySyncState } from 'state/reducers/
 import { FeatureCollection } from 'geojson';
 import { SourceSpecification } from 'maplibre-gl';
 import { GeoJSON } from 'geojson';
-import { LayerSpecificationWithStackingOrder } from '../functional/layers-hook';
-import VECTOR_MAP_FONT_FACE from 'constants/vectorMapFontFace';
-import { shallowEqual } from 'react-redux';
-import { LAYER_Z_FOREGROUND } from '../functional/layer-definitions/types';
 import { Md5 } from 'ts-md5';
+import {
+  createBorderLayer,
+  createCircleLayer,
+  createFillLayer,
+  createLabelLayer
+} from '../functional/layer-definitions/reusable-layer-specifications';
+import { LayerSpecificationWithStackingOrder } from '../functional/layers-hook';
 
 type PropTypes = {
   mapReady: boolean;
+};
+
+type SourceSpecificationType = {
+  layers: LayerSpecificationWithStackingOrder[];
+  sources: { [_: string]: SourceSpecification };
 };
 const OfflineRecordsetLayer = ({ mapReady }: PropTypes) => {
   const OFFLINE_RECORD_ID = RecordSetId.OfflineActivities;
   const LAYER_COLOUR = 'blue';
 
-  const [source, setSource] = useState<SourceSpecification>();
-  const [layers, setLayers] = useState<LayerSpecificationWithStackingOrder[]>([]);
+  const [definition, setDefinition] = useState<SourceSpecificationType>();
 
   const { mapToggle, labelToggle } = useSelector((state) => state.UserSettings.recordSets[OFFLINE_RECORD_ID]);
-  const serializedActivities = useSelector((state) => state.OfflineActivity.serializedActivities, shallowEqual);
+  const serializedActivities = useSelector((state) => state.OfflineActivity.serializedActivities);
 
-  const buildSource = () => {
+  useEffect(() => {
     const geometryList: Array<GeoJSON> = [];
     const locallyStoredActivities = Object.fromEntries(
       Object.entries(serializedActivities).filter(
@@ -58,109 +65,54 @@ const OfflineRecordsetLayer = ({ mapReady }: PropTypes) => {
       }
     });
 
-    setSource({
-      type: 'geojson',
-      data: { type: 'FeatureCollection', features: geometryList } as FeatureCollection
-    });
-  };
+    //Define Hashed IDs to updates rerender only when needed.
+    const SOURCE_ID = OFFLINE_RECORD_ID + Md5.hashStr(JSON.stringify(geometryList));
+    const LAYER_ID = 'offline-activity-' + Md5.hashStr(SOURCE_ID + mapToggle + labelToggle);
 
-  const buildLayers = () => {
-    const layers: LayerSpecificationWithStackingOrder[] = [];
-    const LAYER_ID = Md5.hashStr(OFFLINE_RECORD_ID + mapToggle + labelToggle);
-    if (mapToggle) {
-      layers.push(
-        {
-          id: 'fill-' + LAYER_ID,
-          type: 'fill',
-          source: OFFLINE_RECORD_ID,
-          paint: {
-            'fill-color': LAYER_COLOUR,
-            'fill-outline-color': LAYER_COLOUR,
-            'fill-opacity': 0.5
-          },
-          minzoom: 0,
-          layout: {
-            visibility: 'visible'
-          },
-          stackLayer: LAYER_Z_FOREGROUND
-        },
-        {
-          id: 'polygon-border-' + LAYER_ID,
-          source: OFFLINE_RECORD_ID,
-          type: 'line',
-          paint: {
-            'line-color': LAYER_COLOUR,
-            'line-opacity': 1,
-            'line-width': 3
-          },
-          minzoom: 0,
-          layout: {
-            visibility: 'visible'
-          },
-          stackLayer: LAYER_Z_FOREGROUND
-        },
-        {
-          id: 'polygon-circle-' + LAYER_ID,
-          source: OFFLINE_RECORD_ID,
-          type: 'circle',
-          paint: {
-            'circle-color': LAYER_COLOUR,
-            'circle-radius': 4
-          },
-          minzoom: 0,
-          layout: {
-            visibility: 'visible'
-          },
-          stackLayer: LAYER_Z_FOREGROUND
-        },
-        {
-          id: 'label-' + LAYER_ID,
-          source: OFFLINE_RECORD_ID,
-          type: 'symbol',
-          layout: {
-            'text-field': [
-              'format',
-              ['get', 'short_id'],
-              { 'font-scale': 0.9 },
-              '\n',
-              {},
-              ['get', 'map_symbol'],
-              { 'font-scale': 0.9 }
-            ],
-            'text-font': ['literal', [VECTOR_MAP_FONT_FACE]],
-            'text-offset': [0, 0.6],
-            'text-anchor': 'top',
-            visibility: labelToggle ? 'visible' : 'none'
-          },
-          paint: {
-            'text-color': 'black',
-            'text-halo-color': 'white',
-            'text-halo-width': 1,
-            'text-halo-blur': 1
-          },
-          minzoom: 12,
-          stackLayer: LAYER_Z_FOREGROUND
+    setDefinition({
+      sources: {
+        [SOURCE_ID]: {
+          type: 'geojson',
+          data: { type: 'FeatureCollection', features: geometryList } as FeatureCollection
         }
-      );
-    }
-    setLayers(layers);
-  };
-
-  useEffect(() => {
-    buildSource();
-  }, [serializedActivities]);
-
-  useEffect(() => {
-    buildLayers();
-  }, [mapToggle, labelToggle]);
+      },
+      layers: [
+        createFillLayer({
+          layerId: LAYER_ID,
+          sourceId: SOURCE_ID,
+          color: LAYER_COLOUR
+        }),
+        createBorderLayer({
+          layerId: LAYER_ID,
+          sourceId: SOURCE_ID,
+          color: LAYER_COLOUR
+        }),
+        createCircleLayer({
+          layerId: LAYER_ID,
+          sourceId: SOURCE_ID,
+          color: LAYER_COLOUR
+        }),
+        createLabelLayer({
+          layerId: LAYER_ID,
+          sourceId: SOURCE_ID,
+          visibility: labelToggle ? 'visible' : 'none'
+        })
+      ]
+    });
+  }, [labelToggle, mapToggle, serializedActivities]);
 
   return (
     <>
-      {source && <SourceComponent mapReady={mapReady} id={OFFLINE_RECORD_ID} source={source} />}
-      {layers?.map((layer) => (
-        <LayerComponent mapReady={mapReady} key={layer.id} id={layer.id} layer={layer} />
-      ))}
-      {source && <SourceCleanupComponent mapReady={mapReady} id={OFFLINE_RECORD_ID} />}
+      {definition &&
+        Object.entries(definition.sources).map(([id, value]) => (
+          <SourceComponent mapReady={mapReady} key={id} id={id} source={value} />
+        ))}
+      {mapToggle &&
+        definition?.layers?.map((layer) => (
+          <LayerComponent mapReady={mapReady} key={layer.id} id={layer.id} layer={layer} />
+        ))}
+      {definition &&
+        Object.keys(definition.sources).map((id) => <SourceCleanupComponent mapReady={mapReady} key={id} id={id} />)}
     </>
   );
 };

--- a/app/src/UI/Features/LegacyMap/helpers/components/OfflineRecordsetLayer.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/OfflineRecordsetLayer.tsx
@@ -14,7 +14,8 @@ import {
   createBorderLayer,
   createCircleLayer,
   createFillLayer,
-  createLabelLayer
+  createLabelLayer,
+  getPaintBySchemeOrColor
 } from '../functional/layer-definitions/reusable-layer-specifications';
 import { LayerSpecificationWithStackingOrder } from '../functional/layers-hook';
 
@@ -28,7 +29,7 @@ type SourceSpecificationType = {
 };
 const OfflineRecordsetLayer = ({ mapReady }: PropTypes) => {
   const OFFLINE_RECORD_ID = RecordSetId.OfflineActivities;
-  const LAYER_COLOUR = 'blue';
+  const LAYER_COLOUR = getPaintBySchemeOrColor('blue');
 
   const [definition, setDefinition] = useState<SourceSpecificationType>();
 
@@ -55,6 +56,7 @@ const OfflineRecordsetLayer = ({ mapReady }: PropTypes) => {
             properties: {
               short_id: parsedData.short_id,
               map_symbol: plantCodes,
+              activity_subtype: parsedData.activity_subtype,
               activity_id: parsedData.activity_id,
               type: parsedData.activity_type
             }

--- a/app/src/UI/Features/LegacyMap/helpers/components/OfflineRecordsetLayer.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/OfflineRecordsetLayer.tsx
@@ -20,12 +20,12 @@ type PropTypes = {
 };
 const OfflineRecordsetLayer = ({ mapReady }: PropTypes) => {
   const OFFLINE_RECORD_ID = RecordSetId.OfflineActivities;
+  const LAYER_COLOUR = 'blue';
+
   const [source, setSource] = useState<SourceSpecification>();
   const [layers, setLayers] = useState<LayerSpecificationWithStackingOrder[]>([]);
 
-  const { mapToggle, labelToggle } = useSelector(
-    (state) => state.UserSettings.recordSets[RecordSetId.OfflineActivities]
-  );
+  const { mapToggle, labelToggle } = useSelector((state) => state.UserSettings.recordSets[OFFLINE_RECORD_ID]);
   const serializedActivities = useSelector((state) => state.OfflineActivity.serializedActivities, shallowEqual);
 
   const buildSource = () => {
@@ -74,8 +74,8 @@ const OfflineRecordsetLayer = ({ mapReady }: PropTypes) => {
           type: 'fill',
           source: OFFLINE_RECORD_ID,
           paint: {
-            'fill-color': 'blue',
-            'fill-outline-color': 'blue',
+            'fill-color': LAYER_COLOUR,
+            'fill-outline-color': LAYER_COLOUR,
             'fill-opacity': 0.5
           },
           minzoom: 0,
@@ -89,7 +89,7 @@ const OfflineRecordsetLayer = ({ mapReady }: PropTypes) => {
           source: OFFLINE_RECORD_ID,
           type: 'line',
           paint: {
-            'line-color': 'blue',
+            'line-color': LAYER_COLOUR,
             'line-opacity': 1,
             'line-width': 3
           },
@@ -104,7 +104,7 @@ const OfflineRecordsetLayer = ({ mapReady }: PropTypes) => {
           source: OFFLINE_RECORD_ID,
           type: 'circle',
           paint: {
-            'circle-color': 'blue',
+            'circle-color': LAYER_COLOUR,
             'circle-radius': 4
           },
           minzoom: 0,

--- a/app/src/UI/Features/LegacyMap/helpers/components/OfflineRecordsetLayer.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/OfflineRecordsetLayer.tsx
@@ -1,0 +1,172 @@
+import { RecordSetId } from 'interfaces/UserRecordSet';
+import { useEffect, useState } from 'react';
+import { useSelector } from 'utils/use_selector';
+import { SourceComponent } from './SourceComponent';
+import { LayerComponent } from './LayerComponent';
+import { SourceCleanupComponent } from './SourceCleanupComponent';
+import { findSpeciesCodes, getConcatenatedCodes } from 'utils/addActivity';
+import { OfflineActivityRecord, OfflineActivitySyncState } from 'state/reducers/offlineActivity';
+import { FeatureCollection } from 'geojson';
+import { SourceSpecification } from 'maplibre-gl';
+import { GeoJSON } from 'geojson';
+import { LayerSpecificationWithStackingOrder } from '../functional/layers-hook';
+import VECTOR_MAP_FONT_FACE from 'constants/vectorMapFontFace';
+import { shallowEqual } from 'react-redux';
+import { LAYER_Z_FOREGROUND } from '../functional/layer-definitions/types';
+import { Md5 } from 'ts-md5';
+
+type PropTypes = {
+  mapReady: boolean;
+};
+const OfflineRecordsetLayer = ({ mapReady }: PropTypes) => {
+  const OFFLINE_RECORD_ID = RecordSetId.OfflineActivities;
+  const [source, setSource] = useState<SourceSpecification>();
+  const [layers, setLayers] = useState<LayerSpecificationWithStackingOrder[]>([]);
+
+  const { mapToggle, labelToggle } = useSelector(
+    (state) => state.UserSettings.recordSets[RecordSetId.OfflineActivities]
+  );
+  const serializedActivities = useSelector((state) => state.OfflineActivity.serializedActivities, shallowEqual);
+
+  const buildSource = () => {
+    const geometryList: Array<GeoJSON> = [];
+    const locallyStoredActivities = Object.fromEntries(
+      Object.entries(serializedActivities).filter(
+        ([, value]) => (value as OfflineActivityRecord).sync_state !== OfflineActivitySyncState.SYNCHRONIZED
+      )
+    );
+    Object.values(locallyStoredActivities).forEach((item) => {
+      try {
+        const parsedData = JSON.parse((item as OfflineActivityRecord)?.data);
+        const plantCodes = getConcatenatedCodes(
+          findSpeciesCodes(parsedData.form_data.activity_subtype_data, (item as OfflineActivityRecord)?.record_type)
+        );
+
+        if (parsedData?.geometry?.[0]) {
+          geometryList.push({
+            ...parsedData.geometry[0],
+            properties: {
+              short_id: parsedData.short_id,
+              map_symbol: plantCodes,
+              activity_id: parsedData.activity_id,
+              type: parsedData.activity_type
+            }
+          });
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    });
+
+    setSource({
+      type: 'geojson',
+      data: { type: 'FeatureCollection', features: geometryList } as FeatureCollection
+    });
+  };
+
+  const buildLayers = () => {
+    const layers: LayerSpecificationWithStackingOrder[] = [];
+    const LAYER_ID = Md5.hashStr(OFFLINE_RECORD_ID + mapToggle + labelToggle);
+    if (mapToggle) {
+      layers.push(
+        {
+          id: 'fill-' + LAYER_ID,
+          type: 'fill',
+          source: OFFLINE_RECORD_ID,
+          paint: {
+            'fill-color': 'blue',
+            'fill-outline-color': 'blue',
+            'fill-opacity': 0.5
+          },
+          maxzoom: 24,
+          minzoom: 0,
+          layout: {
+            visibility: 'visible'
+          },
+          stackLayer: LAYER_Z_FOREGROUND
+        },
+        {
+          id: 'polygon-border-' + LAYER_ID,
+          source: OFFLINE_RECORD_ID,
+          type: 'line',
+          paint: {
+            'line-color': 'blue',
+            'line-opacity': 1,
+            'line-width': 3
+          },
+          maxzoom: 24,
+          minzoom: 0,
+          layout: {
+            visibility: 'visible'
+          },
+          stackLayer: LAYER_Z_FOREGROUND
+        },
+        {
+          id: 'polygon-circle-' + LAYER_ID,
+          source: OFFLINE_RECORD_ID,
+          type: 'circle',
+          paint: {
+            'circle-color': 'blue',
+            'circle-radius': 4
+          },
+          maxzoom: 24,
+          minzoom: 0,
+          layout: {
+            visibility: 'visible'
+          },
+          stackLayer: LAYER_Z_FOREGROUND
+        },
+        {
+          id: 'label-' + LAYER_ID,
+          source: OFFLINE_RECORD_ID,
+          type: 'symbol',
+          layout: {
+            'text-field': [
+              'format',
+              ['get', 'short_id'],
+              { 'font-scale': 0.9 },
+              '\n',
+              {},
+              ['get', 'map_symbol'],
+              { 'font-scale': 0.9 }
+            ],
+            'text-font': ['literal', [VECTOR_MAP_FONT_FACE]],
+            'text-offset': [0, 0.6],
+            'text-anchor': 'top',
+            visibility: labelToggle ? 'visible' : 'none'
+          },
+          paint: {
+            'text-color': 'black',
+            'text-halo-color': 'white',
+            'text-halo-width': 1,
+            'text-halo-blur': 1
+          },
+          minzoom: 12,
+          maxzoom: 24,
+          stackLayer: LAYER_Z_FOREGROUND
+        }
+      );
+    }
+    setLayers(layers);
+  };
+
+  useEffect(() => {
+    buildSource();
+  }, [serializedActivities]);
+
+  useEffect(() => {
+    buildLayers();
+  }, [mapToggle, labelToggle]);
+
+  return (
+    <>
+      {source && <SourceComponent mapReady={mapReady} id={OFFLINE_RECORD_ID} source={source} />}
+      {layers?.map((layer) => (
+        <LayerComponent mapReady={mapReady} key={layer.id} id={layer.id} layer={layer} />
+      ))}
+      {source && <SourceCleanupComponent mapReady={mapReady} id={OFFLINE_RECORD_ID} />}
+    </>
+  );
+};
+
+export default OfflineRecordsetLayer;

--- a/app/src/UI/Features/LegacyMap/helpers/components/OfflineRecordsetLayer.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/OfflineRecordsetLayer.tsx
@@ -6,9 +6,8 @@ import { LayerComponent } from './LayerComponent';
 import { SourceCleanupComponent } from './SourceCleanupComponent';
 import { findSpeciesCodes, getConcatenatedCodes } from 'utils/addActivity';
 import { OfflineActivityRecord, OfflineActivitySyncState } from 'state/reducers/offlineActivity';
-import { FeatureCollection } from 'geojson';
+import { FeatureCollection, GeoJSON } from 'geojson';
 import { SourceSpecification } from 'maplibre-gl';
-import { GeoJSON } from 'geojson';
 import { Md5 } from 'ts-md5';
 import {
   createBorderLayer,

--- a/app/src/UI/Features/LegacyMap/helpers/functional/layer-definitions/reusable-layer-specifications.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/layer-definitions/reusable-layer-specifications.ts
@@ -24,21 +24,6 @@ interface LabelOptions extends LayerOptions {
   visibility: 'visible' | 'none';
 }
 
-/**
- * Filter Categories, Each of these represents a globally applied filter a user is able to select on the map.
- * These will render in the LayerPicker as options
- */
-enum MapRecordsetLayerFilterCategory {
-  Observations = 'Observations',
-  Treatments = 'Treatments',
-  Monitoring = 'Monitoring',
-  Biocontrol = 'Biocontrol'
-}
-
-type MapRecordsetLayerFilters = {
-  [key in MapRecordsetLayerFilterCategory]: boolean;
-};
-
 const createFillLayer = (options: PaintLayerOptions): LayerSpecificationWithStackingOrder => ({
   id: 'fill-' + options.layerId,
   source: options.sourceId,
@@ -144,12 +129,5 @@ const getPaintBySchemeOrColor = (color: string): ColorSpecification | Expression
   return color ?? FALLBACK_COLOR;
 };
 
-export {
-  createLabelLayer,
-  createCircleLayer,
-  createBorderLayer,
-  createFillLayer,
-  getPaintBySchemeOrColor,
-  MapRecordsetLayerFilterCategory
-};
-export type { LayerOptions, MapRecordsetLayerFilters };
+export { createLabelLayer, createCircleLayer, createBorderLayer, createFillLayer, getPaintBySchemeOrColor };
+export type { LayerOptions };

--- a/app/src/UI/Features/LegacyMap/helpers/functional/layer-definitions/reusable-layer-specifications.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/layer-definitions/reusable-layer-specifications.ts
@@ -1,12 +1,7 @@
-import {
-  CircleLayerSpecification,
-  ColorSpecification,
-  ExpressionSpecification,
-  FillLayerSpecification,
-  LineLayerSpecification,
-  SymbolLayerSpecification
-} from 'maplibre-gl';
+import { ColorSpecification, ExpressionSpecification } from 'maplibre-gl';
 import { FALLBACK_COLOR } from '../constants';
+import { LayerSpecificationWithStackingOrder } from '../layers-hook';
+import { LAYER_Z_FOREGROUND } from './types';
 import VECTOR_MAP_FONT_FACE from 'constants/vectorMapFontFace';
 import recordsetColourScheme from 'constants/recordsetColourScheme';
 import { white } from 'constants/colors';
@@ -16,7 +11,6 @@ interface LayerOptions {
   sourceId: string;
   minzoom?: number;
   maxzoom?: number;
-  visibility: 'visible' | 'none';
   'source-layer'?: string | undefined;
 }
 
@@ -26,12 +20,13 @@ interface PaintLayerOptions extends LayerOptions {
 
 interface LabelOptions extends LayerOptions {
   get_tag?: string;
+  visibility: 'visible' | 'none';
 }
 
-const createFillLayer = (options: PaintLayerOptions): FillLayerSpecification => ({
+const createFillLayer = (options: PaintLayerOptions): LayerSpecificationWithStackingOrder => ({
   id: 'fill-' + options.layerId,
   source: options.sourceId,
-  'source-layer': options?.['source-layer'],
+  ...(options['source-layer'] ? { 'source-layer': options['source-layer'] } : {}), // If not exist, don't have the key at all
   type: 'fill',
   paint: {
     'fill-color': options.color,
@@ -39,13 +34,14 @@ const createFillLayer = (options: PaintLayerOptions): FillLayerSpecification => 
     'fill-opacity': 0.5
   },
   minzoom: options?.minzoom ?? 0,
-  maxzoom: options?.maxzoom ?? 24
+  maxzoom: options?.maxzoom ?? 24,
+  stackLayer: LAYER_Z_FOREGROUND
 });
 
-const createBorderLayer = (options: PaintLayerOptions): LineLayerSpecification => ({
+const createBorderLayer = (options: PaintLayerOptions): LayerSpecificationWithStackingOrder => ({
   id: 'polygon-border-' + options.layerId,
   source: options.sourceId,
-  'source-layer': options?.['source-layer'],
+  ...(options['source-layer'] ? { 'source-layer': options['source-layer'] } : {}), // If not exist, don't have the key at all
   type: 'line',
   paint: {
     'line-color': options.color,
@@ -53,26 +49,28 @@ const createBorderLayer = (options: PaintLayerOptions): LineLayerSpecification =
     'line-width': 3
   },
   minzoom: options?.minzoom ?? 0,
-  maxzoom: options?.maxzoom ?? 24
+  maxzoom: options?.maxzoom ?? 24,
+  stackLayer: LAYER_Z_FOREGROUND
 });
 
-const createCircleLayer = (options: PaintLayerOptions): CircleLayerSpecification => ({
+const createCircleLayer = (options: PaintLayerOptions): LayerSpecificationWithStackingOrder => ({
   id: 'polygon-circle-' + options.layerId,
   source: options.sourceId,
-  'source-layer': options?.['source-layer'],
+  ...(options['source-layer'] ? { 'source-layer': options['source-layer'] } : {}), // If not exist, don't have the key at all
   type: 'circle',
   paint: {
     'circle-color': options.color,
     'circle-radius': 4
   },
   minzoom: options?.minzoom ?? 0,
-  maxzoom: options?.maxzoom ?? 24
+  maxzoom: options?.maxzoom ?? 24,
+  stackLayer: LAYER_Z_FOREGROUND
 });
 
-const createLabelLayer = (options: LabelOptions): SymbolLayerSpecification => ({
+const createLabelLayer = (options: LabelOptions): LayerSpecificationWithStackingOrder => ({
   id: 'label-' + options.layerId,
   source: options.sourceId,
-  'source-layer': options?.['source-layer'],
+  ...(options['source-layer'] ? { 'source-layer': options['source-layer'] } : {}), // If not exist, don't have the key at all
   type: 'symbol',
   layout: {
     'text-field': [
@@ -97,7 +95,8 @@ const createLabelLayer = (options: LabelOptions): SymbolLayerSpecification => ({
     'text-halo-blur': 1
   },
   minzoom: options?.minzoom ?? 0,
-  maxzoom: options?.maxzoom ?? 24
+  maxzoom: options?.maxzoom ?? 24,
+  stackLayer: LAYER_Z_FOREGROUND
 });
 
 const getPaintBySchemeOrColor = (color: string): ColorSpecification | ExpressionSpecification => {
@@ -117,3 +116,4 @@ const getPaintBySchemeOrColor = (color: string): ColorSpecification | Expression
 };
 
 export { createLabelLayer, createCircleLayer, createBorderLayer, createFillLayer, getPaintBySchemeOrColor };
+export type { LayerOptions };

--- a/app/src/UI/Features/LegacyMap/helpers/functional/layer-definitions/reusable-layer-specifications.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/layer-definitions/reusable-layer-specifications.ts
@@ -77,6 +77,8 @@ const createLabelLayer = (options: LabelOptions): LayerSpecificationWithStacking
       'format',
       ['get', options.get_tag ?? 'short_id'],
       { 'font-scale': 0.9 },
+      ['get', options.get_tag ?? 'site_id'],
+      { 'font-scale': 0.9 },
       '\n',
       {},
       ['get', 'map_symbol'],

--- a/app/src/UI/Features/LegacyMap/helpers/functional/layer-definitions/reusable-layer-specifications.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/layer-definitions/reusable-layer-specifications.ts
@@ -1,4 +1,4 @@
-import { ColorSpecification, ExpressionSpecification } from 'maplibre-gl';
+import { ColorSpecification, ExpressionSpecification, FilterSpecification } from 'maplibre-gl';
 import { FALLBACK_COLOR } from '../constants';
 import { LayerSpecificationWithStackingOrder } from '../layers-hook';
 import { LAYER_Z_FOREGROUND } from './types';
@@ -12,6 +12,7 @@ interface LayerOptions {
   minzoom?: number;
   maxzoom?: number;
   'source-layer'?: string | undefined;
+  filters?: FilterSpecification;
 }
 
 interface PaintLayerOptions extends LayerOptions {
@@ -23,10 +24,26 @@ interface LabelOptions extends LayerOptions {
   visibility: 'visible' | 'none';
 }
 
+/**
+ * Filter Categories, Each of these represents a globally applied filter a user is able to select on the map.
+ * These will render in the LayerPicker as options
+ */
+enum MapRecordsetLayerFilterCategory {
+  Observations = 'Observations',
+  Treatments = 'Treatments',
+  Monitoring = 'Monitoring',
+  Biocontrol = 'Biocontrol'
+}
+
+type MapRecordsetLayerFilters = {
+  [key in MapRecordsetLayerFilterCategory]: boolean;
+};
+
 const createFillLayer = (options: PaintLayerOptions): LayerSpecificationWithStackingOrder => ({
   id: 'fill-' + options.layerId,
   source: options.sourceId,
   ...(options['source-layer'] ? { 'source-layer': options['source-layer'] } : {}), // If not exist, don't have the key at all
+  ...(options?.filters ? { filter: options.filters } : {}),
   type: 'fill',
   paint: {
     'fill-color': options.color,
@@ -42,6 +59,7 @@ const createBorderLayer = (options: PaintLayerOptions): LayerSpecificationWithSt
   id: 'polygon-border-' + options.layerId,
   source: options.sourceId,
   ...(options['source-layer'] ? { 'source-layer': options['source-layer'] } : {}), // If not exist, don't have the key at all
+  ...(options?.filters ? { filter: options.filters } : {}),
   type: 'line',
   paint: {
     'line-color': options.color,
@@ -53,24 +71,33 @@ const createBorderLayer = (options: PaintLayerOptions): LayerSpecificationWithSt
   stackLayer: LAYER_Z_FOREGROUND
 });
 
-const createCircleLayer = (options: PaintLayerOptions): LayerSpecificationWithStackingOrder => ({
-  id: 'polygon-circle-' + options.layerId,
-  source: options.sourceId,
-  ...(options['source-layer'] ? { 'source-layer': options['source-layer'] } : {}), // If not exist, don't have the key at all
-  type: 'circle',
-  paint: {
-    'circle-color': options.color,
-    'circle-radius': 4
-  },
-  minzoom: options?.minzoom ?? 0,
-  maxzoom: options?.maxzoom ?? 24,
-  stackLayer: LAYER_Z_FOREGROUND
-});
+const createCircleLayer = (options: PaintLayerOptions): LayerSpecificationWithStackingOrder => {
+  // Block Drawing Vertices on Polygons in addition to global filters. Points still render as normal.
+  const filter: FilterSpecification = options?.filters
+    ? (['all', ['!=', '$type', 'Polygon'], options.filters] as FilterSpecification)
+    : ['all', ['!=', '$type', 'Polygon']];
+
+  return {
+    id: 'polygon-circle-' + options.layerId,
+    source: options.sourceId,
+    ...(options['source-layer'] ? { 'source-layer': options['source-layer'] } : {}), // If not exist, don't have the key at all
+    filter: filter,
+    type: 'circle',
+    paint: {
+      'circle-color': options.color,
+      'circle-radius': 4
+    },
+    minzoom: options?.minzoom ?? 0,
+    maxzoom: options?.maxzoom ?? 24,
+    stackLayer: LAYER_Z_FOREGROUND
+  };
+};
 
 const createLabelLayer = (options: LabelOptions): LayerSpecificationWithStackingOrder => ({
   id: 'label-' + options.layerId,
   source: options.sourceId,
   ...(options['source-layer'] ? { 'source-layer': options['source-layer'] } : {}), // If not exist, don't have the key at all
+  ...(options?.filters ? { filter: options.filters } : {}),
   type: 'symbol',
   layout: {
     'text-field': [
@@ -117,5 +144,12 @@ const getPaintBySchemeOrColor = (color: string): ColorSpecification | Expression
   return color ?? FALLBACK_COLOR;
 };
 
-export { createLabelLayer, createCircleLayer, createBorderLayer, createFillLayer, getPaintBySchemeOrColor };
-export type { LayerOptions };
+export {
+  createLabelLayer,
+  createCircleLayer,
+  createBorderLayer,
+  createFillLayer,
+  getPaintBySchemeOrColor,
+  MapRecordsetLayerFilterCategory
+};
+export type { LayerOptions, MapRecordsetLayerFilters };

--- a/app/src/UI/Features/LegacyMap/helpers/functional/layer-definitions/reusable-layer-specifications.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/layer-definitions/reusable-layer-specifications.ts
@@ -1,0 +1,119 @@
+import {
+  CircleLayerSpecification,
+  ColorSpecification,
+  ExpressionSpecification,
+  FillLayerSpecification,
+  LineLayerSpecification,
+  SymbolLayerSpecification
+} from 'maplibre-gl';
+import { FALLBACK_COLOR } from '../constants';
+import VECTOR_MAP_FONT_FACE from 'constants/vectorMapFontFace';
+import recordsetColourScheme from 'constants/recordsetColourScheme';
+import { white } from 'constants/colors';
+
+interface LayerOptions {
+  layerId: string;
+  sourceId: string;
+  minzoom?: number;
+  maxzoom?: number;
+  visibility: 'visible' | 'none';
+  'source-layer'?: string | undefined;
+}
+
+interface PaintLayerOptions extends LayerOptions {
+  color: ColorSpecification | ExpressionSpecification;
+}
+
+interface LabelOptions extends LayerOptions {
+  get_tag?: string;
+}
+
+const createFillLayer = (options: PaintLayerOptions): FillLayerSpecification => ({
+  id: 'fill-' + options.layerId,
+  source: options.sourceId,
+  'source-layer': options?.['source-layer'],
+  type: 'fill',
+  paint: {
+    'fill-color': options.color,
+    'fill-outline-color': options.color,
+    'fill-opacity': 0.5
+  },
+  minzoom: options?.minzoom ?? 0,
+  maxzoom: options?.maxzoom ?? 24
+});
+
+const createBorderLayer = (options: PaintLayerOptions): LineLayerSpecification => ({
+  id: 'polygon-border-' + options.layerId,
+  source: options.sourceId,
+  'source-layer': options?.['source-layer'],
+  type: 'line',
+  paint: {
+    'line-color': options.color,
+    'line-opacity': 1,
+    'line-width': 3
+  },
+  minzoom: options?.minzoom ?? 0,
+  maxzoom: options?.maxzoom ?? 24
+});
+
+const createCircleLayer = (options: PaintLayerOptions): CircleLayerSpecification => ({
+  id: 'polygon-circle-' + options.layerId,
+  source: options.sourceId,
+  'source-layer': options?.['source-layer'],
+  type: 'circle',
+  paint: {
+    'circle-color': options.color,
+    'circle-radius': 4
+  },
+  minzoom: options?.minzoom ?? 0,
+  maxzoom: options?.maxzoom ?? 24
+});
+
+const createLabelLayer = (options: LabelOptions): SymbolLayerSpecification => ({
+  id: 'label-' + options.layerId,
+  source: options.sourceId,
+  'source-layer': options?.['source-layer'],
+  type: 'symbol',
+  layout: {
+    'text-field': [
+      'format',
+      ['get', options.get_tag ?? 'short_id'],
+      { 'font-scale': 0.9 },
+      '\n',
+      {},
+      ['get', 'map_symbol'],
+      { 'font-scale': 0.9 }
+    ],
+    // the actual font names that work are here https://github.com/openmaptiles/fonts/blob/gh-pages/fontstacks.json
+    'text-font': ['literal', [VECTOR_MAP_FONT_FACE]],
+    'text-offset': [0, 0.6],
+    'text-anchor': 'top',
+    visibility: options.visibility
+  },
+  paint: {
+    'text-color': 'black',
+    'text-halo-color': 'white',
+    'text-halo-width': 1,
+    'text-halo-blur': 1
+  },
+  minzoom: options?.minzoom ?? 0,
+  maxzoom: options?.maxzoom ?? 24
+});
+
+const getPaintBySchemeOrColor = (color: string): ColorSpecification | ExpressionSpecification => {
+  if (color === white) {
+    const activitySubtypeColours = Object.entries(recordsetColourScheme).flatMap(([activity, colour]) => [
+      activity,
+      colour ?? FALLBACK_COLOR
+    ]);
+    return [
+      'match',
+      ['get', 'activity_subtype'],
+      ...activitySubtypeColours,
+      color ?? FALLBACK_COLOR
+    ] as unknown as ExpressionSpecification;
+  }
+  return color ?? FALLBACK_COLOR;
+};
+
+export { createLabelLayer, createCircleLayer, createBorderLayer, createFillLayer, getPaintBySchemeOrColor };

--- a/app/src/UI/Features/LegacyMap/helpers/functional/layers-hook.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/layers-hook.ts
@@ -164,7 +164,7 @@ const useInvasivesMapLayers = () => {
     setLayers(newLayers);
     setSources(newSources);
   }, [availableLayerDefinitions, tileCacheState]);
-  console.log('AvailableLayers', availableLayerDefinitions);
+
   const setActiveBaseMap = useMemo(
     () =>
       debounce(

--- a/app/src/UI/Features/LegacyMap/helpers/functional/layers-hook.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/layers-hook.ts
@@ -56,51 +56,23 @@ const useInvasivesMapLayers = () => {
 
     // evaluate each potential map definition and remove those not eligible at this moment
     for (const l of [...MAP_DEFINITIONS, ...offlineDefinitions] as InvasivesMapLayerDefinition[]) {
-      let pass = true;
-
-      if (!l.predicates.directlySelectable) {
-        pass = false;
-      }
-
-      if (l.predicates.mobileOnly && !MOBILE) {
-        pass = false;
-      }
-
-      if (l.predicates.webOnly && MOBILE) {
-        pass = false;
-      }
-
-      if (l.predicates.requiresDebug && !DEBUG) {
-        pass = false;
-      }
-
-      if (l.predicates.requiresPlatform !== undefined) {
-        if (l.predicates.requiresPlatform !== platform) {
-          pass = false;
+      const pass = (() => {
+        switch (true) {
+          case !l.predicates.directlySelectable:
+          case l.predicates.mobileOnly && !MOBILE:
+          case l.predicates.webOnly && MOBILE:
+          case l.predicates.requiresDebug && !DEBUG:
+          case l.predicates.requiresPlatform !== undefined && l.predicates.requiresPlatform !== platform:
+          case l.predicates.requiresFeature !== undefined && !features[l.predicates.requiresFeature].enabled:
+          case l.predicates.requiresAuthentication && !loggedInOrWorkingOffline:
+          case l.predicates.requiresAnonymous && loggedInOrWorkingOffline:
+          case l.predicates.requiresNetwork && !connected:
+          case l.predicates.requiresOffline && connected:
+            return false;
+          default:
+            return true;
         }
-      }
-
-      if (l.predicates.requiresFeature !== undefined) {
-        if (!features[l.predicates.requiresFeature].enabled) {
-          pass = false;
-        }
-      }
-
-      if (l.predicates.requiresAuthentication && !loggedInOrWorkingOffline) {
-        pass = false;
-      }
-
-      if (l.predicates.requiresAnonymous && loggedInOrWorkingOffline) {
-        pass = false;
-      }
-
-      if (l.predicates.requiresNetwork && !connected) {
-        pass = false;
-      }
-
-      if (l.predicates.requiresOffline && connected) {
-        pass = false;
-      }
+      })();
 
       if (pass) {
         newFilteredLayerDefinitions.push({
@@ -192,7 +164,7 @@ const useInvasivesMapLayers = () => {
     setLayers(newLayers);
     setSources(newSources);
   }, [availableLayerDefinitions, tileCacheState]);
-
+  console.log('AvailableLayers', availableLayerDefinitions);
   const setActiveBaseMap = useMemo(
     () =>
       debounce(

--- a/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
@@ -153,35 +153,16 @@ function buildRecordsetLayerDefinitionsFromRecordset(rec: UserRecordSet): {
 
 const getPaintBySchemeOrColor = (color: string): ColorSpecification | ExpressionSpecification => {
   if (color === white) {
+    const activitySubtypeColours = Object.entries(recordsetColourScheme).flatMap(([activity, colour]) => [
+      activity,
+      colour ?? FALLBACK_COLOR
+    ]);
     return [
       'match',
       ['get', 'activity_subtype'],
-      'Activity_Biocontrol_Collection',
-      recordsetColourScheme.Activity_Biocontrol_Collection ?? FALLBACK_COLOR,
-      'Activity_Biocontrol_Release',
-      recordsetColourScheme.Activity_Biocontrol_Release ?? FALLBACK_COLOR,
-      'Activity_Monitoring_BiocontrolDispersal_TerrestrialPlant',
-      recordsetColourScheme.Activity_Monitoring_BiocontrolDispersal_TerrestrialPlant ?? FALLBACK_COLOR,
-      'Activity_Monitoring_BiocontrolRelease_TerrestrialPlant',
-      recordsetColourScheme.Activity_Monitoring_BiocontrolRelease_TerrestrialPlant ?? FALLBACK_COLOR,
-      'Activity_Monitoring_ChemicalTerrestrialAquaticPlant',
-      recordsetColourScheme.Activity_Monitoring_ChemicalTerrestrialAquaticPlant ?? FALLBACK_COLOR,
-      'Activity_Monitoring_MechanicalTerrestrialAquaticPlant',
-      recordsetColourScheme.Activity_Monitoring_MechanicalTerrestrialAquaticPlant ?? FALLBACK_COLOR,
-      'Activity_Observation_PlantAquatic',
-      recordsetColourScheme.Activity_Observation_PlantAquatic ?? FALLBACK_COLOR,
-      'Activity_Observation_PlantTerrestrial',
-      recordsetColourScheme.Activity_Observation_PlantTerrestrial ?? FALLBACK_COLOR,
-      'Activity_Treatment_ChemicalPlantAquatic',
-      recordsetColourScheme.Activity_Treatment_ChemicalPlantAquatic ?? FALLBACK_COLOR,
-      'Activity_Treatment_ChemicalPlantTerrestrial',
-      recordsetColourScheme.Activity_Treatment_ChemicalPlantTerrestrial ?? FALLBACK_COLOR,
-      'Activity_Treatment_MechanicalPlantAquatic',
-      recordsetColourScheme.Activity_Treatment_MechanicalPlantAquatic ?? FALLBACK_COLOR,
-      'Activity_Treatment_MechanicalPlantTerrestrial',
-      recordsetColourScheme.Activity_Treatment_MechanicalPlantTerrestrial ?? FALLBACK_COLOR,
+      ...activitySubtypeColours,
       color ?? FALLBACK_COLOR
-    ];
+    ] as unknown as ExpressionSpecification;
   }
   return color ?? FALLBACK_COLOR;
 };

--- a/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
@@ -54,8 +54,7 @@ function buildRecordsetLayerDefinitionsFromRecordset(rec: UserRecordSet): {
       [rec.id]: {
         type: 'vector',
         tiles: [`api:///api/vectors/${api_target}/{z}/{x}/{y}?filterObject=${encodeURI(JSON.stringify(filterObject))}`],
-        minzoom: 0,
-        maxzoom: 24
+        minzoom: 0
       }
     },
     definitions: [
@@ -81,7 +80,6 @@ function buildRecordsetLayerDefinitionsFromRecordset(rec: UserRecordSet): {
               'fill-outline-color': color,
               'fill-opacity': 0.5
             },
-            maxzoom: 24,
             minzoom: 0,
             layout: {
               visibility: 'visible'
@@ -97,7 +95,6 @@ function buildRecordsetLayerDefinitionsFromRecordset(rec: UserRecordSet): {
               'line-opacity': 1,
               'line-width': 3
             },
-            maxzoom: 24,
             minzoom: 0,
             layout: {
               visibility: 'visible'
@@ -112,7 +109,6 @@ function buildRecordsetLayerDefinitionsFromRecordset(rec: UserRecordSet): {
               'circle-color': color,
               'circle-radius': 4
             },
-            maxzoom: 24,
             minzoom: 0,
             layout: {
               visibility: 'visible'
@@ -147,8 +143,7 @@ function buildRecordsetLayerDefinitionsFromRecordset(rec: UserRecordSet): {
               'text-halo-width': 1,
               'text-halo-blur': 1
             },
-            minzoom: 12,
-            maxzoom: 24
+            minzoom: 12
           }
         ]
       }

--- a/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
@@ -1,4 +1,4 @@
-import { SourceSpecification } from 'maplibre-gl';
+import { FilterSpecification, SourceSpecification } from 'maplibre-gl';
 import { Md5 } from 'ts-md5';
 import {
   createBorderLayer,
@@ -13,10 +13,13 @@ import {
 } from 'UI/Features/LegacyMap/helpers/functional/layer-definitions/types';
 import { RecordSetId, RecordSetType, UserRecordSet } from 'interfaces/UserRecordSet';
 
-function buildCompleteRecordsetMapSpecificationFromRecordsets(recordSets: Record<PropertyKey, UserRecordSet>) {
+function buildCompleteRecordsetMapSpecificationFromRecordsets(
+  recordSets: Record<PropertyKey, UserRecordSet>,
+  globalFilterObj: FilterSpecification | undefined
+) {
   return Object.values(recordSets)
     .filter((r) => r.id !== RecordSetId.OfflineActivities)
-    .flatMap((r) => buildRecordsetLayerDefinitionsFromRecordset(r))
+    .flatMap((r) => buildRecordsetLayerDefinitionsFromRecordset(r, globalFilterObj))
     .reduce(
       (previousValue, currentValue) => {
         return {
@@ -27,7 +30,10 @@ function buildCompleteRecordsetMapSpecificationFromRecordsets(recordSets: Record
       { sources: {}, definitions: [] }
     );
 }
-function buildRecordsetLayerDefinitionsFromRecordset(rec: UserRecordSet): {
+function buildRecordsetLayerDefinitionsFromRecordset(
+  rec: UserRecordSet,
+  globalFilterObj: FilterSpecification | undefined
+): {
   definitions: InvasivesMapLayerDefinition[];
   sources: { [_: string]: SourceSpecification };
 } {
@@ -49,12 +55,28 @@ function buildRecordsetLayerDefinitionsFromRecordset(rec: UserRecordSet): {
     }
   })();
   const stringifiedFilters = JSON.stringify(filterObject);
+  const stringifiedGlobalFilters = JSON.stringify(globalFilterObj);
   const SOURCE_ID = rec.id + rec.tableFiltersHash;
   // Forces Layers to refresh when filters/toggles/colours update
   const layerID =
     'recordset-layer-' +
-    Md5.hashStr(SOURCE_ID + stringifiedFilters + rec.mapToggle + rec.labelToggle + JSON.stringify(color));
+    Md5.hashStr(
+      SOURCE_ID +
+        stringifiedFilters +
+        rec.mapToggle +
+        rec.labelToggle +
+        JSON.stringify(color) +
+        stringifiedGlobalFilters
+    );
 
+  /** Common Properties for Layer definitions */
+  const layerConfiguration = {
+    layerId: layerID,
+    sourceId: SOURCE_ID,
+    'source-layer': 'data',
+    color: color,
+    filters: globalFilterObj
+  };
   return {
     sources: {
       [SOURCE_ID]: {
@@ -76,31 +98,14 @@ function buildRecordsetLayerDefinitionsFromRecordset(rec: UserRecordSet): {
           .requiresNetwork(true)
           .build(),
         layers: [
-          createFillLayer({
-            layerId: layerID,
-            sourceId: SOURCE_ID,
-            'source-layer': 'data',
-            color: color
-          }),
-          createCircleLayer({
-            layerId: layerID,
-            sourceId: SOURCE_ID,
-            'source-layer': 'data',
-            color: color
-          }),
+          createFillLayer(layerConfiguration),
+          createCircleLayer(layerConfiguration),
           createLabelLayer({
-            layerId: layerID,
-            sourceId: SOURCE_ID,
-            'source-layer': 'data',
+            ...layerConfiguration,
             visibility: rec.labelToggle ? 'visible' : 'none',
             minzoom: 12
           }),
-          createBorderLayer({
-            layerId: layerID,
-            sourceId: SOURCE_ID,
-            'source-layer': 'data',
-            color: color
-          })
+          createBorderLayer(layerConfiguration)
         ]
       }
     ]

--- a/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
@@ -1,88 +1,163 @@
-import maplibregl, {
-  CircleLayerSpecification,
-  FillLayerSpecification,
-  GeoJSONSourceSpecification,
-  LineLayerSpecification,
-  SourceSpecification,
-  SymbolLayerSpecification
-} from 'maplibre-gl';
-import { FeatureCollection } from 'geojson';
-import { LAYER_Z_FOREGROUND } from 'UI/Features/LegacyMap/helpers/functional/layer-definitions/types';
+import { ColorSpecification, ExpressionSpecification, SourceSpecification } from 'maplibre-gl';
+import { Md5 } from 'ts-md5';
+import {
+  InvasivesMapLayerDefinition,
+  MapDefinitionEligibilityPredicatesBuilder
+} from 'UI/Features/LegacyMap/helpers/functional/layer-definitions/types';
 import { FALLBACK_COLOR } from 'UI/Features/LegacyMap/helpers/functional/constants';
-import { safelySetPaintProperty } from 'UI/Features/LegacyMap/helpers/functional/utility-functions';
-import { buildTimeConfig } from 'state/configuration/build-time-config';
-import { RecordSetId, RecordSetType, UserRecordCacheStatus } from 'interfaces/UserRecordSet';
+import { RecordSetId, RecordSetType, UserRecordSet } from 'interfaces/UserRecordSet';
 import VECTOR_MAP_FONT_FACE from 'constants/vectorMapFontFace';
-import { RecordCacheServiceFactory } from 'utils/record-cache/context';
-import { OfflineActivityRecord } from 'state/reducers/offlineActivity';
-import { getConcatenatedCodes, findSpeciesCodes } from 'utils/addActivity';
 import { white } from 'constants/colors';
 import recordsetColourScheme from 'constants/recordsetColourScheme';
 
-const LAYER_ID_PREFIX = 'recordset-layer-';
-const OFFLINE_ACTIVITIES_LAYER_ID = 'offline-activity';
-
-/** DRY Handler for formatting LayerIDs */
-const formatLayerID = (recordSetID: string, tableFiltersHash: string): string =>
-  `${LAYER_ID_PREFIX}${recordSetID}-hash-${tableFiltersHash}`;
-
-const createCachedIappLayer = async (map: maplibregl.Map, layer: any) => {
-  if (layer?.layerState?.cacheMetadataStatus !== UserRecordCacheStatus.CACHED || !layer.layerState.mapToggle) {
-    return;
-  }
-  const service = await RecordCacheServiceFactory.getPlatformInstance();
-  const repo = await service.getRepository(layer.recordSetID, ['cached_geojson']);
-
-  if (!repo?.cached_geojson) {
-    return;
-  }
-  const layerID = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
-  const source: GeoJSONSourceSpecification = repo.cached_geojson;
-  const color: string = layer.layerState.color ?? FALLBACK_COLOR;
-  const labelsShouldBeVisible = !!layer?.layerState?.labelToggle && !!layer?.layerState?.mapToggle;
-
-  const labelLayer: SymbolLayerSpecification = getLabelLayer(layerID, {
-    color,
-    minzoom: 10,
-    get_tag: 'name',
-    visibility: labelsShouldBeVisible
-  });
-  const circleLayer: CircleLayerSpecification = getCircleMarkerZoomedOutLayer(layerID, { color });
-
-  map.addSource(layerID, source);
-  map.addLayer(circleLayer, LAYER_Z_FOREGROUND);
-  map.addLayer(labelLayer, LAYER_Z_FOREGROUND);
-};
-
-const createOnlineIappLayer = (map: any, layer: any) => {
-  const layerID = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
-  const source: SourceSpecification = {
-    type: 'vector',
-    tiles: [`api:///api/vectors/iapp/{z}/{x}/{y}?filterObject=${encodeURI(JSON.stringify(layer.filterObject))}`],
-    minzoom: 0,
-    maxzoom: 24
+function buildCompleteRecordsetMapSpecificationFromRecordsets(recordSets: Record<PropertyKey, UserRecordSet>) {
+  return Object.values(recordSets)
+    .filter((r) => r.id !== RecordSetId.OfflineActivities)
+    .flatMap((r) => buildRecordsetLayerDefinitionsFromRecordset(r))
+    .reduce(
+      (previousValue, currentValue) => {
+        return {
+          sources: { ...previousValue.sources, ...currentValue.sources },
+          definitions: [...previousValue.definitions, ...currentValue.definitions]
+        };
+      },
+      { sources: {}, definitions: [] }
+    );
+}
+function buildRecordsetLayerDefinitionsFromRecordset(rec: UserRecordSet): {
+  definitions: InvasivesMapLayerDefinition[];
+  sources: { [_: string]: SourceSpecification };
+} {
+  const filterObject = {
+    ids_to_filter: rec?.ids_to_filter,
+    recordSetType: rec.recordSetType,
+    selectColumns: [],
+    tableFilters: rec?.tableFilters ?? []
   };
-  const color: string = layer.layerState.color ?? FALLBACK_COLOR;
-  const labelsShouldBeVisible = !!layer?.layerState?.labelToggle && !!layer?.layerState?.mapToggle;
-  const labelLayer = getLabelLayer(layerID, {
-    color,
-    minzoom: 10,
-    get_tag: 'site_id',
-    visibility: labelsShouldBeVisible
-  });
-  const circleLayer: CircleLayerSpecification = getCircleMarkerZoomedOutLayer(layerID, { color });
-  circleLayer['source-layer'] = 'data';
-  labelLayer['source-layer'] = 'data';
+  const color = getPaintBySchemeOrColor(rec.color);
+  const displayName = rec.recordSetName || `New Recordset - ${rec.recordSetType}`;
+  const api_target = (() => {
+    if (rec.recordSetType === RecordSetType.Activity) {
+      return 'activities';
+    } else if (rec.recordSetType === RecordSetType.IAPP) {
+      return 'iapp';
+    } else {
+      return null;
+    }
+  })();
+  // Forces Layers to refresh when filters/toggles/colours update
+  const layerID = Md5.hashStr(
+    rec.id + JSON.stringify(rec?.tableFilters) + rec.mapToggle + rec.labelToggle + JSON.stringify(color)
+  );
+  return {
+    sources: {
+      [rec.id]: {
+        type: 'vector',
+        tiles: [`api:///api/vectors/${api_target}/{z}/{x}/{y}?filterObject=${encodeURI(JSON.stringify(filterObject))}`],
+        minzoom: 0,
+        maxzoom: 24
+      }
+    },
+    definitions: [
+      {
+        name: rec.id,
+        displayName: displayName,
+        icon: 'N/A',
+        mode: 'overlay',
+        selectionMode: null,
+        tooltip: '',
+        predicates: new MapDefinitionEligibilityPredicatesBuilder()
+          .requiresAuthentication(true)
+          .requiresNetwork(true)
+          .build(),
+        layers: [
+          {
+            id: 'fill-' + layerID,
+            type: 'fill',
+            source: rec.id,
+            'source-layer': 'data',
+            paint: {
+              'fill-color': color,
+              'fill-outline-color': color,
+              'fill-opacity': 0.5
+            },
+            maxzoom: 24,
+            minzoom: 0,
+            layout: {
+              visibility: 'visible'
+            }
+          },
+          {
+            id: 'polygon-border-' + layerID,
+            source: rec.id,
+            'source-layer': 'data',
+            type: 'line',
+            paint: {
+              'line-color': color,
+              'line-opacity': 1,
+              'line-width': 3
+            },
+            maxzoom: 24,
+            minzoom: 0,
+            layout: {
+              visibility: 'visible'
+            }
+          },
+          {
+            id: 'polygon-circle-' + layerID,
+            source: rec.id,
+            'source-layer': 'data',
+            type: 'circle',
+            paint: {
+              'circle-color': color,
+              'circle-radius': 4
+            },
+            maxzoom: 24,
+            minzoom: 0,
+            layout: {
+              visibility: 'visible'
+            }
+          },
+          {
+            id: 'label-' + layerID,
+            source: rec.id,
+            'source-layer': 'data',
+            type: 'symbol',
+            layout: {
+              'text-field': [
+                'format',
+                ['get', 'short_id'],
+                { 'font-scale': 0.9 },
+                ['get', 'site_id'],
+                { 'font-scale': 0.9 },
+                '\n',
+                {},
+                ['get', 'map_symbol'],
+                { 'font-scale': 0.9 }
+              ],
+              // the actual font names that work are here https://github.com/openmaptiles/fonts/blob/gh-pages/fontstacks.json
+              'text-font': ['literal', [VECTOR_MAP_FONT_FACE]],
+              'text-offset': [0, 0.6],
+              'text-anchor': 'top',
+              visibility: rec.labelToggle ? 'visible' : 'none'
+            },
+            paint: {
+              'text-color': 'black',
+              'text-halo-color': 'white',
+              'text-halo-width': 1,
+              'text-halo-blur': 1
+            },
+            minzoom: 12,
+            maxzoom: 24
+          }
+        ]
+      }
+    ]
+  };
+}
 
-  map.addSource(layerID, source);
-  map.addLayer(circleLayer, LAYER_Z_FOREGROUND);
-  map.addLayer(labelLayer, LAYER_Z_FOREGROUND);
-};
-
-const getPaintBySchemeOrColor = (layer: any) => {
-  const defaultRecordsetOrSetToWhite =
-    Object.values(RecordSetId)?.includes(layer?.recordSetID) || layer?.layerState?.color === white;
-  if (defaultRecordsetOrSetToWhite) {
+const getPaintBySchemeOrColor = (color: string): ColorSpecification | ExpressionSpecification => {
+  if (color === white) {
     return [
       'match',
       ['get', 'activity_subtype'],
@@ -110,499 +185,10 @@ const getPaintBySchemeOrColor = (layer: any) => {
       recordsetColourScheme.Activity_Treatment_MechanicalPlantAquatic ?? FALLBACK_COLOR,
       'Activity_Treatment_MechanicalPlantTerrestrial',
       recordsetColourScheme.Activity_Treatment_MechanicalPlantTerrestrial ?? FALLBACK_COLOR,
-      layer?.layerState?.color ?? FALLBACK_COLOR
+      color ?? FALLBACK_COLOR
     ];
   }
-  return layer?.layerState?.color ?? FALLBACK_COLOR;
+  return color ?? FALLBACK_COLOR;
 };
 
-interface LayerOptions {
-  color: string;
-  minzoom?: number;
-  maxzoom?: number;
-  get_tag?: string;
-  visibility?: boolean;
-}
-
-const getFillLayer = (layerID: string, options: LayerOptions): FillLayerSpecification => ({
-  id: layerID,
-  source: layerID,
-  type: 'fill',
-  paint: {
-    'fill-color': options.color,
-    'fill-outline-color': options.color,
-    'fill-opacity': 0.5
-  },
-  maxzoom: options.maxzoom ?? 24,
-  minzoom: options.minzoom ?? 0
-});
-
-const getBorderLayer = (layerID: string, options: LayerOptions): LineLayerSpecification => ({
-  id: 'polygon-border-' + layerID,
-  source: layerID,
-  type: 'line',
-  paint: {
-    'line-color': options.color,
-    'line-opacity': 1,
-    'line-width': 3
-  },
-  maxzoom: options.maxzoom ?? 24,
-  minzoom: options.minzoom ?? 0
-});
-
-const getCircleMarkerZoomedOutLayer = (layerID: string, options: LayerOptions): CircleLayerSpecification => ({
-  id: 'polygon-circle-' + layerID,
-  source: layerID,
-  type: 'circle',
-  paint: {
-    'circle-color': options.color,
-    'circle-radius': 4
-  },
-  maxzoom: options.maxzoom ?? 24,
-  minzoom: options.minzoom ?? 0
-});
-
-const getLabelLayer = (layerID: string, options: LayerOptions): SymbolLayerSpecification => ({
-  id: 'label-' + layerID,
-  source: layerID,
-  type: 'symbol',
-  layout: {
-    'text-field': [
-      'format',
-      ['get', options.get_tag ?? 'short_id'],
-      { 'font-scale': 0.9 },
-      '\n',
-      {},
-      ['get', 'map_symbol'],
-      { 'font-scale': 0.9 }
-    ],
-    // the actual font names that work are here https://github.com/openmaptiles/fonts/blob/gh-pages/fontstacks.json
-    'text-font': ['literal', [VECTOR_MAP_FONT_FACE]],
-    'text-offset': [0, 0.6],
-    'text-anchor': 'top',
-    visibility: options?.visibility ? 'visible' : 'none'
-  },
-  paint: {
-    'text-color': 'black',
-    'text-halo-color': 'white',
-    'text-halo-width': 1,
-    'text-halo-blur': 1
-  },
-  minzoom: options.minzoom ?? 12,
-  maxzoom: options.maxzoom ?? 24
-});
-
-/**
- * @desc Uses the device's recordset Cache data to display geoJson Layers on the map when offline
- *       Displays two layers: Points at high levels, and shapes at lower
- */
-const createCachedActivityLayer = async (map: maplibregl.Map, layer: any) => {
-  if (layer?.layerState?.cacheMetadataStatus !== UserRecordCacheStatus.CACHED || !layer.layerState.mapToggle) {
-    return;
-  }
-  const service = await RecordCacheServiceFactory.getPlatformInstance();
-  const repo = await service.getRepository(layer.recordSetID, ['cached_geojson', 'cached_centroid']);
-
-  if (!repo?.cached_centroid || !repo?.cached_geojson) {
-    return;
-  }
-
-  const CENTROID_TO_GEOJSON_ZOOM = 12;
-  const GEOJSON_ID = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
-  const CENTROID_ID = `${GEOJSON_ID}-centroid`;
-  const color = getPaintBySchemeOrColor(layer);
-  const labelsShouldBeVisible = !!layer?.layerState?.labelToggle && !!layer?.layerState?.mapToggle;
-
-  const circleMarkerZoomedOutLayerCentroid: CircleLayerSpecification = getCircleMarkerZoomedOutLayer(CENTROID_ID, {
-    color,
-    maxzoom: CENTROID_TO_GEOJSON_ZOOM
-  });
-  const labelLayerCentroid: SymbolLayerSpecification = getLabelLayer(CENTROID_ID, {
-    color,
-    maxzoom: CENTROID_TO_GEOJSON_ZOOM,
-    get_tag: 'name',
-    visibility: labelsShouldBeVisible
-  });
-
-  const fillLayer: FillLayerSpecification = getFillLayer(GEOJSON_ID, { color, minzoom: CENTROID_TO_GEOJSON_ZOOM });
-  const borderLayer: LineLayerSpecification = getBorderLayer(GEOJSON_ID, { color, minzoom: CENTROID_TO_GEOJSON_ZOOM });
-  const circleMarkerZoomedOutLayer: CircleLayerSpecification = getCircleMarkerZoomedOutLayer(GEOJSON_ID, {
-    color,
-    minzoom: CENTROID_TO_GEOJSON_ZOOM
-  });
-  const labelLayer: SymbolLayerSpecification = getLabelLayer(GEOJSON_ID, {
-    color,
-    get_tag: 'name',
-    visibility: labelsShouldBeVisible
-  });
-
-  map.addSource(GEOJSON_ID, repo.cached_geojson);
-  map.addLayer(fillLayer, LAYER_Z_FOREGROUND);
-  map.addLayer(borderLayer, LAYER_Z_FOREGROUND);
-  map.addLayer(circleMarkerZoomedOutLayer, LAYER_Z_FOREGROUND);
-  map.addLayer(labelLayer, LAYER_Z_FOREGROUND);
-
-  map.addSource(CENTROID_ID, repo.cached_centroid);
-  map.addLayer(labelLayerCentroid, LAYER_Z_FOREGROUND);
-  map.addLayer(circleMarkerZoomedOutLayerCentroid, LAYER_Z_FOREGROUND);
-};
-
-const createOnlineActivityLayer = (map: maplibregl.Map, layer: any) => {
-  const layerID = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
-
-  // color the feature depending on the property 'Activity Type' matching the keys in the layer colorScheme:
-  const source: SourceSpecification = {
-    type: 'vector',
-    tiles: [`api:///api/vectors/activities/{z}/{x}/{y}?filterObject=${encodeURI(JSON.stringify(layer.filterObject))}`],
-    minzoom: 0,
-    maxzoom: 24
-  };
-  const color = getPaintBySchemeOrColor(layer);
-  const labelsShouldBeVisible = !!layer?.layerState?.labelToggle && !!layer?.layerState?.mapToggle;
-  const fillLayer: FillLayerSpecification = getFillLayer(layerID, { color });
-  const borderLayer: LineLayerSpecification = getBorderLayer(layerID, { color });
-  const circleMarkerZoomedOutLayer: CircleLayerSpecification = getCircleMarkerZoomedOutLayer(layerID, { color });
-  const labelLayer: SymbolLayerSpecification = getLabelLayer(layerID, {
-    color,
-    get_tag: 'short_id',
-    visibility: labelsShouldBeVisible
-  });
-
-  fillLayer['source-layer'] = 'data';
-  borderLayer['source-layer'] = 'data';
-  circleMarkerZoomedOutLayer['source-layer'] = 'data';
-  labelLayer['source-layer'] = 'data';
-
-  map.addSource(layerID, source);
-  map.addLayer(fillLayer, LAYER_Z_FOREGROUND);
-  map.addLayer(borderLayer, LAYER_Z_FOREGROUND);
-  map.addLayer(circleMarkerZoomedOutLayer, LAYER_Z_FOREGROUND);
-  map.addLayer(labelLayer, LAYER_Z_FOREGROUND);
-};
-
-const createOfflineActivitiesLayer = async (
-  map: maplibregl.Map,
-  locallyStoredActivities: Record<PropertyKey, OfflineActivityRecord>,
-  labelVisibility: boolean
-) => {
-  const geometryList = Object.values(locallyStoredActivities)
-    .map((item) => {
-      try {
-        const parsedData = JSON.parse((item as OfflineActivityRecord)?.data);
-        const plantCodes = getConcatenatedCodes(
-          findSpeciesCodes(parsedData.form_data.activity_subtype_data, item.record_type)
-        );
-
-        if (parsedData && parsedData.geometry && parsedData.geometry[0]) {
-          return {
-            ...parsedData.geometry[0],
-            properties: {
-              short_id: parsedData.short_id,
-              map_symbol: plantCodes,
-              activity_id: parsedData.activity_id,
-              type: parsedData.activity_type
-            }
-          };
-        }
-      } catch (error) {
-        console.error(error);
-      }
-      return null;
-    })
-    .filter(Boolean);
-
-  if (!geometryList) return;
-
-  const geoJsonData: FeatureCollection = {
-    type: 'FeatureCollection',
-    features: geometryList || []
-  };
-
-  if (geoJsonData.features) {
-    map
-      .addSource(OFFLINE_ACTIVITIES_LAYER_ID, { type: 'geojson', data: geoJsonData })
-      .addLayer(getFillLayer(OFFLINE_ACTIVITIES_LAYER_ID, { color: 'blue' }), LAYER_Z_FOREGROUND)
-      .addLayer(getBorderLayer(OFFLINE_ACTIVITIES_LAYER_ID, { color: 'blue' }), LAYER_Z_FOREGROUND)
-      .addLayer(getCircleMarkerZoomedOutLayer(OFFLINE_ACTIVITIES_LAYER_ID, { color: 'blue' }), LAYER_Z_FOREGROUND)
-      .addLayer(
-        getLabelLayer(OFFLINE_ACTIVITIES_LAYER_ID, {
-          color: 'black',
-          get_tag: 'short_id',
-          minzoom: 4
-        }),
-        LAYER_Z_FOREGROUND
-      );
-    if (!labelVisibility) {
-      map.setLayoutProperty('label-' + OFFLINE_ACTIVITIES_LAYER_ID, 'visibility', 'none');
-    }
-  }
-};
-const removeOfflineActivitiesLayer = async (map: maplibregl.Map) => {
-  const allLayersOnMap = map.getLayersOrder();
-  const recordSetOfflineLayers = allLayersOnMap.filter((layer) => layer.includes(OFFLINE_ACTIVITIES_LAYER_ID));
-
-  if (recordSetOfflineLayers.length > 0) {
-    recordSetOfflineLayers.forEach((layer) => {
-      try {
-        map.removeLayer(layer);
-      } catch (e) {
-        console.error('error removing layer', e);
-      }
-    });
-    map.removeSource(OFFLINE_ACTIVITIES_LAYER_ID);
-  }
-};
-
-const refreshOfflineActivitiesLayer = async (
-  map: maplibregl.Map,
-  visibility: boolean,
-  labelVisibility: boolean,
-  locallyStoredActivities: Record<PropertyKey, OfflineActivityRecord>
-) => {
-  if (!map) return;
-  await removeOfflineActivitiesLayer(map);
-  if (!visibility || Object.keys(locallyStoredActivities).length === 0) return;
-  await createOfflineActivitiesLayer(map, locallyStoredActivities, labelVisibility);
-};
-
-const toggleOfflineActivityLabels = async (map: maplibregl.Map, labelVisibility: boolean) => {
-  const allLayersOnMap = map.getLayersOrder();
-  const recordSetOfflineLabelLayer = allLayersOnMap.filter((layer) =>
-    layer.includes('label-' + OFFLINE_ACTIVITIES_LAYER_ID)
-  );
-
-  recordSetOfflineLabelLayer.map((layer) => {
-    const visibility = map.getLayoutProperty(layer, 'visibility');
-    if (visibility !== 'none' && !labelVisibility) {
-      map.setLayoutProperty(layer, 'visibility', 'none');
-    }
-    if (visibility !== 'visible' && labelVisibility) {
-      map.setLayoutProperty(layer, 'visibility', 'visible');
-    }
-  });
-};
-
-const purgeRecordsetLayersNotInStore = (
-  map: maplibregl.Map,
-  storeLayerIds: string[],
-  recordsetLayers: string[],
-  recordsetSources: string[]
-) => {
-  const recordSetLayersNotInStore = recordsetLayers.filter(
-    (layer) => storeLayerIds.filter((storeLayerId) => layer.includes(storeLayerId)).length === 0
-  );
-
-  const recordSetSourcesNotInStore = recordsetSources.filter(
-    (source) => storeLayerIds.filter((storeLayerId) => source.includes(storeLayerId)).length === 0
-  );
-
-  recordSetLayersNotInStore.forEach((staleLayer) => {
-    try {
-      map.removeLayer(staleLayer);
-    } catch (_e) {
-      console.error('error removing layer' + staleLayer);
-    }
-  });
-
-  recordSetSourcesNotInStore.forEach((staleSource) => {
-    try {
-      map.removeSource(staleSource);
-    } catch (e) {
-      console.error('error removing source', e);
-    }
-  });
-};
-
-const deleteStaleRecordsetLayer = (map: maplibregl.Map, layer: Record<PropertyKey, any>) => {
-  if (!map) {
-    return;
-  }
-  //get all layers for recordset
-  const allLayersForRecordSet = map.getLayersOrder().filter((mapLayer) => {
-    return (
-      mapLayer.includes(LAYER_ID_PREFIX + layer.recordSetID) ||
-      mapLayer.includes('label-' + layer.recordSetID) ||
-      mapLayer.includes('polygon-border-' + layer.recordSetID) ||
-      mapLayer.includes('polygon-circle-' + layer.recordSetID)
-    );
-  });
-
-  const stale = allLayersForRecordSet.filter((mapLayer) => !mapLayer.includes(layer.tableFiltersHash));
-
-  stale.forEach((staleLayer) => {
-    try {
-      map.removeLayer(staleLayer);
-    } catch (_e) {
-      console.error('error removing layer' + staleLayer);
-    }
-  });
-  const staleSources = Object.keys(map.style.sourceCaches).filter((source) => {
-    return source.includes(LAYER_ID_PREFIX + layer.recordSetID) && !source.includes(layer.tableFiltersHash);
-  });
-
-  staleSources?.map((staleSource) => {
-    if (map.getSource(staleSource)) {
-      try {
-        map.removeSource(staleSource);
-      } catch (e) {
-        console.error('error removing source', e);
-      }
-    }
-  });
-};
-
-/**
- * @desc Delete all recordset layers on the map in response to major app events (connectivity change, or cache update)
- * @param map Current map
- */
-const removeRecordsetLayersOnForcedRedraw = (map: maplibregl.Map) => {
-  const allLayersOnMap = map.getLayersOrder();
-  const allSourcesOnMap = Object.keys(map.style.sourceCaches);
-
-  const recordSetLayers = allLayersOnMap.filter((layer) => layer.includes(LAYER_ID_PREFIX));
-  const recordSetSources = allSourcesOnMap.filter((source) => source.includes(LAYER_ID_PREFIX));
-
-  recordSetLayers.forEach((layer) => {
-    try {
-      map.removeLayer(layer);
-    } catch (e) {
-      console.error('error removing layer', e);
-    }
-  });
-  recordSetSources.forEach((source) => {
-    try {
-      map.removeSource(source);
-    } catch (e) {
-      console.error('error removing source', e);
-    }
-  });
-};
-
-const rebuildLayersOnTableHashUpdate = async (
-  storeLayers: Record<PropertyKey, any>,
-  map: maplibregl.Map,
-  connectedToNetwork: boolean
-) => {
-  const MOBILE_OFFLINE = buildTimeConfig.MOBILE && !connectedToNetwork;
-  /* First need to delete the layers who's record set was deleted altogether: */
-  const storeLayersIds = storeLayers.map((layer) => formatLayerID(layer.recordSetID, layer.tableFiltersHash));
-  const allLayersOnMap = map.getLayersOrder();
-  const allSourcesOnMap = Object.keys(map.style.sourceCaches);
-  const allRecordSetLayers = allLayersOnMap.filter((layer) => layer.includes(LAYER_ID_PREFIX));
-  const allRecordSetSources = allSourcesOnMap.filter((source) => source.startsWith(LAYER_ID_PREFIX));
-
-  purgeRecordsetLayersNotInStore(map, storeLayersIds, allRecordSetLayers, allRecordSetSources);
-
-  // now update the layers that are in the store
-  await storeLayers.forEach(async (layer: Record<PropertyKey, any>) => {
-    if (layer.filterObject) {
-      const sourceId = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
-      deleteStaleRecordsetLayer(map, layer); // cleans up recordset layers with filters
-      const existingSource = map.getSource(sourceId);
-      if (existingSource) return;
-      await createMapLayer(map, layer, MOBILE_OFFLINE);
-    }
-  });
-};
-
-/**
- * @desc Handler logic for creating a new layer based on Network condition and recordset type
- */
-const createMapLayer = async (
-  map: maplibregl.Map,
-  layer: Record<PropertyKey, any>,
-  isOfflineLayer: boolean
-): Promise<void> => {
-  if (layer.type === RecordSetType.Activity) {
-    if (isOfflineLayer) {
-      await createCachedActivityLayer(map, layer);
-    } else {
-      createOnlineActivityLayer(map, layer);
-    }
-  } else if (layer.type === RecordSetType.IAPP) {
-    if (isOfflineLayer) {
-      await createCachedIappLayer(map, layer);
-    } else {
-      createOnlineIappLayer(map, layer);
-    }
-  }
-};
-
-const refreshColoursOnColourUpdate = (storeLayers, map: maplibregl.Map) => {
-  /** Get color value for a given paint property */
-  const currentColor = (paint, property: string) => paint[property] ?? '';
-
-  /** Check if current layer color matches stored color, and that colorScheme is not present */
-  const shouldUpdatePaint = (layer, layerStyle, property: string): boolean =>
-    !currentColor(layerStyle, property) && !Object.hasOwn(layer.layerState, 'colorScheme');
-
-  for (const layer of storeLayers) {
-    const layerSearchString = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
-    const matchingLayers = map.getLayersOrder().filter((mapLayer: any) => mapLayer.includes(layerSearchString));
-
-    matchingLayers.forEach((mapLayer) => {
-      const layerStyle = map.getStyle().layers.find((el) => el.id === mapLayer)?.paint;
-      if (
-        mapLayer.startsWith(LAYER_ID_PREFIX) &&
-        layer.type === RecordSetType.Activity &&
-        shouldUpdatePaint(layer, layerStyle, 'circle-color')
-      ) {
-        safelySetPaintProperty(map, mapLayer, 'fill-color', getPaintBySchemeOrColor(layer));
-        safelySetPaintProperty(map, mapLayer, 'fill-outline-color', getPaintBySchemeOrColor(layer));
-      } else if (mapLayer.startsWith('polygon-border-') && shouldUpdatePaint(layer, layerStyle, 'circle-color')) {
-        safelySetPaintProperty(map, mapLayer, 'line-color', getPaintBySchemeOrColor(layer));
-      } else if (mapLayer.startsWith('polygon-circle-') && shouldUpdatePaint(layer, layerStyle, 'fill-color')) {
-        safelySetPaintProperty(map, mapLayer, 'circle-color', getPaintBySchemeOrColor(layer));
-      }
-    });
-  }
-};
-
-const refreshVisibilityOnToggleUpdate = (storeLayers, map: maplibregl.Map) => {
-  storeLayers.map((layer) => {
-    const layerSearchString = formatLayerID(layer.recordSetID, layer.tableFiltersHash);
-    const mapLayers = map.getLayersOrder();
-    const matchingLayers = mapLayers.filter(
-      (mapLayer: any) => mapLayer.includes(layerSearchString) && !mapLayer.includes('label')
-    );
-    const matchingLabelLayers = mapLayers.filter(
-      (mapLayer: any) => mapLayer.includes(layerSearchString) && mapLayer.includes('label')
-    );
-    matchingLayers?.map((mapLayer) => {
-      const visibility = map.getLayoutProperty(mapLayer, 'visibility');
-      if (visibility !== 'none' && !layer.layerState.mapToggle) {
-        map.setLayoutProperty(mapLayer, 'visibility', 'none');
-      }
-      if (visibility !== 'visible' && layer.layerState.mapToggle) {
-        map.setLayoutProperty(mapLayer, 'visibility', 'visible');
-      }
-    });
-    matchingLabelLayers?.map((mapLayer) => {
-      const visibility = map.getLayoutProperty(mapLayer, 'visibility');
-      const shouldHideLabelLayer =
-        (visibility !== 'none' && !layer.layerState.labelToggle) || !layer.layerState.mapToggle;
-      const shouldShowLabelLayer =
-        visibility !== 'visible' && layer.layerState.labelToggle && layer.layerState.mapToggle;
-      if (shouldShowLabelLayer) {
-        map.setLayoutProperty(mapLayer, 'visibility', 'visible');
-      } else if (shouldHideLabelLayer) {
-        map.setLayoutProperty(mapLayer, 'visibility', 'none');
-      }
-    });
-  });
-};
-
-export {
-  createCachedIappLayer,
-  createOnlineActivityLayer,
-  refreshVisibilityOnToggleUpdate,
-  refreshColoursOnColourUpdate,
-  rebuildLayersOnTableHashUpdate,
-  removeRecordsetLayersOnForcedRedraw,
-  deleteStaleRecordsetLayer,
-  toggleOfflineActivityLabels,
-  removeOfflineActivitiesLayer,
-  refreshOfflineActivitiesLayer,
-  createCachedActivityLayer,
-  createOnlineIappLayer
-};
+export { getPaintBySchemeOrColor, buildCompleteRecordsetMapSpecificationFromRecordsets };

--- a/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
@@ -1,14 +1,17 @@
-import { ColorSpecification, ExpressionSpecification, SourceSpecification } from 'maplibre-gl';
+import { SourceSpecification } from 'maplibre-gl';
 import { Md5 } from 'ts-md5';
+import {
+  createBorderLayer,
+  createCircleLayer,
+  createFillLayer,
+  createLabelLayer,
+  getPaintBySchemeOrColor
+} from './layer-definitions/reusable-layer-specifications';
 import {
   InvasivesMapLayerDefinition,
   MapDefinitionEligibilityPredicatesBuilder
 } from 'UI/Features/LegacyMap/helpers/functional/layer-definitions/types';
-import { FALLBACK_COLOR } from 'UI/Features/LegacyMap/helpers/functional/constants';
 import { RecordSetId, RecordSetType, UserRecordSet } from 'interfaces/UserRecordSet';
-import VECTOR_MAP_FONT_FACE from 'constants/vectorMapFontFace';
-import { white } from 'constants/colors';
-import recordsetColourScheme from 'constants/recordsetColourScheme';
 
 function buildCompleteRecordsetMapSpecificationFromRecordsets(recordSets: Record<PropertyKey, UserRecordSet>) {
   return Object.values(recordSets)
@@ -45,15 +48,18 @@ function buildRecordsetLayerDefinitionsFromRecordset(rec: UserRecordSet): {
       return null;
     }
   })();
+  const stringifiedFilters = JSON.stringify(filterObject);
+  const SOURCE_ID = rec.id + rec.tableFiltersHash;
   // Forces Layers to refresh when filters/toggles/colours update
-  const layerID = Md5.hashStr(
-    rec.id + JSON.stringify(rec?.tableFilters) + rec.mapToggle + rec.labelToggle + JSON.stringify(color)
-  );
+  const layerID =
+    'recordset-layer-' +
+    Md5.hashStr(SOURCE_ID + stringifiedFilters + rec.mapToggle + rec.labelToggle + JSON.stringify(color));
+
   return {
     sources: {
-      [rec.id]: {
+      [SOURCE_ID]: {
         type: 'vector',
-        tiles: [`api:///api/vectors/${api_target}/{z}/{x}/{y}?filterObject=${encodeURI(JSON.stringify(filterObject))}`],
+        tiles: [`api:///api/vectors/${api_target}/{z}/{x}/{y}?filterObject=${encodeURI(stringifiedFilters)}`],
         minzoom: 0
       }
     },
@@ -70,101 +76,38 @@ function buildRecordsetLayerDefinitionsFromRecordset(rec: UserRecordSet): {
           .requiresNetwork(true)
           .build(),
         layers: [
-          {
-            id: 'fill-' + layerID,
-            type: 'fill',
-            source: rec.id,
+          createFillLayer({
+            layerId: layerID,
+            sourceId: SOURCE_ID,
             'source-layer': 'data',
-            paint: {
-              'fill-color': color,
-              'fill-outline-color': color,
-              'fill-opacity': 0.5
-            },
-            minzoom: 0,
-            layout: {
-              visibility: 'visible'
-            }
-          },
-          {
-            id: 'polygon-border-' + layerID,
-            source: rec.id,
+            color: color,
+            visibility: 'visible'
+          }),
+          createCircleLayer({
+            layerId: layerID,
+            sourceId: SOURCE_ID,
             'source-layer': 'data',
-            type: 'line',
-            paint: {
-              'line-color': color,
-              'line-opacity': 1,
-              'line-width': 3
-            },
-            minzoom: 0,
-            layout: {
-              visibility: 'visible'
-            }
-          },
-          {
-            id: 'polygon-circle-' + layerID,
-            source: rec.id,
+            color: color,
+            visibility: 'visible'
+          }),
+          createLabelLayer({
+            layerId: layerID,
+            sourceId: SOURCE_ID,
             'source-layer': 'data',
-            type: 'circle',
-            paint: {
-              'circle-color': color,
-              'circle-radius': 4
-            },
-            minzoom: 0,
-            layout: {
-              visibility: 'visible'
-            }
-          },
-          {
-            id: 'label-' + layerID,
-            source: rec.id,
-            'source-layer': 'data',
-            type: 'symbol',
-            layout: {
-              'text-field': [
-                'format',
-                ['get', 'short_id'],
-                { 'font-scale': 0.9 },
-                ['get', 'site_id'],
-                { 'font-scale': 0.9 },
-                '\n',
-                {},
-                ['get', 'map_symbol'],
-                { 'font-scale': 0.9 }
-              ],
-              // the actual font names that work are here https://github.com/openmaptiles/fonts/blob/gh-pages/fontstacks.json
-              'text-font': ['literal', [VECTOR_MAP_FONT_FACE]],
-              'text-offset': [0, 0.6],
-              'text-anchor': 'top',
-              visibility: rec.labelToggle ? 'visible' : 'none'
-            },
-            paint: {
-              'text-color': 'black',
-              'text-halo-color': 'white',
-              'text-halo-width': 1,
-              'text-halo-blur': 1
-            },
+            visibility: rec.labelToggle ? 'visible' : 'none',
             minzoom: 12
-          }
+          }),
+          createBorderLayer({
+            layerId: layerID,
+            sourceId: SOURCE_ID,
+            'source-layer': 'data',
+            color: color,
+            visibility: 'visible'
+          })
         ]
       }
     ]
   };
 }
 
-const getPaintBySchemeOrColor = (color: string): ColorSpecification | ExpressionSpecification => {
-  if (color === white) {
-    const activitySubtypeColours = Object.entries(recordsetColourScheme).flatMap(([activity, colour]) => [
-      activity,
-      colour ?? FALLBACK_COLOR
-    ]);
-    return [
-      'match',
-      ['get', 'activity_subtype'],
-      ...activitySubtypeColours,
-      color ?? FALLBACK_COLOR
-    ] as unknown as ExpressionSpecification;
-  }
-  return color ?? FALLBACK_COLOR;
-};
-
-export { getPaintBySchemeOrColor, buildCompleteRecordsetMapSpecificationFromRecordsets };
+export { buildCompleteRecordsetMapSpecificationFromRecordsets };

--- a/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/recordset-layers.ts
@@ -80,15 +80,13 @@ function buildRecordsetLayerDefinitionsFromRecordset(rec: UserRecordSet): {
             layerId: layerID,
             sourceId: SOURCE_ID,
             'source-layer': 'data',
-            color: color,
-            visibility: 'visible'
+            color: color
           }),
           createCircleLayer({
             layerId: layerID,
             sourceId: SOURCE_ID,
             'source-layer': 'data',
-            color: color,
-            visibility: 'visible'
+            color: color
           }),
           createLabelLayer({
             layerId: layerID,
@@ -101,8 +99,7 @@ function buildRecordsetLayerDefinitionsFromRecordset(rec: UserRecordSet): {
             layerId: layerID,
             sourceId: SOURCE_ID,
             'source-layer': 'data',
-            color: color,
-            visibility: 'visible'
+            color: color
           })
         ]
       }

--- a/app/src/UI/Features/Training/Training.tsx
+++ b/app/src/UI/Features/Training/Training.tsx
@@ -16,7 +16,6 @@ const TrainingPage = () => {
     (async () => {
       await fetch(`${api_base}/api/training_videos`)
         .then(async (res) => {
-          console.log(res);
           const data = await res.json();
           setVideos(data.result);
         })

--- a/app/src/state/actions/userSettings/UserSettings.ts
+++ b/app/src/state/actions/userSettings/UserSettings.ts
@@ -3,6 +3,7 @@ import { Feature, Point, Polygon } from 'geojson';
 import RecordSet from './RecordSet';
 import Boundary from 'interfaces/Boundary';
 import { RecordSetType, UserRecordSet } from 'interfaces/UserRecordSet';
+import { MapRecordsetLayerFilterCategory } from 'UI/Features/LegacyMap/helpers/functional/layer-definitions/reusable-layer-specifications';
 
 interface IHoverRecordset {
   recordType: RecordSetType;
@@ -100,11 +101,15 @@ class Map {
     layerName: string;
     active?: boolean;
   }>(`${this.PREFIX}/togglePreferredOverlayLayer`);
+
   static readonly setCenter = createAction<number[]>(`${this.PREFIX}/setCenter`);
   static readonly setCenterSuccess = createAction<number[]>(`${this.PREFIX}/setCenterSuccess`);
 
   static readonly setHoveredRecordset = createAction<IHoverRecordset>(`${this.PREFIX}/setHoveredRecordset`);
   static readonly markCoordinate = createAction<IMarkLocation>(`${this.PREFIX}/markCoordinate`);
+  static readonly toggleGlobalMapFilter = createAction<MapRecordsetLayerFilterCategory>(
+    `${this.PREFIX}/toggleGlobalMapFilter`
+  );
 }
 
 class SiteLists {

--- a/app/src/state/actions/userSettings/UserSettings.ts
+++ b/app/src/state/actions/userSettings/UserSettings.ts
@@ -3,7 +3,7 @@ import { Feature, Point, Polygon } from 'geojson';
 import RecordSet from './RecordSet';
 import Boundary from 'interfaces/Boundary';
 import { RecordSetType, UserRecordSet } from 'interfaces/UserRecordSet';
-import { MapRecordsetLayerFilterCategory } from 'UI/Features/LegacyMap/helpers/functional/layer-definitions/reusable-layer-specifications';
+import { MapRecordsetLayerFilterCategory } from 'state/reducers/map';
 
 interface IHoverRecordset {
   recordType: RecordSetType;

--- a/app/src/state/reducers/map.ts
+++ b/app/src/state/reducers/map.ts
@@ -1,4 +1,4 @@
-import { createNextState, nanoid } from '@reduxjs/toolkit';
+import { createNextState, createSelector, nanoid } from '@reduxjs/toolkit';
 import { Draft } from 'immer';
 import { Feature, GeoJSON, Point, Polygon } from 'geojson';
 import { CURRENT_MIGRATION_VERSION, MIGRATION_VERSION_KEY } from 'constants/offline_state_version';
@@ -22,6 +22,7 @@ import {
   MapRecordsetLayerFilterCategory,
   MapRecordsetLayerFilters
 } from 'UI/Features/LegacyMap/helpers/functional/layer-definitions/reusable-layer-specifications';
+import { FilterSpecification } from 'maplibre-gl';
 
 interface IServerLayer {
   id: number | string;
@@ -585,5 +586,50 @@ function createMapReducer(): (MapState, AnyAction) => MapState {
 }
 
 const selectMap: (state) => MapState = (state) => state.Map;
-export { createMapReducer, selectMap };
+
+/**
+ * @desc Calculates the Activity subtypes to be filtered out from the Map Layers based on the current state of 'globalMapFilters'
+ */
+const selectGlobalRecordsetFilters = createSelector(selectMap, (mapState): FilterSpecification | undefined => {
+  const MAP_RECORDSET_BUCKETS = {
+    [MapRecordsetLayerFilterCategory.Observations]: [
+      'Activity_Observation_PlantAquatic',
+      'Activity_Observation_PlantTerrestrial'
+    ],
+
+    [MapRecordsetLayerFilterCategory.Treatments]: [
+      'Activity_Treatment_ChemicalPlantAquatic',
+      'Activity_Treatment_ChemicalPlantTerrestrial',
+      'Activity_Treatment_MechanicalPlantAquatic',
+      'Activity_Treatment_MechanicalPlantTerrestrial'
+    ],
+
+    [MapRecordsetLayerFilterCategory.Monitoring]: [
+      'Activity_Monitoring_ChemicalTerrestrialAquaticPlant',
+      'Activity_Monitoring_MechanicalTerrestrialAquaticPlant'
+    ],
+
+    [MapRecordsetLayerFilterCategory.Biocontrol]: [
+      'Activity_Biocontrol_Collection',
+      'Activity_Biocontrol_Release',
+      'Activity_Monitoring_BiocontrolDispersal_TerrestrialPlant',
+      'Activity_Monitoring_BiocontrolRelease_TerrestrialPlant'
+    ]
+  };
+  const keys = Object.entries(mapState.globalMapFilters)
+    .filter(([_, value]) => !value)
+    .map(([key]) => key);
+
+  const filteredOutSubtypes: Array<string | number> = Array.from(
+    new Set(keys.flatMap((key) => MAP_RECORDSET_BUCKETS?.[key] ?? []))
+  );
+
+  if (filteredOutSubtypes.length === 0) {
+    return undefined; // no filter applied
+  }
+
+  return ['!in', 'activity_subtype', ...filteredOutSubtypes];
+});
+
+export { createMapReducer, selectMap, selectGlobalRecordsetFilters };
 export type { MapState, IServerLayer };

--- a/app/src/state/reducers/map.ts
+++ b/app/src/state/reducers/map.ts
@@ -18,13 +18,10 @@ import PlanMyTrip from 'state/actions/planMyTrip/PlanMyTrip';
 import AppActions from 'state/actions/appActions/appActions';
 import ExportActions from 'state/actions/exports/exportActions';
 import { OfflineProtomapsActions } from 'state/actions/offlineProtomaps';
-
-enum LeafletWhosEditingEnum {
-  ACTIVITY = 'ACTIVITY',
-  WHATSHERE = 'WHATSHERE',
-  BOUNDARY = 'BOUNDARY',
-  NONE = 'NONE'
-}
+import {
+  MapRecordsetLayerFilterCategory,
+  MapRecordsetLayerFilters
+} from 'UI/Features/LegacyMap/helpers/functional/layer-definitions/reusable-layer-specifications';
 
 interface IServerLayer {
   id: number | string;
@@ -75,6 +72,7 @@ interface MapState {
   userRecordOnHoverRecordID?: string | number;
   userRecordOnHoverRecordGeometry?: Feature | Polygon | Point;
   userRecordOnHoverRecordType?: RecordSetType;
+  globalMapFilters: MapRecordsetLayerFilters;
   viewFilters: boolean;
   whatsHere: {
     toggle: boolean;
@@ -133,6 +131,12 @@ const initialState: MapState = {
   drawingCustomLayerName: '',
   error: false,
   initialized: false,
+  globalMapFilters: {
+    [MapRecordsetLayerFilterCategory.Observations]: true,
+    [MapRecordsetLayerFilterCategory.Treatments]: true,
+    [MapRecordsetLayerFilterCategory.Monitoring]: true,
+    [MapRecordsetLayerFilterCategory.Biocontrol]: true
+  },
   layers: [],
   linkToCSV: '',
   panned: false,
@@ -571,6 +575,8 @@ function createMapReducer(): (MapState, AnyAction) => MapState {
         draftState.recordSetForCSV = null;
       } else if (OfflineProtomapsActions.setDebugPanelState.match(action)) {
         draftState.offlineProtomaps.debugPanelOpen = action.payload;
+      } else if (UserSettings.Map.toggleGlobalMapFilter.match(action)) {
+        draftState.globalMapFilters[action.payload] = !draftState.globalMapFilters[action.payload];
       } else if (OfflineProtomapsActions.toggleDebugPanelState.match(action)) {
         draftState.offlineProtomaps.debugPanelOpen = !state.offlineProtomaps.debugPanelOpen;
       }
@@ -580,4 +586,4 @@ function createMapReducer(): (MapState, AnyAction) => MapState {
 
 const selectMap: (state) => MapState = (state) => state.Map;
 export { createMapReducer, selectMap };
-export type { LeafletWhosEditingEnum, MapState, IServerLayer };
+export type { MapState, IServerLayer };

--- a/app/src/state/reducers/map.ts
+++ b/app/src/state/reducers/map.ts
@@ -1,6 +1,7 @@
 import { createNextState, createSelector, nanoid } from '@reduxjs/toolkit';
 import { Draft } from 'immer';
 import { Feature, GeoJSON, Point, Polygon } from 'geojson';
+import { FilterSpecification } from 'maplibre-gl';
 import { CURRENT_MIGRATION_VERSION, MIGRATION_VERSION_KEY } from 'constants/offline_state_version';
 import GeoShapes from 'constants/geoShapes';
 import UserSettings from 'state/actions/userSettings/UserSettings';
@@ -18,11 +19,21 @@ import PlanMyTrip from 'state/actions/planMyTrip/PlanMyTrip';
 import AppActions from 'state/actions/appActions/appActions';
 import ExportActions from 'state/actions/exports/exportActions';
 import { OfflineProtomapsActions } from 'state/actions/offlineProtomaps';
-import {
-  MapRecordsetLayerFilterCategory,
-  MapRecordsetLayerFilters
-} from 'UI/Features/LegacyMap/helpers/functional/layer-definitions/reusable-layer-specifications';
-import { FilterSpecification } from 'maplibre-gl';
+
+/**
+ * Filter Categories, Each of these represents a globally applied filter a user is able to select on the map.
+ * These will render in the LayerPicker as options
+ */
+enum MapRecordsetLayerFilterCategory {
+  Observations = 'Observations',
+  Treatments = 'Treatments',
+  Monitoring = 'Monitoring',
+  Biocontrol = 'Biocontrol'
+}
+
+type MapRecordsetLayerFilters = {
+  [key in MapRecordsetLayerFilterCategory]: boolean;
+};
 
 interface IServerLayer {
   id: number | string;
@@ -631,5 +642,5 @@ const selectGlobalRecordsetFilters = createSelector(selectMap, (mapState): Filte
   return ['!in', 'activity_subtype', ...filteredOutSubtypes];
 });
 
-export { createMapReducer, selectMap, selectGlobalRecordsetFilters };
-export type { MapState, IServerLayer };
+export { createMapReducer, selectMap, selectGlobalRecordsetFilters, MapRecordsetLayerFilterCategory };
+export type { MapState, IServerLayer, MapRecordsetLayerFilters };

--- a/app/src/state/reducers/rootReducer.ts
+++ b/app/src/state/reducers/rootReducer.ts
@@ -160,7 +160,8 @@ function createRootReducer(config: UnifiedConfig) {
           'accuracyToggle',
           'simplePickerLayers2',
           'clientBoundaries',
-          'serverBoundaries'
+          'serverBoundaries',
+          'globalMapFilters'
         ]
       },
       createMapReducer()

--- a/app/src/utils/useRecordSetControls.ts
+++ b/app/src/utils/useRecordSetControls.ts
@@ -1,26 +1,100 @@
-import { MouseEvent } from 'react';
-import { useDispatch } from './use_selector';
+import { MouseEvent, useEffect, useState } from 'react';
+import { SourceSpecification } from 'maplibre-gl';
+import { shallowEqual } from 'react-redux';
+import { useDispatch, useSelector } from './use_selector';
 import UserSettings from 'state/actions/userSettings/UserSettings';
 import Prompt from 'state/actions/prompts/Prompt';
+import {
+  InvasivesMapLayerDefinitionWithState,
+  LayerSpecificationWithStackingOrder
+} from 'UI/Features/LegacyMap/helpers/functional/layers-hook';
+import { buildCompleteRecordsetMapSpecificationFromRecordsets } from 'UI/Features/LegacyMap/helpers/functional/recordset-layers';
+import { LAYER_Z_FOREGROUND } from 'UI/Features/LegacyMap/helpers/functional/layer-definitions/types';
 
 /**
  * @desc Custom Hook for getting Recordset Control actions in one unified location.
  * @param id Recordset identifier
  */
-const useRecordSetControls = (id: string) => {
+const useRecordSetControls = (id?: string) => {
+  const ERROR_MESSAGE = 'ID not provided for this function';
+
   const dispatch = useDispatch();
+
+  const [recordsetLayers, setRecordsetLayers] = useState<LayerSpecificationWithStackingOrder[]>([]);
+  const [recordsetSources, setRecordsetSources] = useState<{ [_: string]: SourceSpecification }>({});
+  const recordsets = useSelector((state) => state.UserSettings.recordSets, shallowEqual);
+  const MOBILE = useSelector((state) => state.Configuration.current.build.MOBILE);
+  const DEBUG = useSelector((state) => state.Configuration.current.build.DEBUG);
+  const platform = useSelector((state) => state.Configuration.current.build.PLATFORM);
+  const features = useSelector((state) => state.Configuration.current.features);
+  const loggedInOrWorkingOffline = useSelector((state) => state.Auth.loggedInOrWorkingOffline);
+  const connected = useSelector((state) => state.Network.connected);
+
+  useEffect(() => {
+    const recordSetData = buildCompleteRecordsetMapSpecificationFromRecordsets(recordsets);
+    const filteredRecordDefinitions: InvasivesMapLayerDefinitionWithState[] = [];
+
+    for (const l of recordSetData.definitions) {
+      const pass = (() => {
+        switch (true) {
+          case !l.predicates.directlySelectable:
+          case l.predicates.mobileOnly && !MOBILE:
+          case l.predicates.webOnly && MOBILE:
+          case l.predicates.requiresDebug && !DEBUG:
+          case l.predicates.requiresPlatform !== undefined && l.predicates.requiresPlatform !== platform:
+          case l.predicates.requiresFeature !== undefined && !features[l.predicates.requiresFeature].enabled:
+          case l.predicates.requiresAuthentication && !loggedInOrWorkingOffline:
+          case l.predicates.requiresAnonymous && loggedInOrWorkingOffline:
+          case l.predicates.requiresNetwork && !connected:
+          case l.predicates.requiresOffline && connected:
+            return false;
+          default:
+            return true;
+        }
+      })();
+
+      if (pass) {
+        filteredRecordDefinitions.push({
+          active: recordsets[l.name].mapToggle,
+          ...l
+        });
+      }
+    }
+    const newLayers: LayerSpecificationWithStackingOrder[] = [];
+
+    const requiredSources: (keyof typeof recordSetData.sources | string)[] = [];
+
+    filteredRecordDefinitions.forEach((l) => {
+      if (l.active) {
+        for (const subLayer of l.layers) {
+          newLayers.push({
+            stackLayer: LAYER_Z_FOREGROUND,
+            ...subLayer
+          });
+          if (subLayer.source && !requiredSources.includes(subLayer.source)) {
+            requiredSources.push(subLayer.source);
+          }
+        }
+      }
+    });
+    setRecordsetSources(recordSetData.sources);
+    setRecordsetLayers(newLayers);
+  }, [recordsets, connected, loggedInOrWorkingOffline]);
 
   const toggleRecordsetLabel = (e?: MouseEvent<HTMLButtonElement>) => {
     e?.stopPropagation();
+    if (!id) throw new Error(ERROR_MESSAGE);
     dispatch(UserSettings.RecordSet.toggleLabelVisibility(id));
   };
 
   const toggleRecordsetLayer = (e?: MouseEvent<HTMLButtonElement>) => {
     e?.stopPropagation();
+    if (!id) throw new Error(ERROR_MESSAGE);
     dispatch(UserSettings.RecordSet.toggleVisibility(id));
   };
   const deleteRecordSet = (e?: MouseEvent<HTMLButtonElement>) => {
     e?.stopPropagation();
+    if (!id) throw new Error(ERROR_MESSAGE);
     const callback = (userConfirmation: boolean) => {
       if (userConfirmation) {
         dispatch(UserSettings.RecordSet.requestRemoval({ setId: id }));
@@ -38,6 +112,7 @@ const useRecordSetControls = (id: string) => {
     );
   };
   const cycleRecordsetColour = (e?: MouseEvent<HTMLButtonElement>) => {
+    if (!id) throw new Error(ERROR_MESSAGE);
     e?.stopPropagation();
     dispatch(UserSettings.RecordSet.cycleColourById(id));
   };
@@ -46,7 +121,9 @@ const useRecordSetControls = (id: string) => {
     cycleRecordsetColour,
     toggleRecordsetLabel,
     toggleRecordsetLayer,
-    deleteRecordSet
+    deleteRecordSet,
+    recordsetLayers,
+    recordsetSources
   };
 };
 

--- a/app/src/utils/useRecordSetControls.ts
+++ b/app/src/utils/useRecordSetControls.ts
@@ -10,6 +10,7 @@ import {
 } from 'UI/Features/LegacyMap/helpers/functional/layers-hook';
 import { buildCompleteRecordsetMapSpecificationFromRecordsets } from 'UI/Features/LegacyMap/helpers/functional/recordset-layers';
 import { LAYER_Z_FOREGROUND } from 'UI/Features/LegacyMap/helpers/functional/layer-definitions/types';
+import { selectGlobalRecordsetFilters } from 'state/reducers/map';
 
 /**
  * @desc Custom Hook for getting Recordset Control actions in one unified location.
@@ -31,12 +32,13 @@ const useRecordSetControls = (id?: string) => {
   const features = useSelector((state) => state.Configuration.current.features);
   const loggedInOrWorkingOffline = useSelector((state) => state.Auth.loggedInOrWorkingOffline);
   const connected = useSelector((state) => state.Network.connected);
+  const globalMapFilters = useSelector(selectGlobalRecordsetFilters);
 
   /**
    * Rebuild Recordset layers when recordsets/auth/online status changes.
    */
   useEffect(() => {
-    const recordSetData = buildCompleteRecordsetMapSpecificationFromRecordsets(recordsets);
+    const recordSetData = buildCompleteRecordsetMapSpecificationFromRecordsets(recordsets, globalMapFilters);
     const filteredRecordDefinitions: Array<InvasivesMapLayerDefinitionWithState> = [];
 
     for (const l of recordSetData.definitions) {
@@ -84,7 +86,7 @@ const useRecordSetControls = (id?: string) => {
 
     setRecordsetSources(recordSetData.sources);
     setRecordsetLayers(newLayers);
-  }, [recordsets, connected, loggedInOrWorkingOffline]);
+  }, [recordsets, connected, loggedInOrWorkingOffline, globalMapFilters]);
 
   const toggleRecordsetLabel = (e?: MouseEvent<HTMLButtonElement>) => {
     e?.stopPropagation();

--- a/app/src/utils/useRecordSetControls.ts
+++ b/app/src/utils/useRecordSetControls.ts
@@ -23,6 +23,8 @@ const useRecordSetControls = (id?: string) => {
   const [recordsetLayers, setRecordsetLayers] = useState<LayerSpecificationWithStackingOrder[]>([]);
   const [recordsetSources, setRecordsetSources] = useState<{ [_: string]: SourceSpecification }>({});
   const recordsets = useSelector((state) => state.UserSettings.recordSets, shallowEqual);
+
+  // Predicate variables.
   const MOBILE = useSelector((state) => state.Configuration.current.build.MOBILE);
   const DEBUG = useSelector((state) => state.Configuration.current.build.DEBUG);
   const platform = useSelector((state) => state.Configuration.current.build.PLATFORM);
@@ -30,9 +32,12 @@ const useRecordSetControls = (id?: string) => {
   const loggedInOrWorkingOffline = useSelector((state) => state.Auth.loggedInOrWorkingOffline);
   const connected = useSelector((state) => state.Network.connected);
 
+  /**
+   * Rebuild Recordset layers when recordsets/auth/online status changes.
+   */
   useEffect(() => {
     const recordSetData = buildCompleteRecordsetMapSpecificationFromRecordsets(recordsets);
-    const filteredRecordDefinitions: InvasivesMapLayerDefinitionWithState[] = [];
+    const filteredRecordDefinitions: Array<InvasivesMapLayerDefinitionWithState> = [];
 
     for (const l of recordSetData.definitions) {
       const pass = (() => {
@@ -61,8 +66,7 @@ const useRecordSetControls = (id?: string) => {
       }
     }
     const newLayers: LayerSpecificationWithStackingOrder[] = [];
-
-    const requiredSources: (keyof typeof recordSetData.sources | string)[] = [];
+    const requiredSources: Array<keyof typeof recordSetData.sources | string> = [];
 
     filteredRecordDefinitions.forEach((l) => {
       if (l.active) {
@@ -77,6 +81,7 @@ const useRecordSetControls = (id?: string) => {
         }
       }
     });
+
     setRecordsetSources(recordSetData.sources);
     setRecordsetLayers(newLayers);
   }, [recordsets, connected, loggedInOrWorkingOffline]);

--- a/app/src/utils/useRecordSetControls.ts
+++ b/app/src/utils/useRecordSetControls.ts
@@ -86,6 +86,7 @@ const useRecordSetControls = (id?: string) => {
 
     setRecordsetSources(recordSetData.sources);
     setRecordsetLayers(newLayers);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recordsets, connected, loggedInOrWorkingOffline, globalMapFilters]);
 
   const toggleRecordsetLabel = (e?: MouseEvent<HTMLButtonElement>) => {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

> [!IMPORTANT]
> This PR is a work in Progress. Merging it in would add breaking changes as Offline Records Layers are not implemented. 


## Recordset Layers
- Refactor the building and management of Recordset Layers

## Global Layer Filter

- Created Selector for getting building filter layers based on buckets.
- Add new State to Map `globalMapFilters`
- Add toggles to the LayerPicker -> Recordset page to toggle the view of specific recordset subtypes (via buckets) 
- Reduce width of LayerPicker from 400px -> 350px.
    - Misc adjustments to ensure things fit neatly on the page (e.g. large recordset names
    - Adjust color of Icons from jarring black to less jarring eigengrau
- Reduce size of LayerPicker Button on map 