### PR TITLE
Implement Mobile Feedback / Bugfixes (April 2nd)

### DIFF
--- a/app/src/UI/Features/IAPP/Summary.tsx
+++ b/app/src/UI/Features/IAPP/Summary.tsx
@@ -36,7 +36,7 @@ export const Summary: React.FC<IAPPSitePropType> = ({ record }) => {
           <Typography>Legacy IAPP Site: {site?.site_id}</Typography>
         </AccordionSummary>
 
-        <AccordionDetails>
+        <AccordionDetails style={{ textAlign: 'left' }}>
           <Grid container spacing={1}>
             <Grid size={{ xs: 3, sm: 2 }}>
               <Typography>Created:</Typography>

--- a/app/src/UI/Features/OfflineDataSync/OfflineDataSyncTable.tsx
+++ b/app/src/UI/Features/OfflineDataSync/OfflineDataSyncTable.tsx
@@ -58,6 +58,7 @@ export const OfflineDataSyncTable = ({ handleClose }: PropTypes) => {
     if (confirmDelete) {
       dispatch(Activity.Offline.delete(contextRecord));
       setConfirmDelete(false);
+      setAnchorEl(null);
     } else {
       setConfirmDelete(true);
     }

--- a/app/src/UI/Features/Records/Activity/form/ChemicalTreatmentDetailsForm/Components/single-objects/Herbicide.tsx
+++ b/app/src/UI/Features/Records/Activity/form/ChemicalTreatmentDetailsForm/Components/single-objects/Herbicide.tsx
@@ -287,6 +287,9 @@ const Herbicide = ({ herbicide, index, insideTankMix }: PropTypes) => {
             <HelpOutlineIcon />
           </Tooltip>
           <TextField
+            slotProps={{
+              htmlInput: { inputMode: 'decimal' }
+            }}
             disabled={formDetails.disabled}
             id="amount-of-mix-used"
             type="text"
@@ -341,6 +344,9 @@ const Herbicide = ({ herbicide, index, insideTankMix }: PropTypes) => {
               value={herbicide?.dilution}
               variant="outlined"
               key={dilutionPercentKey}
+              slotProps={{
+                htmlInput: { inputMode: 'decimal' }
+              }}
               onBlur={(event) => {
                 const input = event.target.value;
                 if (input === '') {
@@ -374,6 +380,9 @@ const Herbicide = ({ herbicide, index, insideTankMix }: PropTypes) => {
               id="area-treated"
               type="text"
               label="Area Treated (sqm)"
+              slotProps={{
+                htmlInput: { inputMode: 'decimal' }
+              }}
               value={herbicide?.area_treated_sqm?.toFixed(2)}
               variant="outlined"
               key={areaTreatedSqmKey}
@@ -412,6 +421,9 @@ const Herbicide = ({ herbicide, index, insideTankMix }: PropTypes) => {
             <TextField
               disabled={formDetails.disabled}
               type="text"
+              slotProps={{
+                htmlInput: { inputMode: 'decimal' }
+              }}
               id="delivery-rate-of-mix"
               label="Delivery Rate of Mix (L/ha)"
               value={herbicide?.delivery_rate_of_mix?.toFixed(2)}
@@ -461,6 +473,9 @@ const Herbicide = ({ herbicide, index, insideTankMix }: PropTypes) => {
               disabled={formDetails.disabled}
               type="decimal"
               id="product-application-rate"
+              slotProps={{
+                htmlInput: { inputMode: 'decimal' }
+              }}
               label={
                 currentHerbicide?.herbicide_type_code === 'G'
                   ? 'Product Application Rate (g/ha)'
@@ -504,6 +519,9 @@ const Herbicide = ({ herbicide, index, insideTankMix }: PropTypes) => {
               <InputLabel>Product Application Rate (L/ha)</InputLabel>
               <TextField
                 disabled
+                slotProps={{
+                  htmlInput: { inputMode: 'decimal' }
+                }}
                 style={{ display: 'none' }}
                 type="number"
                 id="product-application-rate"

--- a/app/src/UI/Features/Records/Record.tsx
+++ b/app/src/UI/Features/Records/Record.tsx
@@ -52,19 +52,15 @@ export const Activity = () => {
   const { id, mode } = useParams<{ id: string; mode: string }>();
   const activity_id = useSelector((state) => state.ActivityPage?.activity?.activity_id);
   const dispatch = useDispatch();
-  const wrapperRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (wrapperRef.current) {
-      wrapperRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'start' });
-    }
     if (id) {
       dispatch(ActivityActions.loadActivityIfRequired(id));
     }
-  }, [activity_id, id]);
+  }, [activity_id, id, activity_id]);
 
   return (
-    <div ref={wrapperRef}>
+    <div>
       <div className="records__activity">
         <div className="records__activity__header">
           <div className="records__activity_buttons">

--- a/app/src/UI/Features/Records/Record.tsx
+++ b/app/src/UI/Features/Records/Record.tsx
@@ -50,14 +50,11 @@ export const Activity = () => {
   const navigate = useNavigate();
 
   const { id, mode } = useParams<{ id: string; mode: string }>();
-  const activity_id = useSelector((state) => state.ActivityPage?.activity?.activity_id);
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if (id) {
-      dispatch(ActivityActions.loadActivityIfRequired(id));
-    }
-  }, [activity_id, id, activity_id]);
+    id && dispatch(ActivityActions.loadActivityIfRequired(id));
+  }, [id]);
 
   return (
     <div>

--- a/app/src/UI/Layout/OverlayLayout/Overlay.tsx
+++ b/app/src/UI/Layout/OverlayLayout/Overlay.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useEffect, useState } from 'react';
+import React, { Suspense, useEffect, useRef, useState } from 'react';
 import 'UI/Layout/OverlayLayout/Overlay.css';
 import { useSelector } from 'utils/use_selector';
 import { OverlayHeader } from 'UI/Layout/OverlayLayout/OverlayHeader';
@@ -22,8 +22,10 @@ const Overlay = () => {
   const [panelOpen, setPanelOpen] = React.useState(true);
   const [fullScreen, setFullScreen] = React.useState(false);
   const [additionalClasses, setAdditionalClasses] = useState<string>('');
-
+  const containerRef = useRef<HTMLDivElement>(null);
   const layoutMode = useSelector((state) => state.AppMode.layout.viewLayout);
+  const url = useSelector((state) => state.AppMode.url);
+  const activity_id = useSelector((state) => state.ActivityPage.activeActivity);
 
   useEffect(() => {
     switch (layoutMode) {
@@ -54,6 +56,11 @@ const Overlay = () => {
     setAdditionalClasses(classesToAdd.join(' '));
   }, [fullScreen, panelOpen]);
 
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }, [url, activity_id]);
   return (
     <>
       <AlertsContainer />
@@ -70,7 +77,7 @@ const Overlay = () => {
       <div id="overlay-anchor">
         <div className={`overlay-panel ${additionalClasses}`}>
           {panelOpen && !fullScreen && <OverlayHeader />}
-          <div className={`overlay-content`}>
+          <div className={`overlay-content`} ref={containerRef}>
             <AppRoutes />
           </div>
         </div>

--- a/app/src/UI/Layout/OverlayLayout/OverlayHeader.tsx
+++ b/app/src/UI/Layout/OverlayLayout/OverlayHeader.tsx
@@ -4,8 +4,9 @@ import 'UI/Layout/OverlayLayout/OverlayHeader.css';
 import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
 import DragHandleIcon from '@mui/icons-material/DragHandle';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import ContextualPopover from '../ContextualPopover/ContextualPopover';
+import { useSelector } from 'utils/use_selector';
 
 const maximize = () => {
   setOverlayStyle({ top: '0px' });
@@ -32,11 +33,8 @@ const getOverlayAnchorDimensions = () => {
   const appElement = document.getElementById('overlay-anchor');
 
   if (appElement !== null) {
-    const currentAppStyle = window.getComputedStyle(appElement);
-    return {
-      height: currentAppStyle.height,
-      top: currentAppStyle.top
-    };
+    const { height, top } = window.getComputedStyle(appElement);
+    return { height, top };
   }
 
   return {
@@ -55,11 +53,8 @@ const throttledRestyle = debounce(
 
 const drag = (e: PointerEvent) => {
   e.preventDefault();
-
   const correctedClientY = e.clientY - 60;
-
   const SNAP_TO_NEAREST = 1; // set to 1 for no snap
-
   throttledRestyle({ top: `${Math.floor(correctedClientY / SNAP_TO_NEAREST) * SNAP_TO_NEAREST}px` });
 };
 
@@ -78,9 +73,15 @@ const onClickDragButton = (e) => {
 };
 
 export const OverlayHeader = () => {
+  const url = useSelector((state) => state.AppMode.url);
+
   useEffect(() => {
-    defaultPosition();
-  }, []);
+    // On URL Change, if the Overlay Header is below 50%, resize it. If greater, do nothing.
+    const overlayY = document.getElementsByClassName('overlay-header')?.[0]?.getBoundingClientRect()?.y;
+    const screenHeight = parseInt(getOverlayAnchorDimensions().height);
+    if (overlayY == undefined || screenHeight == undefined) return;
+    if (overlayY - 90 > screenHeight / 2) defaultPosition();
+  }, [url]);
 
   return (
     <div className="overlay-header">

--- a/app/src/UI/Layout/OverlayLayout/OverlayHeader.tsx
+++ b/app/src/UI/Layout/OverlayLayout/OverlayHeader.tsx
@@ -33,7 +33,7 @@ const getOverlayAnchorDimensions = () => {
   const appElement = document.getElementById('overlay-anchor');
 
   if (appElement !== null) {
-    const { height, top } = window.getComputedStyle(appElement);
+    const { height, top } = globalThis.getComputedStyle(appElement);
     return { height, top };
   }
 
@@ -78,7 +78,7 @@ export const OverlayHeader = () => {
   useEffect(() => {
     // On URL Change, if the Overlay Header is below 50%, resize it. If greater, do nothing.
     const overlayY = document.getElementsByClassName('overlay-header')?.[0]?.getBoundingClientRect()?.y;
-    const screenHeight = parseInt(getOverlayAnchorDimensions().height);
+    const screenHeight = Number.parseInt(getOverlayAnchorDimensions().height);
     if (overlayY == undefined || screenHeight == undefined) return;
     if (overlayY - 90 > screenHeight / 2) defaultPosition();
   }, [url]);

--- a/app/src/UI/Layout/Routes/AppRoutes.tsx
+++ b/app/src/UI/Layout/Routes/AppRoutes.tsx
@@ -48,7 +48,14 @@ const AppRoutes = () => {
       <Route path="/" element={<Navigate to="/Landing" replace />} />
       <Route path="/Map" Component={() => <></>} />
       <Route path="/Landing" Component={() => <LandingComponent />} />
-      <Route path="/Records/Activity/:id/:mode" Component={() => <Activity />}></Route>
+      <Route
+        path="/Records/Activity/:id/:mode"
+        element={
+          <Suspense fallback={<Spinner />}>
+            <Activity />
+          </Suspense>
+        }
+      ></Route>
 
       <Route path="/Records/IAPP/:id/:mode" Component={() => <IAPPRecord />} />
       <Route

--- a/app/src/rjsf/widgets/SingleSelectAutoComplete.tsx
+++ b/app/src/rjsf/widgets/SingleSelectAutoComplete.tsx
@@ -1,6 +1,15 @@
 import { createFilterOptions } from '@mui/material/Autocomplete';
 import StarIcon from '@mui/icons-material/Star';
-import { TextField, Autocomplete, MenuItem } from '@mui/material';
+import {
+  TextField,
+  Autocomplete,
+  MenuItem,
+  Select,
+  OutlinedInput,
+  InputLabel,
+  FormControl,
+  FormHelperText
+} from '@mui/material';
 import { SelectAutoCompleteContext } from 'UI/Features/Records/Activity/form/SelectAutoCompleteContext';
 import { useContext, useEffect, useState } from 'react';
 import { WidgetProps } from '@rjsf/utils';
@@ -45,6 +54,7 @@ export type AutoCompleteSelectOption = {
  */
 
 const SingleSelectAutoComplete = (props: WidgetProps) => {
+  const MIN_ITEMS_FOR_SEARCH = 10;
   const selectAutoCompleteContext = useContext(SelectAutoCompleteContext);
   if (!selectAutoCompleteContext) {
     throw new Error('Context not provided to SingleSelectAutoComplete.tsx');
@@ -111,6 +121,44 @@ const SingleSelectAutoComplete = (props: WidgetProps) => {
 
   if (props.id.includes('jurisdiction_code')) {
     handleSuggestedJurisdictions(suggestedJurisdictionsInState, listOptions);
+  }
+  if (listOptions.length < MIN_ITEMS_FOR_SEARCH) {
+    return (
+      <FormControl fullWidth variant="outlined" disabled={props.disabled || props.readonly} required={props.required}>
+        <InputLabel id={`${props.id}-label`}>{props.label || props.schema.title}</InputLabel>
+        <Select
+          labelId={`${props.id}-label`}
+          id={props.id}
+          value={value ?? ''}
+          onChange={(evt) => {
+            const value = evt.target.value !== '' ? evt.target.value : undefined;
+            setValue(value);
+            props.onChange(value);
+          }}
+          onBlur={() => props.onBlur(props.id, value)}
+          onFocus={() => props.onFocus(props.id, value)}
+          input={<OutlinedInput label={props.label || props.schema.title} />}
+          displayEmpty={!!props.placeholder}
+          sx={{
+            '& .MuiSelect-select': {
+              textAlign: 'left',
+              display: 'flex',
+              alignItems: 'center'
+            }
+          }}
+        >
+          {listOptions.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {/* Keeping your "Suggested" logic if applicable to the data */}
+              {option.suggested && <StarIcon style={{ fontSize: 15, marginRight: 7 }} color="warning" />}
+              {option.label}
+              {option.suggested && <i style={{ marginLeft: 8, opacity: 0.7 }}> - Suggested based on location</i>}
+            </MenuItem>
+          ))}
+        </Select>
+        {props.schema.description && <FormHelperText>{props.schema.description}</FormHelperText>}
+      </FormControl>
+    );
   }
   return (
     <Autocomplete

--- a/app/src/rjsf/widgets/SingleSelectAutoComplete.tsx
+++ b/app/src/rjsf/widgets/SingleSelectAutoComplete.tsx
@@ -131,7 +131,7 @@ const SingleSelectAutoComplete = (props: WidgetProps) => {
           id={props.id}
           value={value ?? ''}
           onChange={(evt) => {
-            const value = evt.target.value !== '' ? evt.target.value : undefined;
+            const value = evt.target.value ?? undefined;
             setValue(value);
             props.onChange(value);
           }}

--- a/app/src/state/reducers/activity.ts
+++ b/app/src/state/reducers/activity.ts
@@ -216,6 +216,7 @@ function createActivityReducer() {
         draftState.schema = action.payload.schema;
       } else if (DrawToolActions.updateGeoSuccess.match(action)) {
         const { geometry, lat, long, utm, reported_area, Well_Information } = action.payload;
+        draftState.pristine = false;
         draftState.activity.geometry = geometry;
         draftState.activity.form_data.activity_data.latitude = lat;
         draftState.activity.form_data.activity_data.longitude = long;

--- a/app/src/state/sagas/activity/offline.ts
+++ b/app/src/state/sagas/activity/offline.ts
@@ -25,7 +25,8 @@ function* handle_ACTIVITY_SAVE_OFFLINE(action: PayloadAction<ISaveOffline>) {
       Alerts.create({
         content: 'Synchronizing records with server.',
         severity: AlertSeverity.Info,
-        subject: AlertSubjects.Form
+        subject: AlertSubjects.Form,
+        autoClose: 6
       })
     );
     yield delay(500);
@@ -35,7 +36,8 @@ function* handle_ACTIVITY_SAVE_OFFLINE(action: PayloadAction<ISaveOffline>) {
       Alerts.create({
         content: 'Saved locally',
         severity: AlertSeverity.Info,
-        subject: AlertSubjects.Form
+        subject: AlertSubjects.Form,
+        autoClose: 6
       })
     );
   }


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

## Features
- Update Overlay pane to at 50% when url change occurs (if pane is <50%)
    - Closes #4475 
- Refactor `SingleSelectAutoComplete` to only autocomplete if `>=10` options
    - Did not Refactor `MultiSelectAutoComplete` as its uses are more limited and the new forms have this functionality designed into them
    - Closes #4471 
- Modify Chem Treatment forms component with `slotProps={{htmlInput: { inputMode: 'decimal' }}}` when numeric values.
    - Forces numeric keys on first render of keyboard in forms.
    - Closes #4474 

## Bugfixes
- Fix 'Scroll to top' behaviour when changing records
    - Issue caused by scroll to top being assigned to the wrong container, lifted behaviour to overlay pane.
    - Closes #4472 
- Prevent Record information being "Carried over to new form"
    - **Issue** caused by Form attempting to re-fetch the previous record during the transition, due to a rerender of the component paired with loose `loadActivityIfRequired` logic.
        - **Replication**: Open an existing form, and from the same page, Create a new form. 
    -  changed Route from anonymous function to `element`, preventing the bouncing that was occurring during the rerendering
    - Closes #4473 
- Update `updateGeoSuccess` to set pristine to false
    - Closes #4470
    - **Issue**: updateGeoSuccess does not trigger `onFormChange` 
- Set AnchorEl null on RecordSyncTable to avoid popover flying off to top-right after record deleted