### PR TITLE
[INV-4298] Allow user to copy a feature shape to their form

### DIFF
--- a/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarker.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarker.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { MapContext } from '../MapContext';
 import { MapMouseEvent, MapTouchEvent, Point, PointLike, Popup } from 'maplibre-gl';
 import ReactDOM from 'react-dom/client';
 import LayerDataMarkerContent from './LayerDataMarkerContent';
-import { useSelector } from 'utils/use_selector';
+import { useDispatch, useSelector } from 'utils/use_selector';
 import { useNavigate } from 'react-router';
 
 const LayerDataMarker = () => {
@@ -12,10 +12,18 @@ const LayerDataMarker = () => {
 
   const map = useContext(MapContext);
   const navigate = useNavigate();
+  const dispatch = useDispatch();
 
+  const isCellPhoneWidth = useSelector((state) => state.AppMode.constraints.tinyScreen);
   const whatsHereEnabled = useSelector((state) => state.Map.whatsHere.toggle);
   const connected = useSelector((state) => state.Network.connected);
   const globalMapFilters = useSelector((state) => state.Map.globalMapFilters);
+
+  // Allow for Copying records geometry
+  const url = useSelector((state) => state.AppMode.url);
+  const editPermission = useSelector((state) => !!state.ActivityPage.activeActivityPermissions?.can_edit);
+  const userCanCopyShape = useMemo(() => editPermission && /\/Activity\//.test(url ?? ''), [url, editPermission]);
+
   const drawToolsActive = useRef<boolean>(false);
   const editModeActive = useRef<boolean>(false);
 
@@ -69,6 +77,7 @@ const LayerDataMarker = () => {
                     label: feature.properties.type,
                     value: feature.properties.short_id,
                     map_symbol: feature.properties.map_symbol,
+                    id: feature.properties.activity_id,
                     url: '/Records/Activity/' + feature.properties.activity_id + '/form'
                   }
                 : {
@@ -91,17 +100,24 @@ const LayerDataMarker = () => {
         className: 'map-features-at-point',
         maxWidth: 'none',
         closeButton: true,
-        closeOnMove: true
+        closeOnMove: !isCellPhoneWidth // Small viewports may need to pan the screen if necessary
       })
         .setLngLat(e.lngLat)
         .setDOMContent(el)
         .addTo(map);
 
-      // Inject React into the new static container
+      // Inject React into the new static container.
       const root = ReactDOM.createRoot(el);
-      root.render(<LayerDataMarkerContent navigate={navigate} features={uniqueFormattedFeaturesAtClickTarget} />);
+      root.render(
+        <LayerDataMarkerContent
+          navigate={navigate}
+          dispatch={dispatch}
+          features={uniqueFormattedFeaturesAtClickTarget}
+          canCopyShape={userCanCopyShape}
+        />
+      );
     },
-    [map, recordsetLayers, popupRef, whatsHereEnabled, connected, globalMapFilters]
+    [map, recordsetLayers, popupRef, whatsHereEnabled, connected, globalMapFilters, userCanCopyShape]
   );
   /**
    * @desc Sets time touch event started at
@@ -151,6 +167,11 @@ const LayerDataMarker = () => {
       map.off('styledata', updateLayers);
     };
   }, [map, whatsHereEnabled, recordsetLayers, connected]);
+
+  // Close popup when URL Changes.
+  useEffect(() => {
+    popupRef.current?.remove();
+  }, [url]);
 
   return null;
 };

--- a/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarkerContent.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarkerContent.tsx
@@ -1,9 +1,12 @@
 import LaunchIcon from '@mui/icons-material/Launch';
-import { IconButton } from '@mui/material';
+import { IconButton, Tooltip } from '@mui/material';
 import './layerDataMarkerContent.css';
-import { ArrowCircleLeftOutlined, ArrowCircleRightOutlined } from '@mui/icons-material';
+import { ArrowCircleLeftOutlined, ArrowCircleRightOutlined, CopyAll } from '@mui/icons-material';
 import { useState } from 'react';
 import { NavigateFunction } from 'react-router';
+import { Dispatch } from 'redux';
+import Prompt from 'state/actions/prompts/Prompt';
+import Activity from 'state/actions/activity/Activity';
 
 type PropTypes = {
   features: Array<{
@@ -11,13 +14,31 @@ type PropTypes = {
     url: string;
     value: string;
     map_symbol: string;
+    id?: string | number;
   }>;
+  canCopyShape: boolean;
+  dispatch: Dispatch;
   navigate: NavigateFunction;
 };
 
-const LayerDataMarkerContent = ({ features, navigate }: PropTypes) => {
+const LayerDataMarkerContent = ({ features, navigate, dispatch, canCopyShape: canCopyRecord }: PropTypes) => {
   const STEP = 3;
   const handleGoTo = (url: string) => navigate(url);
+  const handleCopy = (id: string | number) =>
+    dispatch(
+      Prompt.confirmation({
+        title: 'Copy shape',
+        prompt:
+          'Do you want to replace your current shape with this one? Your existing shape will be lost if you continue.',
+        confirmText: 'Copy shape',
+        callback: (confirm: boolean) => {
+          if (confirm) {
+            dispatch(Activity.Autofill.copyGeometry(id.toString()));
+          }
+        }
+      })
+    );
+
   const inc = () => setFirstPos((oldPos) => Math.min(oldPos + STEP, features.length));
   const dec = () => setFirstPos((oldPos) => Math.max(oldPos - STEP, 0));
   const [firstPos, setFirstPos] = useState<number>(0);
@@ -31,16 +52,26 @@ const LayerDataMarkerContent = ({ features, navigate }: PropTypes) => {
             <tr>
               <th>Type</th>
               <th>Record ID</th>
-              <th colSpan={2}>Map Symbol</th>
+              <th>Map Symbol</th>
             </tr>
           </thead>
           <tbody>
-            {slicedFeatures.map(({ label, map_symbol, value, url }) => (
+            {slicedFeatures.map(({ id, label, map_symbol, value, url }) => (
               <tr key={value + map_symbol + label}>
                 <td>{label}</td>
                 <td>{value}</td>
                 <td>{map_symbol}</td>
-                <td>
+
+                <td className="buttons">
+                  {id && canCopyRecord && (
+                    <Tooltip classes={{ tooltip: 'toolTip' }} title={'Replace your current shape with this one'}>
+                      <span>
+                        <IconButton disabled={!canCopyRecord} onClick={handleCopy.bind(this, id)}>
+                          <CopyAll />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                  )}
                   <IconButton onClick={handleGoTo.bind(this, url)}>
                     <LaunchIcon />
                   </IconButton>

--- a/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/layerDataMarkerContent.css
+++ b/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/layerDataMarkerContent.css
@@ -68,6 +68,10 @@
       tbody tr td {
         text-align: left;
       }
+      td.buttons {
+        display: flex;
+        justify-content: flex-end;
+      }
       tr {
         font-size: 0.85rem;
       }

--- a/app/src/state/actions/activity/AutoFill.ts
+++ b/app/src/state/actions/activity/AutoFill.ts
@@ -5,6 +5,7 @@ class AutoFill {
   static readonly update = createAction(`${this.PREFIX}/update`);
   static readonly updateSuccess = createAction(`${this.PREFIX}/updateSuccess`);
   static readonly updateFailure = createAction(`${this.PREFIX}/updateFailure`);
+  static readonly copyGeometry = createAction<string>(`${this.PREFIX}/copyGeometry`);
 }
 
 export default AutoFill;

--- a/app/src/state/sagas/activity.ts
+++ b/app/src/state/sagas/activity.ts
@@ -418,7 +418,7 @@ function* handle_copyGeometry(action: PayloadAction<string>) {
       if (res?.ok) {
         const data = yield res.json();
         if (data.geometry?.[FIRST_ENTRY]) {
-          yield put(DrawToolActions.createShape(data.geometry[0]));
+          yield put(DrawToolActions.createShape(data.geometry[FIRST_ENTRY]));
           return; // Shape was extracted, no need to continue
         }
       }
@@ -432,7 +432,7 @@ function* handle_copyGeometry(action: PayloadAction<string>) {
       const service = yield RecordCacheServiceFactory.getPlatformInstance();
       const data = yield service.loadActivity(action.payload);
       if (data.geometry?.[FIRST_ENTRY]) {
-        yield put(DrawToolActions.createShape(data.geometry[0]));
+        yield put(DrawToolActions.createShape(data.geometry[FIRST_ENTRY]));
         return; // Shape was extracted, no need to continue
       }
     } catch (e) {

--- a/app/src/state/sagas/activity.ts
+++ b/app/src/state/sagas/activity.ts
@@ -1,5 +1,5 @@
 import { all, call, put, select, take, takeEvery } from 'redux-saga/effects';
-import { buffer, distance, kinks, lineToPolygon, polygon } from '@turf/turf';
+import { buffer, distance, kinks, lineToPolygon } from '@turf/turf';
 import { PayloadAction } from '@reduxjs/toolkit';
 import { Feature } from 'geojson';
 import {

--- a/app/src/state/sagas/activity.ts
+++ b/app/src/state/sagas/activity.ts
@@ -1,5 +1,5 @@
 import { all, call, put, select, take, takeEvery } from 'redux-saga/effects';
-import { buffer, distance, kinks, lineToPolygon } from '@turf/turf';
+import { buffer, distance, kinks, lineToPolygon, polygon } from '@turf/turf';
 import { PayloadAction } from '@reduxjs/toolkit';
 import { Feature } from 'geojson';
 import {
@@ -34,6 +34,7 @@ import {
   handle_ACTIVITY_SAVE_NETWORK_REQUEST
 } from './activity/online';
 import { OFFLINE_ACTIVITY_SAGA_HANDLERS } from './activity/offline';
+import { getCurrentJWT } from './auth/auth';
 import { selectActivity } from 'state/reducers/activity';
 import { selectUserSettings } from 'state/reducers/userSettings';
 import RootUISchemas from 'rjsf/uiSchema/RootUISchemas';
@@ -61,6 +62,7 @@ import { GEO_TRACKING_FEATURE } from 'UI/Features/LegacyMap/helpers/functional/c
 import { isDrawing } from 'utils/geoTrackingHelpers';
 import AppActions from 'state/actions/appActions/appActions';
 import DrawToolActions from 'state/actions/drawtool/drawToolActions';
+import { selectConfiguration, selectRootConfiguration } from 'state/reducers/configuration';
 
 function* handle_ACTIVITY_DELETE_SUCCESS() {
   yield put(UserSettings.RecordSet.setSelected(null));
@@ -397,10 +399,61 @@ function* handle_UPDATE_CACHED_RECORDS() {
     yield Alerts.create(cacheAlertMessages.updateCachesFailed);
   }
 }
+/**
+ * @desc Take a geometry from an existing record and apply it to the active record. Hooks into Draw tools so the shape can be edited after if needed
+ * @param {PayloadAction} action Activity ID of Record
+ */
+function* handle_copyGeometry(action: PayloadAction<string>) {
+  const FIRST_ENTRY = 0;
+  const { API_BASE } = yield select(selectConfiguration);
+  const baseConfig = yield select(selectRootConfiguration);
+  const connected = yield select(selectNetworkConnected);
+  const MOBILE = baseConfig.current.build.MOBILE;
+
+  if (connected) {
+    try {
+      const res = yield fetch(`${API_BASE}/api/activity/${action.payload}`, {
+        headers: { authorization: yield getCurrentJWT(), 'Content-Type': 'application/json' }
+      });
+      if (res?.ok) {
+        const data = yield res.json();
+        if (data.geometry?.[FIRST_ENTRY]) {
+          yield put(DrawToolActions.createShape(data.geometry[0]));
+          return; // Shape was extracted, no need to continue
+        }
+      }
+    } catch (e) {
+      console.error('[handle_copyGeometry]', e);
+    }
+  }
+  if (MOBILE) {
+    try {
+      // Try getting the shape from our local cache
+      const service = yield RecordCacheServiceFactory.getPlatformInstance();
+      const data = yield service.loadActivity(action.payload);
+      if (data.geometry?.[FIRST_ENTRY]) {
+        yield put(DrawToolActions.createShape(data.geometry[0]));
+        return; // Shape was extracted, no need to continue
+      }
+    } catch (e) {
+      console.error('[handle_copyGeometry]', e);
+    }
+  }
+  // Neither the API nor local cache could get us the shape we wanted.
+  yield put(
+    Alerts.create({
+      content: 'Failed to copy shape from record.',
+      severity: AlertSeverity.Error,
+      autoClose: 3,
+      subject: AlertSubjects.Form
+    })
+  );
+}
 
 function* activityPageSaga() {
   yield all([
     takeEvery(UserSettings.InitState.get, handle_UPDATE_CACHED_RECORDS),
+    takeEvery(Activity.Autofill.copyGeometry, handle_copyGeometry),
     takeEvery(Activity.loadActivityIfRequired, handle_LOAD_ACTIVITY_IF_REQUIRED),
     takeEvery(Activity.buildFormSchema, handle_ACTIVITY_BUILD_SCHEMA_FOR_FORM_REQUEST),
     takeEvery(Activity.get, handle_ACTIVITY_GET_REQUEST),


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

> [!IMPORTANT]
> The Vectors on the map are simplified shapes from the ones in dev, so you may notice a hexagon/octagon is more of a circle during the copy operation. 

- Add saga for getting and applying Shape from an existing record into the users active record (if they have permission) 
- Modify `LayerDataMarker` to have this option
- Closes #4298 

## Screenshots

<img width="414" height="247" alt="image" src="https://github.com/user-attachments/assets/75769fa4-d660-45ce-881d-242b6aa4e871" />

[*Popover with copy option. Note that IAPP is not included*]

<img width="380" height="355" alt="image" src="https://github.com/user-attachments/assets/6135890c-3965-4079-b060-365e833393b8" />

[*Note the edges of the simplified vector versus the created shape*]