### PR TITLE
Nmdb validation improvements

### DIFF
--- a/api-rework/invasives/api/legacy_db/mappings/plants.py
+++ b/api-rework/invasives/api/legacy_db/mappings/plants.py
@@ -357,7 +357,7 @@ def add_subtype_payload_for_plant_aquatic_observation(
     add_persons(new, old)
     add_well_information(new, old)
     add_aquatic_plant_observation_information(new, old)
-
+    add_shoreline_types(new, old)
     add_waterbody_data(new, old)
 
     if old.activity_payload.form_data.activity_type_data.pre_treatment_observation:

--- a/api-rework/invasives/api/viewsets/code.py
+++ b/api-rework/invasives/api/viewsets/code.py
@@ -50,6 +50,7 @@ class CodeViewSet(ViewSet):
         TreatmentEfficacyRatingCode,
         WaterbodyFlowCode,
         WaterbodyFlowSeasonalCode,
+        WaterbodySubstrateCode,
         WaterbodyUseCode,
     ]
 

--- a/app/src/UI/Features/Records/Activity/forms/common/Fieldset/Fieldset.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/common/Fieldset/Fieldset.tsx
@@ -13,9 +13,10 @@ interface PropTypes extends PropsWithChildren {
 }
 
 const Fieldset = ({ label, width, tooltip, children, nested, className }: PropTypes) => {
+  const nestedClass = nested ? 'nested' : '';
   return (
-    <fieldset className={`form-fieldset ${getInputWidth(width)} ${nested ? 'nested' : ''} ${className}`}>
-      <legend>
+    <fieldset className={`form-fieldset ${getInputWidth(width)} ${nestedClass} ${className}`}>
+      <legend className={nestedClass}>
         {label} {tooltip && <TooltipWithIcon tooltipText={tooltip} />}
       </legend>
       {children}

--- a/app/src/UI/Features/Records/Activity/forms/common/Fieldset/fieldset.css
+++ b/app/src/UI/Features/Records/Activity/forms/common/Fieldset/fieldset.css
@@ -6,7 +6,6 @@
   box-sizing: border-box;
   align-items: stretch;
   margin-bottom: 3rem;
-  background-color: #fff;
   border: 0;
 
   legend {
@@ -19,7 +18,7 @@
     border: 1pt solid black;
     background-color: #00336610;
 
-    legend {
+    legend.nested {
       width: auto;
       border: 0;
     }
@@ -28,7 +27,7 @@
   &.transparent {
     background-color: transparent;
 
-    legend {
+    legend.nested {
       font-size: var(--form-legend-font-size);
     }
   }

--- a/app/src/UI/Features/Records/Activity/forms/common/MultiSelect/MultiSelect.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/common/MultiSelect/MultiSelect.tsx
@@ -63,7 +63,7 @@ export function MultiSelect<T extends FieldValues>({
             className="select-input"
             classNamePrefix={'select-input'}
           />
-          <ErrorMessage error={error} />
+          <ErrorMessage error={error} label={label} />
         </div>
       )}
     />

--- a/app/src/UI/Features/Records/Activity/forms/debug/DebugFormData.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/debug/DebugFormData.tsx
@@ -17,6 +17,7 @@ const DebugFormData = () => {
   };
   const { watch } = useFormContext<FormSchema>();
   const formData = watch();
+
   return (
     <Debug>
       <Accordion
@@ -27,7 +28,19 @@ const DebugFormData = () => {
           </>
         }
       >
-        <pre style={style}>{JSON.stringify(formData, null, 2)}</pre>
+        <pre style={style}>
+          {/* Truncate any Encoded media Files to avoid massive print outs  */}
+          {JSON.stringify(
+            formData,
+            (key, value) => {
+              if (key === 'encoded_file') {
+                return value.slice(0, 25) + '... [Truncated]';
+              }
+              return value;
+            },
+            2
+          )}
+        </pre>
       </Accordion>
     </Debug>
   );

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/ActivityForm.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/ActivityForm.tsx
@@ -1,92 +1,37 @@
 import { useForm, SubmitHandler, useWatch, FormProvider } from 'react-hook-form';
 import { useDispatch, useSelector } from 'utils/use_selector';
-import TextInput from 'UI/Features/Records/Activity/forms/common/TextInput/TextInput';
-import SingleSelect from 'UI/Features/Records/Activity/forms/common/SingleSelect/SingleSelect';
-import Fieldset from 'UI/Features/Records/Activity/forms/common/Fieldset/Fieldset';
-import DateInput from 'UI/Features/Records/Activity/forms/common/DateInput/DateInput';
-import NumberInput from 'UI/Features/Records/Activity/forms/common/NumberInput/NumberInput';
-import TextArea from 'UI/Features/Records/Activity/forms/common/TextArea/TextArea';
-import {
-  checkSum,
-  maxValue,
-  minArrayLength,
-  minValue,
-  noFutureDate,
-  noRepeatKey
-} from 'UI/Features/Records/Activity/forms/common/validators';
 import { MouseEvent, TouchEvent, useCallback, useEffect, useState } from 'react';
-import ArrayField from 'UI/Features/Records/Activity/forms/common/ArrayField/ArrayField';
-import SubtypeComposite from 'UI/Features/Records/Activity/forms/plant/subtype-component/SubtypeComposite';
-import './activityForm.css';
-import { Width } from 'UI/Features/Records/Activity/forms/common/utils';
-import DeleteControl from 'UI/Features/Records/Activity/forms/common/DeleteControl/DeleteControl';
 import debounce from 'lodash.debounce';
 import FormActions from 'state/actions/activity/FormActions';
-import Alerts from 'state/actions/alerts/Alerts';
-import tripAlertMessages from 'constants/alerts/tripAlerts';
 import Prompt from 'state/actions/prompts/Prompt';
 import RecordMetadata from 'UI/Features/Records/Activity/forms/common/RecordMetadata/RecordMetadata';
 import { FormSchema } from 'UI/Features/Records/Activity/forms/plant/interfaces';
 import getDefaultFormState from 'UI/Features/Records/Activity/forms/plant/builders/getDefaultState';
-import tooltips from 'UI/Features/Records/Activity/forms/plant/content/tooltips';
-import Participants from './Participants';
-import { Feature } from 'geojson';
-import { UtmInputObj } from 'interfaces/prompt-interfaces';
-import GeoShapes from 'constants/geoShapes';
-import MapActions from 'state/actions/map';
-import DrawToolActions from 'state/actions/drawtool/drawToolActions';
 import DebugFormData from 'UI/Features/Records/Activity/forms/debug/DebugFormData';
 import DebugButton from 'UI/Features/Records/Activity/forms/debug/DebugButton';
-import FundingAgency from './FundingAgency';
-import Employer from './Employers';
 import CustomPopover from 'UI/Reusable/CustomPopover/CustomPopover';
-import LinkedActivities from './LinkedActivities';
 import { Error } from '@mui/icons-material';
-import FormSpacer from 'UI/Features/Records/Activity/forms/common/FormSpacer/FormSpacer';
+import { NavLink, useParams } from 'react-router';
+import ActivityActions from 'state/actions/activity/Activity';
+import Form from './Form';
+import './activityForm.css';
+import Photos from './Photos';
 
 const FORM_UPDATE_THROTTLE_DELAY = 1000; //ms
 const FORM_UPDATE_MAX_DELAY = 5000; //ms
 
 const ActivityForm = () => {
+  enum Mode {
+    Photo = 'photos',
+    Form = 'form'
+  }
   // TODO: Replace with Permission Logic
   const [isFormDisabled, setIsFormDisabled] = useState<boolean>(false);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
-  /**
-   * @desc Initiate Mouseclick on Polygon draw icon, alert user to start drawing
-   */
-  const handleDrawStart = () => {
-    (document.getElementsByClassName('mapbox-gl-draw_polygon')?.[0] as HTMLButtonElement).click();
-    dispatch(Alerts.create(tripAlertMessages.drawToolClicked));
-  };
+  const { id, mode } = useParams<{ id: string; mode: Mode }>();
 
   const handleOpenMenu = (evt: MouseEvent<HTMLElement> | TouchEvent<HTMLElement>) => {
     setAnchorEl(evt.currentTarget);
-  };
-  /**
-   * @desc Handler for creating a manual UTM Entry initiated by user
-   */
-  const handleManualUTM = () => {
-    const utmCallback = (input: UtmInputObj) => {
-      const [lng, lat] = input.results;
-      const geo: Feature = {
-        type: 'Feature',
-        geometry: {
-          type: GeoShapes.Point,
-          coordinates: [lng, lat]
-        },
-        properties: {}
-      };
-      dispatch(MapActions.centerMap({ lat, lng, zoom: 16 }));
-      dispatch(DrawToolActions.updateGeo([geo]));
-    };
-
-    dispatch(
-      Prompt.utm({
-        title: 'Enter a manual UTM',
-        prompt: 'Fill in the fields below to create your own UTM Coordinates',
-        callback: utmCallback
-      })
-    );
   };
 
   const handleDuplicateForm = () => {
@@ -150,7 +95,6 @@ const ActivityForm = () => {
 
   const dispatch = useDispatch();
 
-  const codes = useSelector((state) => state.ActivityPage?.formCodes);
   const geometry_details = useSelector((state) => state.ActivityPage?.geometry_details);
   const initState = useSelector((state) => state.ActivityPage?.formState);
   const subtype = useSelector((state) => state.ActivityPage?.formType);
@@ -169,7 +113,6 @@ const ActivityForm = () => {
     handleSubmit,
     getValues,
     control,
-    formState,
     reset,
     resetField,
     setValue,
@@ -180,9 +123,16 @@ const ActivityForm = () => {
     if (!isDirty) return;
     dispatch(FormActions.sendForm({ data, type: 'submission' }));
   };
-
+  if (id) {
+    dispatch(ActivityActions.loadActivityIfRequired(id));
+  }
   const allFormValues = useWatch({ control });
 
+  useEffect(() => {
+    if (id) {
+      dispatch(ActivityActions.loadActivityIfRequired(id));
+    }
+  }, [id]);
   /**
    * After Form is loaded,
    *  - Register jurisdiction Validation (applies to Array),
@@ -229,191 +179,21 @@ const ActivityForm = () => {
   }
   return (
     <div className="activity-page">
+      <nav>
+        {Object.values(Mode ?? {}).map((m) => (
+          <NavLink className={'form-nav'} to={`/Records/HookForm/${id}/${m}`} end={true}>
+            {m}
+          </NavLink>
+        ))}
+      </nav>
       <FormProvider {...methods}>
         <form autoComplete={'off'} id="activity-form" onSubmit={handleSubmit(onSubmit)}>
           <RecordMetadata formState={getValues()} />
-          {/* Start of Geometry Fields */}
-          <Fieldset label={'Geometry Information'}>
-            <NumberInput
-              label={'Area (m²)'}
-              readOnly
-              error={errors?.area_m}
-              required
-              tooltip={tooltips.basic.area_m}
-              {...register(`area_m`, {
-                required: true,
-                min: { value: 1, message: 'Area must be greater than 1m' },
-                max: { value: 500000, message: 'Area cannot exceed 500,000m' }
-              })}
-              width={Width.Third}
-            />
-            <NumberInput
-              label={'Latitude'}
-              readOnly
-              required
-              error={errors?.latitude}
-              tooltip={tooltips.basic.latitude}
-              {...register(`latitude`, { required: true, validate: (val) => !!val })}
-              width={Width.Third}
-            />
-            <NumberInput
-              label={'Longitude'}
-              readOnly
-              required
-              tooltip={tooltips.basic.longitude}
-              error={errors?.longitude}
-              {...register(`longitude`, { required: true, validate: (val) => !!val })}
-              width={Width.Third}
-            />
-            <NumberInput
-              label={'UTM Zone'}
-              readOnly
-              required
-              error={errors?.utm_zone}
-              tooltip={tooltips.basic.utm_zone}
-              {...register(`utm_zone`, { required: true, validate: (val) => !!val })}
-              width={Width.Third}
-            />
-            <NumberInput
-              label={'UTM Easting'}
-              readOnly
-              required
-              tooltip={tooltips.basic.utm_easting}
-              error={errors?.utm_easting}
-              {...register(`utm_easting`, { required: true, validate: (val) => !!val })}
-              width={Width.Third}
-            />
-            <NumberInput
-              label={'UTM Northing'}
-              readOnly
-              required
-              tooltip={tooltips.basic.utm_northing}
-              error={errors?.utm_northing}
-              {...register(`utm_northing`, { required: true, validate: (val) => !!val })}
-              width={Width.Third}
-            />
-            <p>To modify or update, please draw a new shape on the Map</p>
-            <div className="control">
-              <input
-                type="button"
-                className="control-button"
-                disabled={disabled}
-                onClick={handleDrawStart}
-                value="Click to Start Drawing"
-              />
-              <input
-                type="button"
-                className="control-button"
-                disabled={disabled}
-                onClick={handleManualUTM}
-                value="Click to Enter UTM"
-              />
-            </div>
-          </Fieldset>
-          <LinkedActivities />
-          {/* Start Basic Information Fields */}
-          <Fieldset label={'Basic Information'}>
-            <DateInput
-              label={'Date'}
-              tooltip={tooltips.basic.date}
-              required
-              error={errors?.date}
-              {...register('date', { required: true, validate: (val) => noFutureDate(val) })}
-              width={Width.Half}
-            />
-            <Employer width={Width.Half} />
-            <FundingAgency width={Width.Half} />
-            <FormSpacer width={Width.Half} />
-            {/* Start of Jurisdictions section */}
-            <ArrayField<FormSchema, 'jurisdictions'>
-              name="jurisdictions"
-              label="Jurisdictions"
-              rules={{
-                validate: {
-                  minimumItems: (val) => minArrayLength(val, 1),
-                  totalPercent: (val) => checkSum(val, 100, 'percent_covered'),
-                  noRepeatJurisdiction: (val) => noRepeatKey(val, 'jurisdiction')
-                }
-              }}
-              width={Width.Half}
-              emptyValue={{ jurisdiction: '', percent_covered: 0 }}
-              renderRow={(index, remove) => (
-                <>
-                  <SingleSelect
-                    label="Jurisdiction"
-                    options={codes.JurisdictionCode}
-                    tooltip={tooltips.basic.jurisdiction}
-                    name={`jurisdictions.${index}.jurisdiction`}
-                    rules={{ required: true }}
-                    required
-                  />
-                  <NumberInput
-                    label="Percent Covered"
-                    type="number"
-                    required
-                    tooltip={tooltips.basic.jurisdiction_percent_covered}
-                    error={errors.jurisdictions?.[index]?.percent_covered}
-                    {...register(`jurisdictions.${index}.percent_covered`, {
-                      required: true,
-                      valueAsNumber: true,
-                      validate: {
-                        min: (val) => minValue(val, 1),
-                        max: (val) => maxValue(val, 100)
-                      }
-                    })}
-                  />
-                  <DeleteControl onClick={() => remove(index)} />
-                </>
-              )}
-            />
-            {/* Start of Project Codes  */}
-            <ArrayField<FormSchema, 'projects'>
-              name="projects"
-              label="Project Codes"
-              tooltip={tooltips.basic.projects}
-              emptyValue={{ description: '' }}
-              width={Width.Half}
-              renderRow={(index, remove) => (
-                <>
-                  <TextInput
-                    label={'Description'}
-                    id={`projects.${index}.description`}
-                    {...register(`projects.${index}.description`, { required: true })}
-                    error={formState.errors.projects?.[index]?.description}
-                  />
-                  <DeleteControl onClick={() => remove(index)} />
-                </>
-              )}
-            />
-
-            {/* Start General Comment Boxes  */}
-            <TextArea
-              label={'Location Description'}
-              id="location_description"
-              error={errors?.location_description}
-              required
-              tooltip={tooltips.basic.location_description}
-              width={Width.Third}
-              {...register('location_description', { required: true, validate: (val) => minValue(val, 10) })}
-            />
-            <TextArea
-              width={Width.Third}
-              label={'Access Description'}
-              error={errors?.access_description}
-              tooltip={tooltips.basic.access_description}
-              {...register('access_description')}
-            />
-            <TextArea
-              label={'Comment'}
-              error={errors?.comment}
-              tooltip={tooltips.basic.general_comments}
-              width={Width.Third}
-              {...register('comment')}
-            />
-          </Fieldset>
-          <Participants />
-          <SubtypeComposite />
-
+          {mode &&
+            {
+              [Mode.Form]: <Form />,
+              [Mode.Photo]: <Photos />
+            }[mode]}
           {/* Submit Button is tied to react-hook-form */}
           <CustomPopover buttonOverrideOptions={{ anchorEl, setAnchorEl }}>
             <div id="form-popover-menu">

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/Form.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/Form.tsx
@@ -1,0 +1,271 @@
+import { useDispatch, useSelector } from 'utils/use_selector';
+import TextInput from 'UI/Features/Records/Activity/forms/common/TextInput/TextInput';
+import SingleSelect from 'UI/Features/Records/Activity/forms/common/SingleSelect/SingleSelect';
+import Fieldset from 'UI/Features/Records/Activity/forms/common/Fieldset/Fieldset';
+import DateInput from 'UI/Features/Records/Activity/forms/common/DateInput/DateInput';
+import NumberInput from 'UI/Features/Records/Activity/forms/common/NumberInput/NumberInput';
+import TextArea from 'UI/Features/Records/Activity/forms/common/TextArea/TextArea';
+import {
+  checkSum,
+  maxValue,
+  minArrayLength,
+  minValue,
+  noFutureDate,
+  noRepeatKey
+} from 'UI/Features/Records/Activity/forms/common/validators';
+import { MouseEvent, TouchEvent, useState } from 'react';
+import ArrayField from 'UI/Features/Records/Activity/forms/common/ArrayField/ArrayField';
+import SubtypeComposite from 'UI/Features/Records/Activity/forms/plant/subtype-component/SubtypeComposite';
+import { Width } from 'UI/Features/Records/Activity/forms/common/utils';
+import DeleteControl from 'UI/Features/Records/Activity/forms/common/DeleteControl/DeleteControl';
+import Alerts from 'state/actions/alerts/Alerts';
+import tripAlertMessages from 'constants/alerts/tripAlerts';
+import Prompt from 'state/actions/prompts/Prompt';
+import { FormSchema } from 'UI/Features/Records/Activity/forms/plant/interfaces';
+import tooltips from 'UI/Features/Records/Activity/forms/plant/content/tooltips';
+import Participants from './Participants';
+import { Feature } from 'geojson';
+import { UtmInputObj } from 'interfaces/prompt-interfaces';
+import GeoShapes from 'constants/geoShapes';
+import MapActions from 'state/actions/map';
+import DrawToolActions from 'state/actions/drawtool/drawToolActions';
+import FundingAgency from './FundingAgency';
+import Employer from './Employers';
+import LinkedActivities from './LinkedActivities';
+import FormSpacer from 'UI/Features/Records/Activity/forms/common/FormSpacer/FormSpacer';
+import { useFormContext } from 'react-hook-form';
+import './activityForm.css';
+
+const Form = () => {
+  const {
+    register,
+    formState: { disabled, errors }
+  } = useFormContext<FormSchema>();
+  const dispatch = useDispatch();
+  const codes = useSelector((state) => state.ActivityPage.formCodes);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  /**
+   * @desc Initiate Mouseclick on Polygon draw icon, alert user to start drawing
+   */
+  const handleDrawStart = () => {
+    (document.getElementsByClassName('mapbox-gl-draw_polygon')?.[0] as HTMLButtonElement).click();
+    dispatch(Alerts.create(tripAlertMessages.drawToolClicked));
+  };
+
+  const handleOpenMenu = (evt: MouseEvent<HTMLElement> | TouchEvent<HTMLElement>) => {
+    setAnchorEl(evt.currentTarget);
+  };
+  /**
+   * @desc Handler for creating a manual UTM Entry initiated by user
+   */
+  const handleManualUTM = () => {
+    const utmCallback = (input: UtmInputObj) => {
+      const [lng, lat] = input.results;
+      const geo: Feature = {
+        type: 'Feature',
+        geometry: {
+          type: GeoShapes.Point,
+          coordinates: [lng, lat]
+        },
+        properties: {}
+      };
+      dispatch(MapActions.centerMap({ lat, lng, zoom: 16 }));
+      dispatch(DrawToolActions.updateGeo([geo]));
+    };
+
+    dispatch(
+      Prompt.utm({
+        title: 'Enter a manual UTM',
+        prompt: 'Fill in the fields below to create your own UTM Coordinates',
+        callback: utmCallback
+      })
+    );
+  };
+  return (
+    <>
+      {/* Start of Geometry Fields */}
+      <Fieldset label={'Geometry Information'}>
+        <NumberInput
+          label={'Area (m²)'}
+          readOnly
+          error={errors?.area_m}
+          required
+          tooltip={tooltips.basic.area_m}
+          {...register(`area_m`, {
+            required: true,
+            min: { value: 1, message: 'Area must be greater than 1m' },
+            max: { value: 500000, message: 'Area cannot exceed 500,000m' }
+          })}
+          width={Width.Third}
+        />
+        <NumberInput
+          label={'Latitude'}
+          readOnly
+          required
+          error={errors?.latitude}
+          tooltip={tooltips.basic.latitude}
+          {...register(`latitude`, { required: true, validate: (val) => !!val })}
+          width={Width.Third}
+        />
+        <NumberInput
+          label={'Longitude'}
+          readOnly
+          required
+          tooltip={tooltips.basic.longitude}
+          error={errors?.longitude}
+          {...register(`longitude`, { required: true, validate: (val) => !!val })}
+          width={Width.Third}
+        />
+        <NumberInput
+          label={'UTM Zone'}
+          readOnly
+          required
+          error={errors?.utm_zone}
+          tooltip={tooltips.basic.utm_zone}
+          {...register(`utm_zone`, { required: true, validate: (val) => !!val })}
+          width={Width.Third}
+        />
+        <NumberInput
+          label={'UTM Easting'}
+          readOnly
+          required
+          tooltip={tooltips.basic.utm_easting}
+          error={errors?.utm_easting}
+          {...register(`utm_easting`, { required: true, validate: (val) => !!val })}
+          width={Width.Third}
+        />
+        <NumberInput
+          label={'UTM Northing'}
+          readOnly
+          required
+          tooltip={tooltips.basic.utm_northing}
+          error={errors?.utm_northing}
+          {...register(`utm_northing`, { required: true, validate: (val) => !!val })}
+          width={Width.Third}
+        />
+        <p>To modify or update, please draw a new shape on the Map</p>
+        <div className="control">
+          <input
+            type="button"
+            className="control-button"
+            disabled={disabled}
+            onClick={handleDrawStart}
+            value="Click to Start Drawing"
+          />
+          <input
+            type="button"
+            className="control-button"
+            disabled={disabled}
+            onClick={handleManualUTM}
+            value="Click to Enter UTM"
+          />
+        </div>
+      </Fieldset>
+      <LinkedActivities />
+      {/* Start Basic Information Fields */}
+      <Fieldset label={'Basic Information'}>
+        <DateInput
+          label={'Date'}
+          tooltip={tooltips.basic.date}
+          required
+          error={errors?.date}
+          {...register('date', { required: true, validate: (val) => noFutureDate(val) })}
+          width={Width.Half}
+        />
+        <Employer width={Width.Half} />
+        <FundingAgency width={Width.Half} />
+        <FormSpacer width={Width.Half} />
+        {/* Start of Jurisdictions section */}
+        <ArrayField<FormSchema, 'jurisdictions'>
+          name="jurisdictions"
+          label="Jurisdictions"
+          rules={{
+            validate: {
+              minimumItems: (val) => minArrayLength(val, 1),
+              totalPercent: (val) => checkSum(val, 100, 'percent_covered'),
+              noRepeatJurisdiction: (val) => noRepeatKey(val, 'jurisdiction')
+            }
+          }}
+          width={Width.Half}
+          emptyValue={{ jurisdiction: '', percent_covered: 0 }}
+          renderRow={(index, remove) => (
+            <>
+              <SingleSelect
+                label="Jurisdiction"
+                options={codes.JurisdictionCode}
+                tooltip={tooltips.basic.jurisdiction}
+                name={`jurisdictions.${index}.jurisdiction`}
+                rules={{ required: true }}
+                required
+              />
+              <NumberInput
+                label="Percent Covered"
+                type="number"
+                required
+                tooltip={tooltips.basic.jurisdiction_percent_covered}
+                error={errors.jurisdictions?.[index]?.percent_covered}
+                {...register(`jurisdictions.${index}.percent_covered`, {
+                  required: true,
+                  valueAsNumber: true,
+                  validate: {
+                    min: (val) => minValue(val, 1),
+                    max: (val) => maxValue(val, 100)
+                  }
+                })}
+              />
+              <DeleteControl onClick={() => remove(index)} />
+            </>
+          )}
+        />
+        {/* Start of Project Codes  */}
+        <ArrayField<FormSchema, 'projects'>
+          name="projects"
+          label="Project Codes"
+          tooltip={tooltips.basic.projects}
+          emptyValue={{ description: '' }}
+          width={Width.Half}
+          renderRow={(index, remove) => (
+            <>
+              <TextInput
+                label={'Description'}
+                id={`projects.${index}.description`}
+                {...register(`projects.${index}.description`, { required: true })}
+                error={errors.projects?.[index]?.description}
+              />
+              <DeleteControl onClick={() => remove(index)} />
+            </>
+          )}
+        />
+
+        {/* Start General Comment Boxes  */}
+        <TextArea
+          label={'Location Description'}
+          id="location_description"
+          error={errors?.location_description}
+          required
+          tooltip={tooltips.basic.location_description}
+          width={Width.Third}
+          {...register('location_description', { required: true, validate: (val) => minValue(val, 10) })}
+        />
+        <TextArea
+          width={Width.Third}
+          label={'Access Description'}
+          error={errors?.access_description}
+          tooltip={tooltips.basic.access_description}
+          {...register('access_description')}
+        />
+        <TextArea
+          label={'Comment'}
+          error={errors?.comment}
+          tooltip={tooltips.basic.general_comments}
+          width={Width.Third}
+          {...register('comment')}
+        />
+      </Fieldset>
+      <Participants />
+      <SubtypeComposite />
+    </>
+  );
+};
+
+export default Form;

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/Photo.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/Photo.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import { FormSchema } from '../interfaces';
+
+const Photo = ({ photo, index, remove }) => {
+  const {
+    control,
+    formState: { disabled }
+  } = useFormContext<FormSchema>();
+  const { update } = useFieldArray<FormSchema>({ control, name: 'media' });
+
+  const [newPhotoDesc, setNewPhotoDesc] = useState<string>('');
+  const [isEditing, setIsEditing] = useState<boolean>(false);
+
+  /**
+   * @desc Apply Photo Description changes to form, remove text input from view and reset the state.
+   */
+  const changeDescription = () => {
+    update(index, {
+      ...photo,
+      description: newPhotoDesc
+    });
+    setIsEditing(false);
+    setNewPhotoDesc('');
+  };
+
+  return (
+    <div className="photo-card">
+      <div className="photo">
+        <img src={photo.encoded_file} />
+      </div>
+      <div className="description">
+        <caption>{photo.description}</caption>
+      </div>
+      {isEditing && (
+        <div className="edit-control">
+          <input
+            type="text"
+            placeholder="Change Description"
+            value={newPhotoDesc}
+            onChange={(e) => setNewPhotoDesc(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.code === 'Enter' && !disabled) {
+                e.preventDefault();
+                changeDescription();
+              }
+            }}
+          />
+          <input type="button" onClick={changeDescription} value="Save" />
+        </div>
+      )}
+      <div className="photo-control">
+        <input type="button" disabled={disabled} onClick={remove} value="Delete" />
+        <input type="button" disabled={disabled} onClick={() => setIsEditing((prev) => !prev)} value="Edit" />
+      </div>
+    </div>
+  );
+};
+
+export default Photo;

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/Photo.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/Photo.tsx
@@ -16,6 +16,7 @@ const Photo = ({ photo, index, remove }) => {
    * @desc Apply Photo Description changes to form, remove text input from view and reset the state.
    */
   const changeDescription = () => {
+    if (!newPhotoDesc) return;
     update(index, {
       ...photo,
       description: newPhotoDesc
@@ -41,17 +42,29 @@ const Photo = ({ photo, index, remove }) => {
             onChange={(e) => setNewPhotoDesc(e.target.value)}
             onKeyDown={(e) => {
               if (e.code === 'Enter' && !disabled) {
-                e.preventDefault();
+                e.preventDefault(); // Prevent Enter from triggering a form submission
                 changeDescription();
               }
             }}
           />
-          <input type="button" onClick={changeDescription} value="Save" />
+          <input
+            type="button"
+            className="control-button"
+            disabled={!!newPhotoDesc}
+            onClick={changeDescription}
+            value="Save"
+          />
         </div>
       )}
       <div className="photo-control">
-        <input type="button" disabled={disabled} onClick={remove} value="Delete" />
-        <input type="button" disabled={disabled} onClick={() => setIsEditing((prev) => !prev)} value="Edit" />
+        <input type="button" className="control-button" disabled={disabled} onClick={remove} value="Delete" />
+        <input
+          type="button"
+          className="control-button"
+          disabled={disabled}
+          onClick={() => setIsEditing((prev) => !prev)}
+          value="Edit"
+        />
       </div>
     </div>
   );

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/Photos.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/Photos.tsx
@@ -1,0 +1,147 @@
+import { CameraResultType, CameraSource, Camera } from '@capacitor/camera';
+import UploadedPhoto from 'interfaces/UploadedPhoto';
+import { useDispatch } from 'utils/use_selector';
+import 'UI/Features/Records/Activity/PhotoContainer.css';
+import Alerts from 'state/actions/alerts/Alerts';
+import { AlertSeverity, AlertSubjects } from 'constants/alertEnums';
+import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
+import { FormSchema } from '../interfaces';
+import Photo from './Photo';
+
+const Photos = () => {
+  const alertAccessWasDenied = (type: string) =>
+    dispatch(
+      Alerts.create({
+        content: `${type} access is denied. Please enable photo library permissions in your device settings to choose photos.`,
+        severity: AlertSeverity.Warning,
+        subject: AlertSubjects.Photo,
+        autoClose: 5
+      })
+    );
+
+  const processImage = async () => {};
+  async function convertWebPathToDataUrl(webPath: string): Promise<string> {
+    const response = await fetch(webPath);
+    const blob = await response.blob();
+
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve(reader.result as string); // result is a dataUrl
+      reader.onerror = reject;
+      reader.readAsDataURL(blob);
+    });
+  }
+  const checkPermissionsAndAlert = async (photoOption: CameraSource): Promise<void> => {
+    try {
+      const permissions = await Camera.checkPermissions();
+      if (permissions.camera !== 'denied') return;
+      if (photoOption === CameraSource.Camera) {
+        alertAccessWasDenied('Camera');
+      } else if (photoOption === CameraSource.Photos) {
+        alertAccessWasDenied('Photo Library');
+      }
+    } catch (error) {
+      console.error('Error checking permissions:', error);
+    }
+  };
+  const takePhotoFromCamera = async () => {
+    try {
+      await checkPermissionsAndAlert(CameraSource.Camera);
+      const cameraPhoto = await Camera.getPhoto({
+        presentationStyle: 'fullscreen',
+        resultType: CameraResultType.DataUrl,
+        source: CameraSource.Camera,
+        quality: 100
+      });
+
+      const fileName = new Date().toISOString().slice(0, 10) + '.' + cameraPhoto.format;
+      const photo = {
+        file_name: fileName,
+        encoded_file: cameraPhoto.dataUrl,
+        description: 'Untitled'
+      } as UploadedPhoto;
+
+      append(photo);
+    } catch (e) {
+      console.error('User cancelled prematurely or other problem occured.', e);
+    }
+  };
+
+  const choosePhotosFromLibrary = async () => {
+    try {
+      await checkPermissionsAndAlert(CameraSource.Photos);
+      const multiplePhotos = await Camera.pickImages({
+        quality: 100,
+        limit: 10
+      });
+
+      if (!multiplePhotos.photos.length) {
+        console.warn('No photos selected');
+        return;
+      }
+
+      // process all photos concurrently
+      const processedPhotos = await Promise.all(
+        multiplePhotos.photos.map(async (photo, index) => {
+          try {
+            const fileName = `${new Date().toISOString().slice(0, 10)}-${index}.${photo.format}`;
+            const dataUrl = await convertWebPathToDataUrl(photo.webPath);
+
+            return {
+              file_name: fileName,
+              encoded_file: dataUrl,
+              description: 'Untitled'
+            } as UploadedPhoto;
+          } catch (error) {
+            console.error(`Error processing photo ${index + 1}:`, error);
+            return null; // skip photo on failure
+          }
+        })
+      );
+
+      // filter out failed photo conversions
+      const validPhotos = processedPhotos.filter((photo) => photo != null);
+      validPhotos.forEach((photo) => append(photo));
+    } catch (e) {
+      console.error('error occurred: ', e);
+    }
+  };
+
+  const {
+    control,
+    formState: { disabled }
+  } = useFormContext<FormSchema>();
+
+  // Setup FieldArray for push/pop/watch
+  const { fields, append, remove } = useFieldArray<FormSchema>({ control, name: 'media' });
+
+  // useFieldArray won't watch internal changes, so use watch to capture
+  const watchedMedia = useWatch<FormSchema>({
+    control,
+    name: 'media',
+    defaultValue: fields // fallback to initial fields
+  });
+  const dispatch = useDispatch();
+
+  if (!fields) {
+    return <section id="photo-cont">No Images found for Record</section>;
+  }
+  return (
+    <>
+      <section id="photo-cont">
+        <h2>Photos</h2>
+        <div className="content">
+          {watchedMedia.map((photo, index: number) => (
+            <Photo key={photo.id} photo={photo} index={index} remove={() => remove(index)} />
+          ))}
+        </div>
+        <div className="control">
+          <input type="button" disabled={disabled} onClick={takePhotoFromCamera} value={'Capture Photo'} />
+          <input type="button" disabled={disabled} onClick={choosePhotosFromLibrary} value="Choose from Gallery" />
+        </div>
+      </section>
+    </>
+  );
+};
+
+export default Photos;

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/Photos.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/Photos.tsx
@@ -19,7 +19,6 @@ const Photos = () => {
       })
     );
 
-  const processImage = async () => {};
   async function convertWebPathToDataUrl(webPath: string): Promise<string> {
     const response = await fetch(webPath);
     const blob = await response.blob();
@@ -136,8 +135,20 @@ const Photos = () => {
           ))}
         </div>
         <div className="control">
-          <input type="button" disabled={disabled} onClick={takePhotoFromCamera} value={'Capture Photo'} />
-          <input type="button" disabled={disabled} onClick={choosePhotosFromLibrary} value="Choose from Gallery" />
+          <input
+            type="button"
+            className="control-button"
+            disabled={disabled}
+            onClick={takePhotoFromCamera}
+            value={'Capture Photo'}
+          />
+          <input
+            type="button"
+            className="control-button"
+            disabled={disabled}
+            onClick={choosePhotosFromLibrary}
+            value="Choose from Gallery"
+          />
         </div>
       </section>
     </>

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/activityForm.css
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/activityForm.css
@@ -1,3 +1,7 @@
+input[type='button']:hover {
+  cursor: pointer;
+}
+
 .activity-page {
   display: flex;
   flex-direction: column;
@@ -256,22 +260,13 @@
 
   .control {
     border-top: 1px solid #ccc;
-
-    input[type='button'] {
-      width: 100%;
-      border: 1px solid black;
-      font-size: var(--form-input-font-size);
-      padding: 8px;
-      margin: 5px;
-
-      &:not(:disabled) {
-        background-color: var(--bc-blue);
-        color: white;
-      }
-    }
+    display: flex;
   }
 }
 
-input[type='button']:hover {
-  cursor: pointer;
+@media only screen and (width < 800px) {
+  #activity-form #photo-cont .control,
+  #activity-form #photo-cont .photo-control {
+    flex-flow: row wrap;
+  }
 }

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/activityForm.css
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/activityForm.css
@@ -1,10 +1,35 @@
 .activity-page {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   width: 100%;
+  min-height: 100svh;
   box-sizing: border-box;
   background-color: #f1f1f1;
+
+  nav {
+    display: flex;
+    flex-direction: 100%;
+    width: 100%;
+    border-top: 1pt solid black;
+    box-sizing: border-box;
+
+    .form-nav {
+      font-size: var(--form-input-font-size);
+      background-color: var(--bc-blue);
+      color: white;
+      padding: 4px;
+      width: 100%;
+      text-decoration: none;
+      text-transform: capitalize;
+      border-bottom: 5px solid var(--bc-blue);
+
+      &.active {
+        border-color: var(--bc-yellow);
+      }
+    }
+  }
 }
 
 #activity-form {
@@ -123,4 +148,130 @@
 
 #activity-form-control {
   flex-direction: row;
+}
+
+/* Start of Photo Section for Forms  */
+
+#activity-form #photo-cont {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  box-sizing: border-box;
+
+  .content {
+    display: flex;
+    box-sizing: content-box;
+    justify-content: space-around;
+    width: 100%;
+    flex-wrap: wrap;
+
+    & > * {
+      margin-bottom: 20px;
+    }
+
+    /* Single Media Entry  */
+    .photo-card {
+      display: flex;
+      flex-direction: column;
+      box-sizing: border-box;
+      box-shadow: #ccc 2px 2px 1px 1px;
+      border: 1pt solid #888;
+      padding: 5px;
+      width: calc((var(--form-container-width) / 2) - 25px);
+      max-width: 100%;
+
+      /* Photo Container  */
+      .photo {
+        box-sizing: border-box;
+        width: 100%;
+        display: flex;
+
+        img {
+          object-fit: contain;
+          width: 100%;
+          height: 100%;
+          max-height: 350px;
+        }
+      }
+
+      /* Description Text Box, See: "Caption" */
+      .description {
+        box-sizing: border-box;
+        display: flex;
+        border-radius: 8px;
+        height: 100%;
+        width: 100%;
+        margin: 10px 0;
+        padding: 5px;
+
+        caption {
+          font-size: var(--form-input-font-size);
+          width: 100%;
+          text-align: center;
+        }
+      }
+
+      /* Text Input / Save for detailing entries  */
+      .edit-control {
+        input[type='text'] {
+          font-family: BCSans, 'Noto Sans', 'Helvetica Neue', Arial, sans-serif;
+          height: var(--form-input-height);
+          width: 100%;
+          box-sizing: border-box;
+          padding: 0.25rem 0.5rem;
+          font-size: var(--form-input-font-size);
+          margin-bottom: 3px;
+        }
+
+        input[type='button'] {
+          width: 100%;
+          background-color: var(--blue-primary);
+          color: white;
+          padding: 8px;
+          font-size: var(--form-input-font-size);
+        }
+      }
+
+      /* Delete / Edit Buttons  */
+      .photo-control {
+        margin-top: auto;
+        display: flex;
+        border-top: 1pt solid #ccc;
+
+        input[type='button'] {
+          width: 100%;
+          border: 1px solid black;
+          font-size: var(--form-input-font-size);
+          padding: 8px;
+          margin: 5px;
+
+          &:not(:disabled) {
+            background-color: var(--bc-blue);
+            color: white;
+          }
+        }
+      }
+    }
+  }
+
+  .control {
+    border-top: 1px solid #ccc;
+
+    input[type='button'] {
+      width: 100%;
+      border: 1px solid black;
+      font-size: var(--form-input-font-size);
+      padding: 8px;
+      margin: 5px;
+
+      &:not(:disabled) {
+        background-color: var(--bc-blue);
+        color: white;
+      }
+    }
+  }
+}
+
+input[type='button']:hover {
+  cursor: pointer;
 }

--- a/app/src/UI/Features/Records/Activity/forms/plant/builders/getDefaultState.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/builders/getDefaultState.ts
@@ -80,7 +80,8 @@ const getDefaultFormState = (
     utm_northing: 0,
     linked_activities: [],
     participants: [{ name: '', pac_number: isChemical ? 0 : undefined }],
-    subtype_data: subtype_data
+    subtype_data: subtype_data,
+    media: []
   } as FormSchema;
 };
 

--- a/app/src/UI/Features/Records/Activity/forms/plant/builders/getObservationAquaticPlantSubtypeFields.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/builders/getObservationAquaticPlantSubtypeFields.ts
@@ -5,7 +5,7 @@ import { AquaticPlantObservationSchema } from 'UI/Features/Records/Activity/form
  * Used for Form Creation/Reset
  */
 const getObservationAquaticPlantSubtypeFields = (): AquaticPlantObservationSchema['subtype_data'] => ({
-  adjacent_land_use: [''],
+  adjacent_land_use: [],
   entries: [
     {
       density: '',
@@ -17,19 +17,19 @@ const getObservationAquaticPlantSubtypeFields = (): AquaticPlantObservationSchem
     }
   ],
   pretreatment_observation: '',
-  substrate_type: [''],
-  water_use: [''],
-  waterlevel_management: [''],
+  substrate_type: [],
+  water_use: [],
+  waterlevel_management: [],
   shoreline_types: [
     {
       shoreline_type: '',
       percent_covered: 0
     }
   ],
-  inflow_permanent: [''],
-  inflow_seasonal: [''],
-  outflow_permanent: [''],
-  outflow_seasonal: [''],
+  inflow_permanent: [],
+  inflow_seasonal: [],
+  outflow_permanent: [],
+  outflow_seasonal: [],
   access: '',
   colour: '',
   comment: '',

--- a/app/src/UI/Features/Records/Activity/forms/plant/interfaces/BaseForm.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/interfaces/BaseForm.ts
@@ -38,6 +38,10 @@ interface BaseForm {
   projects: Array<{
     description: string;
   }>;
+  media: Array<{
+    description: string;
+    encoded_file: string;
+  }>;
   comment: string;
 }
 

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/common/VoucherCollection.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/common/VoucherCollection.tsx
@@ -19,7 +19,7 @@ const VoucherCollection = ({ index }) => {
     formState: { errors }
   } = useFormContext<Observation>();
   return (
-    <>
+    <Fieldset label={'Voucher Specimen Collection Information'}>
       <TextInput
         required
         label="Voucher Sample ID"
@@ -61,7 +61,7 @@ const VoucherCollection = ({ index }) => {
         width={Width.Half}
         error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.date_verified}
       />
-      <Fieldset nested label={'Voucher Verification Completed By'}>
+      <Fieldset label={'Voucher Verification Completed By'}>
         <TextInput
           required
           label="Completed By (Person)"
@@ -78,7 +78,7 @@ const VoucherCollection = ({ index }) => {
         />
       </Fieldset>
 
-      <Fieldset nested label={'Exact Coordinate of Voucher Collection Site'}>
+      <Fieldset label={'Exact Coordinate of Voucher Collection Site'}>
         <NumberInput
           label="UTM Zone"
           required
@@ -112,7 +112,7 @@ const VoucherCollection = ({ index }) => {
           error={errors?.subtype_data?.entries?.[index]?.voucher_specimen?.utm_northing}
         />
       </Fieldset>
-    </>
+    </Fieldset>
   );
 };
 

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-aquatic/ObservationPlantAquatic.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-aquatic/ObservationPlantAquatic.tsx
@@ -64,16 +64,12 @@ const ObservationPlantAquatic = () => {
           tooltip={tooltips.plant.waterbody.use}
           options={codes?.WaterbodyUseCode}
           name={'subtype_data.water_use'}
-          required
-          rules={{ required: true, validate: (val) => minArrayLength(val, 1) }}
           width={Width.Half}
         />
         <MultiSelect
           label={'Water Level Management'}
           tooltip={tooltips.plant.waterbody.waterlevel_management}
           options={WaterLevelManagement}
-          required
-          rules={{ required: true, validate: (val) => minArrayLength(val, 1) }}
           name={'subtype_data.waterlevel_management'}
           width={Width.Half}
         />

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-aquatic/ObservationPlantAquatic.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-aquatic/ObservationPlantAquatic.tsx
@@ -79,7 +79,7 @@ const ObservationPlantAquatic = () => {
         />
         <MultiSelect
           label={'Substrate Type'}
-          options={codes?.SubstrateCode}
+          options={codes?.WaterbodySubstrateCode}
           tooltip={tooltips.plant.waterbody.substrate_type}
           name={'subtype_data.substrate_type'}
           required

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-mech-plant-aquatic/TreatmentMechPlantAquatic.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-mech-plant-aquatic/TreatmentMechPlantAquatic.tsx
@@ -137,7 +137,7 @@ const TreatmentMechPlantAquatic = () => {
                 name={`${basePath}.disposal_method`}
                 width={Width.Half}
               />
-              <Fieldset nested label={'Disposed Material'}>
+              <Fieldset label={'Disposed Material'}>
                 <SingleSelect
                   label={'Disposed Material Format'}
                   options={DisposedMaterialFormat}

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-mech-plant-aquatic/TreatmentMechPlantAquatic.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-mech-plant-aquatic/TreatmentMechPlantAquatic.tsx
@@ -137,7 +137,7 @@ const TreatmentMechPlantAquatic = () => {
                 name={`${basePath}.disposal_method`}
                 width={Width.Half}
               />
-              <Fieldset label={'Disposed Material'}>
+              <Fieldset nested label={'Disposed Material'}>
                 <SingleSelect
                   label={'Disposed Material Format'}
                   options={DisposedMaterialFormat}

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-mech-plant-terrestrial/TreatmentMechPlantTerrestrial.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-mech-plant-terrestrial/TreatmentMechPlantTerrestrial.tsx
@@ -74,7 +74,7 @@ const TreatmentMechPlantTerrestrial = () => {
                 name={`${basePath}.disposal_method`}
                 width={Width.Half}
               />
-              <Fieldset nested label={'Disposed Material'}>
+              <Fieldset label={'Disposed Material'}>
                 <SingleSelect
                   label={'Disposed Material Format'}
                   options={DisposedMaterialFormat}

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-mech-plant-terrestrial/TreatmentMechPlantTerrestrial.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-mech-plant-terrestrial/TreatmentMechPlantTerrestrial.tsx
@@ -74,7 +74,7 @@ const TreatmentMechPlantTerrestrial = () => {
                 name={`${basePath}.disposal_method`}
                 width={Width.Half}
               />
-              <Fieldset label={'Disposed Material'}>
+              <Fieldset nested label={'Disposed Material'}>
                 <SingleSelect
                   label={'Disposed Material Format'}
                   options={DisposedMaterialFormat}
@@ -85,7 +85,7 @@ const TreatmentMechPlantTerrestrial = () => {
                 <NumberInput
                   label={'Disposed Material Amount'}
                   {...register(`${basePath}.disposed_material_amount`, { valueAsNumber: true })}
-                  error={errors?.subtype_data?.entries?.[index]?.treated_area_msq}
+                  error={errors?.subtype_data?.entries?.[index]?.disposed_material_amount}
                   width={Width.Half}
                 />
               </Fieldset>

--- a/app/src/UI/Features/Records/NewRecordDialog.tsx
+++ b/app/src/UI/Features/Records/NewRecordDialog.tsx
@@ -89,9 +89,9 @@ const NewRecordDialog = () => {
     if (mode === 'new') {
       dispatch(FormActions.createNewForm(recordSubtype as ActivitySubtypes));
     } else {
-      dispatch(FormActions.duplicateForm({ subtype: recordSubtype }));
+      dispatch(FormActions.duplicateForm({ subtype: recordSubtype as ActivitySubtypes }));
     }
-    navigate('/Records/HookForm');
+    navigate('/Records/HookForm/new/form');
   };
 
   const handleRecordCategoryChange = (event) => {

--- a/app/src/UI/Layout/Routes/AppRoutes.tsx
+++ b/app/src/UI/Layout/Routes/AppRoutes.tsx
@@ -48,7 +48,7 @@ const AppRoutes = () => {
   return (
     <Routes>
       <Route path="/" element={<Navigate to="/Landing" replace />} />
-      <Route path="/Records/HookForm" element={<ActivityForm />} />
+      <Route path="/Records/HookForm/:id/:mode" element={<ActivityForm />} />
       <Route path="/Map" Component={() => <></>} />
       <Route path="/Landing" Component={() => <LandingComponent />} />
       <Route path="/Records/Activity/:id/:mode" Component={() => <Activity />}></Route>

--- a/app/src/UI/Layout/Routes/PrimaryNavigation.tsx
+++ b/app/src/UI/Layout/Routes/PrimaryNavigation.tsx
@@ -141,10 +141,11 @@ function usePrimaryNavigationLinks() {
       layout: LayoutMode.MAP_FOCUSED,
       icon: <AssignmentIcon />
     },
+    // TODO: Replace above ^ with Hookform
     {
       id: 'HookForm',
-      path: `/Records/HookForm`,
-      activePaths: [{ path: '/Records/HookForm', end: true }],
+      path: `/Records/HookForm/${activeActivity}/form`,
+      activePaths: [{ path: `/Records/HookForm/:id/*`, end: true }],
       label: 'Hook Form',
       predicate: TabPredicate.AUTHENTICATED_ANY,
       platform: PlatformPredicate.BOTH,

--- a/app/src/state/actions/activity/FormActions.ts
+++ b/app/src/state/actions/activity/FormActions.ts
@@ -42,7 +42,7 @@ class FormActions {
       //Reset record specific details.
       duplicatedForm.created_by = Auth.username;
       duplicatedForm.short_id = ''; // Gets assigned when API receives it.
-      duplicatedForm.date = new Date();
+      duplicatedForm.date = new Date().toISOString().substring(0, 10);
       duplicatedForm.id = crypto.randomUUID();
       if (duplicatedForm.subtype !== subtype) {
         //For mismatched subtype, remove all the subtype_data


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):
- Add Media object to getDefaultState/BaseForm
- Refactor Photo buttons to be RHF Compliant, integrate with forms
    - Truncate encoded_data from debug display object. 
- Fix missing function call in Aquatic Observation Schema
- Un-require some Aquatic Observation Fields (multiselects) to reflect schemas
    - Remove invalid starting values [''] creating false validation positives.
- Add missing Waterbody Substrate Codes to export
- Update React Router for Hook Form
    - Split Form into two segments, Photos/Form to better align with old methods
        - Both maintain the same Form Context, for non-disjointed state management.
- Adjust Fieldset CSS to better handle nested/stacked Fieldsets.
- Fix multi-select error entry that was missing label.
- Correct mislabelled error object in disposed material format (Mech treatment)


## Screenshots

Previous

<img width="1395" height="589" alt="image" src="https://github.com/user-attachments/assets/1be1a88f-1b0b-4fd2-a0cb-7ca32e432326" />


New 

<img width="1217" height="624" alt="image" src="https://github.com/user-attachments/assets/2792a13c-a8ca-4b41-acb2-dfcebee65165" />


