### PR TITLE
Nmdb improve validations

### DIFF
--- a/app/src/UI/Features/Records/Activity/forms/common/ArrayField/arrayField.css
+++ b/app/src/UI/Features/Records/Activity/forms/common/ArrayField/arrayField.css
@@ -13,6 +13,7 @@
 
     & > * {
       margin-right: auto;
+      margin-bottom: 10px;
     }
 
     &:not(:last-child) {

--- a/app/src/UI/Features/Records/Activity/forms/common/DateInput/dateInput.css
+++ b/app/src/UI/Features/Records/Activity/forms/common/DateInput/dateInput.css
@@ -19,6 +19,7 @@
 
   input[type='date'],
   input[type='datetime-local'] {
+    font-family: BCSans, 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
     height: var(--form-input-height);
     width: 100%;
     box-sizing: border-box;

--- a/app/src/UI/Features/Records/Activity/forms/common/Fieldset/Fieldset.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/common/Fieldset/Fieldset.tsx
@@ -4,6 +4,7 @@ import { getInputWidth, Width } from '../utils';
 import TooltipWithIcon from 'UI/Reusable/TooltipWithIcon/TooltipWithIcon';
 
 interface PropTypes extends PropsWithChildren {
+  className?: string;
   children: ReactNode;
   label: string;
   tooltip?: string;
@@ -11,9 +12,9 @@ interface PropTypes extends PropsWithChildren {
   width?: Width;
 }
 
-const Fieldset = ({ label, width, tooltip, children, nested }: PropTypes) => {
+const Fieldset = ({ label, width, tooltip, children, nested, className }: PropTypes) => {
   return (
-    <fieldset className={`form-fieldset ${getInputWidth(width)} ${nested ? 'nested' : ''}`}>
+    <fieldset className={`form-fieldset ${getInputWidth(width)} ${nested ? 'nested' : ''} ${className}`}>
       <legend>
         {label} {tooltip && <TooltipWithIcon tooltipText={tooltip} />}
       </legend>

--- a/app/src/UI/Features/Records/Activity/forms/common/Fieldset/fieldset.css
+++ b/app/src/UI/Features/Records/Activity/forms/common/Fieldset/fieldset.css
@@ -25,6 +25,14 @@
     }
   }
 
+  &.transparent {
+    background-color: transparent;
+
+    legend {
+      font-size: var(--form-legend-font-size);
+    }
+  }
+
   & > *:not(fieldset) {
     margin-bottom: 10px;
     margin-right: auto;

--- a/app/src/UI/Features/Records/Activity/forms/common/NumberInput/numberInput.css
+++ b/app/src/UI/Features/Records/Activity/forms/common/NumberInput/numberInput.css
@@ -5,6 +5,7 @@
   align-items: flex-start;
 
   input[type='number'] {
+    font-family: BCSans, 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
     height: var(--form-input-height);
     width: 100%;
     box-sizing: border-box;

--- a/app/src/UI/Features/Records/Activity/forms/common/TextArea/textArea.css
+++ b/app/src/UI/Features/Records/Activity/forms/common/TextArea/textArea.css
@@ -14,6 +14,7 @@
   }
 
   textarea {
+    font-family: BCSans, 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
     resize: none;
     width: 100%;
     height: 100%;

--- a/app/src/UI/Features/Records/Activity/forms/common/TextInput/textInput.css
+++ b/app/src/UI/Features/Records/Activity/forms/common/TextInput/textInput.css
@@ -12,6 +12,7 @@
   }
 
   input[type='text'] {
+    font-family: BCSans, 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
     height: var(--form-input-height);
     width: 100%;
     box-sizing: border-box;

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/common/VoucherCollection.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/common/VoucherCollection.tsx
@@ -1,0 +1,119 @@
+import { useFormContext } from 'react-hook-form';
+import {
+  AquaticPlantObservationSchema,
+  TerrestrialPlantObservationSchema
+} from 'UI/Features/Records/Activity/forms/plant/interfaces';
+import Fieldset from 'UI/Features/Records/Activity/forms/common/Fieldset/Fieldset';
+import TextInput from 'UI/Features/Records/Activity/forms/common/TextInput/TextInput';
+import tooltips from 'UI/Features/Records/Activity/forms/plant/content/tooltips';
+import { Width } from 'UI/Features/Records/Activity/forms/common/utils';
+import FormSpacer from 'UI/Features/Records/Activity/forms/common/FormSpacer/FormSpacer';
+import DateInput from 'UI/Features/Records/Activity/forms/common/DateInput/DateInput';
+import NumberInput from 'UI/Features/Records/Activity/forms/common/NumberInput/NumberInput';
+
+type Observation = TerrestrialPlantObservationSchema | AquaticPlantObservationSchema;
+
+const VoucherCollection = ({ index }) => {
+  const {
+    register,
+    formState: { errors }
+  } = useFormContext<Observation>();
+  return (
+    <>
+      <TextInput
+        required
+        label="Voucher Sample ID"
+        tooltip={tooltips.plant.voucher_sample_id}
+        {...register(`subtype_data.entries.${index}.voucher_specimen.voucher_sample_id`, { required: true })}
+        width={Width.Half}
+        error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.voucher_sample_id}
+      />
+
+      <TextInput
+        required
+        label="Herbarium"
+        {...register(`subtype_data.entries.${index}.voucher_specimen.herbarium`, { required: true })}
+        width={Width.Half}
+        error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.herbarium}
+      />
+
+      <TextInput
+        required
+        label="Accession Number"
+        {...register(`subtype_data.entries.${index}.voucher_specimen.accession_number`, { required: true })}
+        width={Width.Half}
+        error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.accession_number}
+      />
+      <FormSpacer width={Width.Half} />
+
+      <DateInput
+        required
+        label="Date Voucher Collected"
+        {...register(`subtype_data.entries.${index}.voucher_specimen.date_collected`, { required: true })}
+        width={Width.Half}
+        error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.date_collected}
+      />
+
+      <DateInput
+        required
+        label="Date Voucher Verified"
+        {...register(`subtype_data.entries.${index}.voucher_specimen.date_verified`, { required: true })}
+        width={Width.Half}
+        error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.date_verified}
+      />
+      <Fieldset nested label={'Voucher Verification Completed By'}>
+        <TextInput
+          required
+          label="Completed By (Person)"
+          {...register(`subtype_data.entries.${index}.voucher_specimen.completed_by_person`, { required: true })}
+          width={Width.Half}
+          error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.completed_by_person}
+        />
+        <TextInput
+          label="Completed By (Org)"
+          required
+          {...register(`subtype_data.entries.${index}.voucher_specimen.completed_by_org`, { required: true })}
+          width={Width.Half}
+          error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.completed_by_org}
+        />
+      </Fieldset>
+
+      <Fieldset nested label={'Exact Coordinate of Voucher Collection Site'}>
+        <NumberInput
+          label="UTM Zone"
+          required
+          {...register(`subtype_data.entries.${index}.voucher_specimen.utm_zone`, {
+            required: true,
+            valueAsNumber: true
+          })}
+          width={Width.Third}
+          error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.utm_zone}
+        />
+
+        <NumberInput
+          label="UTM Easting"
+          required
+          {...register(`subtype_data.entries.${index}.voucher_specimen.utm_easting`, {
+            required: true,
+            valueAsNumber: true
+          })}
+          width={Width.Third}
+          error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.utm_easting}
+        />
+
+        <NumberInput
+          label="UTM Northing"
+          required
+          {...register(`subtype_data.entries.${index}.voucher_specimen.utm_northing`, {
+            required: true,
+            valueAsNumber: true
+          })}
+          width={Width.Third}
+          error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.utm_northing}
+        />
+      </Fieldset>
+    </>
+  );
+};
+
+export default VoucherCollection;

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-aquatic/AquaticPlantEntry.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-aquatic/AquaticPlantEntry.tsx
@@ -8,10 +8,8 @@ import SingleSelect from 'UI/Features/Records/Activity/forms/common/SingleSelect
 import tooltips from 'UI/Features/Records/Activity/forms/plant/content/tooltips';
 import { ObservationType } from 'UI/Features/Records/Activity/forms/enums';
 import CheckboxUI from 'UI/Features/Records/Activity/forms/common/CheckboxUI/CheckboxUI';
-import Fieldset from 'UI/Features/Records/Activity/forms/common/Fieldset/Fieldset';
-import DateInput from 'UI/Features/Records/Activity/forms/common/DateInput/DateInput';
-import NumberInput from 'UI/Features/Records/Activity/forms/common/NumberInput/NumberInput';
 import DeleteControl from 'UI/Features/Records/Activity/forms/common/DeleteControl/DeleteControl';
+import VoucherCollection from 'UI/Features/Records/Activity/forms/plant/subtype-component/common/VoucherCollection';
 import FormSpacer from 'UI/Features/Records/Activity/forms/common/FormSpacer/FormSpacer';
 
 interface Props {
@@ -33,7 +31,6 @@ const AquaticPlantEntry = ({ root, index, remove }: Props) => {
     control,
     name: `${basePath}.voucher_specimen`
   });
-
   const [voucherCollected, setVoucherCollected] = useState<boolean>(!!voucherSpecimen);
   const codes = useSelector((state) => state.ActivityPage?.formCodes);
   const observationType = watch(`${basePath}.observation_type`);
@@ -45,13 +42,21 @@ const AquaticPlantEntry = ({ root, index, remove }: Props) => {
     }
   }, [voucherCollected]);
 
+  useEffect(() => {
+    if (observationType === 'Negative' && isDirty) {
+      setVoucherCollected(false);
+      setValue(`${basePath}.voucher_specimen`, undefined);
+      setValue(`${basePath}.density`, '');
+      setValue(`${basePath}.distribution`, '');
+      setValue(`${basePath}.life_stage`, '');
+    }
+  }, [observationType]);
+
   return (
     <>
       <TextInput
         label={'Sample Point ID'}
-        tooltip={
-          'For Presence Surveys. Number each sample point in the same waterbody (e.g. 001, 002, 003, etc). Do not use for Extent Surveys'
-        }
+        tooltip={tooltips.plant.sample_point_id}
         error={errors?.subtype_data?.entries?.[index]?.sample_point_id}
         {...register(`subtype_data.entries.${index}.sample_point_id`)}
         width={Width.Half}
@@ -113,83 +118,8 @@ const AquaticPlantEntry = ({ root, index, remove }: Props) => {
           />
         </>
       )}
-      {voucherCollected && (
-        <Fieldset label="Voucher Collection Information">
-          <TextInput
-            label="Voucher Sample ID"
-            tooltip={tooltips.plant.voucher_sample_id}
-            {...register(`${basePath}.voucher_specimen.voucher_sample_id`, { required: true })}
-            width={Width.Half}
-            error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.voucher_sample_id}
-          />
-
-          <TextInput
-            label="Herbarium"
-            {...register(`${basePath}.voucher_specimen.herbarium`, { required: true })}
-            width={Width.Half}
-            error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.herbarium}
-          />
-
-          <TextInput
-            label="Accession Number"
-            {...register(`${basePath}.voucher_specimen.accession_number`, { required: true })}
-            width={Width.Half}
-            error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.accession_number}
-          />
-          <FormSpacer width={Width.Half} />
-
-          <DateInput
-            label="Date Voucher Collected"
-            {...register(`${basePath}.voucher_specimen.date_collected`, { required: true })}
-            width={Width.Half}
-            error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.date_collected}
-          />
-
-          <DateInput
-            label="Date Voucher Verified"
-            {...register(`${basePath}.voucher_specimen.date_verified`, { required: true })}
-            width={Width.Half}
-            error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.date_verified}
-          />
-          <Fieldset label={'Voucher Verification Completed By'}>
-            <TextInput
-              label="Completed By (Person)"
-              {...register(`${basePath}.voucher_specimen.completed_by_person`, { required: true })}
-              width={Width.Half}
-              error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.completed_by_person}
-            />
-            <TextInput
-              label="Completed By (Org)"
-              {...register(`${basePath}.voucher_specimen.completed_by_org`, { required: true })}
-              width={Width.Half}
-              error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.completed_by_org}
-            />
-          </Fieldset>
-
-          <Fieldset label={'Exact Coordinate of Voucher Collection Site'}>
-            <NumberInput
-              label="UTM Zone"
-              {...register(`${basePath}.voucher_specimen.utm_zone`, { required: true, valueAsNumber: true })}
-              width={Width.Third}
-              error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.utm_zone}
-            />
-
-            <NumberInput
-              label="UTM Easting"
-              {...register(`${basePath}.voucher_specimen.utm_easting`, { required: true, valueAsNumber: true })}
-              width={Width.Third}
-              error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.utm_easting}
-            />
-
-            <NumberInput
-              label="UTM Northing"
-              {...register(`${basePath}.voucher_specimen.utm_northing`, { required: true, valueAsNumber: true })}
-              width={Width.Third}
-              error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.utm_northing}
-            />
-          </Fieldset>
-        </Fieldset>
-      )}
+      <FormSpacer width={Width.Half} />
+      {voucherCollected && <VoucherCollection index={index} />}
       <DeleteControl onClick={() => remove(index)} />
     </>
   );

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-terrestrial/TerrestrialPlantEntry.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-terrestrial/TerrestrialPlantEntry.tsx
@@ -3,16 +3,12 @@ import { useFormContext, useWatch } from 'react-hook-form';
 import SingleSelect from 'UI/Features/Records/Activity/forms/common/SingleSelect/SingleSelect';
 import { Width } from 'UI/Features/Records/Activity/forms/common/utils';
 import { ObservationType } from 'UI/Features/Records/Activity/forms/enums';
-import Fieldset from 'UI/Features/Records/Activity/forms/common/Fieldset/Fieldset';
-import TextInput from 'UI/Features/Records/Activity/forms/common/TextInput/TextInput';
-import DateInput from 'UI/Features/Records/Activity/forms/common/DateInput/DateInput';
-import NumberInput from 'UI/Features/Records/Activity/forms/common/NumberInput/NumberInput';
 import DeleteControl from 'UI/Features/Records/Activity/forms/common/DeleteControl/DeleteControl';
 import { useEffect, useState } from 'react';
 import CheckboxUI from 'UI/Features/Records/Activity/forms/common/CheckboxUI/CheckboxUI';
 import { EntryBasePath, TerrestrialPlantObservationSchema } from 'UI/Features/Records/Activity/forms/plant/interfaces';
 import tooltips from 'UI/Features/Records/Activity/forms/plant/content/tooltips';
-import FormSpacer from 'UI/Features/Records/Activity/forms/common/FormSpacer/FormSpacer';
+import VoucherCollection from 'UI/Features/Records/Activity/forms/plant/subtype-component/common/VoucherCollection';
 
 interface Props {
   root: string;
@@ -22,11 +18,10 @@ interface Props {
 
 const TerrestrialPlantEntry = ({ root, index, remove }: Props) => {
   const {
-    register,
     control,
     setValue,
     watch,
-    formState: { errors, disabled, isDirty }
+    formState: { disabled, isDirty }
   } = useFormContext<TerrestrialPlantObservationSchema>();
   const basePath = `${root}.entries.${index}` as EntryBasePath;
   const voucherSpecimen = useWatch({
@@ -117,84 +112,7 @@ const TerrestrialPlantEntry = ({ root, index, remove }: Props) => {
           />
         </>
       )}
-      {voucherCollected && (
-        <Fieldset label="Voucher Collection Information">
-          <TextInput
-            label="Voucher Sample ID"
-            tooltip={tooltips.plant.voucher_sample_id}
-            {...register(`${basePath}.voucher_specimen.voucher_sample_id`, { required: true })}
-            width={Width.Half}
-            error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.voucher_sample_id}
-          />
-
-          <TextInput
-            label="Herbarium"
-            {...register(`${basePath}.voucher_specimen.herbarium`, { required: true })}
-            width={Width.Half}
-            error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.herbarium}
-          />
-
-          <TextInput
-            label="Accession Number"
-            {...register(`${basePath}.voucher_specimen.accession_number`, { required: true })}
-            width={Width.Half}
-            error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.accession_number}
-          />
-          <FormSpacer width={Width.Half} />
-
-          <DateInput
-            label="Date Voucher Collected"
-            {...register(`${basePath}.voucher_specimen.date_collected`, { required: true })}
-            width={Width.Half}
-            error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.date_collected}
-          />
-
-          <DateInput
-            label="Date Voucher Verified"
-            {...register(`${basePath}.voucher_specimen.date_verified`, { required: true })}
-            width={Width.Half}
-            error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.date_verified}
-          />
-          <Fieldset label={'Voucher Verification Completed By'}>
-            <TextInput
-              label="Completed By (Person)"
-              {...register(`${basePath}.voucher_specimen.completed_by_person`, { required: true })}
-              width={Width.Half}
-              error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.completed_by_person}
-            />
-            <TextInput
-              label="Completed By (Org)"
-              {...register(`${basePath}.voucher_specimen.completed_by_org`, { required: true })}
-              width={Width.Half}
-              error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.completed_by_org}
-            />
-          </Fieldset>
-
-          <Fieldset label={'Exact Coordinate of Voucher Collection Site'}>
-            <NumberInput
-              label="UTM Zone"
-              {...register(`${basePath}.voucher_specimen.utm_zone`, { required: true, valueAsNumber: true })}
-              width={Width.Third}
-              error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.utm_zone}
-            />
-
-            <NumberInput
-              label="UTM Easting"
-              {...register(`${basePath}.voucher_specimen.utm_easting`, { required: true, valueAsNumber: true })}
-              width={Width.Third}
-              error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.utm_easting}
-            />
-
-            <NumberInput
-              label="UTM Northing"
-              {...register(`${basePath}.voucher_specimen.utm_northing`, { required: true, valueAsNumber: true })}
-              width={Width.Third}
-              error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.utm_northing}
-            />
-          </Fieldset>
-        </Fieldset>
-      )}
-
+      {voucherCollected && <VoucherCollection index={index} />}
       <DeleteControl onClick={() => remove(index)} />
     </>
   );

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlant.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlant.tsx
@@ -59,6 +59,8 @@ const TreatmentChemicalPlant = ({ type }: PropTypes) => {
     formState: { isDirty, errors, disabled }
   } = useFormContext<ChemTreatment>();
   const codes = useSelector((state) => state.ActivityPage.formCodes);
+  const wellsInArea = useSelector((state) => state.ActivityPage?.wellsInRecordArea);
+
   const well_entries = watch('subtype_data.well_entries');
   const ntz_bool = watch('subtype_data.ntz_reduction_bool');
   const temp_c = watch('subtype_data.temperature_c');
@@ -107,6 +109,13 @@ const TreatmentChemicalPlant = ({ type }: PropTypes) => {
       setValue('subtype_data.rationale_for_ntz_reduction', '');
     }
   }, [ntz_bool]);
+
+  // Update Nearest Wells when values change
+  useEffect(() => {
+    if (wellsInArea) {
+      setValue('subtype_data.well_entries', wellsInArea);
+    }
+  }, [wellsInArea]);
 
   return (
     <>

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlant.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlant.tsx
@@ -18,7 +18,7 @@ import FormSpacer from 'UI/Features/Records/Activity/forms/common/FormSpacer/For
 import CheckboxInput from 'UI/Features/Records/Activity/forms/common/CheckboxInput/CheckboxInput';
 import { maxValue, minValue, noFutureDate } from 'UI/Features/Records/Activity/forms/common/validators';
 import CheckboxUI from 'UI/Features/Records/Activity/forms/common/CheckboxUI/CheckboxUI';
-import { useEffect, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 
 type PropTypes = {
   type: 'terrestrial' | 'aquatic';
@@ -117,7 +117,7 @@ const TreatmentChemicalPlant = ({ type }: PropTypes) => {
           </p>
         )}
         {well_entries?.map((we) => (
-          <>
+          <Fragment key={we.well_tag}>
             <TextInput
               label={'Well ID'}
               readOnly
@@ -132,7 +132,7 @@ const TreatmentChemicalPlant = ({ type }: PropTypes) => {
               value={we.distance}
               width={Width.Half}
             />
-          </>
+          </Fragment>
         ))}
       </Fieldset>
 

--- a/app/src/state/reducers/activity.ts
+++ b/app/src/state/reducers/activity.ts
@@ -15,7 +15,7 @@ import SuggestedTreatmentId from 'interfaces/SuggestedTreatmentId';
 import IActivityPermissions from 'interfaces/IActivityPermissions';
 import { GeoTrackingStatus } from 'constants/geoTrackingStatus';
 import DrawToolActions from 'state/actions/drawtool/drawToolActions';
-import { FormSchema } from 'UI/Features/Records/Activity/forms/plant/interfaces';
+import { FormSchema, TerrestrialChemicalTreatmentSchema } from 'UI/Features/Records/Activity/forms/plant/interfaces';
 import getDefaultFormState from 'UI/Features/Records/Activity/forms/plant/builders/getDefaultState';
 
 interface ActivityState {
@@ -30,6 +30,7 @@ interface ActivityState {
   failCode: number | null;
   formType?: ActivitySubtypes;
   formState?: FormSchema;
+  wellsInRecordArea?: TerrestrialChemicalTreatmentSchema['subtype_data']['well_entries'];
   formId?: string;
   geometry_details?: {
     geom: Feature;
@@ -206,10 +207,14 @@ function createActivityReducer() {
       } else if (FormActions.createNewForm.match(action)) {
         delete draftState.formState;
         delete draftState.geometry_details;
+        delete draftState.wellsInRecordArea;
+
         draftState.formId = crypto.randomUUID();
         draftState.formType = action.payload;
       } else if (FormActions.clearFormState.match(action) && draftState.formState) {
         delete draftState.geometry_details;
+        delete draftState.wellsInRecordArea;
+
         Object.assign(draftState.formState, {
           ...getDefaultFormState(draftState.formType),
           id: draftState.formId,
@@ -249,6 +254,7 @@ function createActivityReducer() {
         draftState.activityErrors = getCustomErrorTransformer()(action.payload ?? []);
       } else if (Activity.updateGeoFailure.match(action)) {
         delete draftState.geometry_details;
+        delete draftState.wellsInRecordArea;
 
         draftState.activity.geometry = action.payload.geometry;
         draftState.activity.form_data.activity_data.latitude = undefined;
@@ -262,9 +268,16 @@ function createActivityReducer() {
         draftState.schema = action.payload.schema;
       } else if (DrawToolActions.deleteGeo.match(action)) {
         delete draftState.geometry_details;
+        delete draftState.wellsInRecordArea;
       } else if (DrawToolActions.updateGeoSuccess.match(action)) {
         const { geometry, lat, long, utm, reported_area, Well_Information } = action.payload;
-        //TODO: Make its own thing
+        //TODO: Refactor Well information and Geometry_Details to be more cleanly implemented as old source removed
+        const formattedWells = Well_Information?.slice(0, 5).map((well) => ({
+          well_tag: well.well_id,
+          distance: parseInt(well.well_proximity)
+        }));
+        console.log(formattedWells);
+        draftState.wellsInRecordArea = structuredClone(formattedWells);
         draftState.geometry_details = {
           geom: geometry?.[0] as Feature,
           area_m: reported_area ?? undefined,


### PR DESCRIPTION
# Overview

>[!Important]
>Merges to `nmdb-chem-treatments-start` (other open PR)`

This PR includes the following proposed change(s):

- Link Nearest Well Entries to Chemical Treatment Forms 
    - Slatted for larger refactoring when forms are fully up and running (with all Suggestion fetches) 
    - Interaction locked to Chemical Treatment updates
    - Fetching/Clearing Records deletes stored wells, preventing accidental overwrites 
- Adjust margins for entries in ArrayField's rows
- enforce BC Sans for input field text 
- Allow Fieldsets to take additional classnames
- Refactor VoucherSpecimen to own component, adjust Aquatic/Terrestrial Observation Entries accordingly
- Aquatic Plant Entries clear when Observation flipped to `Negative`