### PR TITLE
Update Form Photo Module

### DIFF
--- a/app/src/UI/Features/Records/Activity/forms/common/validators/index.ts
+++ b/app/src/UI/Features/Records/Activity/forms/common/validators/index.ts
@@ -1,6 +1,7 @@
 export { default as noFutureDate } from './noFutureDate';
 export { default as checkSum } from './checkSum';
 export { default as minArrayLength } from './minArrayLength';
+export { default as maxArrayLength } from './maxArrayLength';
 export { default as noRepeatKey } from './noRepeatKey';
 export { default as greaterThan } from './greaterThan';
 export { default as greaterThanEqual } from './greaterThanEqual';

--- a/app/src/UI/Features/Records/Activity/forms/common/validators/maxArrayLength.ts
+++ b/app/src/UI/Features/Records/Activity/forms/common/validators/maxArrayLength.ts
@@ -1,0 +1,5 @@
+const maxArrayLength = (val: Array<unknown>, max: number): boolean | string => {
+  return val?.length <= max || `Maximum ${max} entries are allowed.`;
+};
+
+export default maxArrayLength;

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/ActivityForm.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/ActivityForm.tsx
@@ -158,11 +158,14 @@ const ActivityForm = () => {
       <FormProvider {...methods}>
         <form autoComplete={'off'} id="activity-form" onSubmit={handleSubmit(onSubmit)}>
           <RecordMetadata formState={getValues()} />
-          {mode &&
-            {
-              [Mode.Form]: <Form />,
-              [Mode.Photo]: <Photos />
-            }[mode]}
+          {/* Use conditional Rendering so RHF Doesn't unmount fields in its validation step on submit */}
+          <div className={`form-section ${mode === Mode.Form ? 'active' : ''}`}>
+            <Form />
+          </div>
+          <div className={`form-section ${mode === Mode.Photo ? 'active' : ''}`}>
+            <Photos />
+          </div>
+
           <FormControl />
 
           {/* Debug Information/Options */}

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/Participants.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/Participants.tsx
@@ -2,12 +2,12 @@ import { get, useFormContext } from 'react-hook-form';
 import { useSelector } from 'utils/use_selector';
 import { FormSchema } from 'UI/Features/Records/Activity/forms/plant/interfaces';
 import ArrayField from 'UI/Features/Records/Activity/forms/common/ArrayField/ArrayField';
-import { minArrayLength, greaterThanEqual } from '../../common/validators';
+import { minArrayLength, greaterThanEqual } from 'UI/Features/Records/Activity/forms/common/validators';
 import TextInput from 'UI/Features/Records/Activity/forms/common/TextInput/TextInput';
 import NumberInput from 'UI/Features/Records/Activity/forms/common/NumberInput/NumberInput';
 import { Width } from 'UI/Features/Records/Activity/forms/common/utils';
 import tooltips from 'UI/Features/Records/Activity/forms/plant/content/tooltips';
-import getDefaultFormState from '../builders/getDefaultState';
+import getDefaultFormState from 'UI/Features/Records/Activity/forms/plant/builders/getDefaultState';
 import { isActivityChemicalTreatment } from 'state/reducers/activity';
 
 const Participants = () => {

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/Photos.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/Photos.tsx
@@ -1,12 +1,15 @@
-import { CameraResultType, CameraSource, Camera } from '@capacitor/camera';
+import { Camera, MediaTypeSelection, MediaResult } from '@capacitor/camera';
 import UploadedPhoto from 'interfaces/UploadedPhoto';
 import { useDispatch } from 'utils/use_selector';
 import 'UI/Features/Records/Activity/PhotoContainer.css';
 import Alerts from 'state/actions/alerts/Alerts';
 import { AlertSeverity, AlertSubjects } from 'constants/alertEnums';
-import { useFieldArray, useFormContext, useWatch } from 'react-hook-form';
-import { FormSchema } from '../interfaces';
+import { get, useFieldArray, useFormContext, useWatch } from 'react-hook-form';
+import { FormSchema } from 'UI/Features/Records/Activity/forms/plant/interfaces';
 import Photo from './Photo';
+import ErrorMessage from 'UI/Features/Records/Activity/forms/common/ErrorMessage/ErrorMessage';
+import { maxArrayLength } from 'UI/Features/Records/Activity/forms/common/validators';
+import { useEffect } from 'react';
 
 const Photos = () => {
   const alertAccessWasDenied = (type: string) =>
@@ -19,100 +22,66 @@ const Photos = () => {
       })
     );
 
-  async function convertWebPathToDataUrl(webPath: string): Promise<string> {
-    const response = await fetch(webPath);
-    const blob = await response.blob();
-
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onloadend = () => resolve(reader.result as string); // result is a dataUrl
-      reader.onerror = reject;
-      reader.readAsDataURL(blob);
-    });
-  }
-  const checkPermissionsAndAlert = async (photoOption: CameraSource): Promise<void> => {
-    try {
-      const permissions = await Camera.checkPermissions();
-      if (permissions.camera !== 'denied') return;
-      if (photoOption === CameraSource.Camera) {
-        alertAccessWasDenied('Camera');
-      } else if (photoOption === CameraSource.Photos) {
-        alertAccessWasDenied('Photo Library');
-      }
-    } catch (error) {
-      console.error('Error checking permissions:', error);
-    }
+  const checkPermissionsAndAlert = async (photoOption: 'Photo Gallery' | 'Camera'): Promise<void> => {
+    const permissions = await Camera.checkPermissions();
+    if (permissions.camera !== 'denied') return;
+    alertAccessWasDenied(photoOption);
   };
+
+  const transformImageToFormData = (photo: MediaResult, index = 0): UploadedPhoto => {
+    const fileName = `${new Date().toISOString().slice(0, 10)}-${index}.${photo.metadata?.format}`;
+    const dataUrl = `data:image/${photo.metadata?.format};base64,${photo.thumbnail}`;
+    return {
+      file_name: fileName,
+      encoded_file: dataUrl,
+      description: `Untitled.${photo.metadata?.format}`
+    } as UploadedPhoto;
+  };
+
   const takePhotoFromCamera = async () => {
     try {
-      await checkPermissionsAndAlert(CameraSource.Camera);
-      const cameraPhoto = await Camera.getPhoto({
+      await checkPermissionsAndAlert('Camera');
+      const result = await Camera.takePhoto({
         presentationStyle: 'fullscreen',
-        resultType: CameraResultType.DataUrl,
-        source: CameraSource.Camera,
-        quality: 100
+        quality: 75,
+        includeMetadata: true
       });
-
-      const fileName = new Date().toISOString().slice(0, 10) + '.' + cameraPhoto.format;
-      const photo = {
-        file_name: fileName,
-        encoded_file: cameraPhoto.dataUrl,
-        description: 'Untitled'
-      } as UploadedPhoto;
-
-      append(photo);
+      append(transformImageToFormData(result));
     } catch (e) {
-      console.error('User cancelled prematurely or other problem occured.', e);
+      console.error(e);
     }
   };
 
   const choosePhotosFromLibrary = async () => {
     try {
-      await checkPermissionsAndAlert(CameraSource.Photos);
-      const multiplePhotos = await Camera.pickImages({
-        quality: 100,
-        limit: 10
+      await checkPermissionsAndAlert('Photo Gallery');
+      const { results } = await Camera.chooseFromGallery({
+        mediaType: MediaTypeSelection.Photo,
+        includeMetadata: true,
+        allowMultipleSelection: true,
+        limit: 5,
+        quality: 75
       });
-
-      if (!multiplePhotos.photos.length) {
-        console.warn('No photos selected');
-        return;
-      }
-
-      // process all photos concurrently
-      const processedPhotos = await Promise.all(
-        multiplePhotos.photos.map(async (photo, index) => {
-          try {
-            const fileName = `${new Date().toISOString().slice(0, 10)}-${index}.${photo.format}`;
-            const dataUrl = await convertWebPathToDataUrl(photo.webPath);
-
-            return {
-              file_name: fileName,
-              encoded_file: dataUrl,
-              description: 'Untitled'
-            } as UploadedPhoto;
-          } catch (error) {
-            console.error(`Error processing photo ${index + 1}:`, error);
-            return null; // skip photo on failure
-          }
-        })
-      );
-
+      const processedPhotos = results.map(transformImageToFormData);
       // filter out failed photo conversions
-      const validPhotos = processedPhotos.filter((photo) => photo != null);
-      validPhotos.forEach((photo) => append(photo));
+      processedPhotos.filter(Boolean).forEach((p) => append(p));
     } catch (e) {
-      console.error('error occurred: ', e);
+      console.error(e);
     }
   };
 
   const {
     control,
-    formState: { disabled }
+    formState: { disabled, errors },
+    trigger
   } = useFormContext<FormSchema>();
 
   // Setup FieldArray for push/pop/watch
-  const { fields, append, remove } = useFieldArray<FormSchema>({ control, name: 'media' });
+  const { fields, append, remove } = useFieldArray<FormSchema>({
+    control,
+    name: 'media',
+    rules: { validate: (arr) => maxArrayLength(arr, 5) }
+  });
 
   // useFieldArray won't watch internal changes, so use watch to capture
   const watchedMedia = useWatch<FormSchema>({
@@ -122,36 +91,41 @@ const Photos = () => {
   });
   const dispatch = useDispatch();
 
+  useEffect(() => {
+    trigger('media');
+  }, [watchedMedia]);
+
   if (!fields) {
     return <section id="photo-cont">No Images found for Record</section>;
   }
   return (
-    <>
-      <section id="photo-cont">
-        <h2>Photos</h2>
-        <div className="content">
-          {watchedMedia.map((photo, index: number) => (
-            <Photo key={photo.id} photo={photo} index={index} remove={() => remove(index)} />
-          ))}
-        </div>
-        <div className="control">
-          <input
-            type="button"
-            className="control-button"
-            disabled={disabled}
-            onClick={takePhotoFromCamera}
-            value={'Capture Photo'}
-          />
-          <input
-            type="button"
-            className="control-button"
-            disabled={disabled}
-            onClick={choosePhotosFromLibrary}
-            value="Choose from Gallery"
-          />
-        </div>
-      </section>
-    </>
+    <section id="photo-cont">
+      <h2>Photos</h2>
+      <p>
+        <ErrorMessage error={get(errors, 'media')?.root} />
+      </p>
+      <div className="content">
+        {watchedMedia.map((photo, index: number) => (
+          <Photo key={photo.id} photo={photo} index={index} remove={() => remove(index)} />
+        ))}
+      </div>
+      <div className="control">
+        <input
+          type="button"
+          className="control-button"
+          disabled={disabled}
+          onClick={takePhotoFromCamera}
+          value={'Capture Photo'}
+        />
+        <input
+          type="button"
+          className="control-button"
+          disabled={disabled}
+          onClick={choosePhotosFromLibrary}
+          value="Choose from Gallery"
+        />
+      </div>
+    </section>
   );
 };
 

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/activityForm.css
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/activityForm.css
@@ -16,6 +16,15 @@ input[type='button']:hover {
     margin-bottom: 15px;
   }
 
+  .form-section {
+    width: 100%;
+    display: none;
+
+    &.active {
+      display: block;
+    }
+  }
+
   nav {
     display: flex;
     flex-direction: 100%;

--- a/app/src/UI/Reusable/StyledModal/StyledModal.css
+++ b/app/src/UI/Reusable/StyledModal/StyledModal.css
@@ -58,6 +58,7 @@
 
       img {
         object-fit: contain;
+        max-height: 80vh;
         height: 100%;
         width: 100%;
       }


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Update Capacitor Photo out of deprecated functions
    - Set image quality to 75% to reduce total size.
    - Simplify logic
- Change rendering of `ActivityForm` modules.
    - Keeps RHF from losing context of active fields when switching between tabs (ensures everything is validated in either context).
- Add validation rules to media uploads (max images per file: 5)
    - add maxArrayLength validator 
    - Add error text below `Photo` title.
- Set max image height on `StyledModal`. Prevents iOS from overriding and creating modals outside of what they should be... 
    - not replicable through web browsers, only occured on mobile with large portrait images