### PR TITLE
Nmdb improvements 3

### DIFF
--- a/api-rework/invasives/api/serializers/activity_recordset_row.py
+++ b/api-rework/invasives/api/serializers/activity_recordset_row.py
@@ -1,0 +1,184 @@
+from django.contrib.gis.serializers.geojson import JSONSerializer as GeoJSONSerializer
+from rest_framework import serializers
+from api.models.activity.activity import Activity
+from api.models.activity import (
+    ActivitySubtypes,
+    FundingAgency,
+    Jurisdiction,
+    ProjectCode,
+)
+
+class FundingAgencySerializer(serializers.ModelSerializer):
+    invasive_species_agency_code = serializers.CharField(source="agency_id")
+    class Meta:
+        model = FundingAgency
+        fields = ["invasive_species_agency_code"]
+    def to_representation(self, obj):
+        return obj.agency.full
+
+
+class JurisdictionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Jurisdiction
+        fields = ("jurisdiction", "percent_covered")
+
+    def to_representation(self, obj):
+        return f"{obj.jurisdiction.full} ({obj.percent_covered}%)"
+
+
+class ProjectCodeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ProjectCode
+        fields = ["description"]
+
+    def to_representation(self, obj):
+        return obj.description
+
+
+
+class ActivityRecordsetRowSerializer(serializers.ModelSerializer):
+    """
+    Entry For Serializing Activities to a Recordset Row
+    """
+    invasive_plant = serializers.SerializerMethodField()
+    species_positive_full = serializers.SerializerMethodField()
+    species_negative_full = serializers.SerializerMethodField()
+    species_treated_full = serializers.SerializerMethodField()
+    species_biocontrol_full = serializers.SerializerMethodField()
+    jurisdiction_display = JurisdictionSerializer(source="jurisdiction_set", many=True, read_only=True)
+    project_code = ProjectCodeSerializer(source="projectcode_set", many=True, read_only=True)
+    agency = FundingAgencySerializer(source="fundingagency_set", many=True, read_only=True)
+    updated_by = serializers.CharField(source='created_by', read_only=True)
+    regional_invasive_species_organization_areas = serializers.CharField(source='computed_regional_invasive_species_organization_areas', read_only=True)
+    regional_districts = serializers.CharField(source='computed_regional_districts', read_only=True)
+    invasive_plant_management_areas = serializers.CharField(source='computed_invasive_plant_management_areas', read_only=True)
+    biogeoclimatic_zones =serializers.CharField(source='computed_biogeoclimactic_zone', read_only=True)
+    elevation = serializers.IntegerField(source="computed_elevation_m", read_only=True)
+    activity_type = serializers.CharField(source='id', read_only=True)
+    activity_subtype = serializers.CharField(source='subtype', read_only=True)
+    activity_date = serializers.CharField(source='date', read_only=True)
+
+    def get_entry_destination(self, subtype):
+        """Given an Activity Subtype, map to the set where invasive_plant keys will be"""
+        mapping = {
+            ActivitySubtypes.Observation_Plant_Aquatic.name: 'aquaticplantobservationentry_set',
+            ActivitySubtypes.Observation_Plant_Terrestrial.name: 'terrestrialplantobservationentries_set',
+            ActivitySubtypes.Treatment_Chemical_Plant_Aquatic.name: '', # TODO when calculations added
+            ActivitySubtypes.Treatment_Chemical_Plant_Terrestrial.name:'', # TODO when calculations added
+            ActivitySubtypes.Treatment_Mechanical_Plant_Aquatic.name: 'aquaticplantmechanicaltreatmententry_set',
+            ActivitySubtypes.Treatment_Mechanical_Plant_Terrestrial.name: 'terrestrialplantmechanicaltreatmententry_set',
+            ActivitySubtypes.Monitoring_Biocontrol_Dispersal_Plant_Terrestrial.name: 'terrestrialbiocontroldispersalmonitoringentry_set',
+            ActivitySubtypes.Monitoring_Biocontrol_Release_Plant_Terrestrial.name: 'terrestrialbiocontrolreleaseentry_set',
+            ActivitySubtypes.Monitoring_Chemical_Plant_Terrestrial_Aquatic.name: 'aquatictreatmentmonitoringentry_set',
+            ActivitySubtypes.Monitoring_Mechanical_Plant_Terrestrial_Aquatic.name: 'terrestrialtreatmentmonitoringentry_set',
+            ActivitySubtypes.Biocontrol_Collection.name: 'terrestrialbiocontrolcollectionentry_set',
+            ActivitySubtypes.Biocontrol_Release.name: 'terrestrialbiocontrolreleaseentry_set',
+        }
+        record_entry_location = mapping.get(subtype)
+        if record_entry_location:
+            return record_entry_location
+
+    class Meta:
+        model = Activity
+        fields = (
+            'short_id',
+            'activity_type',
+            'activity_subtype',
+            'activity_date',
+            'project_code',
+            'jurisdiction_display',
+            'invasive_plant',
+            'species_positive_full',
+            'species_negative_full',
+            'species_treated_full',
+            'species_biocontrol_full',
+            'created_by',
+            'updated_by',
+            'agency',
+            'regional_invasive_species_organization_areas',
+            'regional_districts',
+            'invasive_plant_management_areas',
+            'biogeoclimatic_zones',
+            'elevation',
+            'batch_id',
+        )
+
+    def build_response_value(self, values):
+        """Join response values to return to client"""
+        return ", ".join(filter(None, values)) or None
+
+    def get_invasive_plant(self, obj):
+        """ Fetch the Invasive Plant for a record"""
+        destination = self.get_entry_destination(obj.subtype)
+        if destination:
+            entries = getattr(obj, destination).all()
+            plants = [e.invasive_plant.full for e in entries]
+            return self.build_response_value(set(plants))
+
+    def get_species_positive_full(self, obj):
+        """ Fetch Positive species values from a form (Any Non-Negative Observation is a Positive Species)"""
+        destination = self.get_entry_destination(obj.subtype)
+        if destination:
+            entries = getattr(obj, destination).all()
+            is_observation = ActivitySubtypes[obj.subtype].typeOfActivity == 'Observation'
+            plants = [
+                e.invasive_plant.full for e in entries
+                if not is_observation or getattr(e, 'observation_type', None) == 'Positive'
+            ]
+            return self.build_response_value(set(plants))
+
+    def get_species_negative_full(self, obj):
+        """Fetch Negative Species from a form (Only Observations can contain Negative species)"""
+        if ActivitySubtypes[obj.subtype].typeOfActivity == 'Observation':
+            destination = self.get_entry_destination(obj.subtype)
+            if destination:
+                entries = getattr(obj, destination).all()
+                plants = [
+                    e.invasive_plant.full for e in entries
+                    if getattr(e, 'observation_type', None) == 'Negative'
+                ]
+                return self.build_response_value(set(plants))
+
+
+    def get_species_treated_full(self, obj):
+        """Fetch List of Treated Species (Any Non-Observation record contains a Treated Species)"""
+        activity_type = ActivitySubtypes[obj.subtype].typeOfActivity
+        if activity_type in ['Treatment', 'Biocontrol', 'Monitoring']:
+            destination = self.get_entry_destination(obj.subtype)
+            if destination:
+                entries = getattr(obj, destination).all()
+                plants = [e.invasive_plant.full for e in entries]
+                return self.build_response_value(set(plants))
+
+    def get_species_biocontrol_full(self, obj):
+        """Transform Biocontrol records into stringified full names"""
+        mapping = {
+            ActivitySubtypes.Biocontrol_Collection.name: {
+                "set": "terrestrialbiocontrolcollectionentry_set",
+                "key": "biological_agent__full"
+            },
+            ActivitySubtypes.Biocontrol_Release.name: {
+                "set": "terrestrialbiocontrolreleaseentry_set",
+                "key": "biocontrol_agent__full"
+            },
+            ActivitySubtypes.Monitoring_Biocontrol_Dispersal_Plant_Terrestrial.name: {
+                "set": "terrestrialbiocontroldispersalmonitoringentry_set",
+                "key": "biocontrol_agent__full"
+            },
+            ActivitySubtypes.Monitoring_Biocontrol_Release_Plant_Terrestrial.name: {
+                "set": "terrestrialbiocontroldispersalmonitoringentry_set",
+                "key": "biocontrol_agent__full"
+            },
+        }
+        destination = mapping.get(obj.subtype)
+        if destination:
+            manager = getattr(obj, destination['set'])
+            agents = manager.values_list(destination['key'], flat=True)
+            return self.build_response_value(agents)
+
+    def to_representation(self, obj):
+        rep = super().to_representation(obj)
+        rep['project_code'] = ", ".join(rep.get('project_code', [])) or None
+        rep['jurisdiction_display'] = ", ".join(rep.get('jurisdiction_display', [])) or None
+        rep['agency'] = ", ".join(rep.get('agency', [])) or None
+        return rep

--- a/api-rework/invasives/api/serializers/activity_recordset_row.py
+++ b/api-rework/invasives/api/serializers/activity_recordset_row.py
@@ -8,6 +8,7 @@ class ActivityRecordsetRowSerializer(serializers.ModelSerializer):
     """
     Entry For Serializing Activities to a Recordset Row
     """
+
     invasive_plant = serializers.SerializerMethodField()
     species_positive_full = serializers.SerializerMethodField()
     species_negative_full = serializers.SerializerMethodField()
@@ -17,68 +18,76 @@ class ActivityRecordsetRowSerializer(serializers.ModelSerializer):
     project_code = serializers.SerializerMethodField()
     agency = serializers.SerializerMethodField()
     updated_by = serializers.SerializerMethodField()
-    regional_invasive_species_organization_areas = serializers.CharField(source='computed_regional_invasive_species_organization_areas', read_only=True)
-    regional_districts = serializers.CharField(source='computed_regional_districts', read_only=True)
-    invasive_plant_management_areas = serializers.CharField(source='computed_invasive_plant_management_areas', read_only=True)
-    biogeoclimatic_zones =serializers.CharField(source='computed_biogeoclimactic_zone', read_only=True)
+    regional_invasive_species_organization_areas = serializers.CharField(
+        source="computed_regional_invasive_species_organization_areas", read_only=True
+    )
+    regional_districts = serializers.CharField(
+        source="computed_regional_districts", read_only=True
+    )
+    invasive_plant_management_areas = serializers.CharField(
+        source="computed_invasive_plant_management_areas", read_only=True
+    )
+    biogeoclimatic_zones = serializers.CharField(
+        source="computed_biogeoclimactic_zone", read_only=True
+    )
     elevation = serializers.IntegerField(source="computed_elevation_m", read_only=True)
-    activity_type = serializers.CharField(source='id', read_only=True)
-    activity_subtype = serializers.CharField(source='subtype', read_only=True)
-    activity_date = serializers.CharField(source='date', read_only=True)
+    activity_type = serializers.CharField(source="id", read_only=True)
+    activity_subtype = serializers.CharField(source="subtype", read_only=True)
+    activity_date = serializers.CharField(source="date", read_only=True)
 
     PATH_TO_PLANT_MAP = {
-            ActivitySubtypes.Observation_Plant_Aquatic.name: 'aquaticplantobservationentry_set',
-            ActivitySubtypes.Observation_Plant_Terrestrial.name: 'terrestrialplantobservationentries_set',
-            ActivitySubtypes.Treatment_Chemical_Plant_Aquatic.name: '', # TODO when calculations added
-            ActivitySubtypes.Treatment_Chemical_Plant_Terrestrial.name:'', # TODO when calculations added
-            ActivitySubtypes.Treatment_Mechanical_Plant_Aquatic.name: 'aquaticplantmechanicaltreatmententry_set',
-            ActivitySubtypes.Treatment_Mechanical_Plant_Terrestrial.name: 'terrestrialplantmechanicaltreatmententry_set',
-            ActivitySubtypes.Monitoring_Biocontrol_Dispersal_Plant_Terrestrial.name: 'terrestrialbiocontroldispersalmonitoringentry_set',
-            ActivitySubtypes.Monitoring_Biocontrol_Release_Plant_Terrestrial.name: 'terrestrialbiocontrolreleaseentry_set',
-            ActivitySubtypes.Monitoring_Chemical_Plant_Terrestrial_Aquatic.name: 'aquatictreatmentmonitoringentry_set',
-            ActivitySubtypes.Monitoring_Mechanical_Plant_Terrestrial_Aquatic.name: 'terrestrialtreatmentmonitoringentry_set',
-            ActivitySubtypes.Biocontrol_Collection.name: 'terrestrialbiocontrolcollectionentry_set',
-            ActivitySubtypes.Biocontrol_Release.name: 'terrestrialbiocontrolreleaseentry_set',
+        ActivitySubtypes.Observation_Plant_Aquatic.name: "aquaticplantobservationentry_set",
+        ActivitySubtypes.Observation_Plant_Terrestrial.name: "terrestrialplantobservationentries_set",
+        ActivitySubtypes.Treatment_Chemical_Plant_Aquatic.name: "",  # TODO when calculations added
+        ActivitySubtypes.Treatment_Chemical_Plant_Terrestrial.name: "",  # TODO when calculations added
+        ActivitySubtypes.Treatment_Mechanical_Plant_Aquatic.name: "aquaticplantmechanicaltreatmententry_set",
+        ActivitySubtypes.Treatment_Mechanical_Plant_Terrestrial.name: "terrestrialplantmechanicaltreatmententry_set",
+        ActivitySubtypes.Monitoring_Biocontrol_Dispersal_Plant_Terrestrial.name: "terrestrialbiocontroldispersalmonitoringentry_set",
+        ActivitySubtypes.Monitoring_Biocontrol_Release_Plant_Terrestrial.name: "terrestrialbiocontrolreleaseentry_set",
+        ActivitySubtypes.Monitoring_Chemical_Plant_Terrestrial_Aquatic.name: "aquatictreatmentmonitoringentry_set",
+        ActivitySubtypes.Monitoring_Mechanical_Plant_Terrestrial_Aquatic.name: "terrestrialtreatmentmonitoringentry_set",
+        ActivitySubtypes.Biocontrol_Collection.name: "terrestrialbiocontrolcollectionentry_set",
+        ActivitySubtypes.Biocontrol_Release.name: "terrestrialbiocontrolreleaseentry_set",
     }
 
     PATH_TO_AGENT_MAP = {
         ActivitySubtypes.Biocontrol_Collection.name: {
             "set": "terrestrialbiocontrolcollectionentry_set",
-            "key": "biological_agent"
+            "key": "biological_agent",
         },
         ActivitySubtypes.Biocontrol_Release.name: {
             "set": "terrestrialbiocontrolreleaseentry_set",
-            "key": "biocontrol_agent"
+            "key": "biocontrol_agent",
         },
         ActivitySubtypes.Monitoring_Biocontrol_Dispersal_Plant_Terrestrial.name: {
             "set": "terrestrialbiocontroldispersalmonitoringentry_set",
-            "key": "biocontrol_agent"
+            "key": "biocontrol_agent",
         },
     }
 
     class Meta:
         model = Activity
         fields = (
-            'short_id',
-            'activity_type',
-            'activity_subtype',
-            'activity_date',
-            'project_code',
-            'jurisdiction_display',
-            'invasive_plant',
-            'species_positive_full',
-            'species_negative_full',
-            'species_treated_full',
-            'species_biocontrol_full',
-            'created_by',
-            'updated_by',
-            'agency',
-            'regional_invasive_species_organization_areas',
-            'regional_districts',
-            'invasive_plant_management_areas',
-            'biogeoclimatic_zones',
-            'elevation',
-            'batch_id',
+            "short_id",
+            "activity_type",
+            "activity_subtype",
+            "activity_date",
+            "project_code",
+            "jurisdiction_display",
+            "invasive_plant",
+            "species_positive_full",
+            "species_negative_full",
+            "species_treated_full",
+            "species_biocontrol_full",
+            "created_by",
+            "updated_by",
+            "agency",
+            "regional_invasive_species_organization_areas",
+            "regional_districts",
+            "invasive_plant_management_areas",
+            "biogeoclimatic_zones",
+            "elevation",
+            "batch_id",
         )
 
     def get_entry_destination(self, subtype):
@@ -89,7 +98,7 @@ class ActivityRecordsetRowSerializer(serializers.ModelSerializer):
         return ", ".join(filter(None, values)) or None
 
     def get_invasive_plant(self, obj):
-        """ Fetch the Invasive Plant for a record"""
+        """Fetch the Invasive Plant for a record"""
         destination = self.get_entry_destination(obj.subtype)
         if destination:
             entries = getattr(obj, destination).all()
@@ -97,34 +106,38 @@ class ActivityRecordsetRowSerializer(serializers.ModelSerializer):
             return self.build_response_value(set(plants))
 
     def get_species_positive_full(self, obj):
-        """ Fetch Positive species values from a form (Any Non-Negative Observation is a Positive Species)"""
+        """Fetch Positive species values from a form (Any Non-Negative Observation is a Positive Species)"""
         destination = self.get_entry_destination(obj.subtype)
         if destination:
             entries = getattr(obj, destination).all()
-            is_observation = ActivitySubtypes[obj.subtype].typeOfActivity == 'Observation'
+            is_observation = (
+                ActivitySubtypes[obj.subtype].typeOfActivity == "Observation"
+            )
             plants = [
-                e.invasive_plant.full for e in entries
-                if not is_observation or getattr(e, 'observation_type', None) == 'Positive'
+                e.invasive_plant.full
+                for e in entries
+                if not is_observation
+                or getattr(e, "observation_type", None) == "Positive"
             ]
             return self.build_response_value(set(plants))
 
     def get_species_negative_full(self, obj):
         """Fetch Negative Species from a form (Only Observations can contain Negative species)"""
-        if ActivitySubtypes[obj.subtype].typeOfActivity == 'Observation':
+        if ActivitySubtypes[obj.subtype].typeOfActivity == "Observation":
             destination = self.get_entry_destination(obj.subtype)
             if destination:
                 entries = getattr(obj, destination).all()
                 plants = [
-                    e.invasive_plant.full for e in entries
-                    if getattr(e, 'observation_type', None) == 'Negative'
+                    e.invasive_plant.full
+                    for e in entries
+                    if getattr(e, "observation_type", None) == "Negative"
                 ]
                 return self.build_response_value(set(plants))
-
 
     def get_species_treated_full(self, obj):
         """Fetch List of Treated Species (Any Non-Observation record contains a Treated Species)"""
         activity_type = ActivitySubtypes[obj.subtype].typeOfActivity
-        if activity_type in ['Treatment', 'Biocontrol', 'Monitoring']:
+        if activity_type in ["Treatment", "Biocontrol", "Monitoring"]:
             destination = self.get_entry_destination(obj.subtype)
             if destination:
                 entries = getattr(obj, destination).all()
@@ -135,14 +148,17 @@ class ActivityRecordsetRowSerializer(serializers.ModelSerializer):
         """Transform Biocontrol records into stringified agent names"""
         config = self.PATH_TO_AGENT_MAP.get(obj.subtype)
         if config:
-            entries = getattr(obj, config['set']).all()
-            agents = [getattr(getattr(e, config['key']), 'full', None) for e in entries]
+            entries = getattr(obj, config["set"]).all()
+            agents = [getattr(getattr(e, config["key"]), "full", None) for e in entries]
             return self.build_response_value(set(agents))
         return None
 
     def get_jurisdiction_display(self, obj):
         # Accessing prefetched data in memory
-        items = [f"{j.jurisdiction.full} ({j.percent_covered}%)" for j in obj.jurisdiction_set.all()]
+        items = [
+            f"{j.jurisdiction.full} ({j.percent_covered}%)"
+            for j in obj.jurisdiction_set.all()
+        ]
         return ", ".join(items) or None
 
     def get_project_code(self, obj):

--- a/api-rework/invasives/api/serializers/activity_recordset_row.py
+++ b/api-rework/invasives/api/serializers/activity_recordset_row.py
@@ -1,39 +1,7 @@
 from django.contrib.gis.serializers.geojson import JSONSerializer as GeoJSONSerializer
 from rest_framework import serializers
 from api.models.activity.activity import Activity
-from api.models.activity import (
-    ActivitySubtypes,
-    FundingAgency,
-    Jurisdiction,
-    ProjectCode,
-)
-
-class FundingAgencySerializer(serializers.ModelSerializer):
-    invasive_species_agency_code = serializers.CharField(source="agency_id")
-    class Meta:
-        model = FundingAgency
-        fields = ["invasive_species_agency_code"]
-    def to_representation(self, obj):
-        return obj.agency.full
-
-
-class JurisdictionSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Jurisdiction
-        fields = ("jurisdiction", "percent_covered")
-
-    def to_representation(self, obj):
-        return f"{obj.jurisdiction.full} ({obj.percent_covered}%)"
-
-
-class ProjectCodeSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = ProjectCode
-        fields = ["description"]
-
-    def to_representation(self, obj):
-        return obj.description
-
+from api.models.activity import ActivitySubtypes
 
 
 class ActivityRecordsetRowSerializer(serializers.ModelSerializer):
@@ -45,10 +13,10 @@ class ActivityRecordsetRowSerializer(serializers.ModelSerializer):
     species_negative_full = serializers.SerializerMethodField()
     species_treated_full = serializers.SerializerMethodField()
     species_biocontrol_full = serializers.SerializerMethodField()
-    jurisdiction_display = JurisdictionSerializer(source="jurisdiction_set", many=True, read_only=True)
-    project_code = ProjectCodeSerializer(source="projectcode_set", many=True, read_only=True)
-    agency = FundingAgencySerializer(source="fundingagency_set", many=True, read_only=True)
-    updated_by = serializers.CharField(source='created_by', read_only=True)
+    jurisdiction_display = serializers.SerializerMethodField()
+    project_code = serializers.SerializerMethodField()
+    agency = serializers.SerializerMethodField()
+    updated_by = serializers.SerializerMethodField()
     regional_invasive_species_organization_areas = serializers.CharField(source='computed_regional_invasive_species_organization_areas', read_only=True)
     regional_districts = serializers.CharField(source='computed_regional_districts', read_only=True)
     invasive_plant_management_areas = serializers.CharField(source='computed_invasive_plant_management_areas', read_only=True)
@@ -58,9 +26,7 @@ class ActivityRecordsetRowSerializer(serializers.ModelSerializer):
     activity_subtype = serializers.CharField(source='subtype', read_only=True)
     activity_date = serializers.CharField(source='date', read_only=True)
 
-    def get_entry_destination(self, subtype):
-        """Given an Activity Subtype, map to the set where invasive_plant keys will be"""
-        mapping = {
+    PATH_TO_PLANT_MAP = {
             ActivitySubtypes.Observation_Plant_Aquatic.name: 'aquaticplantobservationentry_set',
             ActivitySubtypes.Observation_Plant_Terrestrial.name: 'terrestrialplantobservationentries_set',
             ActivitySubtypes.Treatment_Chemical_Plant_Aquatic.name: '', # TODO when calculations added
@@ -73,10 +39,22 @@ class ActivityRecordsetRowSerializer(serializers.ModelSerializer):
             ActivitySubtypes.Monitoring_Mechanical_Plant_Terrestrial_Aquatic.name: 'terrestrialtreatmentmonitoringentry_set',
             ActivitySubtypes.Biocontrol_Collection.name: 'terrestrialbiocontrolcollectionentry_set',
             ActivitySubtypes.Biocontrol_Release.name: 'terrestrialbiocontrolreleaseentry_set',
-        }
-        record_entry_location = mapping.get(subtype)
-        if record_entry_location:
-            return record_entry_location
+    }
+
+    PATH_TO_AGENT_MAP = {
+        ActivitySubtypes.Biocontrol_Collection.name: {
+            "set": "terrestrialbiocontrolcollectionentry_set",
+            "key": "biological_agent"
+        },
+        ActivitySubtypes.Biocontrol_Release.name: {
+            "set": "terrestrialbiocontrolreleaseentry_set",
+            "key": "biocontrol_agent"
+        },
+        ActivitySubtypes.Monitoring_Biocontrol_Dispersal_Plant_Terrestrial.name: {
+            "set": "terrestrialbiocontroldispersalmonitoringentry_set",
+            "key": "biocontrol_agent"
+        },
+    }
 
     class Meta:
         model = Activity
@@ -102,6 +80,9 @@ class ActivityRecordsetRowSerializer(serializers.ModelSerializer):
             'elevation',
             'batch_id',
         )
+
+    def get_entry_destination(self, subtype):
+        return self.PATH_TO_PLANT_MAP.get(subtype)
 
     def build_response_value(self, values):
         """Join response values to return to client"""
@@ -151,34 +132,25 @@ class ActivityRecordsetRowSerializer(serializers.ModelSerializer):
                 return self.build_response_value(set(plants))
 
     def get_species_biocontrol_full(self, obj):
-        """Transform Biocontrol records into stringified full names"""
-        mapping = {
-            ActivitySubtypes.Biocontrol_Collection.name: {
-                "set": "terrestrialbiocontrolcollectionentry_set",
-                "key": "biological_agent__full"
-            },
-            ActivitySubtypes.Biocontrol_Release.name: {
-                "set": "terrestrialbiocontrolreleaseentry_set",
-                "key": "biocontrol_agent__full"
-            },
-            ActivitySubtypes.Monitoring_Biocontrol_Dispersal_Plant_Terrestrial.name: {
-                "set": "terrestrialbiocontroldispersalmonitoringentry_set",
-                "key": "biocontrol_agent__full"
-            },
-            ActivitySubtypes.Monitoring_Biocontrol_Release_Plant_Terrestrial.name: {
-                "set": "terrestrialbiocontroldispersalmonitoringentry_set",
-                "key": "biocontrol_agent__full"
-            },
-        }
-        destination = mapping.get(obj.subtype)
-        if destination:
-            manager = getattr(obj, destination['set'])
-            agents = manager.values_list(destination['key'], flat=True)
-            return self.build_response_value(agents)
+        """Transform Biocontrol records into stringified agent names"""
+        config = self.PATH_TO_AGENT_MAP.get(obj.subtype)
+        if config:
+            entries = getattr(obj, config['set']).all()
+            agents = [getattr(getattr(e, config['key']), 'full', None) for e in entries]
+            return self.build_response_value(set(agents))
+        return None
 
-    def to_representation(self, obj):
-        rep = super().to_representation(obj)
-        rep['project_code'] = ", ".join(rep.get('project_code', [])) or None
-        rep['jurisdiction_display'] = ", ".join(rep.get('jurisdiction_display', [])) or None
-        rep['agency'] = ", ".join(rep.get('agency', [])) or None
-        return rep
+    def get_jurisdiction_display(self, obj):
+        # Accessing prefetched data in memory
+        items = [f"{j.jurisdiction.full} ({j.percent_covered}%)" for j in obj.jurisdiction_set.all()]
+        return ", ".join(items) or None
+
+    def get_project_code(self, obj):
+        return ", ".join([p.description for p in obj.projectcode_set.all()]) or None
+
+    def get_agency(self, obj):
+        return ", ".join([a.agency.full for a in obj.fundingagency_set.all()]) or None
+
+    def get_updated_by(self, obj):
+        # TODO: Update when Auditing is added
+        return obj.created_by

--- a/api-rework/invasives/api/urls.py
+++ b/api-rework/invasives/api/urls.py
@@ -5,6 +5,7 @@ from api.viewsets.activity import ActivityViewSet
 from api.viewsets.code import CodeViewSet
 from api.viewsets.migration import MigrationStatusViewSet
 from api.viewsets.ids_within_bounds import IdsWithinBoundsViewSet
+from api.viewsets.recordset_rows import RecordsetRowsViewSet
 
 from api.protocol.activity.api import router as activity_router
 
@@ -16,6 +17,7 @@ ROUTER.register(r"activities", ActivityViewSet, "activity")
 ROUTER.register(r"codes", CodeViewSet, "code")
 ROUTER.register(r"migrations", MigrationStatusViewSet, "migration")
 ROUTER.register(r"ids-within-bounds", IdsWithinBoundsViewSet, "ids-within-bounds")
+ROUTER.register(r"recordset-rows", RecordsetRowsViewSet, "recordsets")
 
 ninja_api = NinjaAPI()
 ninja_api.add_router("/activities", activity_router)

--- a/api-rework/invasives/api/viewsets/recordset_rows.py
+++ b/api-rework/invasives/api/viewsets/recordset_rows.py
@@ -1,0 +1,33 @@
+from rest_framework import viewsets, status
+from rest_framework.response import Response
+from api.serializers.activity_recordset_row import ActivityRecordsetRowSerializer
+from api.models.activity import Activity
+
+class RecordsetRowsViewSet(viewsets.GenericViewSet):
+    serializer_class = ActivityRecordsetRowSerializer
+    STEP = 20
+
+    def get_optimized_queryset(self):
+        return Activity.objects.all().prefetch_related(
+            'jurisdiction_set__jurisdiction',
+            'projectcode_set',
+            'fundingagency_set__agency',
+            'aquaticplantobservationentry_set__invasive_plant',
+            'terrestrialplantobservationentries_set__invasive_plant',
+            'aquaticplantmechanicaltreatmententry_set__invasive_plant',
+            'terrestrialplantmechanicaltreatmententry_set__invasive_plant',
+            'terrestrialbiocontroldispersalmonitoringentry_set__invasive_plant',
+            'terrestrialbiocontrolreleaseentry_set__invasive_plant',
+            'aquatictreatmentmonitoringentry_set__invasive_plant',
+            'terrestrialtreatmentmonitoringentry_set__invasive_plant',
+            'terrestrialbiocontrolcollectionentry_set__invasive_plant',
+            'terrestrialbiocontrolcollectionentry_set__biological_agent',
+            'terrestrialbiocontrolreleaseentry_set__biocontrol_agent',
+            'terrestrialbiocontroldispersalmonitoringentry_set__biocontrol_agent',
+            # TODO: Add Chemical Treatment Entry Destinations
+        ).order_by('id')[:self.STEP]
+
+    def create(self, _):
+        queryset = self.get_optimized_queryset()
+        serializer = ActivityRecordsetRowSerializer(queryset, many=True)
+        return Response(data=serializer.data, status=status.HTTP_200_OK)

--- a/api-rework/invasives/api/viewsets/recordset_rows.py
+++ b/api-rework/invasives/api/viewsets/recordset_rows.py
@@ -3,29 +3,34 @@ from rest_framework.response import Response
 from api.serializers.activity_recordset_row import ActivityRecordsetRowSerializer
 from api.models.activity import Activity
 
+
 class RecordsetRowsViewSet(viewsets.GenericViewSet):
     serializer_class = ActivityRecordsetRowSerializer
     STEP = 20
 
     def get_optimized_queryset(self):
-        return Activity.objects.all().prefetch_related(
-            'jurisdiction_set__jurisdiction',
-            'projectcode_set',
-            'fundingagency_set__agency',
-            'aquaticplantobservationentry_set__invasive_plant',
-            'terrestrialplantobservationentries_set__invasive_plant',
-            'aquaticplantmechanicaltreatmententry_set__invasive_plant',
-            'terrestrialplantmechanicaltreatmententry_set__invasive_plant',
-            'terrestrialbiocontroldispersalmonitoringentry_set__invasive_plant',
-            'terrestrialbiocontrolreleaseentry_set__invasive_plant',
-            'aquatictreatmentmonitoringentry_set__invasive_plant',
-            'terrestrialtreatmentmonitoringentry_set__invasive_plant',
-            'terrestrialbiocontrolcollectionentry_set__invasive_plant',
-            'terrestrialbiocontrolcollectionentry_set__biological_agent',
-            'terrestrialbiocontrolreleaseentry_set__biocontrol_agent',
-            'terrestrialbiocontroldispersalmonitoringentry_set__biocontrol_agent',
-            # TODO: Add Chemical Treatment Entry Destinations
-        ).order_by('id')[:self.STEP]
+        return (
+            Activity.objects.all()
+            .prefetch_related(
+                "jurisdiction_set__jurisdiction",
+                "projectcode_set",
+                "fundingagency_set__agency",
+                "aquaticplantobservationentry_set__invasive_plant",
+                "terrestrialplantobservationentries_set__invasive_plant",
+                "aquaticplantmechanicaltreatmententry_set__invasive_plant",
+                "terrestrialplantmechanicaltreatmententry_set__invasive_plant",
+                "terrestrialbiocontroldispersalmonitoringentry_set__invasive_plant",
+                "terrestrialbiocontrolreleaseentry_set__invasive_plant",
+                "aquatictreatmentmonitoringentry_set__invasive_plant",
+                "terrestrialtreatmentmonitoringentry_set__invasive_plant",
+                "terrestrialbiocontrolcollectionentry_set__invasive_plant",
+                "terrestrialbiocontrolcollectionentry_set__biological_agent",
+                "terrestrialbiocontrolreleaseentry_set__biocontrol_agent",
+                "terrestrialbiocontroldispersalmonitoringentry_set__biocontrol_agent",
+                # TODO: Add Chemical Treatment Entry Destinations
+            )
+            .order_by("id")[: self.STEP]
+        )
 
     def create(self, _):
         queryset = self.get_optimized_queryset()

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/Form.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/Form.tsx
@@ -13,7 +13,6 @@ import {
   noFutureDate,
   noRepeatKey
 } from 'UI/Features/Records/Activity/forms/common/validators';
-import { MouseEvent, TouchEvent, useState } from 'react';
 import ArrayField from 'UI/Features/Records/Activity/forms/common/ArrayField/ArrayField';
 import SubtypeComposite from 'UI/Features/Records/Activity/forms/plant/subtype-component/SubtypeComposite';
 import { Width } from 'UI/Features/Records/Activity/forms/common/utils';
@@ -43,7 +42,6 @@ const Form = () => {
   } = useFormContext<FormSchema>();
   const dispatch = useDispatch();
   const codes = useSelector((state) => state.ActivityPage.formCodes);
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   /**
    * @desc Initiate Mouseclick on Polygon draw icon, alert user to start drawing
    */
@@ -52,9 +50,6 @@ const Form = () => {
     dispatch(Alerts.create(tripAlertMessages.drawToolClicked));
   };
 
-  const handleOpenMenu = (evt: MouseEvent<HTMLElement> | TouchEvent<HTMLElement>) => {
-    setAnchorEl(evt.currentTarget);
-  };
   /**
    * @desc Handler for creating a manual UTM Entry initiated by user
    */

--- a/app/src/UI/Features/Records/Activity/forms/plant/builders/getObservationTerrestrialPlantSubtypeFields.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/builders/getObservationTerrestrialPlantSubtypeFields.ts
@@ -21,7 +21,7 @@ const getObservationPlantTerrestrialSubtypeFields = (): TerrestrialPlantObservat
   aspect: '',
   slope_percent: '',
   soil_texture: '',
-  specific_use: '',
+  specific_uses: [],
   suitable_for_biocontrol_agent: ''
 });
 

--- a/app/src/UI/Features/Records/Activity/forms/plant/interfaces/TerrestrialObservation.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/interfaces/TerrestrialObservation.ts
@@ -32,7 +32,7 @@ interface TerrestrialPlantObservationSchema extends BaseForm {
     aspect: string;
     slope_percent: string;
     soil_texture: string;
-    specific_use: string;
+    specific_uses: Array<string>;
     suitable_for_biocontrol_agent: string;
   };
 }

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-terrestrial/ObservationPlantTerrestrial.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/observation-plant-terrestrial/ObservationPlantTerrestrial.tsx
@@ -10,6 +10,7 @@ import { TerrestrialPlantObservationSchema } from 'UI/Features/Records/Activity/
 import tooltips from 'UI/Features/Records/Activity/forms/plant/content/tooltips';
 import getDefaultFormState from 'UI/Features/Records/Activity/forms/plant/builders/getDefaultState';
 import { ActivitySubtypes } from 'sharedAPI';
+import MultiSelect from 'UI/Features/Records/Activity/forms/common/MultiSelect/MultiSelect';
 
 const ObservationPlantTerrestrial = () => {
   const ROOT = 'subtype_data';
@@ -34,10 +35,10 @@ const ObservationPlantTerrestrial = () => {
           width={Width.Half}
           name={`${ROOT}.soil_texture`}
         />
-        <SingleSelect
+        <MultiSelect
           label={'Specific Use'}
           options={codes?.SpecificUseCode}
-          name={`${ROOT}.specific_use`}
+          name={`${ROOT}.specific_uses`}
           required
           tooltip={tooltips.plant.terrestrial_specific_use}
           rules={{ required: true }}


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Start of building a Recordset Row Serializer 
    - uses Dynamic build for views vs baked in details that weren't being updated 
- Scaffolding for Endpoint to fetch Recordset Rows
-  Convert SingleSelect to MultiSelect for `specific_uses` 
- Correct `specific_use` to `specific_uses`

New Response average [no filters] ~400ms 
Old Response Average [no filters] ~600ms