### PR TITLE
[INV-4295] Add Warning when Global filters Applied

### DIFF
--- a/app/src/UI/Features/Records/RecordSet/GlobalFilterWarning/GlobalFilterWarning.css
+++ b/app/src/UI/Features/Records/RecordSet/GlobalFilterWarning/GlobalFilterWarning.css
@@ -1,0 +1,3 @@
+.global-filter-tooltip {
+  font-size: 0.9rem;
+}

--- a/app/src/UI/Features/Records/RecordSet/GlobalFilterWarning/GlobalFilterWarning.tsx
+++ b/app/src/UI/Features/Records/RecordSet/GlobalFilterWarning/GlobalFilterWarning.tsx
@@ -7,7 +7,12 @@ import { WarningAmberRounded } from '@mui/icons-material';
 import TooltipWithIcon from 'UI/Reusable/TooltipWithIcon/TooltipWithIcon';
 
 const GlobalFilterWarning = () => {
-  const START_OF_SUBTYPES = 2; // ["!in", "activity_subtype", ...subtypes]
+  /**
+   *  In a filter expression, index 0 = operator, index 1 = property.
+   *  subtypes start from index 2.
+   *  example filter: ["!in", "activity_subtype", ...subtypes]
+   */
+  const START_OF_SUBTYPES = 2;
   const globalMapFilters = useSelector(selectGlobalRecordsetFilters);
 
   const alertMessage = useMemo<ReactNode>(() => {

--- a/app/src/UI/Features/Records/RecordSet/GlobalFilterWarning/GlobalFilterWarning.tsx
+++ b/app/src/UI/Features/Records/RecordSet/GlobalFilterWarning/GlobalFilterWarning.tsx
@@ -1,4 +1,3 @@
-import { Tooltip } from '@mui/material';
 import { ReactNode, useMemo } from 'react';
 import { selectGlobalRecordsetFilters } from 'state/reducers/map';
 import { useSelector } from 'utils/use_selector';
@@ -13,7 +12,7 @@ const GlobalFilterWarning = () => {
     if (globalMapFilters == undefined) return null;
     return (
       <div className="global-filter-tooltip">
-        <p>Global filters are active. The map may not show all data.</p>
+        <p>Global filters are active. The map will not show the following data:</p>
         <ul>
           {(globalMapFilters as unknown as Array<string>).slice(2).map((f) => (
             <li key={f}>{ActivitySubtypeShortLabels?.[f]}</li>

--- a/app/src/UI/Features/Records/RecordSet/GlobalFilterWarning/GlobalFilterWarning.tsx
+++ b/app/src/UI/Features/Records/RecordSet/GlobalFilterWarning/GlobalFilterWarning.tsx
@@ -1,0 +1,30 @@
+import { Tooltip } from '@mui/material';
+import { ReactNode, useMemo } from 'react';
+import { selectGlobalRecordsetFilters } from 'state/reducers/map';
+import { useSelector } from 'utils/use_selector';
+import { ActivitySubtypeShortLabels } from 'sharedAPI';
+import './GlobalFilterWarning.css';
+import { WarningAmberRounded } from '@mui/icons-material';
+import TooltipWithIcon from 'UI/Reusable/TooltipWithIcon/TooltipWithIcon';
+
+const GlobalFilterWarning = () => {
+  const globalMapFilters = useSelector(selectGlobalRecordsetFilters);
+  const alertMessage = useMemo<ReactNode>(() => {
+    if (globalMapFilters == undefined) return null;
+    return (
+      <div className="global-filter-tooltip">
+        <p>Global filters are active. The map may not show all data.</p>
+        <ul>
+          {(globalMapFilters as unknown as Array<string>).slice(2).map((f) => (
+            <li key={f}>{ActivitySubtypeShortLabels?.[f]}</li>
+          ))}
+        </ul>
+      </div>
+    );
+  }, [globalMapFilters]);
+
+  if (!alertMessage) return null;
+  return <TooltipWithIcon tooltipText={alertMessage} icon={<WarningAmberRounded color="warning" />} />;
+};
+
+export default GlobalFilterWarning;

--- a/app/src/UI/Features/Records/RecordSet/GlobalFilterWarning/GlobalFilterWarning.tsx
+++ b/app/src/UI/Features/Records/RecordSet/GlobalFilterWarning/GlobalFilterWarning.tsx
@@ -7,14 +7,16 @@ import { WarningAmberRounded } from '@mui/icons-material';
 import TooltipWithIcon from 'UI/Reusable/TooltipWithIcon/TooltipWithIcon';
 
 const GlobalFilterWarning = () => {
+  const START_OF_SUBTYPES = 2; // ["!in", "activity_subtype", ...subtypes]
   const globalMapFilters = useSelector(selectGlobalRecordsetFilters);
+
   const alertMessage = useMemo<ReactNode>(() => {
     if (globalMapFilters == undefined) return null;
     return (
       <div className="global-filter-tooltip">
         <p>Global filters are active. The map will not show the following data:</p>
         <ul>
-          {(globalMapFilters as unknown as Array<string>).slice(2).map((f) => (
+          {(globalMapFilters as unknown as Array<string>).slice(START_OF_SUBTYPES).map((f) => (
             <li key={f}>{ActivitySubtypeShortLabels?.[f]}</li>
           ))}
         </ul>

--- a/app/src/UI/Features/Records/RecordSet/RecordSet.css
+++ b/app/src/UI/Features/Records/RecordSet/RecordSet.css
@@ -57,7 +57,7 @@
 
 .recordSet_header_name {
   display: flex;
-  padding-left: 2vw;
+  margin: 0 8pt;
   font-size: large;
   font-weight: bold;
   text-wrap: wrap;

--- a/app/src/UI/Features/Records/RecordSet/RecordSet.tsx
+++ b/app/src/UI/Features/Records/RecordSet/RecordSet.tsx
@@ -13,6 +13,7 @@ import Activity from 'state/actions/activity/Activity';
 import Filters from './Filters/Filters';
 import { MobileOnly } from 'UI/Reusable/Predicates/MobileOnly';
 import { FeatureGated } from 'UI/Reusable/Predicates/FeatureGated';
+import GlobalFilterWarning from './GlobalFilterWarning/GlobalFilterWarning';
 
 type PropTypes = { setID: string };
 
@@ -47,6 +48,7 @@ export const RecordSet = ({ setID }: PropTypes) => {
           <div className="recordSet_header_name">
             {recordSet?.recordSetName || `New Recordset - ${recordSet?.recordSetType}`}
           </div>
+          <GlobalFilterWarning />
           <MobileOnly>
             <FeatureGated requires="CACHE_RECORDSETS">
               {canCacheRecordset && !isCellPhoneWidth && (

--- a/app/src/UI/Reusable/TooltipWithIcon/TooltipWithIcon.tsx
+++ b/app/src/UI/Reusable/TooltipWithIcon/TooltipWithIcon.tsx
@@ -1,12 +1,13 @@
 import { HelpOutline } from '@mui/icons-material';
-import { IconButton, Tooltip } from '@mui/material';
-import { useState } from 'react';
+import { IconButton, SvgIconProps, Tooltip } from '@mui/material';
+import { ReactElement, ReactNode, useState } from 'react';
 
 type PropTypes = {
-  tooltipText: string;
+  tooltipText: string | ReactNode;
+  icon?: ReactElement<SvgIconProps>;
 };
 
-const TooltipWithIcon = ({ tooltipText }: PropTypes) => {
+const TooltipWithIcon = ({ tooltipText, icon }: PropTypes) => {
   const [showTooltip, setShowTooltip] = useState<boolean>(false);
   return (
     <Tooltip
@@ -19,7 +20,7 @@ const TooltipWithIcon = ({ tooltipText }: PropTypes) => {
       title={tooltipText}
     >
       <IconButton sx={{ padding: 0, margin: 0, pointerEvents: 'auto' }}>
-        <HelpOutline color="info" />
+        {icon ? icon : <HelpOutline color="info" />}
       </IconButton>
     </Tooltip>
   );

--- a/app/src/constants/offline_state_version.ts
+++ b/app/src/constants/offline_state_version.ts
@@ -1,5 +1,5 @@
 /*
   handle purging the offline storage on app version upgrade
 */
-export const CURRENT_MIGRATION_VERSION = 20250903;
+export const CURRENT_MIGRATION_VERSION = 20250918;
 export const MIGRATION_VERSION_KEY = '_persistedMigrationVersion';


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Refactor `TooltipWithText` to have overrideable Icon, and extend tooltipText prop to allow React Nodes (As mui tooltip allows this)
- Display Warning Icon when user is in a Recordset with Global Filters applied
- Closes #4295

## Screenshots 

<img width="844" height="397" alt="image" src="https://github.com/user-attachments/assets/720b4732-8b4d-44a3-95d0-5e08364f69d4" />
