### PR TITLE
Mech/Chem Monitoring 

### DIFF
--- a/api-rework/client/src/common-components/form-map/FormMap.tsx
+++ b/api-rework/client/src/common-components/form-map/FormMap.tsx
@@ -12,7 +12,7 @@ type PropTypes = {
 const FormMap = ({ geojson }: PropTypes) => {
   const SRC = 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}';
   const mapRef = useRef<HTMLDivElement>(null);
-  const map= useRef<maplibregl.Map | undefined>(undefined);
+  const map = useRef<maplibregl.Map | undefined>(undefined);
 
   const mapCenter: LngLatLike = (() => {
     if (!geojson) return [-121, 54] as LngLatLike;
@@ -21,31 +21,29 @@ const FormMap = ({ geojson }: PropTypes) => {
 
   useEffect(() => {
     // Init Map after load
-    map.current =
-      new maplibregl.Map({
-        container: 'map',
-        center: mapCenter,
-        zoom: 8,
-        style: {
-          sources: {
-            'raster-tiles': {
-              type: 'raster',
-              tiles: [SRC],
-              tileSize: 256,
-              maxzoom: 18
-            }
-          },
-          layers: [
-            {
-              id: 'raster-tiles',
-              type: 'raster',
-              source: 'raster-tiles'
-            }
-          ],
-          version: 8
-        }
+    map.current = new maplibregl.Map({
+      container: 'map',
+      center: mapCenter,
+      zoom: 8,
+      style: {
+        sources: {
+          'raster-tiles': {
+            type: 'raster',
+            tiles: [SRC],
+            tileSize: 256,
+            maxzoom: 18
+          }
+        },
+        layers: [
+          {
+            id: 'raster-tiles',
+            type: 'raster',
+            source: 'raster-tiles'
+          }
+        ],
+        version: 8
       }
-    );
+    });
   }, [geojson]);
 
   useEffect(() => {
@@ -68,6 +66,16 @@ const FormMap = ({ geojson }: PropTypes) => {
             'fill-opacity': 0.6
           }
         });
+        map.current?.addLayer({
+          id: 'form-feature-point',
+          type: 'circle',
+          source: 'form-feature',
+          layout: {},
+          filter: ['!=', '$type', 'Polygon'],
+          paint: {
+            'circle-color': 'orange'
+          }
+        });
         const bounds = bbox(geojson) as LngLatBoundsLike;
         map.current?.fitBounds(bounds, {
           padding: 10,
@@ -75,7 +83,6 @@ const FormMap = ({ geojson }: PropTypes) => {
         });
       }
     });
-
   }, [map]);
   return (
     <div>

--- a/api-rework/invasives/api/viewsets/code.py
+++ b/api-rework/invasives/api/viewsets/code.py
@@ -47,6 +47,7 @@ class CodeViewSet(ViewSet):
         SpecificUseCode,
         SubstrateCode,
         TerrestrialPlantCode,
+        TreatmentEfficacyRatingCode,
         WaterbodyFlowCode,
         WaterbodyFlowSeasonalCode,
         WaterbodyUseCode,

--- a/app/src/UI/Features/Records/Activity/forms/common/ArrayField/arrayField.css
+++ b/app/src/UI/Features/Records/Activity/forms/common/ArrayField/arrayField.css
@@ -69,7 +69,7 @@
   }
 }
 
-@media screen and (width < 425px) {
+@media screen and (width < 450px) {
   .field-array {
     &.half-width,
     &.third-width,

--- a/app/src/UI/Features/Records/Activity/forms/common/DeleteControl/DeleteControl.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/common/DeleteControl/DeleteControl.tsx
@@ -1,12 +1,18 @@
 import { Delete } from '@mui/icons-material';
 import './deleteControl.css';
+import { useFormContext } from 'react-hook-form';
 
-const DeleteControl = ({ onClick, disabled }) => (
-  <div className="delete-control">
-    <button disabled={disabled} onClick={onClick}>
-      {<Delete color="error" />}
-    </button>
-  </div>
-);
+const DeleteControl = ({ onClick }) => {
+  const {
+    formState: { disabled }
+  } = useFormContext();
+  return (
+    <div className="delete-control">
+      <button disabled={disabled} onClick={onClick}>
+        {<Delete color="error" />}
+      </button>
+    </div>
+  );
+};
 
 export default DeleteControl;

--- a/app/src/UI/Features/Records/Activity/forms/common/validators/noRepeatKey.ts
+++ b/app/src/UI/Features/Records/Activity/forms/common/validators/noRepeatKey.ts
@@ -4,8 +4,12 @@
  * @param key Key to compare e.g. 'invasive_plant'
  * @param keyLabel Plain language representation of key to appear in error message e.g. 'Invasive Plant'
  */
-const noRepeatKey = (arr: Record<PropertyKey, unknown>[], key: PropertyKey, keyLabel?: string): boolean | string =>
-  new Set(arr.map((o) => o[key])).size === arr.length ||
-  `The same ${String(keyLabel ?? key)} cannot appear in multiple entries.`;
+const noRepeatKey = (arr: Record<PropertyKey, unknown>[], key: PropertyKey, keyLabel?: string): boolean | string => {
+  const removedEmpty = arr.filter((entry) => !!entry?.[key]); // Filter out empty keys
+  return (
+    new Set(removedEmpty.map((o) => o?.[key])).size === removedEmpty.length ||
+    `The same ${String(keyLabel ?? key)} cannot appear in multiple entries.`
+  );
+};
 
 export default noRepeatKey;

--- a/app/src/UI/Features/Records/Activity/forms/enums.ts
+++ b/app/src/UI/Features/Records/Activity/forms/enums.ts
@@ -137,4 +137,36 @@ const DisposedMaterialFormat = [
     table: 'PlantDisposalFormat'
   }
 ];
-export { DisposedMaterialFormat, ObservationType, YesNo, YesNoUnknown, WaterbodyType, WaterLevelManagement };
+
+const TreatmentPass = [
+  {
+    full_name: 'First',
+    code: 'First',
+    table: 'TreatmentPass'
+  },
+  {
+    full_name: 'Second',
+    code: 'Second',
+    table: 'TreatmentPass'
+  },
+  {
+    full_name: 'Third',
+    code: 'Third',
+    table: 'TreatmentPass'
+  },
+  {
+    full_name: 'Unknown',
+    code: 'Unknown',
+    table: 'TreatmentPass'
+  }
+];
+
+export {
+  DisposedMaterialFormat,
+  ObservationType,
+  TreatmentPass,
+  YesNo,
+  YesNoUnknown,
+  WaterbodyType,
+  WaterLevelManagement
+};

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/ActivityForm.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/ActivityForm.tsx
@@ -363,7 +363,7 @@ const ActivityForm = () => {
                       }
                     })}
                   />
-                  <DeleteControl disabled={disabled} onClick={() => remove(index)} />
+                  <DeleteControl onClick={() => remove(index)} />
                 </>
               )}
             />
@@ -382,7 +382,7 @@ const ActivityForm = () => {
                     {...register(`projects.${index}.description`, { required: true })}
                     error={formState.errors.projects?.[index]?.description}
                   />
-                  <DeleteControl disabled={disabled} onClick={() => remove(index)} />
+                  <DeleteControl onClick={() => remove(index)} />
                 </>
               )}
             />

--- a/app/src/UI/Features/Records/Activity/forms/plant/builders/getDefaultState.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/builders/getDefaultState.ts
@@ -3,6 +3,10 @@ import getObservationAquaticPlantSubtypeFields from './getObservationAquaticPlan
 import getObservationPlantTerrestrialSubtypeFields from './getObservationTerrestrialPlantSubtypeFields';
 import getTreatmentMechanicalTerrestrialPlantSubtypeFields from './getTreatmentMechanicalTerrestrialPlantSubtypeFields';
 import getTreatmentMechanicalAquaticPlantSubtypeFields from './getTreatmentMechanicalAquaticPlantSubtypeFields';
+import {
+  getMonitoringChemPlantSubtypeFields,
+  getMonitoringMechPlantSubtypeFields
+} from './getMonitoringMechChemPlantSubtypeFields';
 import { FormSchema } from 'UI/Features/Records/Activity/forms/plant/interfaces/FormSchema';
 
 /**
@@ -16,12 +20,14 @@ const getSubtypeData = (subtype: ActivitySubtypes): FormSchema['subtype_data'] =
     case ActivitySubtypes.Observation_Plant_Aquatic:
       return getObservationAquaticPlantSubtypeFields();
     case ActivitySubtypes.Monitoring_Chemical_Plant_Terrestrial_Aquatic:
+      return getMonitoringChemPlantSubtypeFields();
     case ActivitySubtypes.Monitoring_Mechanical_Plant_Terrestrial_Aquatic:
-    case ActivitySubtypes.Monitoring_Biocontrol_Release_Plant_Terrestrial:
+      return getMonitoringMechPlantSubtypeFields();
     case ActivitySubtypes.Treatment_Mechanical_Plant_Terrestrial:
       return getTreatmentMechanicalTerrestrialPlantSubtypeFields();
     case ActivitySubtypes.Treatment_Mechanical_Plant_Aquatic:
       return getTreatmentMechanicalAquaticPlantSubtypeFields();
+    case ActivitySubtypes.Monitoring_Biocontrol_Release_Plant_Terrestrial:
     case ActivitySubtypes.Treatment_Chemical_Plant_Terrestrial:
     case ActivitySubtypes.Treatment_Chemical_Plant_Aquatic:
     case ActivitySubtypes.Monitoring_Biocontrol_Dispersal_Plant_Terrestrial:

--- a/app/src/UI/Features/Records/Activity/forms/plant/builders/getMonitoringMechChemPlantSubtypeFields.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/builders/getMonitoringMechChemPlantSubtypeFields.ts
@@ -3,6 +3,7 @@ import { MonitoringChemPlantSchema, MonitoringMechPlantSchema } from '../interfa
 const getSubtypeFields = (): MonitoringChemPlantSchema['subtype_data'] | MonitoringMechPlantSchema['subtype_data'] => ({
   entries: [
     {
+      invasive_plant: '',
       evidence_of_treatment: '',
       treatment_pass: '',
       comment: '',

--- a/app/src/UI/Features/Records/Activity/forms/plant/builders/getMonitoringMechChemPlantSubtypeFields.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/builders/getMonitoringMechChemPlantSubtypeFields.ts
@@ -1,0 +1,20 @@
+import { MonitoringChemPlantSchema, MonitoringMechPlantSchema } from '../interfaces';
+
+const getSubtypeFields = (): MonitoringChemPlantSchema['subtype_data'] | MonitoringMechPlantSchema['subtype_data'] => ({
+  entries: [
+    {
+      evidence_of_treatment: '',
+      treatment_pass: '',
+      comment: '',
+      invasive_plants_on_site: [],
+      management_efficacy_rating: '',
+      treatment_efficacy_rating: '',
+      invasive_plant_aquatic: ''
+    }
+  ]
+});
+
+const getMonitoringMechPlantSubtypeFields = (): MonitoringMechPlantSchema['subtype_data'] => getSubtypeFields();
+const getMonitoringChemPlantSubtypeFields = (): MonitoringChemPlantSchema['subtype_data'] => getSubtypeFields();
+
+export { getMonitoringChemPlantSubtypeFields, getMonitoringMechPlantSubtypeFields };

--- a/app/src/UI/Features/Records/Activity/forms/plant/builders/index.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/builders/index.ts
@@ -2,3 +2,7 @@ export { default as getObservationAquaticPlantSubtypeFields } from './getObserva
 export { default as getObservationPlantTerrestrialSubtypeFields } from './getObservationTerrestrialPlantSubtypeFields';
 export { default as getTreatmentMechanicalTerrestrialPlantSubtypeFields } from './getTreatmentMechanicalTerrestrialPlantSubtypeFields';
 export { default as getTreatmentAquaticTerrestrialPlantSubtypeFields } from './getTreatmentMechanicalAquaticPlantSubtypeFields';
+export {
+  getMonitoringChemPlantSubtypeFields,
+  getMonitoringMechPlantSubtypeFields
+} from './getMonitoringMechChemPlantSubtypeFields';

--- a/app/src/UI/Features/Records/Activity/forms/plant/content/tooltips.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/content/tooltips.ts
@@ -69,6 +69,16 @@ const tooltips = {
       authorization_info:
         'Description of authorization permit for in-stream work (e.g. In-stream Notification, private landowner authorization in private pond, etc).'
     },
+    evidence_of_treatment: 'Choose the efficacy of the treatment for the area that was treated.',
+    treatment_pass:
+      'Indicate whether you are monitoring the first or second treatment pass of the calendar year, if known',
+    invasive_plant_on_site:
+      'Choose one or more options to indicate whether target invasive plants are still found on site following the treatment.',
+    monitoring_comment:
+      'Note whether chlorosis, necrosis, curling, browning, yellow, epicormic growth etc. is observed, or any additional relevant information',
+    treatment_efficacy_rating: 'Choose the efficacy of the treatment for the area that was treated.',
+    management_efficacy_rating:
+      'Choose the efficacy rating indicating the mortality of all the target species found on the site, including those that were not treated. Eg: 50% of plants on the site have evidence of treatment = Efficacy of 5.',
     disposed_material_format: 'If relevant, choose how the overall quantity/amount of removed biomass was calculated.'
   }
 };

--- a/app/src/UI/Features/Records/Activity/forms/plant/interfaces/EntryBasePath.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/interfaces/EntryBasePath.ts
@@ -1,0 +1,3 @@
+type EntryBasePath = `subtype_data.entries.${number}`;
+
+export type { EntryBasePath };

--- a/app/src/UI/Features/Records/Activity/forms/plant/interfaces/FormSchema.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/interfaces/FormSchema.ts
@@ -3,14 +3,15 @@ import {
   AquaticPlantObservationSchema,
   TerrestrialMechTreatment,
   MonitoringChemPlantSchema,
-  MonitoringMechPlantSchema
+  MonitoringMechPlantSchema,
+  AquaticMechTreatment
 } from '.';
 
 type FormSchema =
   | TerrestrialPlantObservationSchema
   | AquaticPlantObservationSchema
   | TerrestrialMechTreatment
-  | AquaticPlantObservationSchema
+  | AquaticMechTreatment
   | MonitoringChemPlantSchema
   | MonitoringMechPlantSchema;
 

--- a/app/src/UI/Features/Records/Activity/forms/plant/interfaces/FormSchema.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/interfaces/FormSchema.ts
@@ -1,9 +1,17 @@
-import { TerrestrialPlantObservationSchema, AquaticPlantObservationSchema, TerrestrialMechTreatment } from '.';
+import {
+  TerrestrialPlantObservationSchema,
+  AquaticPlantObservationSchema,
+  TerrestrialMechTreatment,
+  MonitoringChemPlantSchema,
+  MonitoringMechPlantSchema
+} from '.';
 
 type FormSchema =
   | TerrestrialPlantObservationSchema
   | AquaticPlantObservationSchema
   | TerrestrialMechTreatment
-  | AquaticPlantObservationSchema;
+  | AquaticPlantObservationSchema
+  | MonitoringChemPlantSchema
+  | MonitoringMechPlantSchema;
 
 export type { FormSchema };

--- a/app/src/UI/Features/Records/Activity/forms/plant/interfaces/MechChemMonitoring.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/interfaces/MechChemMonitoring.ts
@@ -4,6 +4,7 @@ import { BaseForm } from './BaseForm';
 interface MonitoringChemMech extends BaseForm {
   subtype_data: {
     entries: Array<{
+      invasive_plant: string;
       evidence_of_treatment: string;
       treatment_pass: string;
       comment: string;

--- a/app/src/UI/Features/Records/Activity/forms/plant/interfaces/MechChemMonitoring.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/interfaces/MechChemMonitoring.ts
@@ -1,0 +1,25 @@
+import { ActivitySubtypes } from 'sharedAPI';
+import { BaseForm } from './BaseForm';
+
+interface MonitoringChemMech extends BaseForm {
+  subtype_data: {
+    entries: Array<{
+      evidence_of_treatment: string;
+      treatment_pass: string;
+      comment: string;
+      invasive_plants_on_site: string[];
+      management_efficacy_rating: string;
+      treatment_efficacy_rating: string;
+      invasive_plant_aquatic: string;
+    }>;
+  };
+}
+
+interface MonitoringChemPlantSchema extends MonitoringChemMech {
+  subtype: ActivitySubtypes.Monitoring_Chemical_Plant_Terrestrial_Aquatic;
+}
+interface MonitoringMechPlantSchema extends MonitoringChemMech {
+  subtype: ActivitySubtypes.Monitoring_Mechanical_Plant_Terrestrial_Aquatic;
+}
+
+export type { MonitoringChemPlantSchema, MonitoringMechPlantSchema };

--- a/app/src/UI/Features/Records/Activity/forms/plant/interfaces/index.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/interfaces/index.ts
@@ -6,5 +6,7 @@ export type { AquaticPlantObservationSchema } from './AquaticObservation';
 // Mechanical
 export type { TerrestrialMechTreatment } from './TerrestrialMechTreatment';
 export type { AquaticMechTreatment } from './AquaticMechTreatment';
+// Monitoring
+export type { MonitoringChemPlantSchema, MonitoringMechPlantSchema } from './MechChemMonitoring';
 // FormSchema
 export type { FormSchema } from './FormSchema';

--- a/app/src/UI/Features/Records/Activity/forms/plant/interfaces/index.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/interfaces/index.ts
@@ -10,3 +10,4 @@ export type { AquaticMechTreatment } from './AquaticMechTreatment';
 export type { MonitoringChemPlantSchema, MonitoringMechPlantSchema } from './MechChemMonitoring';
 // FormSchema
 export type { FormSchema } from './FormSchema';
+export type { EntryBasePath } from './EntryBasePath';

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/SubtypeComposite.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/SubtypeComposite.tsx
@@ -4,6 +4,7 @@ import ObservationPlantTerrestrial from 'UI/Features/Records/Activity/forms/plan
 import ObservationPlantAquatic from 'UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-aquatic/ObservationPlantAquatic';
 import TreatmentMechPlantTerrestrial from './treatment-mech-plant-terrestrial/TreatmentMechPlantTerrestrial';
 import TreatmentMechPlantAquatic from './treatment-mech-plant-aquatic/TreatmentMechPlantAquatic';
+import MonitoringChemMechPlant from './monitoring-chem-mech-plant/MonitoringChemMechPlant';
 
 /**
  * @desc Handles the Branching Subtypes for Forms, matches Subtype to required Subfields
@@ -15,12 +16,8 @@ const SubtypeComposite = () => {
   return {
     [ActivitySubtypes.Observation_Plant_Terrestrial]: <ObservationPlantTerrestrial />,
     [ActivitySubtypes.Observation_Plant_Aquatic]: <ObservationPlantAquatic />,
-    [ActivitySubtypes.Monitoring_Chemical_Plant_Terrestrial_Aquatic]: (
-      <p>Monitoring_Chemical_Plant_Terrestrial_Aquatic Not Implemented</p>
-    ),
-    [ActivitySubtypes.Monitoring_Mechanical_Plant_Terrestrial_Aquatic]: (
-      <p>Monitoring_Mechanical_Plant_Terrestrial_Aquatic Not Implemented</p>
-    ),
+    [ActivitySubtypes.Monitoring_Chemical_Plant_Terrestrial_Aquatic]: <MonitoringChemMechPlant />,
+    [ActivitySubtypes.Monitoring_Mechanical_Plant_Terrestrial_Aquatic]: <MonitoringChemMechPlant />,
     [ActivitySubtypes.Monitoring_Biocontrol_Release_Plant_Terrestrial]: (
       <p>Monitoring_Biocontrol_Release_Plant_Terrestrial Not Implemented</p>
     ),

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/monitoring-chem-mech-plant/MonitoringChemMechPlant.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/monitoring-chem-mech-plant/MonitoringChemMechPlant.tsx
@@ -1,8 +1,11 @@
 import { useSelector } from 'utils/use_selector';
-import ArrayField from '../../../common/ArrayField/ArrayField';
-import { MonitoringChemPlantSchema, MonitoringMechPlantSchema } from '../../interfaces';
-import getDefaultFormState from '../../builders/getDefaultState';
-import { minArrayLength, noRepeatKey } from '../../../common/validators';
+import ArrayField from 'UI/Features/Records/Activity/forms/common/ArrayField/ArrayField';
+import {
+  MonitoringChemPlantSchema,
+  MonitoringMechPlantSchema
+} from 'UI/Features/Records/Activity/forms/plant/interfaces';
+import getDefaultFormState from 'UI/Features/Records/Activity/forms/plant/builders/getDefaultState';
+import { minArrayLength, noRepeatKey } from 'UI/Features/Records/Activity/forms/common/validators';
 import MonitoringChemMechPlantEntry from './MonitoringChemMechPlantEntry';
 
 const MonitoringChemMechPlant = () => {

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/monitoring-chem-mech-plant/MonitoringChemMechPlant.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/monitoring-chem-mech-plant/MonitoringChemMechPlant.tsx
@@ -1,0 +1,27 @@
+import { useSelector } from 'utils/use_selector';
+import ArrayField from '../../../common/ArrayField/ArrayField';
+import { MonitoringChemPlantSchema, MonitoringMechPlantSchema } from '../../interfaces';
+import getDefaultFormState from '../../builders/getDefaultState';
+import { minArrayLength, noRepeatKey } from '../../../common/validators';
+import MonitoringChemMechPlantEntry from './MonitoringChemMechPlantEntry';
+
+const MonitoringChemMechPlant = () => {
+  const subtype = useSelector((state) => state.ActivityPage?.formType);
+  return (
+    <ArrayField<MonitoringChemPlantSchema | MonitoringMechPlantSchema, 'subtype_data.entries'>
+      name={'subtype_data.entries'}
+      label={'Monitoring Information'}
+      emptyValue={getDefaultFormState(subtype).subtype_data.entries[0]}
+      rules={{
+        validate: {
+          minLength: (arr) => minArrayLength(arr, 1),
+          noDupePlant: (arr) => noRepeatKey(arr, 'invasive_plant', 'Terrestrial Plant'),
+          noDupeAquaticPlant: (arr) => noRepeatKey(arr, 'aquatic_invasive_plant', 'Aquatic Invasive Plant')
+        }
+      }}
+      renderRow={(index, remove) => <MonitoringChemMechPlantEntry index={index} remove={remove} />}
+    />
+  );
+};
+
+export default MonitoringChemMechPlant;

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/monitoring-chem-mech-plant/MonitoringChemMechPlant.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/monitoring-chem-mech-plant/MonitoringChemMechPlant.tsx
@@ -16,7 +16,7 @@ const MonitoringChemMechPlant = () => {
         validate: {
           minLength: (arr) => minArrayLength(arr, 1),
           noDupePlant: (arr) => noRepeatKey(arr, 'invasive_plant', 'Terrestrial Plant'),
-          noDupeAquaticPlant: (arr) => noRepeatKey(arr, 'aquatic_invasive_plant', 'Aquatic Invasive Plant')
+          noDupeAquaticPlant: (arr) => noRepeatKey(arr, 'invasive_plant_aquatic', 'Aquatic Invasive Plant')
         }
       }}
       renderRow={(index, remove) => <MonitoringChemMechPlantEntry index={index} remove={remove} />}

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/monitoring-chem-mech-plant/MonitoringChemMechPlantEntry.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/monitoring-chem-mech-plant/MonitoringChemMechPlantEntry.tsx
@@ -1,0 +1,142 @@
+import { useSelector } from 'utils/use_selector';
+import SingleSelect from 'UI/Features/Records/Activity/forms/common/SingleSelect/SingleSelect';
+import tooltips from 'UI/Features/Records/Activity/forms/plant/content/tooltips';
+import { Width } from 'UI/Features/Records/Activity/forms/common/utils';
+import { TreatmentPass, YesNo } from 'UI/Features/Records/Activity/forms/enums';
+import MultiSelect from 'UI/Features/Records/Activity/forms/common/MultiSelect/MultiSelect';
+import { minArrayLength } from 'UI/Features/Records/Activity/forms/common/validators';
+import TextInput from 'UI/Features/Records/Activity/forms/common/TextInput/TextInput';
+import DeleteControl from 'UI/Features/Records/Activity/forms/common/DeleteControl/DeleteControl';
+import {
+  MonitoringChemPlantSchema,
+  MonitoringMechPlantSchema
+} from 'UI/Features/Records/Activity/forms/plant/interfaces';
+import { useFormContext } from 'react-hook-form';
+import Spacer from 'UI/Reusable/Spacer/Spacer';
+import { useEffect } from 'react';
+
+type PropTypes = {
+  remove: Function;
+  index: number;
+};
+const MonitoringChemMechPlantEntry = ({ index, remove }: PropTypes) => {
+  type EntryBasePath = `subtype_data.entries.${number}`;
+  const BASE = `subtype_data.entries.${index}` as EntryBasePath;
+  const {
+    register,
+    watch,
+    setValue,
+    formState: { errors }
+  } = useFormContext<MonitoringChemPlantSchema | MonitoringMechPlantSchema>();
+
+  const codes = useSelector((state) => state.ActivityPage?.formCodes);
+  const wasEvidenceOfTreatment = watch(`${BASE}.evidence_of_treatment`) === 'Yes';
+  const hasAquaticPlant = watch(`${BASE}.invasive_plant_aquatic`);
+  const hasTerrestrialPlant = watch(`${BASE}.invasive_plant`);
+
+  useEffect(() => {
+    if (!wasEvidenceOfTreatment) {
+      setValue(`${BASE}.treatment_efficacy_rating`, '');
+    }
+  }, [wasEvidenceOfTreatment]);
+
+  return (
+    <>
+      <SingleSelect
+        label={'Terrestrial Invasive Plant'}
+        name={`subtype_data.entries.${index}.invasive_plant`}
+        required={!hasAquaticPlant}
+        tooltip={tooltips.plant.invasive_plant}
+        width={Width.Half}
+        rules={{
+          required: !hasAquaticPlant,
+          validate: (_, formValues) => {
+            const entry = formValues.subtype_data.entries[index];
+            if (!entry.invasive_plant && !entry.invasive_plant_aquatic) {
+              return 'Either Aquatic or Terrestrial Plant must be chosen';
+            } else if (entry.invasive_plant && entry.invasive_plant_aquatic) {
+              return "Can't Specify both Aquatic and Terrestrial Plants.";
+            }
+            return true;
+          }
+        }}
+        options={codes?.TerrestrialPlantCode}
+      />
+      <SingleSelect
+        label={'Aquatic Invasive Plant'}
+        name={`subtype_data.entries.${index}.invasive_plant_aquatic`}
+        options={codes?.AquaticPlantCode}
+        required={!hasTerrestrialPlant}
+        tooltip={tooltips.plant.invasive_plant}
+        width={Width.Half}
+        rules={{
+          required: !hasTerrestrialPlant,
+          validate: (_, formValues) => {
+            const { entry } = formValues.subtype_data.entries[index];
+            if (entry.invasive_plant && entry.invasive_plant_aquatic) {
+              return "Can't Specify both Aquatic and Terrestrial Plants.";
+            } else if (!entry.invasive_plant && !entry.invasive_plant_aquatic) {
+              return 'Either Aquatic or Terrestrial Plant must be chosen';
+            }
+            return true;
+          }
+        }}
+      />
+      <SingleSelect
+        label={'Evidence of Treatment'}
+        name={`subtype_data.entries.${index}.evidence_of_treatment`}
+        options={YesNo}
+        required
+        rules={{ required: true }}
+        tooltip={tooltips.plant.invasive_plant}
+        width={Width.Half}
+      />
+      {wasEvidenceOfTreatment ? (
+        <SingleSelect
+          label={'Treatment Efficacy Rating'}
+          options={codes?.TreatmentEfficacyRatingCode}
+          name={`subtype_data.entries.${index}.treatment_efficacy_rating`}
+          tooltip={tooltips.plant.treatment_efficacy_rating}
+          width={Width.Half}
+        />
+      ) : (
+        <Spacer x={200} y={30} />
+      )}
+      <SingleSelect
+        label={'Management Efficacy Rating'}
+        name={`subtype_data.entries.${index}.management_efficacy_rating`}
+        options={codes?.EfficacyManagementRatingCode}
+        required
+        rules={{ required: true }}
+        tooltip={tooltips.plant.management_efficacy_rating}
+        width={Width.Half}
+      />
+      <MultiSelect
+        label={'Invasive Plants on Site'}
+        name={`subtype_data.entries.${index}.invasive_plants_on_site`}
+        options={codes?.InvasivePlantsOnSiteCode}
+        required
+        rules={{ validate: (arr) => minArrayLength(arr, 1) }}
+        tooltip={tooltips.plant.invasive_plant_on_site}
+        width={Width.Half}
+      />
+      <SingleSelect
+        label={'Treatment Pass'}
+        name={`subtype_data.entries.${index}.treatment_pass`}
+        options={TreatmentPass}
+        tooltip={tooltips.plant.treatment_pass}
+        width={Width.Half}
+      />
+      <TextInput
+        label={'Comment'}
+        error={errors.subtype_data?.entries?.[index]?.comment}
+        tooltip={tooltips.plant.monitoring_comment}
+        width={Width.Half}
+        {...register(`subtype_data.entries.${index}.comment`)}
+      />
+      <DeleteControl onClick={() => remove(index)} />
+    </>
+  );
+};
+
+export default MonitoringChemMechPlantEntry;

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/monitoring-chem-mech-plant/MonitoringChemMechPlantEntry.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/monitoring-chem-mech-plant/MonitoringChemMechPlantEntry.tsx
@@ -8,6 +8,7 @@ import { minArrayLength } from 'UI/Features/Records/Activity/forms/common/valida
 import TextInput from 'UI/Features/Records/Activity/forms/common/TextInput/TextInput';
 import DeleteControl from 'UI/Features/Records/Activity/forms/common/DeleteControl/DeleteControl';
 import {
+  EntryBasePath,
   MonitoringChemPlantSchema,
   MonitoringMechPlantSchema
 } from 'UI/Features/Records/Activity/forms/plant/interfaces';
@@ -20,7 +21,6 @@ type PropTypes = {
   index: number;
 };
 const MonitoringChemMechPlantEntry = ({ index, remove }: PropTypes) => {
-  type EntryBasePath = `subtype_data.entries.${number}`;
   const BASE = `subtype_data.entries.${index}` as EntryBasePath;
   const validatePlantRow = (formValues) => {
     const entry = formValues.subtype_data.entries[index];

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/monitoring-chem-mech-plant/MonitoringChemMechPlantEntry.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/monitoring-chem-mech-plant/MonitoringChemMechPlantEntry.tsx
@@ -22,6 +22,16 @@ type PropTypes = {
 const MonitoringChemMechPlantEntry = ({ index, remove }: PropTypes) => {
   type EntryBasePath = `subtype_data.entries.${number}`;
   const BASE = `subtype_data.entries.${index}` as EntryBasePath;
+  const validatePlantRow = (formValues) => {
+    const entry = formValues.subtype_data.entries[index];
+    if (!entry.invasive_plant && !entry.invasive_plant_aquatic) {
+      return 'Either Aquatic or Terrestrial Plant must be chosen';
+    } else if (entry.invasive_plant && entry.invasive_plant_aquatic) {
+      return "Can't Specify both Aquatic and Terrestrial Plants.";
+    }
+    return true;
+  };
+
   const {
     register,
     watch,
@@ -50,15 +60,7 @@ const MonitoringChemMechPlantEntry = ({ index, remove }: PropTypes) => {
         width={Width.Half}
         rules={{
           required: !hasAquaticPlant,
-          validate: (_, formValues) => {
-            const entry = formValues.subtype_data.entries[index];
-            if (!entry.invasive_plant && !entry.invasive_plant_aquatic) {
-              return 'Either Aquatic or Terrestrial Plant must be chosen';
-            } else if (entry.invasive_plant && entry.invasive_plant_aquatic) {
-              return "Can't Specify both Aquatic and Terrestrial Plants.";
-            }
-            return true;
-          }
+          validate: (_, formValues) => validatePlantRow(formValues)
         }}
         options={codes?.TerrestrialPlantCode}
       />
@@ -71,15 +73,7 @@ const MonitoringChemMechPlantEntry = ({ index, remove }: PropTypes) => {
         width={Width.Half}
         rules={{
           required: !hasTerrestrialPlant,
-          validate: (_, formValues) => {
-            const entry = formValues.subtype_data.entries[index];
-            if (entry.invasive_plant && entry.invasive_plant_aquatic) {
-              return "Can't Specify both Aquatic and Terrestrial Plants.";
-            } else if (!entry.invasive_plant && !entry.invasive_plant_aquatic) {
-              return 'Either Aquatic or Terrestrial Plant must be chosen';
-            }
-            return true;
-          }
+          validate: (_, formValues) => validatePlantRow(formValues)
         }}
       />
       <SingleSelect

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/monitoring-chem-mech-plant/MonitoringChemMechPlantEntry.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/monitoring-chem-mech-plant/MonitoringChemMechPlantEntry.tsx
@@ -72,7 +72,7 @@ const MonitoringChemMechPlantEntry = ({ index, remove }: PropTypes) => {
         rules={{
           required: !hasTerrestrialPlant,
           validate: (_, formValues) => {
-            const { entry } = formValues.subtype_data.entries[index];
+            const entry = formValues.subtype_data.entries[index];
             if (entry.invasive_plant && entry.invasive_plant_aquatic) {
               return "Can't Specify both Aquatic and Terrestrial Plants.";
             } else if (!entry.invasive_plant && !entry.invasive_plant_aquatic) {

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-aquatic/AquaticPlantEntry.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-aquatic/AquaticPlantEntry.tsx
@@ -192,7 +192,7 @@ const AquaticPlantEntry = ({ root, index, remove }: Props) => {
           </Fieldset>
         </Fieldset>
       )}
-      <DeleteControl disabled={disabled} onClick={() => remove(index)} />
+      <DeleteControl onClick={() => remove(index)} />
     </>
   );
 };

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-aquatic/AquaticPlantEntry.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-aquatic/AquaticPlantEntry.tsx
@@ -1,7 +1,7 @@
 import { useSelector } from 'utils/use_selector';
 import { useFormContext, useWatch } from 'react-hook-form';
 import Spacer from 'UI/Reusable/Spacer/Spacer';
-import { AquaticPlantObservationSchema } from '../../interfaces';
+import { AquaticPlantObservationSchema, EntryBasePath } from '../../interfaces';
 import { useEffect, useState } from 'react';
 import TextInput from 'UI/Features/Records/Activity/forms/common/TextInput/TextInput';
 import { Width } from 'UI/Features/Records/Activity/forms/common/utils';
@@ -19,8 +19,6 @@ interface Props {
   index: number;
   remove: (index: number) => void;
 }
-
-type EntryBasePath = `subtype_data.entries.${number}`;
 
 const AquaticPlantEntry = ({ root, index, remove }: Props) => {
   const {

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-aquatic/AquaticPlantEntry.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-aquatic/AquaticPlantEntry.tsx
@@ -1,7 +1,7 @@
 import { useSelector } from 'utils/use_selector';
 import { useFormContext, useWatch } from 'react-hook-form';
 import Spacer from 'UI/Reusable/Spacer/Spacer';
-import { AquaticPlantObservationSchema, EntryBasePath } from '../../interfaces';
+import { AquaticPlantObservationSchema, EntryBasePath } from 'UI/Features/Records/Activity/forms/plant/interfaces';
 import { useEffect, useState } from 'react';
 import TextInput from 'UI/Features/Records/Activity/forms/common/TextInput/TextInput';
 import { Width } from 'UI/Features/Records/Activity/forms/common/utils';

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-aquatic/ObservationPlantAquatic.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-aquatic/ObservationPlantAquatic.tsx
@@ -22,7 +22,7 @@ const ObservationPlantAquatic = () => {
   const codes = useSelector((state) => state.ActivityPage?.formCodes);
   const {
     register,
-    formState: { errors, disabled }
+    formState: { errors }
   } = useFormContext<AquaticPlantObservationSchema>();
 
   return (
@@ -161,7 +161,7 @@ const ObservationPlantAquatic = () => {
               {...register(`subtype_data.shoreline_types.${index}.percent_covered`, { valueAsNumber: true })}
               width={Width.Half}
             />
-            <DeleteControl disabled={disabled} onClick={() => remove(index)} />
+            <DeleteControl onClick={() => remove(index)} />
           </>
         )}
       />

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-terrestrial/ObservationPlantTerrestrial.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-terrestrial/ObservationPlantTerrestrial.tsx
@@ -13,6 +13,15 @@ import { ActivitySubtypes } from 'sharedAPI';
 
 const ObservationPlantTerrestrial = () => {
   const ROOT = 'subtype_data';
+
+  const validateSlopeAspect = (val, formValues) => {
+    const aspect = val?.code ?? val;
+    const slope = formValues.subtype_data?.slope_percent?.code ?? formValues.subtype_data?.slope_percent;
+    if ([aspect, slope].includes('FL') && aspect !== slope)
+      return 'If either Aspect or Slope is flat, both of them must be flat.';
+    return true;
+  };
+
   const codes = useSelector((state) => state.ActivityPage?.formCodes);
 
   return (
@@ -42,13 +51,7 @@ const ObservationPlantTerrestrial = () => {
           rules={{
             deps: [`${ROOT}.aspect`],
             required: true,
-            validate: (val, formValues) => {
-              const slope = val?.code ?? val;
-              const aspect = formValues.subtype_data?.aspect?.code ?? formValues.subtype_data?.aspect;
-              if ([aspect, slope].includes('FL') && aspect !== slope)
-                return 'If either Aspect or Slope is flat, both of them must be flat.';
-              return true;
-            }
+            validate: (val, formValues) => validateSlopeAspect(val, formValues)
           }}
           tooltip={tooltips.plant.slope_percent}
           width={Width.Half}
@@ -62,13 +65,7 @@ const ObservationPlantTerrestrial = () => {
           rules={{
             required: true,
             deps: [`${ROOT}.slope_percent`],
-            validate: (val, formValues) => {
-              const aspect = val?.code ?? val;
-              const slope = formValues.subtype_data?.slope_percent?.code ?? formValues.subtype_data?.slope_percent;
-              if ([aspect, slope].includes('FL') && aspect !== slope)
-                return 'If either Aspect or Slope is flat, both of them must be flat.';
-              return true;
-            }
+            validate: (val, formValues) => validateSlopeAspect(val, formValues)
           }}
           width={Width.Half}
         />

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-terrestrial/TerrestrialPlantEntry.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-terrestrial/TerrestrialPlantEntry.tsx
@@ -188,7 +188,7 @@ const TerrestrialPlantEntry = ({ root, index, remove }: Props) => {
         </Fieldset>
       )}
 
-      <DeleteControl disabled={disabled} onClick={() => remove(index)} />
+      <DeleteControl onClick={() => remove(index)} />
     </>
   );
 };

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-terrestrial/TerrestrialPlantEntry.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-terrestrial/TerrestrialPlantEntry.tsx
@@ -11,7 +11,7 @@ import NumberInput from 'UI/Features/Records/Activity/forms/common/NumberInput/N
 import DeleteControl from 'UI/Features/Records/Activity/forms/common/DeleteControl/DeleteControl';
 import { useEffect, useState } from 'react';
 import CheckboxUI from 'UI/Features/Records/Activity/forms/common/CheckboxUI/CheckboxUI';
-import { TerrestrialPlantObservationSchema } from 'UI/Features/Records/Activity/forms/plant/interfaces';
+import { EntryBasePath, TerrestrialPlantObservationSchema } from 'UI/Features/Records/Activity/forms/plant/interfaces';
 import tooltips from 'UI/Features/Records/Activity/forms/plant/content/tooltips';
 
 interface Props {
@@ -19,8 +19,6 @@ interface Props {
   index: number;
   remove: (index: number) => void;
 }
-
-type EntryBasePath = `subtype_data.entries.${number}`;
 
 const TerrestrialPlantEntry = ({ root, index, remove }: Props) => {
   const {

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-mech-plant-aquatic/TreatmentMechPlantAquatic.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-mech-plant-aquatic/TreatmentMechPlantAquatic.tsx
@@ -25,7 +25,7 @@ const TreatmentMechPlantAquatic = () => {
   const ROOT = 'subtype_data';
   const {
     register,
-    formState: { errors, disabled }
+    formState: { errors }
   } = useFormContext<AquaticMechTreatment>();
   const codes = useSelector((state) => state.ActivityPage.formCodes);
 
@@ -83,7 +83,7 @@ const TreatmentMechPlantAquatic = () => {
                 }
               })}
             />
-            <DeleteControl disabled={disabled} onClick={() => remove(index)} />
+            <DeleteControl onClick={() => remove(index)} />
           </>
         )}
       />
@@ -153,7 +153,7 @@ const TreatmentMechPlantAquatic = () => {
                   width={Width.Half}
                 />
               </Fieldset>
-              <DeleteControl disabled={disabled} onClick={() => remove(index)} />
+              <DeleteControl onClick={() => remove(index)} />
             </>
           );
         }}

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-mech-plant-aquatic/TreatmentMechPlantAquatic.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-mech-plant-aquatic/TreatmentMechPlantAquatic.tsx
@@ -1,5 +1,5 @@
 import { useFormContext } from 'react-hook-form';
-import { AquaticMechTreatment } from 'UI/Features/Records/Activity/forms/plant/interfaces';
+import { AquaticMechTreatment, EntryBasePath } from 'UI/Features/Records/Activity/forms/plant/interfaces';
 import { useSelector } from 'utils/use_selector';
 import ArrayField from 'UI/Features/Records/Activity/forms/common/ArrayField/ArrayField';
 import { ActivitySubtypes } from 'sharedAPI';
@@ -20,7 +20,6 @@ import { DisposedMaterialFormat } from 'UI/Features/Records/Activity/forms/enums
 import DeleteControl from 'UI/Features/Records/Activity/forms/common/DeleteControl/DeleteControl';
 import TextInput from 'UI/Features/Records/Activity/forms/common/TextInput/TextInput';
 
-type EntryBasePath = `subtype_data.entries.${number}`;
 const TreatmentMechPlantAquatic = () => {
   const ROOT = 'subtype_data';
   const {

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-mech-plant-terrestrial/TreatmentMechPlantTerrestrial.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-mech-plant-terrestrial/TreatmentMechPlantTerrestrial.tsx
@@ -2,7 +2,7 @@ import { ActivitySubtypes } from 'sharedAPI';
 import ArrayField from 'UI/Features/Records/Activity/forms/common/ArrayField/ArrayField';
 import Fieldset from 'UI/Features/Records/Activity/forms/common/Fieldset/Fieldset';
 import getDefaultFormState from 'UI/Features/Records/Activity/forms/plant/builders/getDefaultState';
-import { TerrestrialMechTreatment } from 'UI/Features/Records/Activity/forms/plant/interfaces';
+import { EntryBasePath, TerrestrialMechTreatment } from 'UI/Features/Records/Activity/forms/plant/interfaces';
 import { minArrayLength, noRepeatKey } from 'UI/Features/Records/Activity/forms/common/validators';
 import { useSelector } from 'utils/use_selector';
 import tooltips from 'UI/Features/Records/Activity/forms/plant/content/tooltips';
@@ -13,7 +13,6 @@ import { useFormContext } from 'react-hook-form';
 import { DisposedMaterialFormat } from 'UI/Features/Records/Activity/forms/enums';
 import DeleteControl from 'UI/Features/Records/Activity/forms/common/DeleteControl/DeleteControl';
 
-type EntryBasePath = `subtype_data.entries.${number}`;
 const TreatmentMechPlantTerrestrial = () => {
   const ROOT = 'subtype_data';
   const {

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-mech-plant-terrestrial/TreatmentMechPlantTerrestrial.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-mech-plant-terrestrial/TreatmentMechPlantTerrestrial.tsx
@@ -18,7 +18,7 @@ const TreatmentMechPlantTerrestrial = () => {
   const ROOT = 'subtype_data';
   const {
     register,
-    formState: { errors, disabled }
+    formState: { errors }
   } = useFormContext<TerrestrialMechTreatment>();
   const codes = useSelector((state) => state.ActivityPage.formCodes);
   return (
@@ -90,7 +90,7 @@ const TreatmentMechPlantTerrestrial = () => {
                   width={Width.Half}
                 />
               </Fieldset>
-              <DeleteControl disabled={disabled} onClick={() => remove(index)} />
+              <DeleteControl onClick={() => remove(index)} />
             </>
           );
         }}

--- a/app/src/state/actions/activity/Activity.ts
+++ b/app/src/state/actions/activity/Activity.ts
@@ -124,7 +124,7 @@ class Activity {
     const mappedCodes = {};
     for (const arr of formCodes) {
       if (arr.length === 0) continue;
-      mappedCodes[arr[0]?.table] = arr;
+      mappedCodes[arr[0]?.table] = arr.sort((a, b) => a?.sort_order - b?.sort_order);
     }
     return mappedCodes;
   });

--- a/app/src/state/reducers/activity.ts
+++ b/app/src/state/reducers/activity.ts
@@ -3,6 +3,7 @@ import { createNextState } from '@reduxjs/toolkit';
 import { RJSFSchema, UiSchema } from '@rjsf/utils';
 import { Feature } from 'geojson';
 import { ActivitySubtypes } from 'sharedAPI';
+import { RootState } from './rootReducer';
 import FormActions from 'state/actions/activity/FormActions';
 import FormCode from 'interfaces/FormCode';
 import { getCustomErrorTransformer } from 'rjsf/business-rules/customErrorTransformer';
@@ -16,7 +17,6 @@ import { GeoTrackingStatus } from 'constants/geoTrackingStatus';
 import DrawToolActions from 'state/actions/drawtool/drawToolActions';
 import { FormSchema } from 'UI/Features/Records/Activity/forms/plant/interfaces';
 import getDefaultFormState from 'UI/Features/Records/Activity/forms/plant/builders/getDefaultState';
-import { RootState } from './rootReducer';
 
 interface ActivityState {
   [MIGRATION_VERSION_KEY]: number;


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

Adds supports for the following Subtypes:
- Mechanical Treatment Monitoring
- Chemical Treatment Monitoring

Improves Normalization Client:
- Adds layer for Point Geometry

Enhancements:
- Move EntryPath to own file to deduplicate use.
- Add Missing Codetable to form codes (TreatmentEfficacyRating)
- Makes DeleteControl stateful, removing formContexts being implemented specifically for the prop.
- Updates `noRepeatKey` validator to ignore empty
- Adds `TreatmentPass` enum
- Sort incoming codes by SortOrder