### PR TITLE
[INV-4293][INV-4294] BUGFIXES** Filtering Activity Subtype, Count of Sitelist IDs

### DIFF
--- a/api/src/queries/activities-v2-queries.ts
+++ b/api/src/queries/activities-v2-queries.ts
@@ -336,6 +336,7 @@ function additionalCTEStatements(sqlStatement: SQLStatement, filterObject: any) 
 	    a.short_id,
 	    a.activity_type,
 	    a.activity_subtype,
+      a.activity_subtype_full,
 	    a.activity_payload,
 	    a.jurisdiction_display,
 	    a.invasive_plant,
@@ -533,7 +534,6 @@ function fromStatement(sqlStatement: SQLStatement, filterObject: any) {
           'join biocontrol_release_monitoring_summary extract ON extract.activity_id = b.activity_id '
         );
         break;
-
       default:
         sqlStatement.append(
           'join observation_terrestrial_plant_summary extract ON extract.activity_id = b.activity_id '
@@ -592,7 +592,7 @@ function whereStatement(sqlStatement: SQLStatement, filterObject: any) {
         break;
       case 'activity_subtype':
         where.append(
-          `${filter.operator2} LOWER(${tableAlias}.activity_subtype) ${
+          `${filter.operator2} LOWER(${tableAlias}.activity_subtype_full) ${
             filter.operator === 'CONTAINS' ? 'like' : 'not like'
           }  LOWER('%${escapeLiteralUnquoted(filter.filter)}%') `
         );

--- a/app/src/utils/getIdsForRecordset.ts
+++ b/app/src/utils/getIdsForRecordset.ts
@@ -9,7 +9,7 @@ interface Options {
  * @returns {Array<string | number>} Ids for all records matching params for a user with read permissions.
  */
 const getIdsForRecordset = async (record: UserRecordSet, options: Options): Promise<Array<string | number>> => {
-  const { recordSetType, tableFilters } = record;
+  const { ids_to_filter, recordSetType, tableFilters } = record;
   const config = (() => {
     switch (recordSetType) {
       case RecordSetType.IAPP:
@@ -25,7 +25,8 @@ const getIdsForRecordset = async (record: UserRecordSet, options: Options): Prom
     }
   })();
 
-  const filterObjects = { selectColumns: [config.col], tableFilters, limit: 999999 };
+  const filterObjects = { ids_to_filter, selectColumns: [config.col], tableFilters, limit: 999999 };
+
   const res = await fetch(config.url, {
     method: 'POST',
     headers: { Authorization: await getCurrentJWT(), 'Content-Type': 'application/json' },


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Modify query param to filter against the readable activity subtype label instead of the code that the user cannot see. Improves querying
    - Closes #4293
- Modify getIdsForActivity to add missing param `ids_to_filter`. Only affected SiteLists.
    - Closes #4294

Screenshots

<img width="820" height="376" alt="image" src="https://github.com/user-attachments/assets/0b5852fb-aa78-4bae-8718-d794dca72d53" />

[*Label Filter works better*]
