### PR TITLE
Form Improvements - 6

### DIFF
--- a/app/src/UI/Features/Landing/Landing.tsx
+++ b/app/src/UI/Features/Landing/Landing.tsx
@@ -135,7 +135,7 @@ export const LandingComponent = () => {
                         <strong>Roles:</strong>
                       </p>
                       {roles.map((role) => (
-                        <p key={role.role_id}>{role.role_name}</p>
+                        <p key={role.role_id}>{role.role_description}</p>
                       ))}
                     </Box>
                   </Grid>

--- a/app/src/UI/Features/Records/Activity/forms/common/validators/greaterThanEqual.ts
+++ b/app/src/UI/Features/Records/Activity/forms/common/validators/greaterThanEqual.ts
@@ -1,5 +1,5 @@
 const greaterThanEqual = (val: number | string | undefined, min: number) => {
-  if (val == undefined) return true;
+  if (val == undefined || Number.isNaN(val)) return true;
   if (typeof val === 'string') {
     return val.length >= min || `Enter at least ${min} characters.`;
   }

--- a/app/src/UI/Features/Records/Activity/forms/common/validators/lessThanEqual.ts
+++ b/app/src/UI/Features/Records/Activity/forms/common/validators/lessThanEqual.ts
@@ -1,5 +1,6 @@
 const lessThanEqual = (val: number | string | undefined, max: number) => {
-  if (val == undefined) return true;
+  console.log(val);
+  if (val == undefined || Number.isNaN(val)) return true;
   if (typeof val === 'string') {
     return val.length <= max || `Maximum ${max} characters allowed.`;
   }

--- a/app/src/UI/Features/Records/Activity/forms/common/validators/lessThanEqual.ts
+++ b/app/src/UI/Features/Records/Activity/forms/common/validators/lessThanEqual.ts
@@ -1,5 +1,4 @@
 const lessThanEqual = (val: number | string | undefined, max: number) => {
-  console.log(val);
   if (val == undefined || Number.isNaN(val)) return true;
   if (typeof val === 'string') {
     return val.length <= max || `Maximum ${max} characters allowed.`;

--- a/app/src/UI/Features/Records/Activity/forms/common/validators/noRepeatKey.ts
+++ b/app/src/UI/Features/Records/Activity/forms/common/validators/noRepeatKey.ts
@@ -4,11 +4,7 @@
  * @param key Key to compare e.g. 'invasive_plant'
  * @param keyLabel Plain language representation of key to appear in error message e.g. 'Invasive Plant'
  */
-const noRepeatKey = <T extends Record<PropertyKey, unknown>>(
-  arr: T[],
-  key: keyof T,
-  keyLabel?: string
-): boolean | string => {
+const noRepeatKey = <T extends object>(arr: T[], key: keyof T, keyLabel?: string): boolean | string => {
   const seen = new Set();
 
   for (const entry of arr) {

--- a/app/src/UI/Features/Records/Activity/forms/plant/builders/getTreatmentChemicalPlantSubtypeFields.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/builders/getTreatmentChemicalPlantSubtypeFields.ts
@@ -1,9 +1,4 @@
-import {
-  AquaticChemicalTreatmentSchema,
-  TerrestrialChemicalTreatmentSchema
-} from 'UI/Features/Records/Activity/forms/plant/interfaces/';
-
-type ChemTreatment = AquaticChemicalTreatmentSchema | TerrestrialChemicalTreatmentSchema;
+import { ChemTreatment } from 'UI/Features/Records/Activity/forms/plant/interfaces/ChemTreatment';
 
 const getTreatmentChemicalPlantSubtypeFields = (): ChemTreatment['subtype_data'] => ({
   well_entries: [],

--- a/app/src/UI/Features/Records/Activity/forms/plant/hooks/useFieldPath.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/hooks/useFieldPath.ts
@@ -1,0 +1,18 @@
+import { FieldValues, Path } from 'react-hook-form';
+
+export const useFieldPath = <
+  T extends FieldValues,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  P extends string = any
+>(
+  basePath: P & Path<T>
+) => {
+  return {
+    getPath: <S extends string>(subPath: S): Path<T> => {
+      return `${basePath}.${subPath}` as Path<T>;
+    },
+    basePath: basePath as Path<T>
+  };
+};
+
+export default useFieldPath;

--- a/app/src/UI/Features/Records/Activity/forms/plant/hooks/useLocalStorage.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/hooks/useLocalStorage.tsx
@@ -1,0 +1,10 @@
+const useLocalStorage = (key: string) => {
+  const confirm = (): void => localStorage.setItem(key, 'true');
+  const decline = (): void => localStorage.setItem(key, 'false');
+  const get = (): string | null => localStorage.getItem(key);
+  const set = (val: string): void => localStorage.setItem(key, val);
+
+  return { get, set, confirm, decline };
+};
+
+export default useLocalStorage;

--- a/app/src/UI/Features/Records/Activity/forms/plant/hooks/useLocalStorage.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/hooks/useLocalStorage.tsx
@@ -4,7 +4,18 @@ const useLocalStorage = (key: string) => {
   const get = (): string | null => localStorage.getItem(key);
   const set = (val: string): void => localStorage.setItem(key, val);
 
-  return { get, set, confirm, decline };
+  /**
+   * @desc Cast localStorage value to boolean from string.
+   * @param key localStorage Key
+   */
+  const getConfirmation = (): boolean => {
+    const bool = localStorage.getItem(key);
+    if (bool === 'true') return true;
+    if (bool === 'false') return false;
+    return false;
+  };
+
+  return { get, set, confirm, decline, getConfirmation };
 };
 
 export default useLocalStorage;

--- a/app/src/UI/Features/Records/Activity/forms/plant/hooks/useLocalStorage.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/hooks/useLocalStorage.tsx
@@ -3,6 +3,7 @@ const useLocalStorage = (key: string) => {
   const decline = (): void => localStorage.setItem(key, 'false');
   const get = (): string | null => localStorage.getItem(key);
   const set = (val: string): void => localStorage.setItem(key, val);
+  const remove = (): void => localStorage.removeItem(key);
 
   /**
    * @desc Cast localStorage value to boolean from string.
@@ -15,7 +16,7 @@ const useLocalStorage = (key: string) => {
     return false;
   };
 
-  return { get, set, confirm, decline, getConfirmation };
+  return { get, set, confirm, decline, getConfirmation, remove };
 };
 
 export default useLocalStorage;

--- a/app/src/UI/Features/Records/Activity/forms/plant/interfaces/ChemTreatment.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/interfaces/ChemTreatment.ts
@@ -1,0 +1,6 @@
+import { AquaticChemicalTreatmentSchema } from './AquaticChemicalTreatment';
+import { TerrestrialChemicalTreatmentSchema } from './TerrestrialChemicalTreatment';
+
+type ChemTreatment = TerrestrialChemicalTreatmentSchema | AquaticChemicalTreatmentSchema;
+
+export type { ChemTreatment };

--- a/app/src/UI/Features/Records/Activity/forms/plant/interfaces/index.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/interfaces/index.ts
@@ -18,3 +18,4 @@ export type {
   ChemicalContextDilution,
   ChemicalContextApplicationRate
 } from './ChemicalTreatmentContext';
+export type { ChemTreatment } from './ChemTreatment';

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/HerbicideEntry.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/HerbicideEntry.tsx
@@ -1,22 +1,32 @@
-import { useEffect, useMemo } from 'react';
-import { FieldPath, get, useFormContext, useWatch } from 'react-hook-form';
+import { useEffect, useMemo, useState } from 'react';
+import { get, useFormContext, useWatch } from 'react-hook-form';
 import { useSelector } from 'utils/use_selector';
-import { AquaticChemicalTreatmentSchema } from 'UI/Features/Records/Activity/forms/plant/interfaces';
+import { ChemTreatment } from 'UI/Features/Records/Activity/forms/plant/interfaces';
 import SingleSelect from 'UI/Features/Records/Activity/forms/common/SingleSelect/SingleSelect';
 import NumberInput from 'UI/Features/Records/Activity/forms/common/NumberInput/NumberInput';
 import { greaterThan } from 'UI/Features/Records/Activity/forms/common/validators';
 import { CalculationType } from 'UI/Features/Records/Activity/forms/enums';
 import tooltips from 'UI/Features/Records/Activity/forms/plant/content/tooltips';
+import { HerbicideApplicationRates } from 'sharedAPI';
+import CheckboxUI from 'UI/Features/Records/Activity/forms/common/CheckboxUI/CheckboxUI';
+import useLocalStorage from 'UI/Features/Records/Activity/forms/plant/hooks/useLocalStorage';
+import useFieldPath from 'UI/Features/Records/Activity/forms/plant/hooks/useFieldPath';
 
 type PropTypes = {
   idx?: number;
   type: CalculationType;
 };
 
-/**
- * @desc Component Herbicide Entries in a Chemical Treatment Form.
- */
+/** @desc Component Herbicide Entries in a Chemical Treatment Form. */
 const HerbicideEntry = ({ idx, type }: PropTypes) => {
+  /** @desc Validates the Application Rate against the (if known) Max Product Application Rate for an herbicide */
+  const verifyApplicationRate = (val: number) => {
+    const maxRate = HerbicideApplicationRates?.[herbicideEntry.name];
+    if (!maxRate || !val || val <= maxRate) return true;
+    const full = herbicideCodes.find(({ code }) => code === herbicideEntry.name)?.full_name;
+    return `Application rate of ${full} exceeds maximum application rate of ${maxRate}L/ha`;
+  };
+
   enum HerbicideType {
     Granular = 'granular',
     Liquid = 'liquid'
@@ -24,25 +34,36 @@ const HerbicideEntry = ({ idx, type }: PropTypes) => {
 
   const {
     control,
-    unregister,
     register,
     setValue,
-    formState: { isDirty, errors }
-  } = useFormContext<AquaticChemicalTreatmentSchema>();
+    trigger,
+    formState: { isDirty, errors, disabled }
+  } = useFormContext<ChemTreatment>();
 
-  const herbicideEntry = useWatch({
-    control,
-    name: `subtype_data.treatment_context.herbicide.${idx}` as FieldPath<AquaticChemicalTreatmentSchema>
-  });
-
+  const { basePath, getPath } = useFieldPath<ChemTreatment>(`subtype_data.treatment_context.herbicide.${idx}`);
   const codes = useSelector((state) => state.ActivityPage.formCodes);
+  const herbicideEntry = useWatch({ control, name: basePath });
+  const productApplicationRateConsent = useLocalStorage(`applicationRateConsent-${idx}`);
+  const [userConfirmedApplicationRate, setUserConfirmedApplicationRate] = useState<boolean>(
+    productApplicationRateConsent.getConfirmation()
+  );
 
-  // Set Available Herbicide Codes based on Type
+  // Set Herbicide Codes based on Type
   const herbicideCodes = useMemo(() => {
     if (herbicideEntry.type === HerbicideType.Granular) return codes?.GranularHerbicideCode;
     if (herbicideEntry.type === HerbicideType.Liquid) return codes?.LiquidHerbicideCode;
     return [];
   }, [herbicideEntry?.type, codes]);
+
+  // Check if an Application Value exceeds the Allotted amount.
+  const doesProductApplicationRateRequireConfirmation = useMemo(() => {
+    if (disabled || !herbicideEntry.application_rate) return false;
+    const maximumApplicationRate = HerbicideApplicationRates?.[herbicideEntry.name];
+    const rateIsAboveLimit = Boolean(
+      maximumApplicationRate && herbicideEntry.application_rate > maximumApplicationRate
+    );
+    return rateIsAboveLimit;
+  }, [disabled, herbicideEntry?.application_rate, herbicideEntry.name]);
 
   // Clear Herbicide Codes if selection is no longer valid. (e.g. User changed from Solid -> Liquid)
   useEffect(() => {
@@ -50,28 +71,28 @@ const HerbicideEntry = ({ idx, type }: PropTypes) => {
     const currentSelectionNoLongerValid =
       herbicideEntry.name && !herbicideCodes.some(({ code }) => code === herbicideEntry.name);
     if (currentSelectionNoLongerValid) {
-      setValue(
-        `subtype_data.treatment_context.herbicide.${idx}.name` as FieldPath<AquaticChemicalTreatmentSchema>,
-        '',
-        { shouldDirty: true }
-      );
+      setValue(getPath('name'), '', { shouldDirty: true });
     }
   }, [herbicideCodes]);
 
-  // Remove Application Rate from Form Payload if Calculation Type changes to Dilution. (No longer applicable)
+  // Remove any previous confirmation if user changes fields
   useEffect(() => {
     if (!isDirty) return;
-    if (type === CalculationType.Dilution)
-      unregister(
-        `subtype_data.treatment_context.herbicide.${idx}.application_rate` as FieldPath<AquaticChemicalTreatmentSchema>
-      );
-  }, [type]);
+    setUserConfirmedApplicationRate(false);
+    productApplicationRateConsent.remove();
+  }, [herbicideEntry.name, herbicideEntry.code, herbicideEntry.application_rate, idx]);
+
+  // Refire Validation if user confirms/denies accuracy of field.
+  useEffect(() => {
+    if (!isDirty) return;
+    trigger(getPath('application_rate'));
+  }, [userConfirmedApplicationRate]);
 
   return (
     <>
       <SingleSelect
         label={'Herbicide Type'}
-        name={`subtype_data.treatment_context.herbicide.${idx}.type`}
+        name={getPath('type')}
         required
         tooltip={tooltips.plant.chemical.calculation_fields.herbicide_type}
         options={[
@@ -82,23 +103,45 @@ const HerbicideEntry = ({ idx, type }: PropTypes) => {
       />
       <SingleSelect
         label={'Herbicide'}
-        name={`subtype_data.treatment_context.herbicide.${idx}.name`}
+        name={getPath('name')}
         tooltip={tooltips.plant.chemical.calculation_fields.herbicide}
         noOptionsMessage="Select Herbicide Type First"
         options={herbicideCodes}
         rules={{ required: true }}
       />
       {type === CalculationType.ApplicationRate && (
-        <NumberInput
-          label={'Product Application Rate'}
-          tooltip={tooltips.plant.chemical.calculation_fields.application_rate}
-          required
-          error={get(errors, `subtype_data.treatment_context.herbicide.${idx}.application_rate`)}
-          {...register(
-            `subtype_data.treatment_context.herbicide.${idx}.application_rate` as FieldPath<AquaticChemicalTreatmentSchema>,
-            { required: true, valueAsNumber: true, validate: (val) => greaterThan(val, 0) }
+        <>
+          <NumberInput
+            label={'Product Application Rate'}
+            tooltip={tooltips.plant.chemical.calculation_fields.application_rate}
+            required
+            error={get(errors, getPath('application_rate'))}
+            {...register(getPath('application_rate'), {
+              required: true,
+              valueAsNumber: true,
+              shouldUnregister: true,
+              deps: [getPath('name')],
+              validate: {
+                minValue: (val) => greaterThan(val, 0),
+                verifyApplicationRate: (val) => userConfirmedApplicationRate || verifyApplicationRate(val)
+              }
+            })}
+          />
+          {doesProductApplicationRateRequireConfirmation && (
+            <CheckboxUI
+              label={`I verify that this application rate was intentionally applied and accurately recorded.`}
+              required
+              state={userConfirmedApplicationRate}
+              warningConfirmation
+              onChange={() => {
+                setUserConfirmedApplicationRate((prev) => {
+                  prev ? productApplicationRateConsent.remove() : productApplicationRateConsent.confirm();
+                  return !prev;
+                });
+              }}
+            />
           )}
-        />
+        </>
       )}
     </>
   );

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlant.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlant.tsx
@@ -26,7 +26,8 @@ import CheckboxUI from 'UI/Features/Records/Activity/forms/common/CheckboxUI/Che
 import { Fragment, useEffect, useState } from 'react';
 import TreatmentChemicalPlantDetails from './TreatmentChemicalPlantDetails';
 import useFilteredServiceLicenseCodes from 'UI/Features/Records/Activity/forms/plant/hooks/useFilteredServiceLicenseCodes';
-import useLocalStorage from '../../hooks/useLocalStorage';
+import useLocalStorage from 'UI/Features/Records/Activity/forms/plant/hooks/useLocalStorage';
+import useFieldPath from 'UI/Features/Records/Activity/forms/plant/hooks/useFieldPath';
 
 type ChemTreatment = AquaticChemicalTreatmentSchema | TerrestrialChemicalTreatmentSchema;
 
@@ -53,13 +54,15 @@ const TreatmentChemicalPlant = () => {
     setValue,
     formState: { isDirty, errors, disabled }
   } = useFormContext<ChemTreatment>();
+
+  const { getPath } = useFieldPath<ChemTreatment>('subtype_data');
   const codes = useSelector((state) => state.ActivityPage.formCodes);
   const wellsInArea = useSelector((state) => state.ActivityPage?.wellsInRecordArea);
 
-  const well_entries = watch('subtype_data.well_entries');
-  const ntz_bool = watch('subtype_data.ntz_reduction_bool');
-  const temp_c = watch('subtype_data.temperature_c');
-  const wind_speed = watch('subtype_data.wind_speed_kmh');
+  const well_entries = watch(getPath('well_entries'));
+  const ntz_bool = watch(getPath('ntz_reduction_bool'));
+  const temp_c = watch(getPath('temperature_c'));
+  const wind_speed = watch(getPath('wind_speed_kmh'));
 
   const temperatureConsent = useLocalStorage('isTemperatureAccurate');
   const windSpeedConsent = useLocalStorage('isWindSpeedAccurate');
@@ -96,26 +99,26 @@ const TreatmentChemicalPlant = () => {
   useEffect(() => {
     // Refire Temperature validation when confirmation changes
     if (!isDirty) return;
-    trigger('subtype_data.temperature_c');
+    trigger(getPath('temperature_c'));
   }, [userVerifiedTemperatureAccurate]);
 
   useEffect(() => {
     // Refire Temperature validation when confirmation changes
     if (!isDirty) return;
-    trigger('subtype_data.wind_speed_kmh');
+    trigger(getPath('wind_speed_kmh'));
   }, [userVerifiedWindspeedAccurate]);
 
   // Cleanup NTZ Reduction Rationale if Reduction is changed to False
   useEffect(() => {
     if (isDirty && !ntz_bool) {
-      setValue('subtype_data.rationale_for_ntz_reduction', '');
+      setValue(getPath('rationale_for_ntz_reduction'), '');
     }
   }, [ntz_bool]);
 
   // Update Nearest Wells when values change
   useEffect(() => {
     if (wellsInArea) {
-      setValue('subtype_data.well_entries', wellsInArea);
+      setValue(getPath('well_entries'), wellsInArea);
     }
   }, [wellsInArea]);
 
@@ -150,12 +153,12 @@ const TreatmentChemicalPlant = () => {
       {/* Weather Information */}
       <Fieldset label={'Weather Information'}>
         <NumberInput
-          error={get(errors, 'subtype_data.temperature_c')}
+          error={get(errors, getPath('temperature_c'))}
           label={'Temperature (C°)'}
           required
           tooltip={tooltips.plant.chemical.weather.temperature_c}
           width={Width.Half}
-          {...register('subtype_data.temperature_c', {
+          {...register(getPath('temperature_c'), {
             required: true,
             valueAsNumber: true,
             validate: {
@@ -168,12 +171,12 @@ const TreatmentChemicalPlant = () => {
           })}
         />
         <NumberInput
-          error={get(errors, 'subtype_data.wind_speed_kmh')}
+          error={get(errors, getPath('wind_speed_kmh'))}
           label={'Wind Speed (km/h)'}
           required
           tooltip={tooltips.plant.chemical.weather.wind_speed_kmh}
           width={Width.Half}
-          {...register('subtype_data.wind_speed_kmh', {
+          {...register(getPath('wind_speed_kmh'), {
             required: true,
             valueAsNumber: true,
             // If user verifies weather accurate, check for clearly accidental values (extra digits)
@@ -186,14 +189,14 @@ const TreatmentChemicalPlant = () => {
         />
         <SingleSelect
           label={'Wind Direction'}
-          name={'subtype_data.wind_direction'}
+          name={getPath('wind_direction')}
           options={CardinalDirection}
           required
           tooltip={tooltips.plant.chemical.weather.wind_direction}
           width={Width.Half}
           rules={{
             required: true,
-            deps: ['subtype_data.wind_speed_kmh'],
+            deps: [getPath('wind_speed_kmh')],
             validate: (direction, formValues) => {
               const windSpeed = formValues.subtype_data?.wind_speed_kmh;
               if (direction === 'NA' && windSpeed > 0) {
@@ -204,11 +207,17 @@ const TreatmentChemicalPlant = () => {
           }}
         />
         <NumberInput
-          error={get(errors, 'subtype_data.humidity')}
+          error={get(errors, getPath('humidity'))}
           label={'Humidity (%)'}
           tooltip={tooltips.plant.chemical.weather.humidity}
           width={Width.Half}
-          {...register('subtype_data.humidity', { valueAsNumber: true })}
+          {...register(getPath('humidity'), {
+            valueAsNumber: true,
+            validate: {
+              min: (val) => greaterThanEqual(val, 0),
+              max: (val) => lessThanEqual(val, 100)
+            }
+          })}
         />
         {shouldVerifyTemperatureAccuracy && (
           <CheckboxUI
@@ -246,7 +255,7 @@ const TreatmentChemicalPlant = () => {
       <Fieldset label={'Chemical Treatment Information'}>
         <SingleSelect
           label={'Service License Number and Company Name'}
-          name={'subtype_data.service_license_number'}
+          name={getPath('service_license_number')}
           options={serviceLicenseCodes}
           required
           rules={{ required: true }}
@@ -254,36 +263,36 @@ const TreatmentChemicalPlant = () => {
           width={Width.Half}
         />
         <TextInput
-          error={get(errors, 'subtype_data.pesticide_use_permit')}
+          error={get(errors, getPath('pesticide_use_permit'))}
           label={'Pesticide Use Permit'}
           tooltip={tooltips.plant.chemical.pesticide_use_permit}
           width={Width.Half}
-          {...register('subtype_data.pesticide_use_permit')}
+          {...register(getPath('pesticide_use_permit'))}
         />
         <SingleSelect
           label={'Pest Management Plan (PMP)'}
-          name={'subtype_data.pest_management_plan'}
+          name={getPath('pest_management_plan')}
           options={codes?.PestManagementPlan}
           tooltip={tooltips.plant.chemical.pest_management_plan}
           width={Width.Half}
           rules={{
-            deps: ['subtype_data.pest_management_plan_manual'],
+            deps: [getPath('pest_management_plan_manual')],
             validate: validatePMPSelection
           }}
         />
         <TextInput
-          error={get(errors, 'subtype_data.pest_management_plan_manual')}
+          error={get(errors, getPath('pest_management_plan_manual'))}
           label={'PMP # Not in Dropdown'}
           tooltip={tooltips.plant.chemical.pest_management_plan_manual}
           width={Width.Half}
-          {...register('subtype_data.pest_management_plan_manual', {
-            deps: ['subtype_data.pest_management_plan'],
+          {...register(getPath('pest_management_plan_manual'), {
+            deps: [getPath('pest_management_plan')],
             validate: validatePMPSelection
           })}
         />
         <SingleSelect
           label={'Treatment Notice Signs'}
-          name={'subtype_data.treatment_notice_signs'}
+          name={getPath('treatment_notice_signs')}
           options={YesNoUnknown}
           required
           rules={{ required: true }}
@@ -292,7 +301,7 @@ const TreatmentChemicalPlant = () => {
         />
         <SingleSelect
           label={'Precautionary Statement'}
-          name={'subtype_data.precautionary_statement'}
+          name={getPath('precautionary_statement')}
           options={codes?.ChemicalPrecautionaryStatement}
           required
           rules={{ required: true }}
@@ -300,22 +309,22 @@ const TreatmentChemicalPlant = () => {
           width={Width.Half}
         />
         <DateInput
-          error={get(errors, 'subtype_data.application_start_time')}
+          error={get(errors, getPath('application_start_time'))}
           includeTime
           label={'Application Start Time'}
           required
           width={Width.Half}
-          {...register('subtype_data.application_start_time', { required: true, validate: noFutureDate })}
+          {...register(getPath('application_start_time'), { required: true, validate: noFutureDate })}
         />
         <CheckboxInput
           label={'Additional/Unmapped Wells or Water License intakes within 30m'}
           tooltip={tooltips.plant.chemical.additional_unmapped_water}
           width={Width.Half}
-          {...register('subtype_data.additional_unmapped_well_water_bool')}
+          {...register(getPath('additional_unmapped_well_water_bool'))}
         />
         <RadioInput
           label={'NTZ Reduction'}
-          name={'subtype_data.ntz_reduction_bool'}
+          name={getPath('ntz_reduction_bool')}
           required
           rules={{ validate: (value) => value !== undefined || 'NTZ reduction is required' }}
           tooltip={tooltips.plant.chemical.required_under_license}
@@ -328,12 +337,12 @@ const TreatmentChemicalPlant = () => {
         {ntz_bool ? (
           <TextInput
             advisoryText="Only the PMP or permit holder may approve an NTZ reduction on public lands."
-            error={get(errors, 'subtype_data.rationale_for_ntz_reduction')}
+            error={get(errors, getPath('rationale_for_ntz_reduction'))}
             label={'Rationale for NTZ Reduction'}
             tooltip={tooltips.plant.chemical.required_under_license}
             required
             width={Width.Half}
-            {...register('subtype_data.rationale_for_ntz_reduction', { required: true })}
+            {...register(getPath('rationale_for_ntz_reduction'), { required: true })}
           />
         ) : (
           <FormSpacer width={Width.Half} />
@@ -344,7 +353,7 @@ const TreatmentChemicalPlant = () => {
       <Fieldset label={'Pest Injury Threshold Determination'}>
         <RadioInput
           label={'Choose either option'}
-          name={'subtype_data.pest_injury_threshold_determination_bool'}
+          name={getPath('pest_injury_threshold_determination_bool')}
           required
           rules={{ validate: (value) => value !== undefined || 'NTZ reduction is required' }}
           tooltip={tooltips.plant.chemical.required_under_license}

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlant.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlant.tsx
@@ -67,8 +67,12 @@ const TreatmentChemicalPlant = () => {
     Entry Policy: Out-of-range values (temperature, wind speed) are permitted only if the user has manually flagged them as accurate.
     This prevents data entry errors without blocking edge-case submissions.
   */
-  const [isTemperatureAccurate, setIsTemperatureAccurate] = useState<boolean>(temperatureConsent.getConfirmation());
-  const [isWindSpeedAccurate, setIsWindSpeedAccurate] = useState<boolean>(windSpeedConsent.getConfirmation());
+  const [userVerifiedTemperatureAccurate, setUserVerifiedTemperatureAccurate] = useState<boolean>(
+    temperatureConsent.getConfirmation()
+  );
+  const [userVerifiedWindspeedAccurate, setUserVerifiedWindspeedAccurate] = useState<boolean>(
+    windSpeedConsent.getConfirmation()
+  );
   const { serviceLicenseCodes } = useFilteredServiceLicenseCodes(disabled);
 
   const shouldVerifyWindSpeedAccuracy = !disabled && wind_speed != undefined && wind_speed > MAX_WIND_SPEED;
@@ -78,28 +82,28 @@ const TreatmentChemicalPlant = () => {
   useEffect(() => {
     // Uncheck confirmation if temperature is changed
     if (!isDirty) return;
-    setIsTemperatureAccurate(false);
-    temperatureConsent.decline();
+    temperatureConsent.remove();
+    setUserVerifiedTemperatureAccurate(false);
   }, [temp_c]);
 
   useEffect(() => {
     // Uncheck confirmation if Wind speed is changed
     if (!isDirty) return;
-    setIsWindSpeedAccurate(false);
-    windSpeedConsent.decline();
+    windSpeedConsent.remove();
+    setUserVerifiedWindspeedAccurate(false);
   }, [wind_speed]);
 
   useEffect(() => {
     // Refire Temperature validation when confirmation changes
     if (!isDirty) return;
     trigger('subtype_data.temperature_c');
-  }, [isTemperatureAccurate]);
+  }, [userVerifiedTemperatureAccurate]);
 
   useEffect(() => {
     // Refire Temperature validation when confirmation changes
     if (!isDirty) return;
     trigger('subtype_data.wind_speed_kmh');
-  }, [isWindSpeedAccurate]);
+  }, [userVerifiedWindspeedAccurate]);
 
   // Cleanup NTZ Reduction Rationale if Reduction is changed to False
   useEffect(() => {
@@ -155,9 +159,9 @@ const TreatmentChemicalPlant = () => {
             required: true,
             valueAsNumber: true,
             validate: {
-              minValueBeforeVerify: (val) => isTemperatureAccurate || greaterThanEqual(val, MIN_ALLOWED_TEMP),
+              minValueBeforeVerify: (val) => userVerifiedTemperatureAccurate || greaterThanEqual(val, MIN_ALLOWED_TEMP),
               maxValueBeforeVerify: (val) =>
-                isTemperatureAccurate
+                userVerifiedTemperatureAccurate
                   ? lessThan(val, 100) // If user verifies weather accuracy, check for clearly accidental values (extra digits)
                   : lessThanEqual(val, MAX_ALLOWED_TEMP)
             }
@@ -175,7 +179,8 @@ const TreatmentChemicalPlant = () => {
             // If user verifies weather accurate, check for clearly accidental values (extra digits)
             validate: {
               minSpeed: (val) => greaterThanEqual(val, 0),
-              maxSpeed: (val) => (isWindSpeedAccurate ? lessThan(val, 100) : lessThanEqual(val, MAX_WIND_SPEED))
+              maxSpeed: (val) =>
+                userVerifiedWindspeedAccurate ? lessThan(val, 100) : lessThanEqual(val, MAX_WIND_SPEED)
             }
           })}
         />
@@ -211,24 +216,28 @@ const TreatmentChemicalPlant = () => {
               'The temperature recorded at the time of treatment is an accurate representation of site conditions.'
             }
             required
-            state={isTemperatureAccurate}
+            state={userVerifiedTemperatureAccurate}
             warningConfirmation
-            onChange={() => {
-              isTemperatureAccurate ? temperatureConsent.decline() : temperatureConsent.confirm();
-              setIsTemperatureAccurate(temperatureConsent.getConfirmation());
-            }}
+            onChange={() =>
+              setUserVerifiedTemperatureAccurate((prev) => {
+                prev ? temperatureConsent.remove() : temperatureConsent.confirm();
+                return !prev;
+              })
+            }
           />
         )}
         {shouldVerifyWindSpeedAccuracy && (
           <CheckboxUI
             label={'The wind speed recorded at the time of treatment is an accurate representation of site conditions.'}
             required
-            state={isWindSpeedAccurate}
+            state={userVerifiedWindspeedAccurate}
             warningConfirmation
-            onChange={() => {
-              isWindSpeedAccurate ? windSpeedConsent.decline() : windSpeedConsent.confirm();
-              setIsWindSpeedAccurate(windSpeedConsent.getConfirmation());
-            }}
+            onChange={() =>
+              setUserVerifiedWindspeedAccurate((prev) => {
+                prev ? windSpeedConsent.remove() : windSpeedConsent.confirm();
+                return !prev;
+              })
+            }
           />
         )}
       </Fieldset>

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlant.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlant.tsx
@@ -26,6 +26,7 @@ import CheckboxUI from 'UI/Features/Records/Activity/forms/common/CheckboxUI/Che
 import { Fragment, useEffect, useState } from 'react';
 import TreatmentChemicalPlantDetails from './TreatmentChemicalPlantDetails';
 import useFilteredServiceLicenseCodes from 'UI/Features/Records/Activity/forms/plant/hooks/useFilteredServiceLicenseCodes';
+import useLocalStorage from '../../hooks/useLocalStorage';
 
 type ChemTreatment = AquaticChemicalTreatmentSchema | TerrestrialChemicalTreatmentSchema;
 
@@ -34,15 +35,6 @@ const TreatmentChemicalPlant = () => {
   const MIN_ALLOWED_TEMP = 10;
   const MAX_WIND_SPEED = 9;
 
-  /**
-   * @desc Cast localStorage value to boolean from string.
-   * @param key localStorage Key
-   */
-  const coerceLocalBool = (key: string): boolean => {
-    const bool = localStorage.getItem(key);
-    if (bool === 'true') return true;
-    return false;
-  };
   /**
    * @desc Validate only PMP or Manual PMP are filled in, not both.
    */
@@ -69,12 +61,14 @@ const TreatmentChemicalPlant = () => {
   const temp_c = watch('subtype_data.temperature_c');
   const wind_speed = watch('subtype_data.wind_speed_kmh');
 
+  const temperatureConsent = useLocalStorage('isTemperatureAccurate');
+  const windSpeedConsent = useLocalStorage('isWindSpeedAccurate');
   /*
     Entry Policy: Out-of-range values (temperature, wind speed) are permitted only if the user has manually flagged them as accurate.
     This prevents data entry errors without blocking edge-case submissions.
   */
-  const [isTemperatureAccurate, setIsTemperatureAccurate] = useState<boolean>(coerceLocalBool('isTemperatureAccurate'));
-  const [isWindSpeedAccurate, setIsWindSpeedAccurate] = useState<boolean>(coerceLocalBool('isWindSpeedAccurate'));
+  const [isTemperatureAccurate, setIsTemperatureAccurate] = useState<boolean>(temperatureConsent.getConfirmation());
+  const [isWindSpeedAccurate, setIsWindSpeedAccurate] = useState<boolean>(windSpeedConsent.getConfirmation());
   const { serviceLicenseCodes } = useFilteredServiceLicenseCodes(disabled);
 
   const shouldVerifyWindSpeedAccuracy = !disabled && wind_speed != undefined && wind_speed > MAX_WIND_SPEED;
@@ -85,14 +79,14 @@ const TreatmentChemicalPlant = () => {
     // Uncheck confirmation if temperature is changed
     if (!isDirty) return;
     setIsTemperatureAccurate(false);
-    localStorage.setItem('isTemperatureAccurate', 'false');
+    temperatureConsent.decline();
   }, [temp_c]);
 
   useEffect(() => {
     // Uncheck confirmation if Wind speed is changed
     if (!isDirty) return;
     setIsWindSpeedAccurate(false);
-    localStorage.setItem('isWindSpeedAccurate', 'false');
+    windSpeedConsent.decline();
   }, [wind_speed]);
 
   useEffect(() => {
@@ -220,8 +214,8 @@ const TreatmentChemicalPlant = () => {
             state={isTemperatureAccurate}
             warningConfirmation
             onChange={() => {
-              localStorage.setItem('isTemperatureAccurate', 'true');
-              setIsTemperatureAccurate((prev) => !prev);
+              isTemperatureAccurate ? temperatureConsent.decline() : temperatureConsent.confirm();
+              setIsTemperatureAccurate(temperatureConsent.getConfirmation());
             }}
           />
         )}
@@ -232,8 +226,8 @@ const TreatmentChemicalPlant = () => {
             state={isWindSpeedAccurate}
             warningConfirmation
             onChange={() => {
-              localStorage.setItem('isWindSpeedAccurate', 'true');
-              setIsWindSpeedAccurate((prev) => !prev);
+              isWindSpeedAccurate ? windSpeedConsent.decline() : windSpeedConsent.confirm();
+              setIsWindSpeedAccurate(windSpeedConsent.getConfirmation());
             }}
           />
         )}

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlant.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlant.tsx
@@ -1,9 +1,6 @@
 import { get, useFormContext } from 'react-hook-form';
 import Fieldset from 'UI/Features/Records/Activity/forms/common/Fieldset/Fieldset';
-import {
-  AquaticChemicalTreatmentSchema,
-  TerrestrialChemicalTreatmentSchema
-} from 'UI/Features/Records/Activity/forms/plant/interfaces';
+import { ChemTreatment } from 'UI/Features/Records/Activity/forms/plant/interfaces';
 import NumberInput from 'UI/Features/Records/Activity/forms/common/NumberInput/NumberInput';
 import TextInput from 'UI/Features/Records/Activity/forms/common/TextInput/TextInput';
 import { Width } from 'UI/Features/Records/Activity/forms/common/utils';
@@ -28,8 +25,6 @@ import TreatmentChemicalPlantDetails from './TreatmentChemicalPlantDetails';
 import useFilteredServiceLicenseCodes from 'UI/Features/Records/Activity/forms/plant/hooks/useFilteredServiceLicenseCodes';
 import useLocalStorage from 'UI/Features/Records/Activity/forms/plant/hooks/useLocalStorage';
 import useFieldPath from 'UI/Features/Records/Activity/forms/plant/hooks/useFieldPath';
-
-type ChemTreatment = AquaticChemicalTreatmentSchema | TerrestrialChemicalTreatmentSchema;
 
 const TreatmentChemicalPlant = () => {
   const MAX_ALLOWED_TEMP = 28;

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlantCalculations.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlantCalculations.tsx
@@ -1,10 +1,7 @@
 import { useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import Fieldset from 'UI/Features/Records/Activity/forms/common/Fieldset/Fieldset';
-import {
-  AquaticChemicalTreatmentSchema,
-  TerrestrialChemicalTreatmentSchema
-} from 'UI/Features/Records/Activity/forms/plant/interfaces';
+import { ChemTreatment } from 'UI/Features/Records/Activity/forms/plant/interfaces';
 import {
   mSpecie_mLGHerb_spray_usingProdAppRate,
   mSpecie_sGHerb_spray_usingDilutionPercent,
@@ -17,7 +14,6 @@ import {
 } from './calculations';
 import { useSelector } from 'utils/use_selector';
 
-type ChemTreatment = AquaticChemicalTreatmentSchema | TerrestrialChemicalTreatmentSchema;
 enum CalculationType {
   Dilution = 'Dilution',
   ApplicationRate = 'Product Application Rate'
@@ -63,9 +59,51 @@ const TreatmentChemicalPlantCalculations = () => {
     }
 
     if (!isMultiplePlants && isHerbicideLiquid && isApplicationCalculation) {
-      return sSpecie_sLHerb_spray_usingProdAppRate(area_m, application_rate, amount_mix_used_l, delivery_rate);
+      /**
+       * TODO: Finalize and remove.
+       * Original: Single Species response.
+       *
+       * This Scenario anticipates the singleSpecies result. but is near identical to the multipleSpecies result.
+       * Leaving both as a return for stakeholders to test and visualize before a proper ui component is created.
+       */
+      return {
+        singleSpecies: sSpecie_sLHerb_spray_usingProdAppRate(
+          area_m,
+          application_rate,
+          amount_mix_used_l,
+          delivery_rate
+        ),
+        multiSpecies: mSpecie_sLHerb_spray_usingProdAppRate(
+          area_m,
+          application_rate,
+          amount_mix_used_l,
+          delivery_rate,
+          plants_treated
+        )
+      };
     } else if (!isMultiplePlants && isHerbicideLiquid && isDilutionCalculation) {
-      return sSpecie_sLHerb_spray_usingDilutionPercent(area_m, amount_mix_used_l, dilution_percent, area_treated_sqm);
+      /**
+       * TODO: Finalize and remove.
+       * Original: Single Species response.
+       *
+       * This Scenario anticipates the singleSpecies result. but is near identical to the multipleSpecies result.
+       * Leaving both as a return for stakeholders to test and visualize before a proper ui component is created.
+       */
+      return {
+        singleSpecies: sSpecie_sLHerb_spray_usingDilutionPercent(
+          area_m,
+          amount_mix_used_l,
+          dilution_percent,
+          area_treated_sqm
+        ),
+        multiSpecies: mSpecie_sLHerb_spray_usingDilutionPercent(
+          area_m,
+          amount_mix_used_l,
+          dilution_percent,
+          area_treated_sqm,
+          plants_treated
+        )
+      };
     } else if (isHerbicideSolid && isApplicationCalculation) {
       return mSpecie_sGHerb_spray_usingProdAppRate(
         area_m,

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlantDetails.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlantDetails.tsx
@@ -1,10 +1,7 @@
 import { get, useFormContext } from 'react-hook-form';
 import { useSelector } from 'utils/use_selector';
 import { useEffect, useMemo } from 'react';
-import {
-  AquaticChemicalTreatmentSchema,
-  TerrestrialChemicalTreatmentSchema
-} from 'UI/Features/Records/Activity/forms/plant/interfaces';
+import { ChemTreatment } from 'UI/Features/Records/Activity/forms/plant/interfaces';
 import Fieldset from 'UI/Features/Records/Activity/forms/common/Fieldset/Fieldset';
 import RadioInput from 'UI/Features/Records/Activity/forms/common/RadioInput/RadioInput';
 import { Width } from 'UI/Features/Records/Activity/forms/common/utils';
@@ -24,8 +21,6 @@ import {
   noRepeatKey
 } from 'UI/Features/Records/Activity/forms/common/validators';
 import TreatmentChemicalPlantCalculations from './TreatmentChemicalPlantCalculations';
-
-type ChemTreatment = AquaticChemicalTreatmentSchema | TerrestrialChemicalTreatmentSchema;
 
 const TreatmentChemicalPlantDetails = () => {
   enum CalculationType {

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlantDetails.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlantDetails.tsx
@@ -38,7 +38,6 @@ const TreatmentChemicalPlantDetails = () => {
     watch,
     setValue,
     trigger,
-    unregister,
     formState: { isDirty, errors }
   } = useFormContext<ChemTreatment>();
 
@@ -101,17 +100,6 @@ const TreatmentChemicalPlantDetails = () => {
       setValue('subtype_data.treatment_context.calculation_type', '', { shouldDirty: true });
     }
   }, [calculationOptions]);
-
-  // When Calculation Type is changed, unregister any stale fields
-  useEffect(() => {
-    if (!isDirty) return;
-    if (calculation_type === CalculationType.ApplicationRate) {
-      unregister('subtype_data.treatment_context.dilution_percent');
-      unregister('subtype_data.treatment_context.area_treated_sqm');
-    } else if (calculation_type === CalculationType.Dilution) {
-      unregister('subtype_data.treatment_context.delivery_rate');
-    }
-  }, [calculation_type]);
 
   return (
     <Fieldset label={'Chemical Treatment Details'}>
@@ -226,6 +214,7 @@ const TreatmentChemicalPlantDetails = () => {
             {...register('subtype_data.treatment_context.dilution_percent', {
               required: true,
               valueAsNumber: true,
+              shouldUnregister: true,
               validate: {
                 min: (val) => greaterThan(val, 0),
                 max: (val) => lessThanEqual(val, 100)
@@ -241,6 +230,7 @@ const TreatmentChemicalPlantDetails = () => {
             {...register('subtype_data.treatment_context.area_treated_sqm', {
               required: true,
               valueAsNumber: true,
+              shouldUnregister: true,
               validate: (val) => greaterThan(val, 0)
             })}
           />
@@ -256,6 +246,7 @@ const TreatmentChemicalPlantDetails = () => {
           {...register('subtype_data.treatment_context.delivery_rate', {
             required: true,
             valueAsNumber: true,
+            shouldUnregister: true,
             validate: (val) => greaterThan(val, 0)
           })}
         />

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlantDetails.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlantDetails.tsx
@@ -196,7 +196,8 @@ const TreatmentChemicalPlantDetails = () => {
           required: true,
           validate: {
             min: (val) => greaterThanEqual(val.length, 1),
-            max: (val) => tank_mix || lessThanEqual(val.length, 1) // Only limit on non-tank mixes
+            max: (val) => tank_mix || lessThanEqual(val.length, 1), // Only limit on non-tank mixes
+            noDuplicateHerbicide: (val) => noRepeatKey(val, 'name', 'name')
           }
         }}
         renderRow={(index) => <HerbicideEntry idx={index} type={calculation_type as CalculationType} />}

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/calculations.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/calculations.ts
@@ -84,7 +84,7 @@ const mSpecie_sLHerb_spray_usingProdAppRate = (
       index,
       amount_of_mix_used,
       area_covered_pct,
-      area_treates_sqm: trunc(area_treated_hectares * HECTARE_TO_SQM),
+      area_treated_sqm: trunc(area_treated_hectares * HECTARE_TO_SQM),
       undiluted_herbicide_used_l
     };
   });

--- a/app/src/state/reducers/auth.ts
+++ b/app/src/state/reducers/auth.ts
@@ -59,7 +59,7 @@ interface AuthState {
   loggedInOrWorkingOffline: boolean;
   loginInProgress: boolean;
 
-  roles: { role_id: number; role_name: string }[];
+  roles: Array<{ role_id: number; role_name: string; role_description: string }>;
   writePrivilege: Array<ActivitySubtype>;
   accessRoles: { role_id: number; role_name: string }[];
   rolesInitialized: boolean;


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Change Landing page to show role descriptions instead of codes
- modify gte/lte functions to ignore NaN 
- modify noRepeatKey to extend `object`, resolving typescript flagging on `Typed` objects
- Modify `<HerbicideEntry/>` so users have to confirm an application rating in order to submit (If over the maximum amount)
- remove `unregister` calls, and set respective components to `shouldUnregister` removing them automagically if they're removed from the DOM.
- 

Add Hooks
- useFieldPath: An Alternative to using RHF's `long.object.drilling.names`
    - Only implemented as POC, full implementation not in PR
- useLocalStorage: a shorthand for fetching confirmation booleans from a form
    - These scenarios so far only apply for Chemical Treatment forms 
    - preferred localStorage over sessionStorage due to the mobile nature of the form resulting in the application being closed more than a browser window.

>[!NOTE]
>Noticed the Chemical Treatment Form had different scenarios based on single or multiple plants being present. The end result was the payload being passed back was different, but contained the same value. Adding that change to this PR to bring to stakeholders for testing as this could be used to determine end chemical treatment formats. 

```json
{
  "singleSpecies": {
    "area_treated_sqm": 33,
    "area_covered_pct": 330,
    "undiluted_herbicide_used_l": 4.84
  },
  "multiSpecies": {
    "area_treated_sqm": 33,
    "invasive_plants": [
      {
        "index": 0,
        "area_treated_sqm": 33,
        "percentage_area_covered": 330,
        "undiluted_herbicide_used_l": 4.84
      }
    ]
  }
}
```