### PR TITLE
Add Chemical Calculations

### DIFF
--- a/app/src/UI/Features/Records/Activity/forms/plant/interfaces/ChemicalTreatmentContext.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/interfaces/ChemicalTreatmentContext.ts
@@ -18,7 +18,6 @@ interface ApplicationRateHerbicide extends BaseHerbicide {
 interface ProductApplicationRate {
   herbicide: Array<ApplicationRateHerbicide>;
   delivery_rate: number;
-  application_rate: number;
   amount_mix_used_l: number;
 }
 
@@ -45,8 +44,10 @@ type ChemicalTreatmentContext =
   | ChemicalContextApplicationRate;
 
 export type {
+  BaseChemicalContext,
   ChemicalTreatmentContext,
   TankMixChemicalContext,
   ChemicalContextDilution,
-  ChemicalContextApplicationRate
+  ChemicalContextApplicationRate,
+  ApplicationRateHerbicide
 };

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlantCalculations.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlantCalculations.tsx
@@ -1,0 +1,149 @@
+import { useMemo } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+import Fieldset from 'UI/Features/Records/Activity/forms/common/Fieldset/Fieldset';
+import {
+  AquaticChemicalTreatmentSchema,
+  TerrestrialChemicalTreatmentSchema
+} from 'UI/Features/Records/Activity/forms/plant/interfaces';
+import {
+  mSpecie_mLGHerb_spray_usingProdAppRate,
+  mSpecie_sGHerb_spray_usingDilutionPercent,
+  mSpecie_sGHerb_spray_usingProdAppRate,
+  mSpecie_sLHerb_spray_usingDilutionPercent,
+  mSpecie_sLHerb_spray_usingProdAppRate,
+  sSpecie_sLHerb_direct_usingDilutionPercent,
+  sSpecie_sLHerb_spray_usingDilutionPercent,
+  sSpecie_sLHerb_spray_usingProdAppRate
+} from './calculations';
+import { useSelector } from 'utils/use_selector';
+
+type ChemTreatment = AquaticChemicalTreatmentSchema | TerrestrialChemicalTreatmentSchema;
+enum CalculationType {
+  Dilution = 'Dilution',
+  ApplicationRate = 'Product Application Rate'
+}
+const TreatmentChemicalPlantCalculations = () => {
+  const performCalculation = () => {
+    const NUM_INVASIVE_PLANTS = plants_treated.length;
+    const NUM_HERBICIDES = herbicide.length;
+
+    if (!NUM_HERBICIDES || !NUM_INVASIVE_PLANTS) return 'Violation: Missing Herbicides and/or Invasive Plants';
+
+    const isMultipleHerbicides = NUM_HERBICIDES > 1;
+    const isMultiplePlants = NUM_INVASIVE_PLANTS > 1;
+
+    if (tank_mix && !isMultipleHerbicides) return 'Violation: Tank mix requires multiple herbicides';
+    if (tank_mix && isMultipleHerbicides) {
+      return mSpecie_mLGHerb_spray_usingProdAppRate(
+        area_m,
+        amount_mix_used_l,
+        delivery_rate,
+        plants_treated,
+        herbicide
+      );
+    }
+    if (isMultipleHerbicides) return 'Violation: Only tank mix may have multiple herbicides.';
+
+    const { type: herbicide_type, application_rate } = herbicide[0];
+    const applicationMethod = (() => {
+      const isSprayMethod = codes.ChemicalApplicationMethodSprayCode.some(({ code }) => code === application_method);
+      if (isSprayMethod) return 'Spray';
+      const isDirectMethod = codes.ChemicalApplicationMethodDirectCode.some(({ code }) => code === application_method);
+      if (isDirectMethod) return 'Direct';
+    })();
+    const isHerbicideLiquid = herbicide_type === 'liquid';
+    const isHerbicideSolid = herbicide_type === 'granular';
+    const isApplicationCalculation = calculation_type === CalculationType.ApplicationRate;
+    const isDilutionCalculation = calculation_type === CalculationType.Dilution;
+
+    if (applicationMethod === 'Direct' && !isMultiplePlants && isHerbicideLiquid && isDilutionCalculation) {
+      return sSpecie_sLHerb_direct_usingDilutionPercent(area_m, amount_mix_used_l, dilution_percent, area_treated_sqm);
+    } else if (applicationMethod !== 'Spray') {
+      return 'The information provided is an invalid scenario';
+    }
+
+    if (!isMultiplePlants && isHerbicideLiquid && isApplicationCalculation) {
+      return sSpecie_sLHerb_spray_usingProdAppRate(area_m, application_rate, amount_mix_used_l, delivery_rate);
+    } else if (!isMultiplePlants && isHerbicideLiquid && isDilutionCalculation) {
+      return sSpecie_sLHerb_spray_usingDilutionPercent(area_m, amount_mix_used_l, dilution_percent, area_treated_sqm);
+    } else if (isHerbicideSolid && isApplicationCalculation) {
+      return mSpecie_sGHerb_spray_usingProdAppRate(
+        area_m,
+        application_rate,
+        amount_mix_used_l,
+        delivery_rate,
+        plants_treated
+      );
+    } else if (isHerbicideSolid && isDilutionCalculation) {
+      return mSpecie_sGHerb_spray_usingDilutionPercent(
+        area_m,
+        amount_mix_used_l,
+        dilution_percent,
+        area_treated_sqm,
+        plants_treated
+      );
+    } else if (isMultiplePlants && isHerbicideLiquid && isApplicationCalculation) {
+      return mSpecie_sLHerb_spray_usingProdAppRate(
+        area_m,
+        application_rate,
+        amount_mix_used_l,
+        delivery_rate,
+        plants_treated
+      );
+    } else if (isMultiplePlants && isHerbicideLiquid && isDilutionCalculation) {
+      return mSpecie_sLHerb_spray_usingDilutionPercent(
+        area_m,
+        amount_mix_used_l,
+        dilution_percent,
+        area_treated_sqm,
+        plants_treated
+      );
+    }
+    return 'The information provided is an invalid scenario';
+  };
+
+  const codes = useSelector((state) => state.ActivityPage.formCodes);
+  const { control, watch } = useFormContext<ChemTreatment>();
+
+  const {
+    tank_mix,
+    application_method,
+    calculation_type,
+    herbicide,
+    plants_treated,
+    amount_mix_used_l,
+    dilution_percent,
+    area_treated_sqm,
+    delivery_rate
+  } = useWatch<ChemTreatment>({
+    control,
+    name: 'subtype_data.treatment_context'
+  });
+  const area_m = watch('area_m');
+
+  const calculations = useMemo(() => {
+    try {
+      return performCalculation();
+    } catch (e) {
+      console.error(e);
+    }
+  }, [
+    area_m,
+    tank_mix,
+    application_method,
+    calculation_type,
+    herbicide,
+    plants_treated,
+    amount_mix_used_l,
+    dilution_percent,
+    area_treated_sqm
+  ]);
+
+  return (
+    <Fieldset label={'Calculations'}>
+      <pre style={{ textAlign: 'left' }}>{JSON.stringify(calculations, null, 2)}</pre>
+    </Fieldset>
+  );
+};
+
+export default TreatmentChemicalPlantCalculations;

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlantDetails.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlantDetails.tsx
@@ -246,20 +246,18 @@ const TreatmentChemicalPlantDetails = () => {
         </>
       )}
       {calculation_type === CalculationType.ApplicationRate && (
-        <>
-          <NumberInput
-            label={`Delivery Rate of Mix (L)`}
-            width={Width.Half}
-            tooltip={tooltips.plant.chemical.calculation_fields.delivery_rate_of_mix}
-            required
-            error={get(errors, 'subtype_data.treatment_context.delivery_rate')}
-            {...register('subtype_data.treatment_context.delivery_rate', {
-              required: true,
-              valueAsNumber: true,
-              validate: (val) => greaterThan(val, 0)
-            })}
-          />
-        </>
+        <NumberInput
+          label={`Delivery Rate of Mix (L)`}
+          width={Width.Half}
+          tooltip={tooltips.plant.chemical.calculation_fields.delivery_rate_of_mix}
+          required
+          error={get(errors, 'subtype_data.treatment_context.delivery_rate')}
+          {...register('subtype_data.treatment_context.delivery_rate', {
+            required: true,
+            valueAsNumber: true,
+            validate: (val) => greaterThan(val, 0)
+          })}
+        />
       )}
       <TreatmentChemicalPlantCalculations />
     </Fieldset>

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlantDetails.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlantDetails.tsx
@@ -23,6 +23,7 @@ import {
   greaterThanEqual,
   noRepeatKey
 } from 'UI/Features/Records/Activity/forms/common/validators';
+import TreatmentChemicalPlantCalculations from './TreatmentChemicalPlantCalculations';
 
 type ChemTreatment = AquaticChemicalTreatmentSchema | TerrestrialChemicalTreatmentSchema;
 
@@ -88,6 +89,7 @@ const TreatmentChemicalPlantDetails = () => {
 
   // Trigger Validation on Herbicides when tank mix changes (modifies maxLength Constraints)
   useEffect(() => {
+    if (!isDirty) return;
     trigger('subtype_data.treatment_context.herbicide');
   }, [tank_mix]);
 
@@ -107,7 +109,6 @@ const TreatmentChemicalPlantDetails = () => {
       unregister('subtype_data.treatment_context.dilution_percent');
       unregister('subtype_data.treatment_context.area_treated_sqm');
     } else if (calculation_type === CalculationType.Dilution) {
-      unregister('subtype_data.treatment_context.application_rate');
       unregister('subtype_data.treatment_context.delivery_rate');
     }
   }, [calculation_type]);
@@ -202,7 +203,7 @@ const TreatmentChemicalPlantDetails = () => {
       />
       <NumberInput
         label={`Amount of Mix Used (L)`}
-        width={Width.Third}
+        width={Width.Half}
         tooltip={tooltips.plant.chemical.calculation_fields.amount_mix_used}
         required
         error={get(errors, 'subtype_data.treatment_context.amount_mix_used_l')}
@@ -217,7 +218,7 @@ const TreatmentChemicalPlantDetails = () => {
         <>
           <NumberInput
             label={`Dilution (%)`} // Figure out G/L measurement
-            width={Width.Third}
+            width={Width.Half}
             tooltip={tooltips.plant.chemical.calculation_fields.dilution_percent}
             required
             error={get(errors, 'subtype_data.treatment_context.dilution_percent')}
@@ -232,7 +233,7 @@ const TreatmentChemicalPlantDetails = () => {
           />
           <NumberInput
             label={`Area Treated (m²)`}
-            width={Width.Third}
+            width={Width.Half}
             tooltip={tooltips.plant.chemical.calculation_fields.area_treated_msq}
             error={get(errors, 'subtype_data.treatment_context.area_treated_sqm')}
             required
@@ -248,7 +249,7 @@ const TreatmentChemicalPlantDetails = () => {
         <>
           <NumberInput
             label={`Delivery Rate of Mix (L)`}
-            width={Width.Third}
+            width={Width.Half}
             tooltip={tooltips.plant.chemical.calculation_fields.delivery_rate_of_mix}
             required
             error={get(errors, 'subtype_data.treatment_context.delivery_rate')}
@@ -258,20 +259,9 @@ const TreatmentChemicalPlantDetails = () => {
               validate: (val) => greaterThan(val, 0)
             })}
           />
-          <NumberInput
-            label={`Product Application Rate`} // TODO: Add Units
-            width={Width.Third}
-            tooltip={tooltips.plant.chemical.calculation_fields.application_rate}
-            required
-            error={get(errors, 'subtype_data.treatment_context.application_rate')}
-            {...register('subtype_data.treatment_context.application_rate', {
-              required: true,
-              valueAsNumber: true,
-              validate: (val) => greaterThan(val, 0)
-            })}
-          />
         </>
       )}
+      <TreatmentChemicalPlantCalculations />
     </Fieldset>
   );
 };

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/calculations.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/calculations.ts
@@ -1,0 +1,341 @@
+/**
+ * GENERAL INFO on function names:
+ *  - sSpecie: single specie
+ *  - mSpecies: multiple species
+ *  - sHerb: single herbicide
+ *  - mHerb: multiple herbicides
+ *  - LHerb: liquid herbicide
+ *  - GHerb: granular herbicide
+ *  - mLGHerb: liquid and granular herbicides (tank_mix only)
+ *  - spray: spray application method
+ *  - direct: direct application method
+ *  - usingProdAppRate: calculations are based on product_application_rate input
+ *  - usingDilutionPercent: calculations are based on dilution input
+ *
+ *  FORMATTING : {specie}_{herbicide}_{method}_{using}
+ */
+import {
+  ApplicationRateHerbicide,
+  BaseChemicalContext
+} from 'UI/Features/Records/Activity/forms/plant/interfaces/ChemicalTreatmentContext';
+
+const HECTARE_TO_SQM = 10000;
+const trunc = (value: number) => Number(value.toFixed(10));
+
+/**
+ *    **Application Method**: Spray
+ *
+ *    **Calculation Type**: Product Application Rate
+ *
+ *    **Herbicides**: x1 Liquid
+ *
+ *    **Plants**: One
+ *
+ *    **Scenario**: One
+ */
+const sSpecie_sLHerb_spray_usingProdAppRate = (
+  area: number,
+  product_application_rate_lha: number,
+  amount_of_mix: number,
+  delivery_rate_of_mix: number
+): object => {
+  console.debug('Calculation scenario: 1');
+  const dilution = (product_application_rate_lha / delivery_rate_of_mix) * 100;
+  const area_treated_sqm = (amount_of_mix / delivery_rate_of_mix) * HECTARE_TO_SQM;
+  const area_covered_pct = trunc((area_treated_sqm / area) * 100);
+  const undiluted_herbicide_used_l = trunc((dilution / 100) * amount_of_mix);
+
+  return {
+    dilution: trunc(dilution),
+    area_treated_sqm: trunc(area_treated_sqm),
+    area_covered_pct,
+    undiluted_herbicide_used_l
+  };
+};
+
+/**
+ *    **Application Method**: Spray
+ *
+ *    **Calculation Type**: Product Application Rate
+ *
+ *    **Herbicides**: x1 Liquid
+ *
+ *    **Plants** : Two+
+ *
+ *    **Scenario**: Two
+ */
+const mSpecie_sLHerb_spray_usingProdAppRate = (
+  area: number,
+  product_application_rate_lha: number,
+  amount_of_mix: number,
+  delivery_rate_of_mix: number,
+  plant_treated: BaseChemicalContext['plants_treated']
+): object => {
+  console.debug('Calculation scenario: 2');
+  const dilution = (product_application_rate_lha / delivery_rate_of_mix) * 100;
+
+  const species = plant_treated.map((plant, index) => {
+    const amount_of_mix_used = trunc(amount_of_mix * (plant.percent_covered / 100));
+    const area_treated_hectares = ((amount_of_mix / delivery_rate_of_mix) * plant.percent_covered) / 100;
+    const area_treated_by_plant = area_treated_hectares * HECTARE_TO_SQM;
+    const area_covered_pct = trunc((area_treated_by_plant / area) * 100);
+    const undiluted_herbicide_used_l = trunc((dilution / 100) * amount_of_mix * (plant.percent_covered / 100));
+    return {
+      index,
+      amount_of_mix_used,
+      area_covered_pct,
+      area_treates_sqm: trunc(area_treated_hectares * HECTARE_TO_SQM),
+      undiluted_herbicide_used_l
+    };
+  });
+  return {
+    dilution: trunc(dilution),
+    invasive_plants: species
+  };
+};
+
+/**
+ *    **Application Method**: Spray
+ *
+ *    **Calculation Type**: Dilution
+ *
+ *    **Herbicides**: x1 Liquid
+ *
+ *    **Plants**: One
+ *
+ *    **Scenario**: Three
+ */
+const sSpecie_sLHerb_spray_usingDilutionPercent = (
+  area: number,
+  amount_of_mix: number,
+  dilution: number,
+  area_treated_sqm: number
+) => {
+  console.debug('Calculation scenario: 3');
+  const area_treated_hectares = trunc(area_treated_sqm / HECTARE_TO_SQM);
+  const area_covered_pct = trunc((area_treated_sqm / area) * 100);
+  const undiluted_herbicide_used_l = trunc((dilution / 100) * amount_of_mix);
+  return {
+    area_treated_sqm: area_treated_hectares * HECTARE_TO_SQM,
+    area_covered_pct,
+    undiluted_herbicide_used_l
+  };
+};
+
+/**
+ *    **Application Method**: Spray
+ *
+ *    **Calculation Type**: Dilution
+ *
+ *    **Herbicides**: x1 Liquid
+ *
+ *    **Plants** : Two+
+ *
+ *    **Scenario**: Four
+ */
+const mSpecie_sLHerb_spray_usingDilutionPercent = (
+  area: number,
+  amount_of_mix: number,
+  dilution: number,
+  area_treated_sqm: number,
+  plants_treated: BaseChemicalContext['plants_treated']
+) => {
+  console.debug('Calculation scenario: 4');
+  const species = plants_treated.map((plant, index) => {
+    const plant_area_treated_sqm = area_treated_sqm * (plant.percent_covered / 100);
+    const percentage_area_covered = trunc((plant_area_treated_sqm / area) * 100);
+    const undiluted_herbicide_used_l = trunc((dilution / 100) * amount_of_mix * (plant.percent_covered / 100));
+    return {
+      index,
+      area_treated_sqm: plant_area_treated_sqm,
+      percentage_area_covered: percentage_area_covered,
+      undiluted_herbicide_used_l: undiluted_herbicide_used_l
+    };
+  });
+  return {
+    area_treated_sqm,
+    invasive_plants: species
+  };
+};
+
+/**
+ *    **Application Method**: Spray
+ *
+ *    **Calculation Type**: Product Application Rate
+ *
+ *    **Herbicides**: x1 Granular
+ *
+ *    **Plants** : Two+
+ *
+ *    **Scenario**: Five
+ */
+const mSpecie_sGHerb_spray_usingProdAppRate = (
+  area_m: number,
+  product_application_rate_lha: number,
+  amount_mix_used_l: number,
+  delivery_rate: number,
+  plants_treated: BaseChemicalContext['plants_treated']
+) => {
+  console.debug('Calculation scenario: 5');
+  const dilution = (product_application_rate_lha / 1000 / delivery_rate) * 100;
+
+  const species = plants_treated.map((plant, index) => {
+    const amount_of_mix_used = amount_mix_used_l * (plant.percent_covered / 100);
+    const area_treated_sqm = (((amount_mix_used_l / delivery_rate) * plant.percent_covered) / 100) * HECTARE_TO_SQM;
+    const percentage_area_covered = trunc((area_treated_sqm / area_m) * 100);
+    const undiluted_herbicide_used_l = trunc((dilution / 100) * amount_mix_used_l * (plant.percent_covered / 100));
+    return {
+      index,
+      amount_of_mix_used: trunc(amount_of_mix_used),
+      area_treated_sqm: trunc(area_treated_sqm),
+      percentage_area_covered,
+      undiluted_herbicide_used_l
+    };
+  });
+  return {
+    dilution: trunc(dilution),
+    invasive_plants: species
+  };
+};
+
+/**
+ *    **Application Method**: Spray
+ *
+ *    **Calculation Type**: Dilution
+ *
+ *    **Herbicides**: x1 Granular
+ *
+ *    **Plants** : One+
+ *
+ *    **Scenario**: Six
+ */
+const mSpecie_sGHerb_spray_usingDilutionPercent = (
+  area_m: number,
+  amount_mix_used_l: number,
+  dilution_percent: number,
+  area_treated_sqm: number,
+  plants_treated: BaseChemicalContext['plants_treated']
+) => {
+  console.debug('Calculation scenario: 6');
+  const species = plants_treated.map((plant, index) => {
+    const area_treated_by_plant = area_treated_sqm * (plant.percent_covered / 100);
+    const percentage_area_covered = trunc((area_treated_by_plant / area_m) * 100);
+    const undiluted_herbicide_used_l = trunc(
+      (dilution_percent / 100) * amount_mix_used_l * (plant.percent_covered / 100)
+    );
+    return {
+      index: index,
+      area_treated_sqm: trunc(area_treated_by_plant),
+      percentage_area_covered,
+      undiluted_herbicide_used_l
+    };
+  });
+  return {
+    area_treated_sqm: area_treated_sqm,
+    invasive_plants: species
+  };
+};
+
+/**
+ *    **Application Method**: Direct
+ *
+ *    **Calculation Type**: Dilution
+ *
+ *    **Herbicides**: x1 Liquid
+ *
+ *    **Plants** : One
+ *
+ *    **Scenario**: Seven
+ */
+const sSpecie_sLHerb_direct_usingDilutionPercent = (
+  area_m: number,
+  amount_mix_used_l: number,
+  dilution_percent: number,
+  area_treated_sqm: number
+) => {
+  console.debug('Calculation scenario: 7');
+  const area_covered_pct = trunc((area_treated_sqm / area_m) * 100);
+  const undiluted_herbicide_used_l = trunc((dilution_percent / 100) * amount_mix_used_l);
+  return {
+    area_treated_sqm,
+    area_covered_pct,
+    undiluted_herbicide_used_l
+  };
+};
+
+/**
+ *    **Application Method**: Spray
+ *
+ *    **Calculation Type**: Product Application Rate
+ *
+ *    **Herbicides**: Two+ Liquid or Solid
+ *
+ *    **Plants** : One+
+ *
+ *    **Scenario**: 8-11
+ */
+const mSpecie_mLGHerb_spray_usingProdAppRate = (
+  area_m: number,
+  amount_mix_used_l: number,
+  delivery_rate: number,
+  plants_treated: BaseChemicalContext['plants_treated'],
+  herbicide: ApplicationRateHerbicide[]
+) => {
+  console.debug('Calculation scenario: 8-10 (11)');
+  const outputInvPlantsArr: Array<OutputSpecie> = plants_treated.map(({ percent_covered }, plantIndex) => {
+    const amount_of_mix_used = amount_mix_used_l * (percent_covered / 100);
+    const area_treated_sqm = (amount_mix_used_l / delivery_rate) * (percent_covered / 100) * HECTARE_TO_SQM;
+    const area_covered_pct = (area_treated_sqm / area_m) * 100;
+    const herbicides = herbicide.map(({ application_rate, type }, herbIndex) => {
+      const dilution = (() => {
+        if (type === 'granular') return (application_rate / 1000 / delivery_rate) * 100;
+        return (application_rate / delivery_rate) * 100;
+      })();
+
+      const undiluted_herbicide_used_l = ((dilution / 100) * amount_mix_used_l * percent_covered) / 100;
+      const outputHerb: OutputHerb = {
+        dilution: trunc(dilution),
+        plantIndex,
+        herbIndex,
+        undiluted_herbicide_used_l: trunc(undiluted_herbicide_used_l),
+        product_application_rate: application_rate
+      };
+      return outputHerb;
+    });
+    return {
+      index: plantIndex,
+      amount_of_mix_used: trunc(amount_of_mix_used),
+      area_treated_sqm: trunc(area_treated_sqm),
+      area_covered_pct: trunc(area_covered_pct),
+      herbicides
+    };
+  });
+  return {
+    invasive_plants: outputInvPlantsArr
+  };
+};
+
+type OutputHerb = {
+  plantIndex: number;
+  herbIndex: number;
+  dilution: number;
+  undiluted_herbicide_used_l: number;
+  product_application_rate: number;
+};
+type OutputSpecie = {
+  index: number;
+  amount_of_mix_used: number;
+  area_treated_sqm: number;
+  area_covered_pct: number;
+  herbicides: Array<OutputHerb>;
+};
+export {
+  sSpecie_sLHerb_spray_usingProdAppRate,
+  mSpecie_sLHerb_spray_usingProdAppRate,
+  sSpecie_sLHerb_spray_usingDilutionPercent,
+  mSpecie_sLHerb_spray_usingDilutionPercent,
+  mSpecie_sGHerb_spray_usingProdAppRate,
+  mSpecie_sGHerb_spray_usingDilutionPercent,
+  sSpecie_sLHerb_direct_usingDilutionPercent,
+  mSpecie_mLGHerb_spray_usingProdAppRate
+};


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

Simplifies the Herbicide Calculations by making them more DRY and readable. Does not affect how the calculations are performed

Removed Hectares from responses, as the standard unit across the app is meters, and its an easily derived value where needed. This reduces payloads and redundancy.

## How was it tested
- Tested Every scenario between the original files and new ones, validating outputs matched
