### PR TITLE
Improve phenology rendering/validation

### DIFF
--- a/api-rework/client/src/activities/subtypes/BiocontrolCollection.tsx
+++ b/api-rework/client/src/activities/subtypes/BiocontrolCollection.tsx
@@ -10,7 +10,7 @@ const BiocontrolCollection = ({ subtypeData }) => {
   return (
     <>
       <WeatherConditions subtypeData={subtypeData} />
-      <MicrositeConditions microsite_conditions={subtypeData?.microsite_conditions} />
+      <MicrositeConditions microsite_conditions={subtypeData} />
       <Fieldset label={'Collection Information'}>
         {!!subtypeData?.entries?.length && <p>No Data</p>}
         {subtypeData?.entries?.map((ci) => (

--- a/api-rework/client/src/activities/subtypes/BiocontrolRelease.tsx
+++ b/api-rework/client/src/activities/subtypes/BiocontrolRelease.tsx
@@ -9,7 +9,7 @@ const BiocontrolRelease = ({ subtypeData }: SubtypeData) => {
   return (
     <>
       <WeatherConditions subtypeData={subtypeData} />
-      <MicrositeConditions microsite_conditions={subtypeData?.microsite_conditions} />
+      <MicrositeConditions microsite_conditions={subtypeData} />
       <Fieldset label={'Treatment Information'}>
         {!!subtypeData?.entries?.length && <p>No Data</p>}
         {subtypeData?.entries?.map((ti) => (

--- a/api-rework/client/src/activities/subtypes/DispersalMonitoring.tsx
+++ b/api-rework/client/src/activities/subtypes/DispersalMonitoring.tsx
@@ -8,7 +8,7 @@ const DispersalMonitoring = ({ subtypeData }: SubtypeData) => {
   return (
     <>
       <WeatherConditions subtypeData={subtypeData} />
-      <MicrositeConditions microsite_conditions={subtypeData?.microsite_conditions} />
+      <MicrositeConditions microsite_conditions={subtypeData} />
       <BiocontrolMonitoring entries={subtypeData?.entries} />
       <TargetPlantPhenology targetPlantPhenology={subtypeData?.target_plant_phenology} />
     </>

--- a/api-rework/client/src/activities/subtypes/ReleaseMonitoring.tsx
+++ b/api-rework/client/src/activities/subtypes/ReleaseMonitoring.tsx
@@ -7,7 +7,7 @@ import MicrositeConditions from './common/MicrositeConditions';
 
 const ReleaseMonitoring = ({ subtypeData }: SubtypeData) => (
   <>
-    <MicrositeConditions microsite_conditions={subtypeData?.microsite_conditions} />
+    <MicrositeConditions microsite_conditions={subtypeData} />
     <BiocontrolMonitoring entries={subtypeData.entries} />
     <TargetPlantPhenology targetPlantPhenology={subtypeData?.target_plant_phenology} />
     <Fieldset label={'Spread Results'}>

--- a/api-rework/client/src/activities/subtypes/common/TargetPlantPhenology.tsx
+++ b/api-rework/client/src/activities/subtypes/common/TargetPlantPhenology.tsx
@@ -12,7 +12,7 @@ const TargetPlantPhenology = ({ targetPlantPhenology }) => (
     <TextInput label={'winter dormant'} value={targetPlantPhenology?.winter_dormant} />
     <Fieldset small label={'target plant heights'}>
       {targetPlantPhenology?.target_plant_heights.map((h) => (
-        <TextInput value={h} />
+        <TextInput value={h.height_cm} />
       ))}
     </Fieldset>
   </Fieldset>

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/biocontrol-release/BiocontrolReleaseEntry.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/biocontrol-release/BiocontrolReleaseEntry.tsx
@@ -30,7 +30,7 @@ const BiocontrolReleaseEntry = ({ index, remove }: PropTypes) => {
     register,
     watch,
     setValue,
-    formState: { errors }
+    formState: { errors, isDirty }
   } = useFormContext<BiocontrolReleaseSchema>();
   const codes = useSelector((state) => state.ActivityPage.formCodes);
   const plantToAgentMap = useSelector((state) => state.ActivityPage.biocontrol?.plantToAgentMap);
@@ -51,7 +51,7 @@ const BiocontrolReleaseEntry = ({ index, remove }: PropTypes) => {
       agentsForPlant.some((a) => a.agent_code_name === code)
     );
     const currentSelectionNoLongerValid = selectedAgent && !validAgents.some(({ code }) => code === selectedAgent);
-    if (currentSelectionNoLongerValid) {
+    if (currentSelectionNoLongerValid && isDirty) {
       setValue(`subtype_data.entries.${index}.biocontrol_agent`, '');
     }
     return validAgents;

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/common/TargetPlantPhenology.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/common/TargetPlantPhenology.tsx
@@ -1,25 +1,23 @@
 import { FieldError, useFormContext, useWatch } from 'react-hook-form';
 import Fieldset from 'UI/Features/Records/Activity/forms/common/Fieldset/Fieldset';
-import { BiocontrolReleaseSchema } from 'UI/Features/Records/Activity/forms/plant/interfaces';
+import { BiocontrolReleaseSchema, EntryBasePath } from 'UI/Features/Records/Activity/forms/plant/interfaces';
 import CheckboxUI from 'UI/Features/Records/Activity/forms/common/CheckboxUI/CheckboxUI';
-import { Fragment, useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Width } from 'UI/Features/Records/Activity/forms/common/utils';
 import NumberInput from 'UI/Features/Records/Activity/forms/common/NumberInput/NumberInput';
-import Spacer from 'UI/Reusable/Spacer/Spacer';
 import ArrayField from 'UI/Features/Records/Activity/forms/common/ArrayField/ArrayField';
 import DeleteControl from 'UI/Features/Records/Activity/forms/common/DeleteControl/DeleteControl';
 import { minArrayLength, minValue } from 'UI/Features/Records/Activity/forms/common/validators';
 import { ActivitySubtypes } from 'sharedAPI';
 import getDefaultFormState from 'UI/Features/Records/Activity/forms/plant/builders/getDefaultState';
 import ErrorMessage from 'UI/Features/Records/Activity/forms/common/ErrorMessage/ErrorMessage';
-import debounce from 'lodash.debounce';
 
 const TargetPlantPhenology = () => {
-  const TRIGGER_DELAY = 500; //ms
   const {
     register,
     control,
     setValue,
+    getValues,
     clearErrors,
     setError,
     formState: { disabled, isDirty, errors }
@@ -27,41 +25,19 @@ const TargetPlantPhenology = () => {
   const plantPhenologyExists = useWatch({ control, name: 'subtype_data.target_plant_phenology' });
   const [isPhenologyDetails, setIsPhenologyDetails] = useState<boolean>(!!plantPhenologyExists);
 
-  const phenologyValues = useWatch({
-    control,
-    name: [
-      'subtype_data.target_plant_phenology.winter_dormant',
-      'subtype_data.target_plant_phenology.seedlings',
-      'subtype_data.target_plant_phenology.rosettes',
-      'subtype_data.target_plant_phenology.bolts',
-      'subtype_data.target_plant_phenology.flowering',
-      'subtype_data.target_plant_phenology.seeds_forming',
-      'subtype_data.target_plant_phenology.senescent'
-    ]
-  });
-
-  const debouncedValidate = useMemo(
-    () =>
-      debounce((values: any[]) => {
-        const sum = values.reduce((acc: number, curr) => acc + (Number(curr) || 0), 0);
-        if (sum !== 100) {
-          setError('subtype_data.target_plant_phenology.root' as any, {
-            type: 'manual',
-            message: `Sum must be 100 (current: ${sum})`
-          });
-        } else {
-          clearErrors('subtype_data.target_plant_phenology.root' as any);
-        }
-      }, TRIGGER_DELAY),
-    [setError, clearErrors]
-  );
-
-  useEffect(() => {
-    if (phenologyValues) {
-      debouncedValidate(phenologyValues);
+  const handleChange = async () => {
+    const data = getValues('subtype_data.target_plant_phenology');
+    if (!data) return;
+    const { target_plant_heights, ...percentages } = data;
+    const sum = Object.values(percentages).reduce((acc, curr) => acc + (Number(curr) || 0), 0);
+    if (sum !== 100) {
+      setError('subtype_data.target_plant_phenology.root' as EntryBasePath, {
+        message: `Sum must be 100 (current: ${sum})`
+      });
+    } else {
+      clearErrors('subtype_data.target_plant_phenology.root' as EntryBasePath);
     }
-    return () => debouncedValidate.cancel();
-  }, [phenologyValues, debouncedValidate]);
+  };
 
   useEffect(() => {
     // Delete Phenology if box unchecked
@@ -70,7 +46,6 @@ const TargetPlantPhenology = () => {
     }
   }, [isPhenologyDetails]);
 
-  useEffect(() => {});
   return (
     <Fieldset label={'Target Plant Phenology'}>
       <CheckboxUI
@@ -81,84 +56,119 @@ const TargetPlantPhenology = () => {
       />
       {isPhenologyDetails && (
         <>
-          <NumberInput
-            label="Winter Dormant (%)"
-            required
-            width={Width.Half}
-            {...register('subtype_data.target_plant_phenology.winter_dormant', { required: true, valueAsNumber: true })}
-          />
-          <NumberInput
-            label="Seedlings (%)"
-            required
-            width={Width.Half}
-            {...register('subtype_data.target_plant_phenology.seedlings', { required: true, valueAsNumber: true })}
-          />
-          <NumberInput
-            label="Rosettes (%)"
-            required
-            width={Width.Half}
-            {...register('subtype_data.target_plant_phenology.rosettes', { required: true, valueAsNumber: true })}
-          />
-          <NumberInput
-            label="Bolts (%)"
-            required
-            width={Width.Half}
-            {...register('subtype_data.target_plant_phenology.bolts', { required: true, valueAsNumber: true })}
-          />
-          <NumberInput
-            label="Flowering (%)"
-            required
-            width={Width.Half}
-            {...register('subtype_data.target_plant_phenology.flowering', { required: true, valueAsNumber: true })}
-          />
-          <NumberInput
-            label="Seeds Forming (%)"
-            required
-            width={Width.Half}
-            {...register('subtype_data.target_plant_phenology.seeds_forming', { required: true, valueAsNumber: true })}
-          />
-          <NumberInput
-            label="Senescent (%)"
-            required
-            width={Width.Half}
-            {...register('subtype_data.target_plant_phenology.senescent', { required: true, valueAsNumber: true })}
-          />
-          <Spacer x={187} y={20} />
           <ArrayField<BiocontrolReleaseSchema, any>
             name="subtype_data.target_plant_phenology.target_plant_heights"
             label={'Target Plant Heights'}
-            width={Width.Half}
+            width={Width.Full}
             rules={{ validate: (arr) => minArrayLength(arr, 1) }}
             emptyValue={
               (getDefaultFormState(ActivitySubtypes.Biocontrol_Release) as BiocontrolReleaseSchema).subtype_data
                 .target_plant_phenology?.target_plant_heights[0]
             }
             renderRow={(index, remove) => (
-              <Fragment key={index}>
+              <>
                 <NumberInput
                   label="Height"
                   required
                   error={errors?.subtype_data?.target_plant_phenology?.target_plant_heights?.[index]?.height_cm}
                   {...register(`subtype_data.target_plant_phenology.target_plant_heights.${index}.height_cm`, {
                     required: true,
+                    onChange: handleChange,
                     valueAsNumber: true,
                     validate: (val) => minValue(val!, 1)
                   })}
                 />
                 <DeleteControl onClick={() => remove(index)} />
-              </Fragment>
+              </>
             )}
           />
-          {errors?.subtype_data?.target_plant_phenology && (
+          <NumberInput
+            label="Winter Dormant (%)"
+            required
+            width={Width.Half}
+            error={errors?.subtype_data?.target_plant_phenology?.winter_dormant}
+            {...register('subtype_data.target_plant_phenology.winter_dormant', {
+              required: true,
+              onChange: handleChange,
+              valueAsNumber: true
+            })}
+          />
+          <NumberInput
+            label="Seedlings (%)"
+            required
+            width={Width.Half}
+            error={errors?.subtype_data?.target_plant_phenology?.seedlings}
+            {...register('subtype_data.target_plant_phenology.seedlings', {
+              required: true,
+              onChange: handleChange,
+              valueAsNumber: true
+            })}
+          />
+          <NumberInput
+            label="Rosettes (%)"
+            required
+            width={Width.Half}
+            error={errors?.subtype_data?.target_plant_phenology?.rosettes}
+            {...register('subtype_data.target_plant_phenology.rosettes', {
+              required: true,
+              onChange: handleChange,
+              valueAsNumber: true
+            })}
+          />
+          <NumberInput
+            label="Bolts (%)"
+            required
+            width={Width.Half}
+            error={errors?.subtype_data?.target_plant_phenology?.bolts}
+            {...register('subtype_data.target_plant_phenology.bolts', {
+              required: true,
+              onChange: handleChange,
+              valueAsNumber: true
+            })}
+          />
+          <NumberInput
+            label="Flowering (%)"
+            required
+            width={Width.Half}
+            error={errors?.subtype_data?.target_plant_phenology?.flowering}
+            {...register('subtype_data.target_plant_phenology.flowering', {
+              required: true,
+              onChange: handleChange,
+              valueAsNumber: true
+            })}
+          />
+          <NumberInput
+            label="Seeds Forming (%)"
+            required
+            width={Width.Half}
+            error={errors?.subtype_data?.target_plant_phenology?.seeds_forming}
+            {...register('subtype_data.target_plant_phenology.seeds_forming', {
+              required: true,
+              onChange: handleChange,
+              valueAsNumber: true
+            })}
+          />
+          <NumberInput
+            label="Senescent (%)"
+            required
+            width={Width.Half}
+            error={errors?.subtype_data?.target_plant_phenology?.senescent}
+            {...register('subtype_data.target_plant_phenology.senescent', {
+              required: true,
+              onChange: handleChange,
+              valueAsNumber: true
+            })}
+          />
+          {errors?.subtype_data?.target_plant_phenology?.root && (
             <ErrorMessage
               error={errors.subtype_data.target_plant_phenology.root as FieldError}
               label="Phenology Total"
             />
           )}
-          <Spacer x={200} y={20} />
         </>
       )}
     </Fieldset>
   );
 };
+
 export default TargetPlantPhenology;


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):
- Refactors the Validation from Phenology section of Biocontrol Release
   - Moves plant heights to top
- Fixes `client` UI to accept microsites from lower level entry. 
- eliminates a minor console error when pulling up biocontrol entries and the match is invalid. (should only occur during development, when manually entered to db, not via form.)
- 