### PR TITLE
[N/A] Correct funding agencies typing

### DIFF
--- a/app/src/state/actions/auth/Auth.ts
+++ b/app/src/state/actions/auth/Auth.ts
@@ -41,7 +41,7 @@ class AuthActions {
       account_status: number | null;
       activation_status: number | null;
       work_phone_number: string | null;
-      funding_agencies: any[];
+      funding_agencies: string;
       employer: string | null;
       pac_number: string | null;
       pac_service_number_1: string | null;

--- a/app/src/state/reducers/auth.ts
+++ b/app/src/state/reducers/auth.ts
@@ -10,7 +10,7 @@ interface IUserExtendedInfo {
   account_status: number | null;
   activation_status: number | null;
   work_phone_number: string | null;
-  funding_agencies: any[];
+  funding_agencies?: string;
   employer: string | null;
   pac_number: string | null;
   pac_service_number_1: string | null;
@@ -126,7 +126,7 @@ const initialState: AuthState = {
     account_status: 0,
     activation_status: 0,
     employer: null,
-    funding_agencies: [],
+    funding_agencies: null,
     pac_number: null,
     pac_service_number_1: null,
     pac_service_number_2: null,
@@ -214,7 +214,7 @@ function createAuthReducer(_configuration: AppConfig) {
           account_status: 0,
           activation_status: 0,
           employer: null,
-          funding_agencies: [],
+          funding_agencies: null,
           pac_number: null,
           pac_service_number_1: null,
           pac_service_number_2: null,
@@ -328,7 +328,7 @@ function createAuthReducer(_configuration: AppConfig) {
           account_status: 0,
           activation_status: 0,
           employer: null,
-          funding_agencies: [],
+          funding_agencies: null,
           pac_number: null,
           pac_service_number_1: null,
           pac_service_number_2: null,


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Corrects typing for funding agencies from String Array, to String as this data is CSV formatted. 
- Fixes niche bug where logging out with an activity open, causes a crash due to `split` not working on funding_agencies default value of `[]` when it should be null or a string.