### PR TITLE
[INV-4204] Set Max area for WhatsHere

### DIFF
--- a/app/src/UI/Features/LegacyMap/helpers/components/DrawControls.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/DrawControls.tsx
@@ -504,7 +504,7 @@ const DrawControls = () => {
           id: 'gl-drawn-fill.hot',
           type: 'fill',
           layout: {},
-          filter: ['all', ['==', 'active', 'false'], ['!=', 'user_error', 'true']],
+          filter: ['all', ['==', 'active', 'false'], ['!=', 'user_error', 'true'], ['==', '$type', 'Polygon']],
           paint: {
             'fill-color': 'white',
             'fill-opacity': 0.5

--- a/app/src/UI/Features/LegacyMap/helpers/functional/whats-here.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/whats-here.ts
@@ -27,6 +27,7 @@ export const refreshWhatsHereFeature = (map, options: any) => {
           id: layerID + 'shape',
           source: layerID,
           type: 'fill',
+          filter: ['==', '$type', 'Polygon'],
           paint: {
             'fill-color': 'white',
             'fill-outline-color': 'black',

--- a/app/src/state/sagas/map.ts
+++ b/app/src/state/sagas/map.ts
@@ -82,15 +82,18 @@ function* handle_WHATS_HERE_FEATURE(whatsHereFeature: PayloadAction<Feature>) {
 
   const isOversized = newGeom && area(newGeom) > METERS_IN_HECTARE * MAX_HECTARES;
   if (isOversized) {
-    yield put(
-      Alerts.create({
-        subject: AlertSubjects.Map,
-        severity: AlertSeverity.Error,
-        content: `Reduce area of search to <${MAX_HECTARES.toLocaleString()} Hectares`,
-        autoClose: 4
-      })
-    );
-    yield put(WhatsHere.server_filtered_ids_fetched([], []));
+    yield all([
+      // Terminate process, end loading spinner/status
+      yield put(WhatsHere.server_filtered_ids_fetched([], [])),
+      yield put(
+        Alerts.create({
+          subject: AlertSubjects.Map,
+          severity: AlertSeverity.Error,
+          content: `Reduce area of search to <${MAX_HECTARES.toLocaleString()} Hectares`,
+          autoClose: 4
+        })
+      )
+    ]);
     return;
   }
 

--- a/app/src/state/sagas/map.ts
+++ b/app/src/state/sagas/map.ts
@@ -1,4 +1,4 @@
-import { buffer } from '@turf/turf';
+import { area, buffer } from '@turf/turf';
 import { Feature } from 'geojson';
 import { actionChannel, all, call, debounce, fork, put, select, take, takeEvery, takeLatest } from 'redux-saga/effects';
 import { PayloadAction } from '@reduxjs/toolkit';
@@ -52,6 +52,8 @@ import AppActions from 'state/actions/appActions/appActions';
 import DrawToolActions from 'state/actions/drawtool/drawToolActions';
 import getIdsForRecordset from 'utils/getIdsForRecordset';
 import { selectConfiguration } from 'state/reducers/configuration';
+import Alerts from 'state/actions/alerts/Alerts';
+import { AlertSeverity, AlertSubjects } from 'constants/alertEnums';
 
 function* handle_USER_SETTINGS_GET_INITIAL_STATE_SUCCESS() {
   yield put(MapActions.initRequest());
@@ -71,7 +73,29 @@ function* refetchServerBoundaries() {
 }
 
 function* handle_WHATS_HERE_FEATURE(whatsHereFeature: PayloadAction<Feature>) {
+  const METERS_IN_HECTARE = 10000;
+  const MAX_HECTARES = 3000;
+  const newGeom =
+    whatsHereFeature.payload.geometry.type === GeoShapes.Polygon
+      ? whatsHereFeature.payload
+      : buffer(whatsHereFeature.payload, 5, { units: 'centimeters' });
+
+  const isOversized = newGeom && area(newGeom) > METERS_IN_HECTARE * MAX_HECTARES;
+  if (isOversized) {
+    yield put(
+      Alerts.create({
+        subject: AlertSubjects.Map,
+        severity: AlertSeverity.Error,
+        content: `Reduce area of search to <${MAX_HECTARES.toLocaleString()} Hectares`,
+        autoClose: 4
+      })
+    );
+    yield put(WhatsHere.server_filtered_ids_fetched([], []));
+    return;
+  }
+
   const { connected } = yield select(selectNetworkState);
+
   if (connected) {
     // get all the toggled on recordsets
     const tableFilters = [


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Pre-check the area the `Whats here` shape occupies before submitting for search. Current limit defined at 3k `hectares`
    - Area decided by @brennanwebster  
- Massive areas can bog down the database that has to calculate the overlapping area, and the user receives a less-than-useful table containing `n` records. This forces them to use it in the more intended way, for getting data about a  (more) specific area.
- Alert user if area too large.
- Apply Filters to Draw Tools / Whats Here layers to linestrings/points don't render fill layers 
- Closes #4204 


<img width="124" height="134" alt="image" src="https://github.com/user-attachments/assets/658dd052-77a4-47e8-ba85-f9119cc73871" />

[*This no longer happens*]

<img width="171" height="149" alt="image" src="https://github.com/user-attachments/assets/b2063cb8-adf0-4ec6-bd5b-6684625fc6a5" />

[*Improved Result*]