### PR TITLE
Form Autopopulated fields fixes, map tracking fix

### DIFF
--- a/app/src/UI/Features/LegacyMap/Controls/FindMe.tsx
+++ b/app/src/UI/Features/LegacyMap/Controls/FindMe.tsx
@@ -7,6 +7,8 @@ import MapActions from 'state/actions/map';
 import { GpsFixed, GpsNotFixed, GpsOff } from '@mui/icons-material';
 import { MapContext } from '../helpers/components/MapContext';
 import { MapLibreEvent } from 'maplibre-gl';
+import { isTracking } from 'utils/geoTrackingHelpers';
+import GeoTracking from 'state/actions/geotracking/GeoTracking';
 
 export const FindMeToggle = () => {
   enum Mode {
@@ -21,6 +23,9 @@ export const FindMeToggle = () => {
     if (mode === Mode.ON) {
       dispatch(MapActions.panningOn());
     } else {
+      if (userIsGeoTracking && mode === Mode.FOLLOWING) {
+        dispatch(GeoTracking.stop());
+      }
       dispatch(MapActions.trackLocationToggle());
     }
     setShow(false);
@@ -32,6 +37,7 @@ export const FindMeToggle = () => {
 
   const positionTracking = useSelector((state) => state.Map?.positionTracking);
   const positionFollowing = useSelector((state) => state.Map?.panned);
+  const userIsGeoTracking: boolean = useSelector((state) => isTracking(state.Map.track_me_draw_geo.status));
 
   const [show, setShow] = useState<boolean>(false);
   const [mode, setMode] = useState<Mode>(Mode.OFF);

--- a/app/src/constants/alerts/mappingAlerts.ts
+++ b/app/src/constants/alerts/mappingAlerts.ts
@@ -12,17 +12,20 @@ const mappingAlertMessages: Record<string, AlertMessage> = {
   notWithinBC: {
     content: 'Activity is not within BC',
     severity: AlertSeverity.Error,
-    subject: AlertSubjects.Map
+    subject: AlertSubjects.Map,
+    autoClose: 8
   },
   noAreaCalculated: {
     content: 'The calculated area of your shape is 0, please add more points',
     severity: AlertSeverity.Error,
-    subject: AlertSubjects.Map
+    subject: AlertSubjects.Map,
+    autoClose: 8
   },
   willContainIntersections: {
     severity: AlertSeverity.Error,
     subject: AlertSubjects.Map,
-    content: 'Closing this geometry will result in a shape intersection being formed. Please adjust appropriately.'
+    content: 'Closing this geometry will result in a shape intersection being formed. Please adjust appropriately.',
+    autoClose: 8
   },
   containsIntersections: {
     severity: AlertSeverity.Error,
@@ -45,7 +48,8 @@ const mappingAlertMessages: Record<string, AlertMessage> = {
   doesNotEvaluateAsPolygon: {
     content: 'Given Coordinates could not be evaluated as a Polygon. you may need to update or add new points',
     severity: AlertSeverity.Error,
-    subject: AlertSubjects.Map
+    subject: AlertSubjects.Map,
+    autoClose: 8
   },
 
   // Info

--- a/app/src/state/sagas/activity.ts
+++ b/app/src/state/sagas/activity.ts
@@ -235,6 +235,8 @@ function* handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_STOP() {
           DrawToolActions.updateGeo([]),
           Alerts.create(mappingAlertMessages.trackMyPathStoppedEarly)
         ];
+      } else {
+        return [MapActions.trackLocationStart()];
       }
     };
     yield put(
@@ -295,6 +297,8 @@ function* handle_MAP_TOGGLE_TRACK_ME_DRAW_GEO_STOP() {
           DrawToolActions.updateGeo([]),
           Alerts.create(mappingAlertMessages.trackMyPathStoppedEarly)
         ];
+      } else {
+        return [MapActions.trackLocationStart()];
       }
     };
     yield put(

--- a/app/src/state/sagas/activity.ts
+++ b/app/src/state/sagas/activity.ts
@@ -450,6 +450,12 @@ function* handle_copyGeometry(action: PayloadAction<string>) {
   );
 }
 
+// Force updates to occur (Populating species arrays, jurisdictions, shapes if needed, etc)
+function* handle_PASTE() {
+  const activityState = yield select(selectActivity);
+  yield put(Activity.onFormChangeRequest(activityState.activity.form_data));
+}
+
 function* activityPageSaga() {
   yield all([
     takeEvery(UserSettings.InitState.get, handle_UPDATE_CACHED_RECORDS),
@@ -458,6 +464,7 @@ function* activityPageSaga() {
     takeEvery(Activity.buildFormSchema, handle_ACTIVITY_BUILD_SCHEMA_FOR_FORM_REQUEST),
     takeEvery(Activity.get, handle_ACTIVITY_GET_REQUEST),
     takeEvery(Activity.copy, handle_ACTIVITY_COPY_REQUEST),
+    takeEvery(Activity.paste, handle_PASTE),
     takeEvery(Activity.getNetworkRequest, handle_ACTIVITY_GET_NETWORK_REQUEST),
     takeEvery(AppActions.setUserCoords, handle_MAP_SET_COORDS),
     takeEvery(DrawToolActions.updateGeo, handle_ACTIVITY_UPDATE_GEO_REQUEST),

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -369,7 +369,7 @@ export function* handle_ACTIVITY_ON_FORM_CHANGE_REQUEST(action: PayloadAction<Us
 
       let updatedActivity = populateSpeciesArrays({ ...cloneDeep(previousActivityState), form_data: updatedFormData });
       updatedActivity = populateJurisdictionArray(updatedActivity);
-      updatedActivity = { ...updatedActivity, map_symbol: updatedActivity.species_positive.join(', ') };
+      updatedActivity.map_symbol = updatedActivity.species_positive.join(', ');
       yield put(Activity.OnFormChangeRequestSuccess(updatedActivity));
     } catch (error) {
       console.error(error);

--- a/app/src/utils/addActivity.ts
+++ b/app/src/utils/addActivity.ts
@@ -182,21 +182,14 @@ export function isLinkedTreatmentSubtype(subType: ActivitySubtype): boolean {
 // extract and set the species codes (both positive and negative) of a given activity (or POI, once they're editable)
 
 export function populateJurisdictionArray(record) {
-  const jurisdictions = record?.form_data?.activity_data?.jurisdictions;
+  const jurisdictions = record?.form_data?.activity_data?.jurisdictions ?? [];
 
-  let jurisdiction = [];
-  if (jurisdictions) {
-    jurisdiction = jurisdictions?.map((j) => {
-      return j.jurisdiction_code;
-    });
-  } else {
-    return record;
-  }
+  const jurisdiction = jurisdictions
+    .map(({ jurisdiction_code }) => jurisdiction_code)
+    .filter(Boolean)
+    .sort();
 
-  return {
-    ...record,
-    jurisdiction: jurisdiction.sort() || []
-  };
+  return { ...record, jurisdiction };
 }
 
 /**

--- a/sharedAPI/src/index.ts
+++ b/sharedAPI/src/index.ts
@@ -237,123 +237,163 @@ export const getShortActivityID = (activity) => {
 };
 
 export function populateSpeciesArrays(record) {
-  let species_positive: any = [];
-  let species_negative: any[] = [];
-  let species_treated: any[] = [];
+  const species_positive: Array<string> = [];
+  const species_negative: Array<string> = [];
+  const species_treated: Array<string> = [];
 
   const subtypeData = record?.form_data?.activity_subtype_data;
 
   switch (record.activity_subtype) {
-    case ActivitySubtype.Observation_PlantTerrestrial:
-      species_positive = subtypeData?.TerrestrialPlants?.filter((plant) =>
-        plant.observation_type?.includes('Positive')
-      ).map((plant) => plant.invasive_plant_code);
-      species_negative = subtypeData?.TerrestrialPlants?.filter((plant) =>
-        plant.observation_type?.includes('Negative')
-      ).map((plant) => plant.invasive_plant_code);
+    // Observation Types
+    case ActivitySubtype.Observation_PlantTerrestrial: {
+      const arr = subtypeData?.TerrestrialPlants ?? [];
+      species_positive.push(
+        ...arr
+          .filter((plant) => plant.observation_type?.includes('Positive'))
+          .map(({ invasive_plant_code }) => invasive_plant_code)
+      );
+      species_negative.push(
+        ...arr
+          .filter((plant) => plant.observation_type?.includes('Negative'))
+          .map(({ invasive_plant_code }) => invasive_plant_code)
+      );
       break;
-    case ActivitySubtype.Observation_PlantAquatic:
-      species_positive = subtypeData?.AquaticPlants?.filter((plant) =>
-        plant.observation_type?.includes('Positive')
-      ).map((plant) => plant.invasive_plant_code);
-      species_negative = subtypeData?.AquaticPlants?.filter((plant) =>
-        plant.observation_type?.includes('Negative')
-      ).map((plant) => plant.invasive_plant_code);
+    }
+    case ActivitySubtype.Observation_PlantAquatic: {
+      const arr = subtypeData.AquaticPlants ?? [];
+      species_positive.push(
+        ...arr
+          .filter((plant) => plant.observation_type?.includes('Positive'))
+          .map(({ invasive_plant_code }) => invasive_plant_code)
+      );
+      species_negative.push(
+        ...arr
+          .filter((plant) => plant.observation_type?.includes('Negative'))
+          .map(({ invasive_plant_code }) => invasive_plant_code)
+      );
       break;
+    }
+    // Treatment Types
+    case ActivitySubtype.Treatment_ChemicalPlantAquatic: {
+      const arr = subtypeData?.chemical_treatment_details?.invasive_plants ?? [];
+      species_treated.push(...arr.map(({ invasive_plant_code }) => invasive_plant_code));
+      break;
+    }
+    case ActivitySubtype.Treatment_ChemicalPlant: {
+      const arr = subtypeData?.chemical_treatment_details?.invasive_plants ?? [];
+      species_treated.push(...arr.map(({ invasive_plant_code }) => invasive_plant_code));
+      break;
+    }
+    case ActivitySubtype.Treatment_MechanicalPlantAquatic: // Intentional Fallthrough
+    case ActivitySubtype.Treatment_MechanicalPlant: {
+      const arr = subtypeData?.Treatment_MechanicalPlant_Information ?? [];
+      species_treated.push(...arr.map(({ invasive_plant_code }) => invasive_plant_code));
+      break;
+    }
+    case ActivitySubtype.Treatment_BiologicalPlant: {
+      const arr = subtypeData?.Biocontrol_Release_Information ?? [];
+      species_treated.push(...arr.map(({ invasive_plant_code }) => invasive_plant_code));
+      break;
+    }
+    // Monitoring Types
+    case ActivitySubtype.Monitoring_ChemicalTerrestrialAquaticPlant: {
+      const arr = subtypeData?.Monitoring_ChemicalTerrestrialAquaticPlant_Information ?? [];
+      species_treated.push(
+        ...arr.flatMap(({ invasive_plant_code, invasive_plant_aquatic_code }) =>
+          [invasive_plant_code, invasive_plant_aquatic_code].filter(Boolean)
+        )
+      );
+      break;
+    }
+    case ActivitySubtype.Monitoring_MechanicalTerrestrialAquaticPlant: {
+      const arr = subtypeData?.Monitoring_MechanicalTerrestrialAquaticPlant_Information ?? [];
+      species_treated.push(
+        ...arr.flatMap(({ invasive_plant_code, invasive_plant_aquatic_code }) =>
+          [invasive_plant_code, invasive_plant_aquatic_code].filter(Boolean)
+        )
+      );
+      break;
+    }
+    case ActivitySubtype.Monitoring_BiologicalTerrestrialPlant: {
+      const arr = subtypeData?.Monitoring_BiocontrolRelease_TerrestrialPlant_Information ?? [];
+      species_treated.push(...arr.map(({ invasive_plant_code }) => invasive_plant_code));
+      break;
+    }
+    case ActivitySubtype.Monitoring_BiologicalDispersal: {
+      const arr = subtypeData?.Monitoring_BiocontrolDispersal_Information ?? [];
+      species_treated.push(...arr.map(({ invasive_plant_code }) => invasive_plant_code));
+      break;
+    }
+    // Biocontrol Types
+    case ActivitySubtype.Collection_Biocontrol: {
+      const arr = subtypeData?.Biocontrol_Collection_Information ?? [];
+      species_treated.push(...arr.map(({ invasive_plant_code }) => invasive_plant_code));
+      break;
+    }
 
-    case ActivitySubtype.Activity_AnimalTerrestrial:
-      // no species selection currently
-      break;
-    case ActivitySubtype.Activity_AnimalAquatic:
-      species_treated = subtypeData?.invasive_aquatic_animals?.map((animal) => animal.invasive_animal_code);
-      break;
-    case ActivitySubtype.Treatment_ChemicalPlantAquatic:
-      species_treated = subtypeData?.chemical_treatment_details?.invasive_plants?.map(
-        (plant) => plant.invasive_plant_code
-      );
-      break;
-    case ActivitySubtype.Treatment_ChemicalPlant:
-      species_treated = subtypeData?.chemical_treatment_details?.invasive_plants?.map(
-        (plant) => plant.invasive_plant_code
-      );
-      break;
-    case ActivitySubtype.Treatment_MechanicalPlantAquatic:
-      species_treated = subtypeData?.Treatment_MechanicalPlant_Information?.map((plant) => plant.invasive_plant_code);
-      break;
-    case ActivitySubtype.Treatment_MechanicalPlant:
-      species_treated = subtypeData?.Treatment_MechanicalPlant_Information?.map((plant) => plant.invasive_plant_code);
-      break;
-    case ActivitySubtype.Treatment_BiologicalPlant:
-      species_treated = subtypeData?.Biocontrol_Release_Information?.map((plant) => plant.invasive_plant_code);
-      break;
-    case ActivitySubtype.Monitoring_ChemicalTerrestrialAquaticPlant:
-      species_treated = subtypeData?.Monitoring_ChemicalTerrestrialAquaticPlant_Information?.flatMap((plantInfo) =>
-        [plantInfo?.invasive_plant_code, plantInfo?.invasive_plant_aquatic_code].filter(Boolean)
-      );
-      break;
-    case ActivitySubtype.Monitoring_MechanicalTerrestrialAquaticPlant:
-      species_treated = subtypeData?.Monitoring_MechanicalTerrestrialAquaticPlant_Information?.flatMap((plantInfo) =>
-        [plantInfo?.invasive_plant_code, plantInfo?.invasive_plant_aquatic_code].filter(Boolean)
-      );
-      break;
-    case ActivitySubtype.Monitoring_BiologicalTerrestrialPlant:
-      species_treated = subtypeData?.Monitoring_BiocontrolRelease_TerrestrialPlant_Information?.map(
-        (plantInfo) => plantInfo?.invasive_plant_code
-      );
-      break;
-    case ActivitySubtype.Monitoring_BiologicalDispersal:
-      species_treated = subtypeData?.Monitoring_BiocontrolDispersal_Information?.map(
-        (plantInfo) => plantInfo?.invasive_plant_code
-      );
-      break;
-    case ActivitySubtype.Transect_FireMonitoring:
-      species_positive = subtypeData?.fire_monitoring_transect_lines
-        ?.map((line) =>
-          line.fire_monitoring_transect_points?.map((point) =>
-            point.invasive_plants?.map((plant) => plant.invasive_plant_code)
-          )
-        )
-        .flat(3);
-      break;
-    case ActivitySubtype.Transect_Vegetation:
-      species_positive = subtypeData?.vegetation_transect_lines
-        ?.map((line) =>
-          [
-            line.vegetation_transect_points_percent_cover,
-            line.vegetation_transect_points_number_plants,
-            line.vegetation_transect_points_daubenmire
-          ]
-            .flat(2)
-            .filter((point) => point)
-            .map((point) =>
-              point.vegetation_transect_species?.invasive_plants?.map((plant) => plant.invasive_plant_code)
+    // None implemented
+    case ActivitySubtype.Transect_FireMonitoring: {
+      const arr = subtypeData?.fire_monitoring_transect_lines ?? [];
+      species_positive.push(
+        ...arr
+          .map((line) =>
+            line.fire_monitoring_transect_points?.map((point) =>
+              point.invasive_plants?.map((plant) => plant.invasive_plant_code)
             )
-        )
-        .flat(3);
+          )
+          .flat(3)
+      );
       break;
-    case ActivitySubtype.Transect_BiocontrolEfficacy:
-      species_positive = subtypeData?.transect_invasive_plants?.map((plant) => plant.invasive_plant_code) || [];
+    }
+    case ActivitySubtype.Transect_Vegetation: {
+      const arr = subtypeData?.vegetation_transect_lines ?? [];
+      species_positive.push(
+        ...arr
+          .map((line) =>
+            [
+              line.vegetation_transect_points_percent_cover,
+              line.vegetation_transect_points_number_plants,
+              line.vegetation_transect_points_daubenmire
+            ]
+              .flat(2)
+              .filter((point) => point)
+              .map((point) =>
+                point.vegetation_transect_species?.invasive_plants?.map((plant) => plant.invasive_plant_code)
+              )
+          )
+          .flat(3)
+      );
       break;
-    case ActivitySubtype.Collection_Biocontrol:
-      species_treated = subtypeData?.Biocontrol_Collection_Information?.map((plant) => plant.invasive_plant_code);
+    }
+    case ActivitySubtype.Transect_BiocontrolEfficacy: {
+      const arr = subtypeData?.transect_invasive_plants ?? [];
+      species_positive.push(...arr.map((plant) => plant.invasive_plant_code));
       break;
+    }
+    case ActivitySubtype.Activity_AnimalTerrestrial: {
+      console.warn('no species selection currently available for Activity_AnimalTerrestrial');
+      break;
+    }
+    case ActivitySubtype.Activity_AnimalAquatic: {
+      const arr = subtypeData?.invasive_aquatic_animals ?? [];
+      species_treated.push(...arr.map((animal) => animal.invasive_animal_code));
+      break;
+    }
     default:
       break;
   }
   const returnVal = {
     ...record,
-    species_positive:
-      Array.from(new Set(species_positive || []))
-        ?.filter((code) => typeof code === 'string')
-        .sort() || [],
-    species_negative:
-      Array.from(new Set(species_negative || []))
-        ?.filter((code) => typeof code === 'string')
-        .sort() || [],
-    species_treated:
-      Array.from(new Set(species_treated || []))
-        ?.filter((code) => typeof code === 'string')
-        .sort() || []
+    species_positive: Array.from(new Set(species_positive))
+      ?.filter((code) => typeof code === 'string')
+      .sort(),
+    species_negative: Array.from(new Set(species_negative))
+      ?.filter((code) => typeof code === 'string')
+      .sort(),
+    species_treated: Array.from(new Set(species_treated))
+      ?.filter((code) => typeof code === 'string')
+      .sort()
   };
+
   return returnVal;
 }


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- If user attempts to stop tracking themselves but are **actively** Geotracking, disable geotracking, else, keep map tracking on.
    - Prevents user from turning off panning, losing render of tracking button, and having draw tools be disabled. 
    - Closes #4486
- When records are Duplicated, immediately fire formChangeRequest to ensure autopopulated fields are filled in. 
    - This was being skipped, and if a user only updated the geometry and submitted, would never occur.
    - Fixes issue where fields in db (species_positive, species_negative, species_treated) were `null` when they should not have been
    - Closes #4484
- Make all map alerts autoclose where not previously assigned
- Cleanup `populateSpeciesArrays` to not keep reassigning `let` variables, prefer const for consistency.