### PR TITLE
[INV-4537] Upgrade Capacitor Photo handling, fix IAPP image UI/Bug

### DIFF
--- a/api/src/paths/media.ts
+++ b/api/src/paths/media.ts
@@ -44,7 +44,7 @@ function getMedia(): RequestHandler {
     return res.status(200).json({
       message: 'Successfully got media',
       request: req.query,
-      result: getMediaItemsList(response, keys),
+      result: await getMediaItemsList(response, keys),
       namespace: 'media',
       code: 200
     });

--- a/app/src/UI/Features/IAPP/IAPPRecords.css
+++ b/app/src/UI/Features/IAPP/IAPPRecords.css
@@ -64,6 +64,7 @@
 
 .records__activity .control {
   width: 100%;
+  box-sizing: border-box;
   max-width: 1200px;
   color: red;
   padding: 10pt;

--- a/app/src/UI/Features/IAPP/Photos.css
+++ b/app/src/UI/Features/IAPP/Photos.css
@@ -1,0 +1,59 @@
+.main-photo-cont {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.iapp-photo-container {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  width: 100%;
+  max-width: 1100px;
+  justify-content: center;
+}
+
+.iapp-photo {
+  width: 100%;
+  max-width: 1000px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-sizing: border-box;
+  padding: 5px;
+
+  .image-details {
+    display: grid;
+    justify-content: center;
+    grid-template-columns: auto;
+    padding: 1rem;
+    border: 1pt solid black;
+    margin: 0.5rem;
+    background-color: #eee;
+
+    div {
+      margin: 2px;
+      padding: 0.55rem 1rem;
+      text-align: left;
+      display: flex;
+      background-color: white;
+      justify-content: space-between;
+
+      dt::after {
+        content: ':';
+      }
+    }
+  }
+
+  img {
+    width: 100%;
+    object-fit: contain;
+  }
+}
+
+@media only screen and (width >= 575px) {
+  .iapp-photo .image-details {
+    grid-template-columns: auto auto;
+  }
+}

--- a/app/src/UI/Features/IAPP/Photos.tsx
+++ b/app/src/UI/Features/IAPP/Photos.tsx
@@ -1,7 +1,7 @@
-import { Accordion, AccordionSummary, Paper } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import { useInvasivesApi } from 'hooks/useInvasivesApi';
 import Spinner from 'UI/Reusable/Spinner/Spinner';
+import './Photos.css';
 
 type MediaDescriptor = {
   media_key: string;
@@ -14,7 +14,6 @@ type MediaDescriptor = {
 };
 
 export const Photos: React.FC<{ media: MediaDescriptor[] }> = ({ media }) => {
-  const [expanded, setExpanded] = React.useState(true);
   const [mediaURLs, setMediaURLs] = useState<MediaDescriptor[]>([]);
   const [error, setError] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -43,14 +42,13 @@ export const Photos: React.FC<{ media: MediaDescriptor[] }> = ({ media }) => {
     }
   }, [media]);
 
+  const MISSING_CONTENT = 'Not Provided.';
   function renderContent() {
     if (loading) {
       return <Spinner />;
-    }
-    if (error) {
+    } else if (error) {
       return <span>Error loading images</span>;
-    }
-    if (media.length === 0) {
+    } else if (media.length === 0) {
       return <span>This record has no photos associated with it.</span>;
     }
     return mediaURLs?.map((m) => {
@@ -63,24 +61,29 @@ export const Photos: React.FC<{ media: MediaDescriptor[] }> = ({ media }) => {
       return (
         <div className={'iapp-photo'} key={m.media_key}>
           <img alt="IAPP Photo" src={m.encoded_file} />
-          <dl>
-            <dt>Comments</dt>
-            <dd>{mediaData.comments}</dd>
-
-            <dt>Image Date</dt>
-            <dd>{mediaData.image_date}</dd>
-
-            <dt>Perspective Code</dt>
-            <dd>{mediaData.perspective_code || 'None'}</dd>
-
-            <dt>Reference Number</dt>
-            <dd>{mediaData.reference_no}</dd>
+          <dl className="image-details">
+            <div>
+              <dt>Comments</dt>
+              <dd>{mediaData.comments ?? MISSING_CONTENT}</dd>
+            </div>
+            <div>
+              <dt>Image Date</dt>
+              <dd>{mediaData.image_date ?? MISSING_CONTENT}</dd>
+            </div>
+            <div>
+              <dt>Perspective Code</dt>
+              <dd>{mediaData.perspective_code ?? MISSING_CONTENT}</dd>
+            </div>
+            <div>
+              <dt>Reference Number</dt>
+              <dd>{mediaData.reference_no ?? MISSING_CONTENT}</dd>
+            </div>
 
             {mediaData.treatment_id !== null && (
-              <>
+              <div>
                 <dt>Treatment ID</dt>
-                <dd>{mediaData.treatment_id}</dd>
-              </>
+                <dd>{mediaData.treatment_id ?? MISSING_CONTENT}</dd>
+              </div>
             )}
           </dl>
         </div>
@@ -89,17 +92,11 @@ export const Photos: React.FC<{ media: MediaDescriptor[] }> = ({ media }) => {
   }
 
   return (
-    <Accordion expanded={expanded} style={{ marginTop: 15, alignItems: 'center' }}>
-      <AccordionSummary
-        onClick={() => setExpanded(!expanded)}
-        style={{ fontSize: '1.125rem', marginLeft: 10, marginRight: 10 }}
-      >
-        Media
-      </AccordionSummary>
-
-      <Paper sx={{ width: '100%', overflow: 'hidden' }}>
-        <div className={'iapp-photo-container'}>{renderContent()}</div>
-      </Paper>
-    </Accordion>
+    <div className="main-photo-cont">
+      <div className={'iapp-photo-container'}>
+        <h2>Media</h2>
+        {renderContent()}
+      </div>
+    </div>
   );
 };

--- a/app/src/UI/Features/Records/Activity/PhotoContainer.tsx
+++ b/app/src/UI/Features/Records/Activity/PhotoContainer.tsx
@@ -1,4 +1,4 @@
-import { CameraResultType, CameraSource, Camera } from '@capacitor/camera';
+import { Camera, MediaResult, MediaTypeSelection } from '@capacitor/camera';
 import {
   Box,
   Button,
@@ -39,114 +39,60 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
   const dispatch = useDispatch();
   const media = useSelector((state) => state.ActivityPage.activity?.media || []);
 
-  async function convertWebPathToDataUrl(webPath: string): Promise<string> {
-    const response = await fetch(webPath);
-
-    // convert response into a blob
-    const blob = await response.blob();
-
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onloadend = () => resolve(reader.result as string); // result is a dataUrl
-      reader.onerror = reject;
-      reader.readAsDataURL(blob);
-    });
-  }
-
-  const checkPermissionsAndAlert = async (photoOption: CameraSource): Promise<void> => {
-    try {
-      const permissions = await Camera.checkPermissions();
-
-      if (photoOption === CameraSource.Camera && permissions.camera === 'denied') {
-        dispatch(
-          Alerts.create({
-            content:
-              'Camera access is denied. Please enable camera permissions in your device settings to take photos.',
-            severity: AlertSeverity.Warning,
-            subject: AlertSubjects.Photo,
-            autoClose: 5
-          })
-        );
-      } else if (photoOption === CameraSource.Photos && permissions.photos === 'denied') {
-        dispatch(
-          Alerts.create({
-            content:
-              'Photo library access is denied. Please enable photo library permissions in your device settings to choose photos.',
-            severity: AlertSeverity.Warning,
-            subject: AlertSubjects.Photo,
-            autoClose: 5
-          })
-        );
-      }
-    } catch (error) {
-      console.error('Error checking permissions:', error);
+  const checkPermissionsAndAlert = async (permission: 'Photo Gallery' | 'Camera'): Promise<void> => {
+    const { camera, photos } = await Camera.checkPermissions();
+    if ((permission == 'Camera' && camera === 'denied') || (permission === 'Photo Gallery' && photos === 'denied')) {
+      dispatch(
+        Alerts.create({
+          content: 'Camera access is denied. Please enable camera permissions in your device settings to take photos.',
+          severity: AlertSeverity.Warning,
+          subject: AlertSubjects.Photo,
+          autoClose: 5
+        })
+      );
     }
+  };
+
+  const transformImageToFormData = (photo: MediaResult, index = 0): UploadedPhoto => {
+    const fileName = `${new Date().toISOString().slice(0, 10)}-${index}.${photo.metadata?.format}`;
+    const dataUrl = `data:image/${photo.metadata?.format};base64,${photo.thumbnail}`;
+    return {
+      file_name: fileName,
+      encoded_file: dataUrl,
+      description: `Untitled.${photo.metadata?.format}`,
+      editing: false
+    } as UploadedPhoto;
   };
 
   const takePhotoFromCamera = async () => {
     try {
-      await checkPermissionsAndAlert(CameraSource.Camera);
-      const cameraPhoto = await Camera.getPhoto({
+      await checkPermissionsAndAlert('Camera');
+      const result = await Camera.takePhoto({
         presentationStyle: 'fullscreen',
-        resultType: CameraResultType.DataUrl,
-        source: CameraSource.Camera,
-        quality: 100
+        quality: 75,
+        includeMetadata: true
       });
-
-      const fileName = new Date().getTime() + '.' + cameraPhoto.format;
-      const photo: UploadedPhoto = {
-        file_name: fileName,
-        encoded_file: cameraPhoto.dataUrl,
-        description: 'untitled',
-        editing: false
-      };
-
-      dispatch(Activity.Photo.add(photo));
+      dispatch(Activity.Photo.add(transformImageToFormData(result)));
     } catch (e) {
-      console.error('user cancelled or other camera problem', e);
+      console.error(e);
     }
   };
 
   const choosePhotosFromLibrary = async () => {
     try {
-      await checkPermissionsAndAlert(CameraSource.Photos);
-      const multiplePhotos = await Camera.pickImages({
-        quality: 100,
-        limit: 10
+      await checkPermissionsAndAlert('Photo Gallery');
+      const { results } = await Camera.chooseFromGallery({
+        mediaType: MediaTypeSelection.Photo,
+        includeMetadata: true,
+        allowMultipleSelection: true,
+        limit: 5,
+        quality: 75
       });
-
-      if (!multiplePhotos.photos.length) {
-        console.log('No photos selected');
-        return;
-      }
-
-      // process all photos concurrently
-      const processedPhotos = await Promise.all(
-        multiplePhotos.photos.map(async (photo, index) => {
-          try {
-            const fileName = `${new Date().getTime()}-${index}.${photo.format}`;
-            const dataUrl = await convertWebPathToDataUrl(photo.webPath);
-
-            return {
-              file_name: fileName,
-              encoded_file: dataUrl,
-              description: 'untitled',
-              editing: false
-            } as UploadedPhoto;
-          } catch (error) {
-            console.error(`Error processing photo ${index + 1}:`, error);
-            return null; // skip photo on failure
-          }
-        })
-      );
-
+      const processedPhotos = results.map(transformImageToFormData);
       // filter out failed photo conversions
-      const validPhotos = processedPhotos.filter((photo) => photo !== null);
-      validPhotos.forEach((photo) => {
-        if (photo) dispatch(Activity.Photo.add(photo));
-      });
+      processedPhotos.filter(Boolean).forEach((p) => dispatch(Activity.Photo.add(p)));
     } catch (e) {
-      console.error('error occurred: ', e);
+      console.error(e);
     }
   };
 

--- a/app/src/UI/Layout/OverlayLayout/Overlay.css
+++ b/app/src/UI/Layout/OverlayLayout/Overlay.css
@@ -2,7 +2,6 @@
   --overlay-top: var(--header-bar-height);
   --overlay-grip-height: 25px; /* grab handle */
 
-
   #app.overlay-layout {
     position: relative;
 
@@ -42,6 +41,7 @@
         width: 100%;
         overflow: auto;
         box-sizing: border-box;
+        padding-bottom: calc(var(--footer-bar-height) + 5px);
       }
     }
 
@@ -102,5 +102,4 @@
       }
     }
   }
-
 }


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Remedy missing await causing bug with IAPP images.
- Restyle the Image viewer for IAPP records
    - On Mobile, current style would crop out images.
- Apply padding to Overlay for footer height, so everything will appear above it instead of doing that repeatedly.
- Replace deprecated Capacitor methods with shiny new ones.
- Closes #4537  

# Testing
Tested on IOS and Web
Created forms offline with images, went online and synced images. Viewed records on web on separate device.