### PR TITLE
Serializers Rename

### DIFF
--- a/api-rework/client/src/activities/subtypes/AquaticChemTreatment.tsx
+++ b/api-rework/client/src/activities/subtypes/AquaticChemTreatment.tsx
@@ -8,7 +8,7 @@ const AquaticChemTreatment = ({ subtypeData }: SubtypeData) => {
     <>
       <ChemTreatmentInfo subtypeData={subtypeData} />
       <Fieldset label={'Chem Treatment Details'}>
-        <TextInput value={subtypeData?.chem_treatment_details} />
+        <TextInput value={subtypeData?.entries} />
       </Fieldset>
     </>
   );

--- a/api-rework/client/src/activities/subtypes/AquaticMechTreatment.tsx
+++ b/api-rework/client/src/activities/subtypes/AquaticMechTreatment.tsx
@@ -18,7 +18,7 @@ const AquaticMechTreatment = ({ subtypeData }: SubtypeData) => (
         </div>
       ))}
     </Fieldset>
-    <MechTreatmentInfo treatmentInfo={subtypeData?.mechanical_treatments} />
+    <MechTreatmentInfo entries={subtypeData?.entries} />
   </>
 );
 

--- a/api-rework/client/src/activities/subtypes/AquaticObservation.tsx
+++ b/api-rework/client/src/activities/subtypes/AquaticObservation.tsx
@@ -47,7 +47,7 @@ const AquaticObservation = ({ subtypeData }: SubtypeData) => {
       </Fieldset>
 
       <Fieldset label={'observation details'}>
-        {subtypeData?.observation_details.map((od) => (
+        {subtypeData?.entries.map((od) => (
           <div className="group-wrap">
             <TextInput label="density" value={od.density} />
             <TextInput label="distribution" value={od.distribution} />

--- a/api-rework/client/src/activities/subtypes/BiocontrolCollection.tsx
+++ b/api-rework/client/src/activities/subtypes/BiocontrolCollection.tsx
@@ -12,8 +12,8 @@ const BiocontrolCollection = ({ subtypeData }) => {
       <WeatherConditions subtypeData={subtypeData} />
       <MicrositeConditions microsite_conditions={subtypeData?.microsite_conditions} />
       <Fieldset label={'Collection Information'}>
-        {!!subtypeData?.collection_information?.length && <p>No Data</p>}
-        {subtypeData?.collection_information?.map((ci) => (
+        {!!subtypeData?.entries?.length && <p>No Data</p>}
+        {subtypeData?.entries?.map((ci) => (
           <div className="group-wrap">
             <TextInput label={'invasive plant'} value={ci?.invasive_plant} />
             <TextInput label={'biological agent'} value={ci?.biological_agent} />

--- a/api-rework/client/src/activities/subtypes/BiocontrolRelease.tsx
+++ b/api-rework/client/src/activities/subtypes/BiocontrolRelease.tsx
@@ -11,8 +11,8 @@ const BiocontrolRelease = ({ subtypeData }: SubtypeData) => {
       <WeatherConditions subtypeData={subtypeData} />
       <MicrositeConditions microsite_conditions={subtypeData?.microsite_conditions} />
       <Fieldset label={'Treatment Information'}>
-        {!!subtypeData?.treatment_information?.length && <p>No Data</p>}
-        {subtypeData?.treatment_information?.map((ti) => (
+        {!!subtypeData?.entries?.length && <p>No Data</p>}
+        {subtypeData?.entries?.map((ti) => (
           <div className="group-wrap">
             <TextInput label={'agent source'} value={ti.agent_source} />
             <TextInput label={'biocontrol agent'} value={ti.biocontrol_agent} />

--- a/api-rework/client/src/activities/subtypes/ChemicalMonitoring.tsx
+++ b/api-rework/client/src/activities/subtypes/ChemicalMonitoring.tsx
@@ -6,9 +6,9 @@ import NearestWells from './common/NearestWells';
 const ChemicalMonitoring = ({ subtypeData }: SubtypeData) => {
   return (
     <>
-      <NearestWells data={subtypeData?.nearest_wells} />
+      <NearestWells data={subtypeData?.well_entries} />
       <Fieldset label={'Monitoring Information'}>
-        {subtypeData?.treatment_monitoring_information?.map((d) => (
+        {subtypeData?.entries?.map((d) => (
           <MonitoringInfo data={d} />
         ))}
       </Fieldset>

--- a/api-rework/client/src/activities/subtypes/DispersalMonitoring.tsx
+++ b/api-rework/client/src/activities/subtypes/DispersalMonitoring.tsx
@@ -9,7 +9,7 @@ const DispersalMonitoring = ({ subtypeData }: SubtypeData) => {
     <>
       <WeatherConditions subtypeData={subtypeData} />
       <MicrositeConditions microsite_conditions={subtypeData?.microsite_conditions} />
-      <BiocontrolMonitoring monitoring_information={subtypeData?.monitoring_information} />
+      <BiocontrolMonitoring entries={subtypeData?.entries} />
       <TargetPlantPhenology targetPlantPhenology={subtypeData?.target_plant_phenology} />
     </>
   );

--- a/api-rework/client/src/activities/subtypes/MechanicalMonitoring.tsx
+++ b/api-rework/client/src/activities/subtypes/MechanicalMonitoring.tsx
@@ -4,7 +4,7 @@ import MonitoringInfo from './common/MonitoringInfo';
 
 const MechanicalMonitoring = ({ subtypeData }: SubtypeData) => (
   <Fieldset label={'Monitoring Information'}>
-    {subtypeData?.treatment_monitoring_information?.map((d) => (
+    {subtypeData?.entries?.map((d) => (
       <MonitoringInfo data={d} />
     ))}
   </Fieldset>

--- a/api-rework/client/src/activities/subtypes/ReleaseMonitoring.tsx
+++ b/api-rework/client/src/activities/subtypes/ReleaseMonitoring.tsx
@@ -8,7 +8,7 @@ import MicrositeConditions from './common/MicrositeConditions';
 const ReleaseMonitoring = ({ subtypeData }: SubtypeData) => (
   <>
     <MicrositeConditions microsite_conditions={subtypeData?.microsite_conditions} />
-    <BiocontrolMonitoring monitoring_information={subtypeData.monitoring_information} />
+    <BiocontrolMonitoring entries={subtypeData.entries} />
     <TargetPlantPhenology targetPlantPhenology={subtypeData?.target_plant_phenology} />
     <Fieldset label={'Spread Results'}>
       <TextInput

--- a/api-rework/client/src/activities/subtypes/TerrestrialChemTreatment.tsx
+++ b/api-rework/client/src/activities/subtypes/TerrestrialChemTreatment.tsx
@@ -8,7 +8,7 @@ const TerrestrialChemTreatment = ({ subtypeData }: SubtypeData) => {
     <>
       <ChemTreatmentInfo subtypeData={subtypeData} />
       <Fieldset label={'Chem Treatment Details'}>
-        <TextInput value={subtypeData?.chem_treatment_details} />
+        <TextInput value={subtypeData?.entries} />
       </Fieldset>
     </>
   );

--- a/api-rework/client/src/activities/subtypes/TerrestrialMechTreatment.tsx
+++ b/api-rework/client/src/activities/subtypes/TerrestrialMechTreatment.tsx
@@ -1,7 +1,5 @@
 import { SubtypeData } from 'constants';
 import MechTreatmentInfo from './common/MechTreatmentInfo';
 
-const TerrestrialMechTreatment = ({ subtypeData }: SubtypeData) => (
-  <MechTreatmentInfo treatmentInfo={subtypeData?.mechanical_treatments} />
-);
+const TerrestrialMechTreatment = ({ subtypeData }: SubtypeData) => <MechTreatmentInfo entries={subtypeData?.entries} />;
 export default TerrestrialMechTreatment;

--- a/api-rework/client/src/activities/subtypes/TerrestrialObservation.tsx
+++ b/api-rework/client/src/activities/subtypes/TerrestrialObservation.tsx
@@ -3,29 +3,20 @@ import TextInput from 'common-components/inputs/TextInput';
 import { SubtypeData } from 'constants';
 
 const TerrestrialObservation = ({ subtypeData }: SubtypeData) => {
-  const BLANK = 'N/A';
+  console.log(subtypeData);
   return (
     <>
       <Fieldset label={'observation info'}>
         <TextInput label="pretreatment observation" value={subtypeData?.pretreatment_observation} />
         <TextInput label="research observation" value={subtypeData?.research_observation} />
-        <TextInput
-          label="aspect"
-          value={`${subtypeData?.aspect?.full ?? BLANK} (${subtypeData?.aspect?.code ?? BLANK})`}
-        />
-        <TextInput
-          label="slope percent"
-          value={`${subtypeData.slope_percent.full ?? BLANK} (${subtypeData.slope_percent.code ?? BLANK})`}
-        />
-        <TextInput
-          label="soil texture"
-          value={`${subtypeData?.soil_texture?.full ?? BLANK} (${subtypeData.soil_texture?.code ?? BLANK})`}
-        />
-        <TextInput label="specific use" value={`${subtypeData.specific_use.full} (${subtypeData.specific_use.code})`} />
+        <TextInput label="aspect" value={subtypeData?.aspect} />
+        <TextInput label="slope percent" value={subtypeData?.slope_percent} />
+        <TextInput label="soil texture" value={subtypeData?.soil_texture} />
+        <TextInput label="specific use" value={subtypeData.specific_use} />
         <TextInput label="suitable for biocontrol agent" value={subtypeData.suitable_for_biocontrol_agent} />
       </Fieldset>
       <Fieldset label={'observation details'}>
-        {subtypeData?.observation_details.map((od) => (
+        {subtypeData?.entries.map((od) => (
           <div className="group-wrap">
             <TextInput label="density" value={od?.density} />
             <TextInput label="distribution" value={od?.distribution} />

--- a/api-rework/client/src/activities/subtypes/common/BiocontrolMonitoring.tsx
+++ b/api-rework/client/src/activities/subtypes/common/BiocontrolMonitoring.tsx
@@ -3,9 +3,9 @@ import Fieldset from 'common-components/inputs/Fieldset';
 import Spacer from 'common-components/inputs/Spacer';
 import TextInput from 'common-components/inputs/TextInput';
 
-const BiocontrolMonitoring = ({ monitoring_information }) => (
+const BiocontrolMonitoring = ({ entries }) => (
   <Fieldset label={'Biological Monitoring Information'}>
-    {monitoring_information.map((mi) => (
+    {entries.map((mi) => (
       <div className="group-wrap">
         <TextInput label={'Invasive plant'} value={mi.invasive_plant} />
         <TextInput label={'Biological Agent'} value={mi.biocontrol_agent} />

--- a/api-rework/client/src/activities/subtypes/common/ChemTreatmentInfo.tsx
+++ b/api-rework/client/src/activities/subtypes/common/ChemTreatmentInfo.tsx
@@ -6,7 +6,7 @@ import Fieldset from 'common-components/inputs/Fieldset';
 const ChemTreatmentInfo = ({ subtypeData }: SubtypeData) => {
   return (
     <>
-      <NearestWells data={subtypeData?.well_information} />
+      <NearestWells data={subtypeData?.well_entries} />
       <div className="group-wrap">
         <TextInput label={'service license number'} value={subtypeData?.service_license_number} />
         <TextInput label={'pesticide use permit'} value={subtypeData?.pesticide_use_permit} />

--- a/api-rework/client/src/activities/subtypes/common/MechTreatmentInfo.tsx
+++ b/api-rework/client/src/activities/subtypes/common/MechTreatmentInfo.tsx
@@ -1,9 +1,9 @@
 import Fieldset from 'common-components/inputs/Fieldset';
 import TextInput from 'common-components/inputs/TextInput';
 
-const MechTreatmentInfo = ({ treatmentInfo }) => (
+const MechTreatmentInfo = ({ entries }) => (
   <Fieldset label={'Mechanical Treatment Info'}>
-    {treatmentInfo?.map((ti) => (
+    {entries?.map((ti) => (
       <div className="group-wrap">
         <TextInput label={'Invasive Plant'} value={ti?.invasive_plant} />
         <TextInput label={'Treated Area (m2)'} value={ti?.treated_area_msq} />

--- a/api-rework/invasives/api/serializers/common/__init__.py
+++ b/api-rework/invasives/api/serializers/common/__init__.py
@@ -1,6 +1,6 @@
 from .shoreline_type import ShorelineTypesSerializer
 from .treatment_monitoring_information import (
-    TreatmentMonitoringInfoSerializer,
+    TreatmentMonitoringEntriesSerializer,
     AquaticMechanicalMonitoringSerializer,
     TerrestrialTreatmentMonitoringSerializer,
     AquaticInvasivePlantOnSiteSerializer,
@@ -16,6 +16,6 @@ from .microsite_conditions import MicrositeConditionSerializer
 from .weather_conditions import WeatherConditionsSerializer
 from .spread_results import SpreadResultsSerializer
 from .biocontrol_dispersal_monitoring_information import (
-    TerrestrialBiologicalMonitoringInformationSerializer,
+    TerrestrialBiologicalMonitoringEntriesSerializer,
 )
-from .chemical_treatment_information import ChemicalTreatmentInformationSerializer
+from .chemical_treatment_information import ChemicalTreatmentContextSerializer

--- a/api-rework/invasives/api/serializers/common/biocontrol_dispersal_monitoring_information.py
+++ b/api-rework/invasives/api/serializers/common/biocontrol_dispersal_monitoring_information.py
@@ -27,7 +27,7 @@ class LocationBiocontrolAgentsFoundTerrestrialSerializer(serializers.ModelSerial
         return super().to_representation(instance)["location_agent_found"]
 
 
-class TerrestrialBiologicalMonitoringInformationSerializer(serializers.ModelSerializer):
+class TerrestrialBiologicalMonitoringEntriesSerializer(serializers.ModelSerializer):
     """Serializer for Biocontrol Dispersal/Release Monitoring records"""
 
     biocontrol_present = serializers.SerializerMethodField()

--- a/api-rework/invasives/api/serializers/common/chemical_treatment_information.py
+++ b/api-rework/invasives/api/serializers/common/chemical_treatment_information.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 from api.models.activity import ChemTreatment
 
 
-class ChemicalTreatmentInformationSerializer(serializers.ModelSerializer):
+class ChemicalTreatmentContextSerializer(serializers.ModelSerializer):
     class Meta:
         model = ChemTreatment
         fields = (

--- a/api-rework/invasives/api/serializers/common/treatment_monitoring_information.py
+++ b/api-rework/invasives/api/serializers/common/treatment_monitoring_information.py
@@ -103,7 +103,7 @@ class AquaticMechanicalMonitoringSerializer(BaseTreatmentMonitoringSerializer):
         return ret
 
 
-class TreatmentMonitoringInfoSerializer(serializers.Serializer):
+class TreatmentMonitoringEntriesSerializer(serializers.Serializer):
     """Shared Between Mechanical and Chemical Treatments"""
 
     a_monitoring_information = AquaticMechanicalMonitoringSerializer(

--- a/api-rework/invasives/api/serializers/common/treatment_monitoring_information.py
+++ b/api-rework/invasives/api/serializers/common/treatment_monitoring_information.py
@@ -128,7 +128,7 @@ class TreatmentMonitoringEntriesSerializer(serializers.Serializer):
 
     def to_internal_value(self, data):
         """Split incoming list into respective models, normalize aquatic plant key to consistent generic in DB"""
-        items = data.get("treatment_monitoring_information", [])
+        items = data.get("entries", [])
         a_items = []
         t_items = []
         errors = {}

--- a/api-rework/invasives/api/serializers/common/treatment_monitoring_information.py
+++ b/api-rework/invasives/api/serializers/common/treatment_monitoring_information.py
@@ -123,7 +123,7 @@ class TreatmentMonitoringEntriesSerializer(serializers.Serializer):
         ret = super().to_representation(instance)
         am = ret.pop("a_monitoring_information", [])
         tm = ret.pop("t_monitoring_information", [])
-        ret.update({"treatment_monitoring_information": am + tm})
+        ret.update({"entries": am + tm})
         return ret
 
     def to_internal_value(self, data):
@@ -158,9 +158,7 @@ class TreatmentMonitoringEntriesSerializer(serializers.Serializer):
                 errors[idx] = serializer.errors
 
             if errors:
-                raise serializers.ValidationError(
-                    {"treatmentmonitoring_information": errors}
-                )
+                raise serializers.ValidationError({"entries": errors})
         return {
             "aquatictreatmentmonitoringinformation_set": a_items,
             "terrestrialtreatmentmonitoringinformation_set": t_items,

--- a/api-rework/invasives/api/serializers/type/subtype/aquatic_chemical_treatment.py
+++ b/api-rework/invasives/api/serializers/type/subtype/aquatic_chemical_treatment.py
@@ -1,22 +1,22 @@
 from rest_framework import serializers
 from api.serializers.common import (
     NearestWellSerializer,
-    ChemicalTreatmentInformationSerializer,
+    ChemicalTreatmentContextSerializer,
 )
 
 
 class AquaticChemicalTreatmentSerializer(serializers.Serializer):
-    chem_treatment = ChemicalTreatmentInformationSerializer(source="chemtreatment")
-    well_information = NearestWellSerializer(source="nearestwell_set", many=True)
-    chem_treatment_details = serializers.SerializerMethodField()
+    context = ChemicalTreatmentContextSerializer(source="chemtreatment")
+    well_entries = NearestWellSerializer(source="nearestwell_set", many=True)
+    entries = serializers.SerializerMethodField()
 
-    def get_chem_treatment_details(self, obj):
+    def get_treatment_chemical_details(self, obj):
         # TODO:
         return "NOT IMPLEMENTED"
 
     def to_representation(self, instance):
         ret = super().to_representation(instance)
-        info_data = ret.pop("chem_treatment", None)
+        info_data = ret.pop("context", None)
         if info_data and isinstance(info_data, dict):
             ret.update(info_data)
         return ret

--- a/api-rework/invasives/api/serializers/type/subtype/aquatic_chemical_treatment.py
+++ b/api-rework/invasives/api/serializers/type/subtype/aquatic_chemical_treatment.py
@@ -10,7 +10,7 @@ class AquaticChemicalTreatmentSerializer(serializers.Serializer):
     well_entries = NearestWellSerializer(source="nearestwell_set", many=True)
     entries = serializers.SerializerMethodField()
 
-    def get_treatment_chemical_details(self, obj):
+    def get_entries(self, obj):
         # TODO:
         return "NOT IMPLEMENTED"
 

--- a/api-rework/invasives/api/serializers/type/subtype/aquatic_mechanical_treatment.py
+++ b/api-rework/invasives/api/serializers/type/subtype/aquatic_mechanical_treatment.py
@@ -17,7 +17,7 @@ class AquaticPlantMechanicalTreatmentSerializer(serializers.ModelSerializer):
 
 
 class AquaticPlantTreatmentMechanicalSerializer(serializers.Serializer):
-    mechanical_treatments = AquaticPlantMechanicalTreatmentSerializer(
+    entries = AquaticPlantMechanicalTreatmentSerializer(
         source="aquaticplantmechanicaltreatment_set", many=True
     )
     authorization_info = serializers.CharField(

--- a/api-rework/invasives/api/serializers/type/subtype/aquatic_observation.py
+++ b/api-rework/invasives/api/serializers/type/subtype/aquatic_observation.py
@@ -169,7 +169,7 @@ class AquaticObservationSerializer(serializers.Serializer):
     adjacent_land_use = WaterbodyAdjacentLandUseSerializer(
         source="waterbodyadjacentlanduse_set", many=True
     )
-    observation_details = AquaticPlantObservationDetailSerializer(
+    entries = AquaticPlantObservationDetailSerializer(
         source="aquaticplantobservationdetail_set", many=True
     )
     pretreatment_observation = serializers.CharField(

--- a/api-rework/invasives/api/serializers/type/subtype/aquatic_observation.py
+++ b/api-rework/invasives/api/serializers/type/subtype/aquatic_observation.py
@@ -182,8 +182,8 @@ class AquaticObservationSerializer(serializers.Serializer):
     # suitable_for_biocontrol = serializers.CharField(
     #     source="suitableforbiocontrol.suitable_for_biocontrol"
     # )
-    waterbody_details = WaterbodyDataSerializer(source="waterbodydata")
-    waterbody_use = WaterbodyUseSerializer(source="waterbodyuse_set", many=True)
+    waterbody_context = WaterbodyDataSerializer(source="waterbodydata")
+    water_use = WaterbodyUseSerializer(source="waterbodyuse_set", many=True)
     waterlevel_management = WaterbodyLevelManagementSerializer(
         source="waterbodylevelmanagement_set", many=True
     )
@@ -206,7 +206,7 @@ class AquaticObservationSerializer(serializers.Serializer):
     def to_representation(self, instance):
         """Flatten Waterbody Details into top_level"""
         ret = super().to_representation(instance)
-        info_data = ret.pop("waterbody_details", None)
+        info_data = ret.pop("waterbody_context", None)
 
         if info_data and isinstance(info_data, dict):
             ret.update(info_data)

--- a/api-rework/invasives/api/serializers/type/subtype/biocontrol_collection.py
+++ b/api-rework/invasives/api/serializers/type/subtype/biocontrol_collection.py
@@ -58,7 +58,7 @@ class BiocontrolCollectionSerializer(serializers.Serializer):
     target_plant_phenology = TargetPlantPhenologySerializer(
         source="targetplantphenology"
     )
-    collection_information = TerrestrialBiocontrolCollectionInfoSerializer(
+    entries = TerrestrialBiocontrolCollectionInfoSerializer(
         source="terrestrialbiocontrolcollectioninformation_set", many=True
     )
 

--- a/api-rework/invasives/api/serializers/type/subtype/biocontrol_dispersal_monitoring.py
+++ b/api-rework/invasives/api/serializers/type/subtype/biocontrol_dispersal_monitoring.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 from api.serializers.common import (
     MicrositeConditionSerializer,
-    TerrestrialBiologicalMonitoringInformationSerializer,
+    TerrestrialBiologicalMonitoringEntriesSerializer,
     TargetPlantPhenologySerializer,
     WeatherConditionsSerializer,
 )
@@ -9,7 +9,7 @@ from api.serializers.common import (
 
 class BiocontrolDispersalMonitoringSerializer(serializers.Serializer):
     microsite_condition = MicrositeConditionSerializer(source="micrositecondition")
-    monitoring_information = TerrestrialBiologicalMonitoringInformationSerializer(
+    entries = TerrestrialBiologicalMonitoringEntriesSerializer(
         source="terrestrialbiocontroldispersalmonitoring_set", many=True
     )
     target_plant_phenology = TargetPlantPhenologySerializer(

--- a/api-rework/invasives/api/serializers/type/subtype/biocontrol_release.py
+++ b/api-rework/invasives/api/serializers/type/subtype/biocontrol_release.py
@@ -50,7 +50,7 @@ class TerrestrialBiocontrolReleaseSerializer(serializers.ModelSerializer):
 
 
 class BiocontrolReleaseSerializer(serializers.Serializer):
-    treatment_information = TerrestrialBiocontrolReleaseSerializer(
+    entries = TerrestrialBiocontrolReleaseSerializer(
         source="terrestrialbiocontrolrelease_set", many=True
     )
     target_plant_phenology = TargetPlantPhenologySerializer(

--- a/api-rework/invasives/api/serializers/type/subtype/biocontrol_release_monitoring.py
+++ b/api-rework/invasives/api/serializers/type/subtype/biocontrol_release_monitoring.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 from api.serializers.common import (
     MicrositeConditionSerializer,
-    TerrestrialBiologicalMonitoringInformationSerializer,
+    TerrestrialBiologicalMonitoringEntriesSerializer,
     TargetPlantPhenologySerializer,
     SpreadResultsSerializer,
     WeatherConditionsSerializer,
@@ -10,7 +10,7 @@ from api.serializers.common import (
 
 class BiocontrolReleaseMonitoringSerializer(serializers.Serializer):
     microsite_condition = MicrositeConditionSerializer(source="micrositecondition")
-    monitoring_information = TerrestrialBiologicalMonitoringInformationSerializer(
+    entries = TerrestrialBiologicalMonitoringEntriesSerializer(
         source="terrestrialbiocontroldispersalmonitoring_set", many=True
     )
     target_plant_phenology = TargetPlantPhenologySerializer(

--- a/api-rework/invasives/api/serializers/type/subtype/chemical_treatment_monitoring.py
+++ b/api-rework/invasives/api/serializers/type/subtype/chemical_treatment_monitoring.py
@@ -7,9 +7,9 @@ from api.serializers.common import (
 
 class ChemicalMonitoringSerializer(serializers.Serializer):
     entries = serializers.SerializerMethodField()
-    nearest_wells = NearestWellSerializer(source="nearestwell_set", many=True)
+    well_entries = NearestWellSerializer(source="nearestwell_set", many=True)
 
-    def get_treatment_monitoring_information(self, obj):
+    def get_entries(self, obj):
         return TreatmentMonitoringEntriesSerializer(obj, context=self.context).data
 
     def to_representation(self, instance):

--- a/api-rework/invasives/api/serializers/type/subtype/chemical_treatment_monitoring.py
+++ b/api-rework/invasives/api/serializers/type/subtype/chemical_treatment_monitoring.py
@@ -1,21 +1,21 @@
 from rest_framework import serializers
 from api.serializers.common import (
-    TreatmentMonitoringInfoSerializer,
+    TreatmentMonitoringEntriesSerializer,
     NearestWellSerializer,
 )
 
 
 class ChemicalMonitoringSerializer(serializers.Serializer):
-    treatment_monitoring_information = serializers.SerializerMethodField()
+    entries = serializers.SerializerMethodField()
     nearest_wells = NearestWellSerializer(source="nearestwell_set", many=True)
 
     def get_treatment_monitoring_information(self, obj):
-        return TreatmentMonitoringInfoSerializer(obj, context=self.context).data
+        return TreatmentMonitoringEntriesSerializer(obj, context=self.context).data
 
     def to_representation(self, instance):
         """Flatten"""
         ret = super().to_representation(instance)
-        info_data = ret.pop("treatment_monitoring_information", None)
+        info_data = ret.pop("entries", None)
 
         if info_data and isinstance(info_data, dict):
             ret.update(info_data)

--- a/api-rework/invasives/api/serializers/type/subtype/mechanical_treatment_monitoring.py
+++ b/api-rework/invasives/api/serializers/type/subtype/mechanical_treatment_monitoring.py
@@ -1,12 +1,12 @@
 from rest_framework import serializers
-from api.serializers.common import TreatmentMonitoringInfoSerializer
+from api.serializers.common import TreatmentMonitoringEntriesSerializer
 
 
 class MechanicalMonitoringSerializer(serializers.Serializer):
     treatment_monitoring_information = serializers.SerializerMethodField()
 
     def get_treatment_monitoring_information(self, obj):
-        return TreatmentMonitoringInfoSerializer(obj, context=self.context).data
+        return TreatmentMonitoringEntriesSerializer(obj, context=self.context).data
 
     def to_representation(self, instance):
         """Flatten"""

--- a/api-rework/invasives/api/serializers/type/subtype/mechanical_treatment_monitoring.py
+++ b/api-rework/invasives/api/serializers/type/subtype/mechanical_treatment_monitoring.py
@@ -3,15 +3,15 @@ from api.serializers.common import TreatmentMonitoringEntriesSerializer
 
 
 class MechanicalMonitoringSerializer(serializers.Serializer):
-    treatment_monitoring_information = serializers.SerializerMethodField()
+    entries = serializers.SerializerMethodField()
 
-    def get_treatment_monitoring_information(self, obj):
+    def get_entries(self, obj):
         return TreatmentMonitoringEntriesSerializer(obj, context=self.context).data
 
     def to_representation(self, instance):
         """Flatten"""
         ret = super().to_representation(instance)
-        info_data = ret.pop("treatment_monitoring_information", None)
+        info_data = ret.pop("entries", None)
 
         if info_data and isinstance(info_data, dict):
             ret.update(info_data)

--- a/api-rework/invasives/api/serializers/type/subtype/terrestrial_chemical_treatment.py
+++ b/api-rework/invasives/api/serializers/type/subtype/terrestrial_chemical_treatment.py
@@ -7,7 +7,7 @@ from api.serializers.common import (
 
 class TerrestrialChemicalTreatmentSerializer(serializers.Serializer):
     details = ChemicalTreatmentContextSerializer(source="chemtreatment")
-    well_information = NearestWellSerializer(source="nearestwell_set", many=True)
+    well_entries = NearestWellSerializer(source="nearestwell_set", many=True)
     entries = serializers.SerializerMethodField()
 
     def get_entries(self, obj):

--- a/api-rework/invasives/api/serializers/type/subtype/terrestrial_chemical_treatment.py
+++ b/api-rework/invasives/api/serializers/type/subtype/terrestrial_chemical_treatment.py
@@ -6,17 +6,17 @@ from api.serializers.common import (
 
 
 class TerrestrialChemicalTreatmentSerializer(serializers.Serializer):
-    chem_treatment = ChemicalTreatmentContextSerializer(source="chemtreatment")
+    details = ChemicalTreatmentContextSerializer(source="chemtreatment")
     well_information = NearestWellSerializer(source="nearestwell_set", many=True)
-    chem_treatment_details = serializers.SerializerMethodField()
+    entries = serializers.SerializerMethodField()
 
-    def get_chem_treatment_details(self, obj):
+    def get_entries(self, obj):
         # TODO:
         return "NOT IMPLEMENTED"
 
     def to_representation(self, instance):
         ret = super().to_representation(instance)
-        info_data = ret.pop("chem_treatment", None)
+        info_data = ret.pop("details", None)
         if info_data and isinstance(info_data, dict):
             ret.update(info_data)
         return ret

--- a/api-rework/invasives/api/serializers/type/subtype/terrestrial_chemical_treatment.py
+++ b/api-rework/invasives/api/serializers/type/subtype/terrestrial_chemical_treatment.py
@@ -1,12 +1,12 @@
 from rest_framework import serializers
 from api.serializers.common import (
     NearestWellSerializer,
-    ChemicalTreatmentInformationSerializer,
+    ChemicalTreatmentContextSerializer,
 )
 
 
 class TerrestrialChemicalTreatmentSerializer(serializers.Serializer):
-    chem_treatment = ChemicalTreatmentInformationSerializer(source="chemtreatment")
+    chem_treatment = ChemicalTreatmentContextSerializer(source="chemtreatment")
     well_information = NearestWellSerializer(source="nearestwell_set", many=True)
     chem_treatment_details = serializers.SerializerMethodField()
 

--- a/api-rework/invasives/api/serializers/type/subtype/terrestrial_mechanical_treatment.py
+++ b/api-rework/invasives/api/serializers/type/subtype/terrestrial_mechanical_treatment.py
@@ -16,6 +16,6 @@ class TerrestrialPlantMechanicalTreatmentSerializer(serializers.ModelSerializer)
 
 
 class TerrestrialPlantTreatmentMechanicalSerializer(serializers.Serializer):
-    mechanical_treatments = TerrestrialPlantMechanicalTreatmentSerializer(
+    entries = TerrestrialPlantMechanicalTreatmentSerializer(
         source="terrestrialplantmechanicaltreatment_set", many=True
     )

--- a/api-rework/invasives/api/serializers/type/subtype/terrestrial_observation.py
+++ b/api-rework/invasives/api/serializers/type/subtype/terrestrial_observation.py
@@ -66,7 +66,7 @@ class TerrestrialVoucherSpecimenSerializer(serializers.ModelSerializer):
         )
 
 
-class TerrestrialPlantObservationDetailSerializer(serializers.ModelSerializer):
+class TerrestrialPlantObservationContextSerializer(serializers.ModelSerializer):
     voucher_specimen = serializers.SerializerMethodField()
 
     class Meta:
@@ -97,7 +97,7 @@ class TerrestrialPlantObservationDetailSerializer(serializers.ModelSerializer):
             return None
 
 
-class TerrestrialPlantObservationInfoSerializer(serializers.ModelSerializer):
+class TerrestrialPlantObservationEntriesSerializer(serializers.ModelSerializer):
     specific_use = SpecificUseCodeSerializer()
     soil_texture = SoilTextureCodeSerializer()
     aspect = AspectCodeSerializer()
@@ -117,10 +117,10 @@ class TerrestrialPlantObservationInfoSerializer(serializers.ModelSerializer):
 
 
 class TerrestrialObservationSerializer(serializers.Serializer):
-    observation_details = TerrestrialPlantObservationDetailSerializer(
+    entries = TerrestrialPlantObservationContextSerializer(
         source="terrestrialplantobservationdetail_set", many=True
     )
-    observation_information = TerrestrialPlantObservationInfoSerializer(
+    context = TerrestrialPlantObservationEntriesSerializer(
         source="terrestrialplantobservationinfo"
     )
     pretreatment_observation = serializers.CharField(

--- a/api-rework/invasives/api/serializers/type/subtype/terrestrial_observation.py
+++ b/api-rework/invasives/api/serializers/type/subtype/terrestrial_observation.py
@@ -129,7 +129,7 @@ class TerrestrialObservationSerializer(serializers.Serializer):
 
     def to_representation(self, instance):
         ret = super().to_representation(instance)
-        info_data = ret.pop("observation_information", None)
+        info_data = ret.pop("context", None)
 
         if info_data and isinstance(info_data, dict):
             ret.update(info_data)

--- a/api-rework/invasives/api/tests/subtypes/test_aquatic_chemical_treatment.py
+++ b/api-rework/invasives/api/tests/subtypes/test_aquatic_chemical_treatment.py
@@ -18,7 +18,7 @@ class AquaticChemicalTreatmentTest(BaseActivitySubtypeTest):
         self.pac_number_is_present()
 
     def test_casting_fixture_into_serializer(self):
-        self.casting_fixture_into_serializer(expected_subtype_key="well_information")
+        self.casting_fixture_into_serializer(expected_subtype_key="entries")
 
     def test_subtype_values(self):
         record = self.fetch_a().json()
@@ -40,13 +40,13 @@ class AquaticChemicalTreatmentTest(BaseActivitySubtypeTest):
         self.assertEqual(sd["additional_unmapped_well_water_bool"], True)
         self.assertEqual(sd["pest_injury_threshold_determination_bool"], True)
 
-        wells = sd["well_information"]
+        wells = sd["well_entries"]
         self.assertEqual(len(wells), 3)
 
         for well in wells:
             self.assertIsNotNone(well["well_tag_number"])
             self.assertIsNotNone(well["distance"])
 
-        if sd["chem_treatment_details"] != "NOT IMPLEMENTED":
+        if sd["entries"] != "NOT IMPLEMENTED":
             # TODO
             self.fail("UPDATE TEST FOR CHEM TREATMENT DETAILS")

--- a/api-rework/invasives/api/tests/subtypes/test_aquatic_mechanical_treatment.py
+++ b/api-rework/invasives/api/tests/subtypes/test_aquatic_mechanical_treatment.py
@@ -17,20 +17,16 @@ class AquaticMechanicalTreatmentTest(BaseActivitySubtypeTest):
         self.no_pac_number_present()
 
     def test_casting_fixture_into_serializer(self):
-        self.casting_fixture_into_serializer(
-            expected_subtype_key="mechanical_treatments"
-        )
+        self.casting_fixture_into_serializer(expected_subtype_key="entries")
 
     def test_subtype_details_full(self):
         """Subtype keys match the information from fixtures."""
         response_object = self.fetch_a().json()
 
-        self.assertEqual(
-            len(response_object["subtype_data"]["mechanical_treatments"]), 1
-        )
+        self.assertEqual(len(response_object["subtype_data"]["entries"]), 1)
 
         sd = response_object["subtype_data"]
-        mt = sd["mechanical_treatments"][0]
+        mt = sd["entries"][0]
 
         self.assertEqual(mt["disposed_material_amount"], 544)
         self.assertEqual(mt["disposed_material_format"], "kg")
@@ -53,7 +49,7 @@ class AquaticMechanicalTreatmentTest(BaseActivitySubtypeTest):
         sd = response_object["subtype_data"]
         self.assertEqual(sd["authorization_info"], "The test looks for this")
 
-        mt = sd["mechanical_treatments"]
+        mt = sd["entries"]
         self.assertEqual(len(mt), 2)
 
         expected = [

--- a/api-rework/invasives/api/tests/subtypes/test_aquatic_observation.py
+++ b/api-rework/invasives/api/tests/subtypes/test_aquatic_observation.py
@@ -28,13 +28,13 @@ class AquaticObservationTest(BaseActivitySubtypeTest):
         # self.assertEqual(sd["suitable_for_biocontrol"], "No")
         self.assertEqual(sd["pretreatment_observation"], "Yes")
 
-        self.assertGreaterEqual(len(sd["observation_details"]), 1)
+        self.assertGreaterEqual(len(sd["entries"]), 1)
         self.assertIn("WET", sd["inflow_permanent"])
         self.assertIn("DISP", sd["inflow_seasonal"])
         self.assertIn("WET", sd["outflow_permanent"])
         self.assertIn("WET", sd["outflow_seasonal"])
         self.assertIn("Dam", sd["waterlevel_management"])
-        self.assertIn("AI", sd["waterbody_use"])
+        self.assertIn("AI", sd["water_use"])
         self.assertIn("GR", sd["substrate_type"])
         self.assertIn("H", sd["adjacent_land_use"])
 
@@ -42,7 +42,7 @@ class AquaticObservationTest(BaseActivitySubtypeTest):
         self.assertEqual(st["shoreline_type"], "LGA")
         self.assertEqual(st["percent_covered"], 100)
 
-        od = sd["observation_details"][0]
+        od = sd["entries"][0]
         self.assertEqual(od["density"], "D")
         self.assertEqual(od["distribution"], "WS")
         self.assertEqual(od["invasive_plant"], "JK")
@@ -72,7 +72,7 @@ class AquaticObservationTest(BaseActivitySubtypeTest):
         # @todo add subtype observation info class
         # self.assertEqual(sd["suitable_for_biocontrol"], "Yes")
         self.assertEqual(sd["pretreatment_observation"], "No")
-        self.assertEqual(len(sd["observation_details"]), 2)
+        self.assertEqual(len(sd["entries"]), 2)
 
         obs_detail = [
             {
@@ -95,4 +95,4 @@ class AquaticObservationTest(BaseActivitySubtypeTest):
             },
         ]
 
-        self.assertCountEqual(obs_detail, sd["observation_details"])
+        self.assertCountEqual(obs_detail, sd["entries"])

--- a/api-rework/invasives/api/tests/subtypes/test_biocontrol_collection.py
+++ b/api-rework/invasives/api/tests/subtypes/test_biocontrol_collection.py
@@ -17,9 +17,7 @@ class BiocontrolReleaseTest(BaseActivitySubtypeTest):
         self.no_pac_number_present()
 
     def test_casting_fixture_into_serializer(self):
-        self.casting_fixture_into_serializer(
-            expected_subtype_key="collection_information"
-        )
+        self.casting_fixture_into_serializer(expected_subtype_key="entries")
 
     def test_subtype_details_full(self):
         """Subtype keys match the information from fixtures."""
@@ -27,7 +25,7 @@ class BiocontrolReleaseTest(BaseActivitySubtypeTest):
 
         sd = response_object["subtype_data"]
 
-        ti = sd["collection_information"]
+        ti = sd["entries"]
         self.assertEqual(len(ti), 1)
         ti = ti[0]
         self.assertEqual(ti["collection_type"], "Timed")

--- a/api-rework/invasives/api/tests/subtypes/test_biocontrol_dispersal_monitoring.py
+++ b/api-rework/invasives/api/tests/subtypes/test_biocontrol_dispersal_monitoring.py
@@ -17,16 +17,14 @@ class BiocontrolReleaseTest(BaseActivitySubtypeTest):
         self.no_pac_number_present()
 
     def test_casting_fixture_into_serializer(self):
-        self.casting_fixture_into_serializer(
-            expected_subtype_key="monitoring_information"
-        )
+        self.casting_fixture_into_serializer(expected_subtype_key="entries")
 
     def test_subtype_details_full(self):
         response_object = self.fetch_a().json()
 
         sd = response_object["subtype_data"]
 
-        mi = sd["monitoring_information"]
+        mi = sd["entries"]
 
         self.assertEqual(len(mi), 1)
         mi = mi[0]

--- a/api-rework/invasives/api/tests/subtypes/test_biocontrol_release.py
+++ b/api-rework/invasives/api/tests/subtypes/test_biocontrol_release.py
@@ -17,9 +17,7 @@ class BiocontrolReleaseTest(BaseActivitySubtypeTest):
         self.no_pac_number_present()
 
     def test_casting_fixture_into_serializer(self):
-        self.casting_fixture_into_serializer(
-            expected_subtype_key="treatment_information"
-        )
+        self.casting_fixture_into_serializer(expected_subtype_key="entries")
 
     def test_subtype_details_full(self):
         """Subtype keys match the information from fixtures."""
@@ -27,7 +25,7 @@ class BiocontrolReleaseTest(BaseActivitySubtypeTest):
 
         sd = response_object["subtype_data"]
 
-        ti = sd["treatment_information"]
+        ti = sd["entries"]
         self.assertEqual(len(ti), 1)
         ti = ti[0]
 

--- a/api-rework/invasives/api/tests/subtypes/test_biocontrol_release_monitoring.py
+++ b/api-rework/invasives/api/tests/subtypes/test_biocontrol_release_monitoring.py
@@ -17,16 +17,14 @@ class BiocontrolReleaseTest(BaseActivitySubtypeTest):
         self.no_pac_number_present()
 
     def test_casting_fixture_into_serializer(self):
-        self.casting_fixture_into_serializer(
-            expected_subtype_key="monitoring_information"
-        )
+        self.casting_fixture_into_serializer(expected_subtype_key="entries")
 
     def test_subtype_details_full(self):
         response_object = self.fetch_a().json()
 
         sd = response_object["subtype_data"]
 
-        mi = sd["monitoring_information"]
+        mi = sd["entries"]
 
         self.assertEqual(len(mi), 1)
         mi = mi[0]

--- a/api-rework/invasives/api/tests/subtypes/test_chemical_treatment_monitoring.py
+++ b/api-rework/invasives/api/tests/subtypes/test_chemical_treatment_monitoring.py
@@ -18,15 +18,13 @@ class ChemicalTreatmentMonitoringTest(BaseActivitySubtypeTest):
         self.no_pac_number_present()
 
     def test_casting_fixture_into_serializer(self):
-        self.casting_fixture_into_serializer(
-            expected_subtype_key="treatment_monitoring_information"
-        )
+        self.casting_fixture_into_serializer(expected_subtype_key="entries")
 
     def test_subtype_details_full(self):
         """Subtype keys match the information from fixtures."""
 
         response_object = self.fetch_a().json()
-        tmi = response_object["subtype_data"]["treatment_monitoring_information"]
+        tmi = response_object["subtype_data"]["entries"]
         self.assertEqual(len(tmi), 1)
         tmi = tmi[0]
         self.assertEqual(tmi["comment"], "Several plants remain")
@@ -62,14 +60,14 @@ class ChemicalTreatmentMonitoringTest(BaseActivitySubtypeTest):
         ]
 
         response_object = self.fetch_b().json()
-        tmi = response_object["subtype_data"]["treatment_monitoring_information"]
+        tmi = response_object["subtype_data"]["entries"]
         self.assertListEqual(payload, tmi)
 
     def test_nearest_wells_present(self):
         """Tests Wells tied to a Chemical Monitoring Record are present"""
 
         response_object = self.fetch_b().json()
-        nw = response_object["subtype_data"]["nearest_wells"]
+        nw = response_object["subtype_data"]["well_entries"]
 
         self.assertEqual(len(nw), 3)
 

--- a/api-rework/invasives/api/tests/subtypes/test_mechanical_treatment_monitoring.py
+++ b/api-rework/invasives/api/tests/subtypes/test_mechanical_treatment_monitoring.py
@@ -17,14 +17,12 @@ class MechanicalTreatmentMonitoringTest(BaseActivitySubtypeTest):
         self.no_pac_number_present()
 
     def test_casting_fixture_into_serializer(self):
-        self.casting_fixture_into_serializer(
-            expected_subtype_key="treatment_monitoring_information"
-        )
+        self.casting_fixture_into_serializer(expected_subtype_key="entries")
 
     def test_subtype_details_full(self):
         """Subtype keys match the information from fixtures."""
         response_object = self.fetch_a().json()
-        tmi = response_object["subtype_data"]["treatment_monitoring_information"]
+        tmi = response_object["subtype_data"]["entries"]
         self.assertEqual(len(tmi), 1)
         tmi = tmi[0]
         self.assertEqual(tmi["comment"], "Several plants remain")
@@ -60,5 +58,5 @@ class MechanicalTreatmentMonitoringTest(BaseActivitySubtypeTest):
         ]
 
         response_object = self.fetch_b().json()
-        tmi = response_object["subtype_data"]["treatment_monitoring_information"]
+        tmi = response_object["subtype_data"]["entries"]
         self.assertListEqual(payload, tmi)

--- a/api-rework/invasives/api/tests/subtypes/test_terrestrial_chemical_treatment.py
+++ b/api-rework/invasives/api/tests/subtypes/test_terrestrial_chemical_treatment.py
@@ -18,7 +18,7 @@ class TerrestrialChemicalTreatmentTest(BaseActivitySubtypeTest):
         self.pac_number_is_present()
 
     def test_casting_fixture_into_serializer(self):
-        self.casting_fixture_into_serializer(expected_subtype_key="well_information")
+        self.casting_fixture_into_serializer(expected_subtype_key="well_entries")
 
     def test_subtype_values(self):
         record = self.fetch_a().json()
@@ -40,13 +40,13 @@ class TerrestrialChemicalTreatmentTest(BaseActivitySubtypeTest):
         self.assertEqual(sd["additional_unmapped_well_water_bool"], True)
         self.assertEqual(sd["pest_injury_threshold_determination_bool"], True)
 
-        wells = sd["well_information"]
+        wells = sd["well_entries"]
         self.assertEqual(len(wells), 3)
 
         for well in wells:
             self.assertIsNotNone(well["well_tag_number"])
             self.assertIsNotNone(well["distance"])
 
-        if sd["chem_treatment_details"] != "NOT IMPLEMENTED":
+        if sd["entries"] != "NOT IMPLEMENTED":
             # TODO
             self.fail("UPDATE TESTS FOR CHEM TREATMENT DETAILS")

--- a/api-rework/invasives/api/tests/subtypes/test_terrestrial_mechanical_treatment.py
+++ b/api-rework/invasives/api/tests/subtypes/test_terrestrial_mechanical_treatment.py
@@ -17,18 +17,14 @@ class TerrestrialMechanicalTreatmentTest(BaseActivitySubtypeTest):
         self.no_pac_number_present()
 
     def test_casting_fixture_into_serializer(self):
-        self.casting_fixture_into_serializer(
-            expected_subtype_key="mechanical_treatments"
-        )
+        self.casting_fixture_into_serializer(expected_subtype_key="entries")
 
     def test_subtype_details_full(self):
         """Subtype keys match the information from fixtures."""
         response_object = self.fetch_a().json()
-        self.assertEqual(
-            len(response_object["subtype_data"]["mechanical_treatments"]), 1
-        )
+        self.assertEqual(len(response_object["subtype_data"]["entries"]), 1)
 
-        mt = response_object["subtype_data"]["mechanical_treatments"][0]
+        mt = response_object["subtype_data"]["entries"][0]
         self.assertEqual(mt["disposed_material_amount"], 544)
         self.assertEqual(mt["disposed_material_format"], "kg")
         self.assertEqual(mt["disposal_method"], "II")
@@ -39,7 +35,7 @@ class TerrestrialMechanicalTreatmentTest(BaseActivitySubtypeTest):
     def test_subtype_details_two_entries(self):
         """Subtype keys match the information from fixtures."""
         response_object = self.fetch_b().json()
-        mt = response_object["subtype_data"]["mechanical_treatments"]
+        mt = response_object["subtype_data"]["entries"]
         self.assertEqual(len(mt), 2)
 
         expected = [

--- a/api-rework/invasives/api/tests/subtypes/test_terrestrial_observation.py
+++ b/api-rework/invasives/api/tests/subtypes/test_terrestrial_observation.py
@@ -33,9 +33,9 @@ class TerrestrialObservationTest(BaseActivitySubtypeTest):
         self.assertEqual(sd["slope_percent"]["code"], "SS")
         self.assertEqual(sd["soil_texture"]["code"], "M")
         self.assertEqual(sd["pretreatment_observation"], "Yes")
-        self.assertGreaterEqual(len(sd["observation_details"]), 1)
+        self.assertGreaterEqual(len(sd["entries"]), 1)
 
-        od = sd["observation_details"][0]
+        od = sd["entries"][0]
         self.assertEqual(od["density"], "D")
         self.assertEqual(od["distribution"], "WS")
         self.assertEqual(od["invasive_plant"], "JK")
@@ -68,7 +68,7 @@ class TerrestrialObservationTest(BaseActivitySubtypeTest):
         self.assertEqual(sd["aspect"]["code"], "NA")
         self.assertEqual(sd["slope_percent"]["code"], "VT")
         self.assertEqual(sd["soil_texture"]["code"], "F")
-        self.assertEqual(len(sd["observation_details"]), 2)
+        self.assertEqual(len(sd["entries"]), 2)
 
         obs_detail = [
             {
@@ -89,4 +89,4 @@ class TerrestrialObservationTest(BaseActivitySubtypeTest):
             },
         ]
 
-        self.assertCountEqual(obs_detail, sd["observation_details"])
+        self.assertCountEqual(obs_detail, sd["entries"])


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Renames Serializers and Form Viewers to use `Context` and `Entries` Keys instead of generics
- Updates all Tests
- Does not Update the models (Will do in next PR)