### PR TITLE
[INV-4329][INV-4330] Custom Widgets

### DIFF
--- a/app/src/UI/Features/Records/Activity/form/FormContainer.tsx
+++ b/app/src/UI/Features/Records/Activity/form/FormContainer.tsx
@@ -25,6 +25,8 @@ import { ActivitySubtype } from 'sharedAPI';
 import { validatorForActivity } from 'rjsf/business-rules/custom-validation/activity';
 import ArrayItemTemplate from 'rjsf/templates/ArrayItemTemplate';
 import ArrayItemButtonTemplate from 'rjsf/templates/ArrayFieldButtonTemplate';
+import FundingAgencySelectAutoComplete from 'rjsf/widgets/FundingAgencySelectAutoComplete';
+import EmployerSelectAutoComplete from 'rjsf/widgets/EmployerSelectAutoComplete';
 
 const FormContainer = () => {
   const ref = useRef(0);
@@ -123,6 +125,8 @@ const FormContainer = () => {
               ErrorListTemplate: ErrorListTemplate
             }}
             widgets={{
+              'funding-agency-select-autocomplete': FundingAgencySelectAutoComplete,
+              'employer-select-autocomplete': EmployerSelectAutoComplete,
               'multi-select-autocomplete': MultiSelectAutoComplete,
               'single-select-autocomplete': SingleSelectAutoComplete,
               'agent-select-autocomplete': AgentSelectAutoComplete,

--- a/app/src/UI/Features/Records/RecordSet/Filters/Filters.tsx
+++ b/app/src/UI/Features/Records/RecordSet/Filters/Filters.tsx
@@ -111,7 +111,6 @@ const Filters = ({ recordsetId }: PropTypes) => {
   }, [cacheFilters, recordset?.tableFilters]);
 
   if (!recordset) return;
-  console.log(filters);
   return (
     <Accordion title={accordionTitle} icon={<FilterAlt color="primary" />}>
       <div id="filters-cont">

--- a/app/src/rjsf/uiSchema/BaseUISchemaComponents.ts
+++ b/app/src/rjsf/uiSchema/BaseUISchemaComponents.ts
@@ -41,8 +41,8 @@ const Activity = {
   utm_zone: { 'ui:readonly': true },
   utm_easting: { 'ui:readonly': true },
   utm_northing: { 'ui:readonly': true },
-  employer_code: { 'ui:widget': 'single-select-autocomplete' },
-  invasive_species_agency_code: { 'ui:widget': 'multi-select-autocomplete' },
+  employer_code: { 'ui:widget': 'employer-select-autocomplete' },
+  invasive_species_agency_code: { 'ui:widget': 'funding-agency-select-autocomplete' },
   jurisdictions: {
     items: {
       jurisdiction_code: { 'ui:widget': 'single-select-autocomplete' },

--- a/app/src/rjsf/widgets/EmployerSelectAutoComplete.tsx
+++ b/app/src/rjsf/widgets/EmployerSelectAutoComplete.tsx
@@ -1,0 +1,112 @@
+import { createFilterOptions } from '@mui/material/Autocomplete';
+import { TextField, Autocomplete, MenuItem } from '@mui/material';
+import { SelectAutoCompleteContext } from 'UI/Features/Records/Activity/form/SelectAutoCompleteContext';
+import { useContext, useEffect, useMemo, useState } from 'react';
+import { WidgetProps } from '@rjsf/utils';
+import { nanoid } from '@reduxjs/toolkit';
+import { useSelector } from 'utils/use_selector';
+import { Role } from 'constants/roles';
+
+// Custom type to support this widget
+export type AutoCompleteSelectOption = {
+  label: string;
+  value: any;
+  title: any;
+  suggested?: boolean;
+};
+
+const EmployerSelectAutoComplete = (props: WidgetProps) => {
+  const { setLastFieldChanged } = useContext(SelectAutoCompleteContext);
+  if (!setLastFieldChanged) {
+    throw new Error('Context not provided to EmployerSelectAutoComplete.tsx');
+  }
+  /**
+   * @desc Converts an option value into an option label
+   * @param value Code value
+   * @returns Matching label, or value provided
+   */
+  const getLabelFromValue = (value: string): string =>
+    filteredOptions.find((item) => item.value === value)?.label ?? value;
+
+  const handleChange = (_, option: AutoCompleteSelectOption, reason: string) => {
+    if (reason === 'clear') {
+      setValue(null);
+      props.onChange(undefined);
+    } else {
+      setValue(option);
+      props.onChange(option.value ?? option);
+    }
+  };
+
+  const usersEmployers = useSelector((state) => state.Auth?.extendedInfo?.employer)?.split(',') ?? [];
+  const created_by = useSelector((state) => state.ActivityPage?.activity?.created_by);
+  const currentSessionUsername = useSelector((state) => state.Auth?.username);
+  const userIsMasterAdmin = useSelector((state) =>
+    state.Auth.roles.some((r) => r.role_name === Role.MASTER_ADMINISTRATOR)
+  );
+
+  const filteredOptions: Array<AutoCompleteSelectOption> = useMemo(() => {
+    const isEnums = props.options?.enumOptions && props.options.enumOptions.length > 0;
+    const options = isEnums
+      ? JSON.parse(JSON.stringify(props.options.enumOptions ?? []))
+      : (JSON.parse(JSON.stringify(props?.schema?.options ?? [])) ?? []);
+    const userShouldHaveFilteredOptions = currentSessionUsername === created_by && !userIsMasterAdmin;
+    if (userShouldHaveFilteredOptions) {
+      // If user fills out form for themselves, limit options to their assigned employers
+      const limitedOptions = options.filter((o: AutoCompleteSelectOption) => usersEmployers.includes(o.value));
+      return limitedOptions;
+    }
+    return options;
+  }, [usersEmployers, currentSessionUsername, created_by, userIsMasterAdmin]);
+
+  const [value, setValue] = useState(props.value ?? null);
+  const [inputValue, setInputValue] = useState(getLabelFromValue(props.value ?? null));
+  const [renderKey] = useState(props.id + nanoid());
+
+  useEffect(() => {
+    setLastFieldChanged({ id: props.id, option: value?.value ?? value });
+  }, [value]);
+
+  return (
+    <Autocomplete
+      autoHighlight
+      autoSelect={props.required}
+      blurOnSelect
+      clearOnEscape={!props.required}
+      disableClearable={props.required}
+      disabled={props.disabled}
+      filterOptions={createFilterOptions({
+        stringify: (option) => `${option?.label} ${option?.value}`
+      })}
+      getOptionLabel={(option) => option.label ?? getLabelFromValue(option) ?? ''}
+      id={props.id}
+      inputValue={inputValue ?? ''}
+      isOptionEqualToValue={(option) => !value || option.value === value || option.value === value.value}
+      key={renderKey}
+      onChange={handleChange}
+      onFocus={(event) => props.onFocus(event.target.id, event.target.nodeValue)}
+      onInputChange={(_, newInputValue) => setInputValue(newInputValue)}
+      openOnFocus
+      options={filteredOptions}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          autoComplete="new-password"
+          variant="outlined"
+          required={props.required}
+          label={props.label || props.schema.title}
+          placeholder={'Begin typing to filter results...'}
+        />
+      )}
+      renderOption={(props, option) => (
+        <MenuItem {...props} key={`rjsfSingleSelect${nanoid()}`}>
+          {option.label ?? ''}
+        </MenuItem>
+      )}
+      selectOnFocus
+      value={value ?? ''}
+    />
+  );
+};
+
+export default EmployerSelectAutoComplete;

--- a/app/src/rjsf/widgets/FundingAgencySelectAutoComplete.tsx
+++ b/app/src/rjsf/widgets/FundingAgencySelectAutoComplete.tsx
@@ -1,0 +1,52 @@
+import { WidgetProps } from '@rjsf/utils';
+import { Autocomplete, TextField } from '@mui/material';
+import { useSelector } from 'utils/use_selector';
+import { Role } from 'constants/roles';
+import { useMemo } from 'react';
+
+interface SelectOption {
+  label: string;
+  value: unknown;
+}
+const FundingAgencySelectAutoComplete = (props: WidgetProps) => {
+  const usersFundingAgencies = useSelector((state) => state.Auth?.extendedInfo?.funding_agencies)?.split(',') ?? [];
+  const created_by = useSelector((state) => state.ActivityPage?.activity?.created_by);
+  const currentSessionUsername = useSelector((state) => state.Auth?.username);
+  const userIsMasterAdmin = useSelector((state) =>
+    state.Auth.roles.some((r) => r.role_name === Role.MASTER_ADMINISTRATOR)
+  );
+
+  const filteredOptions = useMemo(() => {
+    const enumOptions = props.schema.options?.map(({ value, label }) => ({ value, label })) ?? [];
+    if (created_by === currentSessionUsername && !userIsMasterAdmin) {
+      // If user fills out form for themselves, limit options to their assigned employers
+      return enumOptions.filter((o) => usersFundingAgencies.includes(o.value));
+    }
+    return enumOptions;
+  }, [created_by, currentSessionUsername, userIsMasterAdmin, usersFundingAgencies]);
+
+  const selectedOptions = filteredOptions.filter((opt) => {
+    // restructure the CSV format of the prop
+    const val = props.value?.split(',');
+    return val?.includes(opt.value);
+  });
+
+  return (
+    <Autocomplete
+      multiple
+      id={props.id}
+      options={filteredOptions}
+      value={selectedOptions}
+      onChange={(_, newValue: SelectOption[]) => {
+        // Maintain the value as CSV. Set undefined if new value is empty array.
+        props.onChange(newValue.length > 0 ? newValue.map((opt) => opt.value).join(',') : undefined);
+      }}
+      getOptionLabel={(option) => option.label}
+      isOptionEqualToValue={(option, val) => option.value === val.value}
+      disabled={props.disabled || props.readonly}
+      renderInput={(params) => <TextField {...params} required={props.required} label={props.label} />}
+    />
+  );
+};
+
+export default FundingAgencySelectAutoComplete;

--- a/app/src/state/reducers/auth.ts
+++ b/app/src/state/reducers/auth.ts
@@ -69,7 +69,7 @@ interface AuthState {
     account_status: number | null;
     activation_status: number | null;
     work_phone_number: string | null;
-    funding_agencies: any[];
+    funding_agencies: string | null;
     employer: string | null;
     pac_number: string | null;
     pac_service_number_1: string | null;


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

Adds two new widgets to the form to fulfill the role that have apiWithView and apiWithSelect provided. This step can bring us closer to removing the two options and providing a baked in option to the application.

Both widgets are relatives to the existing Select/Multi select components, but with only focusing on their respective job.

- Add Widget for Employer codes
    - Perform functionality that having two API Docs handled, without requiring two API Docs
- Add Widget for Funding Agency codes
    - Perform functionality that having two API Docs handled, without requiring two API Docs
- Implement Widgets in forms
- Update typing to reflect the correct format of `employer_codes`
- Closes #4329 
- Closes #4330

## Testing

For testing functionality you can modify `handle_ACTIVITY_BUILD_SCHEMA_FOR_FORM_REQUEST` to only return the `apiDocsWithViewOptions`
then toggle on/off the admin role check in the widget to see both render as expected. 