### PR TITLE
Form Improvements [RJSF]

### DIFF
--- a/app/src/UI/Features/LegacyMap/Controls/FindMe.tsx
+++ b/app/src/UI/Features/LegacyMap/Controls/FindMe.tsx
@@ -7,6 +7,8 @@ import MapActions from 'state/actions/map';
 import { GpsFixed, GpsNotFixed, GpsOff } from '@mui/icons-material';
 import { MapContext } from '../helpers/components/MapContext';
 import { MapLibreEvent } from 'maplibre-gl';
+import { isTracking } from 'utils/geoTrackingHelpers';
+import GeoTracking from 'state/actions/geotracking/GeoTracking';
 
 export const FindMeToggle = () => {
   enum Mode {
@@ -21,6 +23,9 @@ export const FindMeToggle = () => {
     if (mode === Mode.ON) {
       dispatch(MapActions.panningOn());
     } else {
+      if (userIsGeoTracking && mode === Mode.FOLLOWING) {
+        dispatch(GeoTracking.stop());
+      }
       dispatch(MapActions.trackLocationToggle());
     }
     setShow(false);
@@ -32,6 +37,7 @@ export const FindMeToggle = () => {
 
   const positionTracking = useSelector((state) => state.Map?.positionTracking);
   const positionFollowing = useSelector((state) => state.Map?.panned);
+  const userIsGeoTracking: boolean = useSelector((state) => isTracking(state.Map.track_me_draw_geo.status));
 
   const [show, setShow] = useState<boolean>(false);
   const [mode, setMode] = useState<Mode>(Mode.OFF);

--- a/app/src/UI/Features/Records/Activity/form/FormContainer.tsx
+++ b/app/src/UI/Features/Records/Activity/form/FormContainer.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, CircularProgress, createTheme, Theme, ThemeOptions, ThemeProvider } from '@mui/material';
 import { Form } from '@rjsf/mui';
 import CoreForm from '@rjsf/core';
-import { createRef, Fragment, RefObject, useCallback, useEffect, useRef, useState } from 'react';
+import { createRef, RefObject, useCallback, useEffect, useRef, useState } from 'react';
 import { SelectAutoCompleteContextProvider } from 'UI/Features/Records/Activity/form/SelectAutoCompleteContext';
 import ArrayFieldTemplate from 'rjsf/templates/ArrayFieldTemplate';
 import FieldTemplate from 'rjsf/templates/FieldTemplate';
@@ -178,6 +178,7 @@ const FormContainer = () => {
 
           {isActivityChemTreatment && (
             <ChemicalTreatmentDetailsForm
+              key={activity_ID}
               activitySubType={activity_subtype}
               disabled={isDisabled}
               onChange={(form_data, callback) => {

--- a/app/src/UI/Features/Records/Activity/form/FormContainer.tsx
+++ b/app/src/UI/Features/Records/Activity/form/FormContainer.tsx
@@ -27,6 +27,8 @@ import ArrayItemTemplate from 'rjsf/templates/ArrayItemTemplate';
 import ArrayItemButtonTemplate from 'rjsf/templates/ArrayFieldButtonTemplate';
 import FundingAgencySelectAutoComplete from 'rjsf/widgets/FundingAgencySelectAutoComplete';
 import EmployerSelectAutoComplete from 'rjsf/widgets/EmployerSelectAutoComplete';
+import FormMenuButtons from '../../FormMenuButtons/FormMenuButtons';
+import CustomPopover from 'UI/Reusable/CustomPopover/CustomPopover';
 
 const FormContainer = () => {
   const ref = useRef(0);
@@ -59,6 +61,7 @@ const FormContainer = () => {
   const activity_subtype = useSelector((state) => state.ActivityPage.activity.activity_subtype);
   const activitySchema = useSelector((state) => state.ActivityPage.schema);
   const activityUISchema = useSelector((state) => state.ActivityPage.uiSchema);
+  const isCellPhoneWidth = useSelector((state) => state.AppMode.constraints.tinyScreen);
 
   const can_edit = useSelector((state) => !!state.ActivityPage?.activeActivityPermissions?.can_edit);
   const created_by = useSelector((state) => state.ActivityPage.activity.created_by);
@@ -87,10 +90,6 @@ const FormContainer = () => {
   }, [JSON.stringify(activity_subtype)]);
 
   const formRef: RefObject<CoreForm> = createRef();
-
-  useEffect(() => {
-    dispatch(Activity.setErrors(formRef.current?.state?.errors ?? []));
-  }, [formDataState]);
 
   useEffect(() => {
     setIsCreatedByUser(username === created_by);
@@ -135,6 +134,7 @@ const FormContainer = () => {
             readonly={isDisabled}
             key={activity_ID + pasteCount + reported_area}
             disabled={isDisabled}
+            id="rjsf-form"
             formData={formDataState}
             schema={activitySchema}
             uiSchema={activityUISchema}
@@ -145,8 +145,19 @@ const FormContainer = () => {
             transformErrors={getCustomErrorTransformer()}
             autoComplete="off"
             ref={formRef}
+            noHtml5Validate={true}
+            onSubmit={() => dispatch(Activity.submit())}
+            onError={(errors) => dispatch(Activity.setErrors(errors ?? []))}
             onChange={(event) => debouncedFormChange(event)}
           >
+            <CustomPopover
+              buttonClasses={'overlay-menu'}
+              buttonText={isCellPhoneWidth ? 'Save' : 'Save Menu'}
+              closeAfterPress={true}
+              disablePortal={true}
+            >
+              <FormMenuButtons />
+            </CustomPopover>
             {/* This seemingly useless Fragment prevents a generic submit button from rendering through RJSF */}
             <Fragment />
           </Form>

--- a/app/src/UI/Features/Records/Activity/form/FormContainer.tsx
+++ b/app/src/UI/Features/Records/Activity/form/FormContainer.tsx
@@ -138,6 +138,7 @@ const FormContainer = () => {
             formData={formDataState}
             schema={activitySchema}
             uiSchema={activityUISchema}
+            focusOnFirstError
             liveValidate={'onChange'}
             customValidate={customValidators()}
             validator={validator}
@@ -158,8 +159,6 @@ const FormContainer = () => {
             >
               <FormMenuButtons />
             </CustomPopover>
-            {/* This seemingly useless Fragment prevents a generic submit button from rendering through RJSF */}
-            <Fragment />
           </Form>
 
           {isActivityChemTreatment && (

--- a/app/src/UI/Features/Records/Activity/form/FormContainer.tsx
+++ b/app/src/UI/Features/Records/Activity/form/FormContainer.tsx
@@ -31,6 +31,7 @@ import FormMenuButtons from '../../FormMenuButtons/FormMenuButtons';
 import CustomPopover from 'UI/Reusable/CustomPopover/CustomPopover';
 import Alerts from 'state/actions/alerts/Alerts';
 import { AlertSeverity, AlertSubjects } from 'constants/alertEnums';
+import { RJSFValidationError } from '@rjsf/utils';
 
 const FormContainer = () => {
   const ref = useRef(0);
@@ -39,7 +40,7 @@ const FormContainer = () => {
     console.log('%c FormContainer render:' + ref.current.toString(), 'color: yellow');
   }
 
-  const handleFormErrors = (err = []) => {
+  const handleFormErrors = (err: Array<RJSFValidationError> = []) => {
     dispatch(Activity.setErrors(err));
     dispatch(
       Alerts.create({

--- a/app/src/UI/Features/Records/Activity/form/FormContainer.tsx
+++ b/app/src/UI/Features/Records/Activity/form/FormContainer.tsx
@@ -111,6 +111,10 @@ const FormContainer = () => {
     setIsDisabled(username !== created_by || !can_edit);
   }, [username, created_by, can_edit]);
 
+  useEffect(() => {
+    dispatch(Activity.setErrors(formRef.current?.state?.errors ?? []));
+  }, [formDataState]);
+
   const isActivityChemTreatment =
     activity_subtype === ActivitySubtype.Treatment_ChemicalPlant ||
     activity_subtype === ActivitySubtype.Treatment_ChemicalPlantAquatic;

--- a/app/src/UI/Features/Records/Activity/form/FormContainer.tsx
+++ b/app/src/UI/Features/Records/Activity/form/FormContainer.tsx
@@ -29,6 +29,8 @@ import FundingAgencySelectAutoComplete from 'rjsf/widgets/FundingAgencySelectAut
 import EmployerSelectAutoComplete from 'rjsf/widgets/EmployerSelectAutoComplete';
 import FormMenuButtons from '../../FormMenuButtons/FormMenuButtons';
 import CustomPopover from 'UI/Reusable/CustomPopover/CustomPopover';
+import Alerts from 'state/actions/alerts/Alerts';
+import { AlertSeverity, AlertSubjects } from 'constants/alertEnums';
 
 const FormContainer = () => {
   const ref = useRef(0);
@@ -36,6 +38,18 @@ const FormContainer = () => {
   if (RENDER_DEBUG) {
     console.log('%c FormContainer render:' + ref.current.toString(), 'color: yellow');
   }
+
+  const handleFormErrors = (err = []) => {
+    dispatch(Activity.setErrors(err));
+    dispatch(
+      Alerts.create({
+        subject: AlertSubjects.Form,
+        severity: AlertSeverity.Error,
+        content: `Cannot submit form! ${err.length} error(s) found.`,
+        autoClose: 5
+      })
+    );
+  };
 
   const dispatch = useDispatch();
 
@@ -148,7 +162,7 @@ const FormContainer = () => {
             ref={formRef}
             noHtml5Validate={true}
             onSubmit={() => dispatch(Activity.submit())}
-            onError={(errors) => dispatch(Activity.setErrors(errors ?? []))}
+            onError={handleFormErrors}
             onChange={(event) => debouncedFormChange(event)}
           >
             <CustomPopover

--- a/app/src/UI/Features/Records/Activity/form/aditionalFormStyles.css
+++ b/app/src/UI/Features/Records/Activity/form/aditionalFormStyles.css
@@ -1,3 +1,7 @@
+.overlay-menu {
+  background-color: red;
+  padding: 1rem;
+}
 /* ----------Show just 1 error at a time for the field-------------*/
 #invasivesbc-activity-form ul li .Mui-error {
   display: none;
@@ -13,4 +17,22 @@ div[class*='indicatorContainer'] {
 
 .editFormButtonCont {
   margin: 1rem;
+}
+
+#rjsf-form .overlay-menu {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 100000;
+  color: black;
+  background-color: white;
+  border-radius: 2px;
+  border: 1px solid darkgrey;
+  height: var(--overlay-grip-height);
+  vertical-align: baseline;
+  box-shadow: none;
+
+  &:hover {
+    border: 1px solid #036;
+  }
 }

--- a/app/src/UI/Features/Records/FormMenuButtons/FormMenuButtons.css
+++ b/app/src/UI/Features/Records/FormMenuButtons/FormMenuButtons.css
@@ -1,13 +1,15 @@
 #form-menu-buttons {
-  display: flex;
-  border: 1pt solid black;
-  box-sizing: border-box;
   max-width: 100%;
-  overflow: hidden;
-  flex-direction: column;
   width: 300pt;
+  background-color: none;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  border: 1pt solid black;
+
   button {
     min-height: 50pt;
+    background-color: var(--blue-primary);
     border-radius: 0;
   }
 }

--- a/app/src/UI/Features/Records/FormMenuButtons/FormMenuButtons.css
+++ b/app/src/UI/Features/Records/FormMenuButtons/FormMenuButtons.css
@@ -11,5 +11,10 @@
     min-height: 50pt;
     background-color: var(--blue-primary);
     border-radius: 0;
+
+    &:disabled {
+      background-color: #ccc;
+      color: black;
+    }
   }
 }

--- a/app/src/UI/Features/Records/FormMenuButtons/FormMenuButtons.tsx
+++ b/app/src/UI/Features/Records/FormMenuButtons/FormMenuButtons.tsx
@@ -12,6 +12,7 @@ const FormMenuButtons = () => {
   const navigate = useNavigate();
 
   const pristine = useSelector((state) => state.ActivityPage.pristine);
+  const activityErrors = useSelector((state) => state.ActivityPage?.activityErrors);
   const activity_id = useSelector((state) => state.ActivityPage?.activity?.activity_id);
 
   const can_delete = useSelector((state) => !!state.ActivityPage?.activeActivityPermissions?.can_delete);
@@ -27,11 +28,11 @@ const FormMenuButtons = () => {
 
   const recordIsSerializedActivity = !!serializedActivities[activity_id];
   // Users must have write permission and be online to delete, or record is users offline record
-
+  console.log(activityErrors);
   useEffect(() => {
-    setSaveDisabled(!can_edit);
+    setSaveDisabled(!can_edit || pristine || activityErrors?.length > 0);
     setDraftDisabled(pristine || status === 'Submitted' || !can_edit);
-  }, [activity_id, can_edit, pristine]);
+  }, [activity_id, can_edit, pristine, activityErrors]);
 
   const handleSaveDraft = () => {
     dispatch(Activity.save());

--- a/app/src/UI/Features/Records/FormMenuButtons/FormMenuButtons.tsx
+++ b/app/src/UI/Features/Records/FormMenuButtons/FormMenuButtons.tsx
@@ -12,7 +12,6 @@ const FormMenuButtons = () => {
   const navigate = useNavigate();
 
   const pristine = useSelector((state) => state.ActivityPage.pristine);
-  const activityErrors = useSelector((state) => state.ActivityPage?.activityErrors);
   const activity_id = useSelector((state) => state.ActivityPage?.activity?.activity_id);
 
   const can_delete = useSelector((state) => !!state.ActivityPage?.activeActivityPermissions?.can_delete);
@@ -30,16 +29,14 @@ const FormMenuButtons = () => {
   // Users must have write permission and be online to delete, or record is users offline record
 
   useEffect(() => {
-    setSaveDisabled(pristine || activityErrors?.length > 0 || !can_edit);
+    setSaveDisabled(!can_edit);
     setDraftDisabled(pristine || status === 'Submitted' || !can_edit);
   }, [activity_id, can_edit, pristine]);
 
   const handleSaveDraft = () => {
     dispatch(Activity.save());
   };
-  const handlePublish = () => {
-    dispatch(Activity.submit());
-  };
+
   const handleDuplicate = () => {
     dispatch(Activity.copy());
   };
@@ -58,7 +55,7 @@ const FormMenuButtons = () => {
       <Button onClick={handleSaveDraft} disabled={draftDisabled} variant="contained">
         SAVE TO DRAFT {connected || '(LOCAL OFFLINE)'}
       </Button>
-      <Button onClick={handlePublish} disabled={saveDisabled} variant="contained">
+      <Button type="submit" disabled={saveDisabled} variant="contained">
         SAVE & PUBLISH TO SUBMITTED {connected || '(LOCAL OFFLINE)'}
       </Button>
       <Button onClick={handleDuplicate} disabled={!can_write} variant="contained">

--- a/app/src/UI/Layout/OverlayLayout/OverlayHeader.css
+++ b/app/src/UI/Layout/OverlayLayout/OverlayHeader.css
@@ -11,20 +11,6 @@
     flex-direction: row;
     justify-content: space-between;
 
-    .overlay-menu {
-      color: black;
-      background-color: white;
-      border-radius: 2px;
-      border: 1px solid darkgrey;
-      height: 100%;
-      vertical-align: baseline;
-      box-shadow: none;
-
-      &:hover {
-        border: 1px solid #036;
-      }
-    }
-
     .left {
       width: 33%;
     }

--- a/app/src/UI/Layout/OverlayLayout/OverlayHeader.tsx
+++ b/app/src/UI/Layout/OverlayLayout/OverlayHeader.tsx
@@ -5,7 +5,6 @@ import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
 import DragHandleIcon from '@mui/icons-material/DragHandle';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import { useEffect } from 'react';
-import ContextualPopover from '../ContextualPopover/ContextualPopover';
 import { useSelector } from 'utils/use_selector';
 
 const maximize = () => {

--- a/app/src/UI/Layout/OverlayLayout/OverlayHeader.tsx
+++ b/app/src/UI/Layout/OverlayLayout/OverlayHeader.tsx
@@ -85,7 +85,7 @@ export const OverlayHeader = () => {
 
   return (
     <div className="overlay-header">
-      <div className={'left'}></div>
+      <div className={'left'} />
       <div className={'center'}>
         <IconButton className="overlay-control" onClick={maximize}>
           <ArrowDropUpIcon />
@@ -99,9 +99,7 @@ export const OverlayHeader = () => {
           <ArrowDropDownIcon />
         </IconButton>
       </div>
-      <div className={'right'}>
-        <ContextualPopover />
-      </div>
+      <div className={'right'} />
     </div>
   );
 };

--- a/app/src/UI/Layout/WideLayout/WideLayout.tsx
+++ b/app/src/UI/Layout/WideLayout/WideLayout.tsx
@@ -19,7 +19,6 @@ import { OfflineUserMenu } from 'UI/Features/OfflineUserMenu/OfflineUserMenu';
 import DebugMenu from 'UI/Layout/DebugMenu/DebugMenu';
 import { NetworkStateControl } from 'UI/Reusable/NetworkStateControl';
 import { FeatureGated } from 'UI/Reusable/Predicates/FeatureGated';
-import ContextualPopover from 'UI/Layout/ContextualPopover/ContextualPopover';
 import { Map as InvasivesMap } from 'UI/Features/LegacyMap/Map';
 
 const WideLayout = () => {
@@ -126,9 +125,6 @@ const WideLayout = () => {
             <InvasivesMap />
           </div>
         )}
-
-        <ContextualPopover />
-
         <AppRoutes />
       </div>
       <FeatureGated requires={'OFFLINE_SYNC'}>

--- a/app/src/UI/Reusable/CustomPopover/CustomPopover.tsx
+++ b/app/src/UI/Reusable/CustomPopover/CustomPopover.tsx
@@ -79,6 +79,7 @@ const CustomPopover = ({
         onClick={handleCloseAfterClick}
         onClose={handleClose}
         disablePortal={disablePortal}
+        style={{ zIndex: 100001 }}
       >
         {children}
       </Popover>

--- a/app/src/constants/alerts/mappingAlerts.ts
+++ b/app/src/constants/alerts/mappingAlerts.ts
@@ -12,17 +12,20 @@ const mappingAlertMessages: Record<string, AlertMessage> = {
   notWithinBC: {
     content: 'Activity is not within BC',
     severity: AlertSeverity.Error,
-    subject: AlertSubjects.Map
+    subject: AlertSubjects.Map,
+    autoClose: 8
   },
   noAreaCalculated: {
     content: 'The calculated area of your shape is 0, please add more points',
     severity: AlertSeverity.Error,
-    subject: AlertSubjects.Map
+    subject: AlertSubjects.Map,
+    autoClose: 8
   },
   willContainIntersections: {
     severity: AlertSeverity.Error,
     subject: AlertSubjects.Map,
-    content: 'Closing this geometry will result in a shape intersection being formed. Please adjust appropriately.'
+    content: 'Closing this geometry will result in a shape intersection being formed. Please adjust appropriately.',
+    autoClose: 8
   },
   containsIntersections: {
     severity: AlertSeverity.Error,
@@ -45,7 +48,8 @@ const mappingAlertMessages: Record<string, AlertMessage> = {
   doesNotEvaluateAsPolygon: {
     content: 'Given Coordinates could not be evaluated as a Polygon. you may need to update or add new points',
     severity: AlertSeverity.Error,
-    subject: AlertSubjects.Map
+    subject: AlertSubjects.Map,
+    autoClose: 8
   },
 
   // Info

--- a/app/src/state/sagas/activity.ts
+++ b/app/src/state/sagas/activity.ts
@@ -235,6 +235,8 @@ function* handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_STOP() {
           DrawToolActions.updateGeo([]),
           Alerts.create(mappingAlertMessages.trackMyPathStoppedEarly)
         ];
+      } else {
+        return [MapActions.trackLocationStart()];
       }
     };
     yield put(
@@ -295,6 +297,8 @@ function* handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_STOP() {
           DrawToolActions.updateGeo([]),
           Alerts.create(mappingAlertMessages.trackMyPathStoppedEarly)
         ];
+      } else {
+        return [MapActions.trackLocationStart()];
       }
     };
     yield put(
@@ -450,6 +454,12 @@ function* handle_copyGeometry(action: PayloadAction<string>) {
   );
 }
 
+// Force updates to occur (Populating species arrays, jurisdictions, shapes if needed, etc)
+function* handle_PASTE() {
+  const activityState = yield select(selectActivity);
+  yield put(Activity.onFormChangeRequest(activityState.activity.form_data));
+}
+
 function* activityPageSaga() {
   yield all([
     takeEvery(UserSettings.InitState.get, handle_UPDATE_CACHED_RECORDS),
@@ -458,6 +468,7 @@ function* activityPageSaga() {
     takeEvery(Activity.buildFormSchema, handle_ACTIVITY_BUILD_SCHEMA_FOR_FORM_REQUEST),
     takeEvery(Activity.get, handle_ACTIVITY_GET_REQUEST),
     takeEvery(Activity.copy, handle_ACTIVITY_COPY_REQUEST),
+    takeEvery(Activity.paste, handle_PASTE),
     takeEvery(Activity.getNetworkRequest, handle_ACTIVITY_GET_NETWORK_REQUEST),
     takeEvery(AppActions.setUserCoords, handle_MAP_SET_COORDS),
     takeEvery(DrawToolActions.updateGeo, handle_ACTIVITY_UPDATE_GEO_REQUEST),

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -321,12 +321,34 @@ export function* handle_ACTIVITY_CREATE_SUCCESS(action: PayloadAction<string>) {
 }
 
 export function* handle_ACTIVITY_ON_FORM_CHANGE_REQUEST(action: PayloadAction<UserRecord>) {
+  /**
+   * Set Null Fields to Undefined. RJSF Will clear out undefined values, but null values persist and and throw validation
+   */
+  const setNullsToUndefined = (data: unknown): unknown => {
+    if (data === null) {
+      return undefined;
+    }
+    if (Array.isArray(data)) {
+      return data.map(setNullsToUndefined);
+    }
+    if (typeof data === 'object' && data !== undefined) {
+      const result: Record<string, unknown> = {};
+      for (const key in data) {
+        if (Object.hasOwn(data, key)) {
+          result[key] = setNullsToUndefined(data[key]);
+        }
+      }
+      return result;
+    }
+    return data;
+  };
+
   try {
     const previousState = yield select(selectActivity);
     const previousActivityState = previousState.activity;
 
     try {
-      let updatedFormData = cloneDeep(action.payload);
+      let updatedFormData = setNullsToUndefined(cloneDeep(action.payload));
       if (
         previousActivityState.activity_type === ActivityType.Biocontrol ||
         [

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -369,7 +369,7 @@ export function* handle_ACTIVITY_ON_FORM_CHANGE_REQUEST(action: PayloadAction<Us
 
       let updatedActivity = populateSpeciesArrays({ ...cloneDeep(previousActivityState), form_data: updatedFormData });
       updatedActivity = populateJurisdictionArray(updatedActivity);
-      updatedActivity = { ...updatedActivity, map_symbol: updatedActivity.species_positive.join(', ') };
+      updatedActivity.map_symbol = updatedActivity.species_positive.join(', ');
       yield put(Activity.OnFormChangeRequestSuccess(updatedActivity));
     } catch (error) {
       console.error(error);

--- a/app/src/utils/addActivity.ts
+++ b/app/src/utils/addActivity.ts
@@ -182,21 +182,14 @@ export function isLinkedTreatmentSubtype(subType: ActivitySubtype): boolean {
 // extract and set the species codes (both positive and negative) of a given activity (or POI, once they're editable)
 
 export function populateJurisdictionArray(record) {
-  const jurisdictions = record?.form_data?.activity_data?.jurisdictions;
+  const jurisdictions = record?.form_data?.activity_data?.jurisdictions ?? [];
 
-  let jurisdiction = [];
-  if (jurisdictions) {
-    jurisdiction = jurisdictions?.map((j) => {
-      return j.jurisdiction_code;
-    });
-  } else {
-    return record;
-  }
+  const jurisdiction = jurisdictions
+    .map(({ jurisdiction_code }) => jurisdiction_code)
+    .filter(Boolean)
+    .sort();
 
-  return {
-    ...record,
-    jurisdiction: jurisdiction.sort() || []
-  };
+  return { ...record, jurisdiction };
 }
 
 /**

--- a/sharedAPI/src/index.ts
+++ b/sharedAPI/src/index.ts
@@ -237,123 +237,163 @@ export const getShortActivityID = (activity) => {
 };
 
 export function populateSpeciesArrays(record) {
-  let species_positive: any = [];
-  let species_negative: any[] = [];
-  let species_treated: any[] = [];
+  const species_positive: Array<string> = [];
+  const species_negative: Array<string> = [];
+  const species_treated: Array<string> = [];
 
   const subtypeData = record?.form_data?.activity_subtype_data;
 
   switch (record.activity_subtype) {
-    case ActivitySubtype.Observation_PlantTerrestrial:
-      species_positive = subtypeData?.TerrestrialPlants?.filter((plant) =>
-        plant.observation_type?.includes('Positive')
-      ).map((plant) => plant.invasive_plant_code);
-      species_negative = subtypeData?.TerrestrialPlants?.filter((plant) =>
-        plant.observation_type?.includes('Negative')
-      ).map((plant) => plant.invasive_plant_code);
+    // Observation Types
+    case ActivitySubtype.Observation_PlantTerrestrial: {
+      const arr = subtypeData?.TerrestrialPlants ?? [];
+      species_positive.push(
+        ...arr
+          .filter((plant) => plant.observation_type?.includes('Positive'))
+          .map(({ invasive_plant_code }) => invasive_plant_code)
+      );
+      species_negative.push(
+        ...arr
+          .filter((plant) => plant.observation_type?.includes('Negative'))
+          .map(({ invasive_plant_code }) => invasive_plant_code)
+      );
       break;
-    case ActivitySubtype.Observation_PlantAquatic:
-      species_positive = subtypeData?.AquaticPlants?.filter((plant) =>
-        plant.observation_type?.includes('Positive')
-      ).map((plant) => plant.invasive_plant_code);
-      species_negative = subtypeData?.AquaticPlants?.filter((plant) =>
-        plant.observation_type?.includes('Negative')
-      ).map((plant) => plant.invasive_plant_code);
+    }
+    case ActivitySubtype.Observation_PlantAquatic: {
+      const arr = subtypeData.AquaticPlants ?? [];
+      species_positive.push(
+        ...arr
+          .filter((plant) => plant.observation_type?.includes('Positive'))
+          .map(({ invasive_plant_code }) => invasive_plant_code)
+      );
+      species_negative.push(
+        ...arr
+          .filter((plant) => plant.observation_type?.includes('Negative'))
+          .map(({ invasive_plant_code }) => invasive_plant_code)
+      );
       break;
+    }
+    // Treatment Types
+    case ActivitySubtype.Treatment_ChemicalPlantAquatic: {
+      const arr = subtypeData?.chemical_treatment_details?.invasive_plants ?? [];
+      species_treated.push(...arr.map(({ invasive_plant_code }) => invasive_plant_code));
+      break;
+    }
+    case ActivitySubtype.Treatment_ChemicalPlant: {
+      const arr = subtypeData?.chemical_treatment_details?.invasive_plants ?? [];
+      species_treated.push(...arr.map(({ invasive_plant_code }) => invasive_plant_code));
+      break;
+    }
+    case ActivitySubtype.Treatment_MechanicalPlantAquatic: // Intentional Fallthrough
+    case ActivitySubtype.Treatment_MechanicalPlant: {
+      const arr = subtypeData?.Treatment_MechanicalPlant_Information ?? [];
+      species_treated.push(...arr.map(({ invasive_plant_code }) => invasive_plant_code));
+      break;
+    }
+    case ActivitySubtype.Treatment_BiologicalPlant: {
+      const arr = subtypeData?.Biocontrol_Release_Information ?? [];
+      species_treated.push(...arr.map(({ invasive_plant_code }) => invasive_plant_code));
+      break;
+    }
+    // Monitoring Types
+    case ActivitySubtype.Monitoring_ChemicalTerrestrialAquaticPlant: {
+      const arr = subtypeData?.Monitoring_ChemicalTerrestrialAquaticPlant_Information ?? [];
+      species_treated.push(
+        ...arr.flatMap(({ invasive_plant_code, invasive_plant_aquatic_code }) =>
+          [invasive_plant_code, invasive_plant_aquatic_code].filter(Boolean)
+        )
+      );
+      break;
+    }
+    case ActivitySubtype.Monitoring_MechanicalTerrestrialAquaticPlant: {
+      const arr = subtypeData?.Monitoring_MechanicalTerrestrialAquaticPlant_Information ?? [];
+      species_treated.push(
+        ...arr.flatMap(({ invasive_plant_code, invasive_plant_aquatic_code }) =>
+          [invasive_plant_code, invasive_plant_aquatic_code].filter(Boolean)
+        )
+      );
+      break;
+    }
+    case ActivitySubtype.Monitoring_BiologicalTerrestrialPlant: {
+      const arr = subtypeData?.Monitoring_BiocontrolRelease_TerrestrialPlant_Information ?? [];
+      species_treated.push(...arr.map(({ invasive_plant_code }) => invasive_plant_code));
+      break;
+    }
+    case ActivitySubtype.Monitoring_BiologicalDispersal: {
+      const arr = subtypeData?.Monitoring_BiocontrolDispersal_Information ?? [];
+      species_treated.push(...arr.map(({ invasive_plant_code }) => invasive_plant_code));
+      break;
+    }
+    // Biocontrol Types
+    case ActivitySubtype.Collection_Biocontrol: {
+      const arr = subtypeData?.Biocontrol_Collection_Information ?? [];
+      species_treated.push(...arr.map(({ invasive_plant_code }) => invasive_plant_code));
+      break;
+    }
 
-    case ActivitySubtype.Activity_AnimalTerrestrial:
-      // no species selection currently
-      break;
-    case ActivitySubtype.Activity_AnimalAquatic:
-      species_treated = subtypeData?.invasive_aquatic_animals?.map((animal) => animal.invasive_animal_code);
-      break;
-    case ActivitySubtype.Treatment_ChemicalPlantAquatic:
-      species_treated = subtypeData?.chemical_treatment_details?.invasive_plants?.map(
-        (plant) => plant.invasive_plant_code
-      );
-      break;
-    case ActivitySubtype.Treatment_ChemicalPlant:
-      species_treated = subtypeData?.chemical_treatment_details?.invasive_plants?.map(
-        (plant) => plant.invasive_plant_code
-      );
-      break;
-    case ActivitySubtype.Treatment_MechanicalPlantAquatic:
-      species_treated = subtypeData?.Treatment_MechanicalPlant_Information?.map((plant) => plant.invasive_plant_code);
-      break;
-    case ActivitySubtype.Treatment_MechanicalPlant:
-      species_treated = subtypeData?.Treatment_MechanicalPlant_Information?.map((plant) => plant.invasive_plant_code);
-      break;
-    case ActivitySubtype.Treatment_BiologicalPlant:
-      species_treated = subtypeData?.Biocontrol_Release_Information?.map((plant) => plant.invasive_plant_code);
-      break;
-    case ActivitySubtype.Monitoring_ChemicalTerrestrialAquaticPlant:
-      species_treated = subtypeData?.Monitoring_ChemicalTerrestrialAquaticPlant_Information?.flatMap((plantInfo) =>
-        [plantInfo?.invasive_plant_code, plantInfo?.invasive_plant_aquatic_code].filter(Boolean)
-      );
-      break;
-    case ActivitySubtype.Monitoring_MechanicalTerrestrialAquaticPlant:
-      species_treated = subtypeData?.Monitoring_MechanicalTerrestrialAquaticPlant_Information?.flatMap((plantInfo) =>
-        [plantInfo?.invasive_plant_code, plantInfo?.invasive_plant_aquatic_code].filter(Boolean)
-      );
-      break;
-    case ActivitySubtype.Monitoring_BiologicalTerrestrialPlant:
-      species_treated = subtypeData?.Monitoring_BiocontrolRelease_TerrestrialPlant_Information?.map(
-        (plantInfo) => plantInfo?.invasive_plant_code
-      );
-      break;
-    case ActivitySubtype.Monitoring_BiologicalDispersal:
-      species_treated = subtypeData?.Monitoring_BiocontrolDispersal_Information?.map(
-        (plantInfo) => plantInfo?.invasive_plant_code
-      );
-      break;
-    case ActivitySubtype.Transect_FireMonitoring:
-      species_positive = subtypeData?.fire_monitoring_transect_lines
-        ?.map((line) =>
-          line.fire_monitoring_transect_points?.map((point) =>
-            point.invasive_plants?.map((plant) => plant.invasive_plant_code)
-          )
-        )
-        .flat(3);
-      break;
-    case ActivitySubtype.Transect_Vegetation:
-      species_positive = subtypeData?.vegetation_transect_lines
-        ?.map((line) =>
-          [
-            line.vegetation_transect_points_percent_cover,
-            line.vegetation_transect_points_number_plants,
-            line.vegetation_transect_points_daubenmire
-          ]
-            .flat(2)
-            .filter((point) => point)
-            .map((point) =>
-              point.vegetation_transect_species?.invasive_plants?.map((plant) => plant.invasive_plant_code)
+    // None implemented
+    case ActivitySubtype.Transect_FireMonitoring: {
+      const arr = subtypeData?.fire_monitoring_transect_lines ?? [];
+      species_positive.push(
+        ...arr
+          .map((line) =>
+            line.fire_monitoring_transect_points?.map((point) =>
+              point.invasive_plants?.map((plant) => plant.invasive_plant_code)
             )
-        )
-        .flat(3);
+          )
+          .flat(3)
+      );
       break;
-    case ActivitySubtype.Transect_BiocontrolEfficacy:
-      species_positive = subtypeData?.transect_invasive_plants?.map((plant) => plant.invasive_plant_code) || [];
+    }
+    case ActivitySubtype.Transect_Vegetation: {
+      const arr = subtypeData?.vegetation_transect_lines ?? [];
+      species_positive.push(
+        ...arr
+          .map((line) =>
+            [
+              line.vegetation_transect_points_percent_cover,
+              line.vegetation_transect_points_number_plants,
+              line.vegetation_transect_points_daubenmire
+            ]
+              .flat(2)
+              .filter((point) => point)
+              .map((point) =>
+                point.vegetation_transect_species?.invasive_plants?.map((plant) => plant.invasive_plant_code)
+              )
+          )
+          .flat(3)
+      );
       break;
-    case ActivitySubtype.Collection_Biocontrol:
-      species_treated = subtypeData?.Biocontrol_Collection_Information?.map((plant) => plant.invasive_plant_code);
+    }
+    case ActivitySubtype.Transect_BiocontrolEfficacy: {
+      const arr = subtypeData?.transect_invasive_plants ?? [];
+      species_positive.push(...arr.map((plant) => plant.invasive_plant_code));
       break;
+    }
+    case ActivitySubtype.Activity_AnimalTerrestrial: {
+      console.warn('no species selection currently available for Activity_AnimalTerrestrial');
+      break;
+    }
+    case ActivitySubtype.Activity_AnimalAquatic: {
+      const arr = subtypeData?.invasive_aquatic_animals ?? [];
+      species_treated.push(...arr.map((animal) => animal.invasive_animal_code));
+      break;
+    }
     default:
       break;
   }
   const returnVal = {
     ...record,
-    species_positive:
-      Array.from(new Set(species_positive || []))
-        ?.filter((code) => typeof code === 'string')
-        .sort() || [],
-    species_negative:
-      Array.from(new Set(species_negative || []))
-        ?.filter((code) => typeof code === 'string')
-        .sort() || [],
-    species_treated:
-      Array.from(new Set(species_treated || []))
-        ?.filter((code) => typeof code === 'string')
-        .sort() || []
+    species_positive: Array.from(new Set(species_positive))
+      ?.filter((code) => typeof code === 'string')
+      .sort(),
+    species_negative: Array.from(new Set(species_negative))
+      ?.filter((code) => typeof code === 'string')
+      .sort(),
+    species_treated: Array.from(new Set(species_treated))
+      ?.filter((code) => typeof code === 'string')
+      .sort()
   };
+
   return returnVal;
 }


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Move Menu Controls into form scope
    - Submission triggers validation through RJSF instead of relying on Redux state (Preventing submission loopholes)
    - Added Alert for when errors exist to notify user
    - Added Focus on first error in form.   
    - Close #4482  
    - Create a Chemical or Mechanical Monitoring Form, then create a new one (in mobile)
- Add recursive cleanup function to form that sets all null values to undefined
    - RJSF views `undefined` as `please delete me` whereas when `null` it subjects it to validation
        - Attempting to refactor this behaviour in the single select clear functionality did not work. It was always null
        - Closes #4483
        - Replication: In a Monitoring Chem Record, select an invasive plant then clear it with the `x`
 - Add key to Chemical Treatment Details
     - This forces the component to rerender and lose its state when a new component is rendered in
     - Closes #4480 
     - Replication: Fill in a Chem Treatment Form, submit the form, from the same page create a new chemical treatment form. The old details will still be there. (This is because the component was stateful and not being rerendered, thus persisting then syncing its data.) 