### PR TITLE
[INV-4565] TEMP** Re-implement Offline geojson layers

### DIFF
--- a/.github/workflows/build_ios.yaml
+++ b/.github/workflows/build_ios.yaml
@@ -1,6 +1,6 @@
 name: app IOS
 on:
-  workflow_dispatch: { }
+  workflow_dispatch: {}
   push:
     branches:
       - dev
@@ -27,9 +27,9 @@ jobs:
         run: |
           sudo ls -la /Applications | grep "Xcode"
 
-      - name: XCode select 26
+      - name: XCode select 26.4.1
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.1.1.app/Contents/Developer
+          sudo xcode-select -s /Applications/Xcode_26.4.1.app/Contents/Developer
 
       - name: Install sharedAPI dependencies
         working-directory: ./sharedAPI

--- a/app/ios/App/Podfile.lock
+++ b/app/ios/App/Podfile.lock
@@ -1,31 +1,33 @@
 PODS:
-  - AppAuth (1.7.5):
-    - AppAuth/Core (= 1.7.5)
-    - AppAuth/ExternalUserAgent (= 1.7.5)
-  - AppAuth/Core (1.7.5)
-  - AppAuth/ExternalUserAgent (1.7.5):
+  - AppAuth (2.0.0):
+    - AppAuth/Core (= 2.0.0)
+    - AppAuth/ExternalUserAgent (= 2.0.0)
+  - AppAuth/Core (2.0.0)
+  - AppAuth/ExternalUserAgent (2.0.0):
     - AppAuth/Core
-  - Capacitor (8.0.0):
+  - Capacitor (8.3.4):
     - CapacitorCordova
-  - CapacitorCamera (8.0.0):
+  - CapacitorCamera (8.2.0):
     - Capacitor
+    - IONCameraLib (~> 1.0.4)
   - CapacitorCommunityBackgroundGeolocation (1.2.26):
     - Capacitor
-  - CapacitorCommunitySqlite (7.0.2):
+  - CapacitorCommunitySqlite (7.0.3):
     - Capacitor
     - SQLCipher
     - ZIPFoundation
-  - CapacitorCordova (8.0.0)
-  - CapacitorGeolocation (8.0.0):
+  - CapacitorCordova (8.3.4)
+  - CapacitorGeolocation (8.2.0):
     - Capacitor
-    - IONGeolocationLib (= 2.0.0)
-  - IONGeolocationLib (2.0.0)
-  - SQLCipher (4.5.1):
-    - SQLCipher/standard (= 4.5.1)
-  - SQLCipher/common (4.5.1)
-  - SQLCipher/standard (4.5.1):
+    - IONGeolocationLib (= 2.1.0)
+  - IONCameraLib (1.0.4)
+  - IONGeolocationLib (2.1.0)
+  - SQLCipher (4.10.0):
+    - SQLCipher/standard (= 4.10.0)
+  - SQLCipher/common (4.10.0)
+  - SQLCipher/standard (4.10.0):
     - SQLCipher/common
-  - ZIPFoundation (0.9.13)
+  - ZIPFoundation (0.9.20)
 
 DEPENDENCIES:
   - AppAuth
@@ -39,6 +41,7 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - AppAuth
+    - IONCameraLib
     - IONGeolocationLib
     - SQLCipher
     - ZIPFoundation
@@ -58,16 +61,17 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/geolocation"
 
 SPEC CHECKSUMS:
-  AppAuth: 501c04eda8a8d11f179dbe8637b7a91bb7e5d2fa
-  Capacitor: 341ff7cf652ec695d1a8ebf604db448ac7b6d635
-  CapacitorCamera: 592acb7ab9fb748e2d8571eb03af30ec4e1ace12
+  AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
+  Capacitor: d13cad5fa09155679672808cc4ca9fbc2997e1b4
+  CapacitorCamera: 8f6acf83664118321111e76acef86390211ccb08
   CapacitorCommunityBackgroundGeolocation: 750523ec6dd1cc94cf4e2bf7787605106753f73c
-  CapacitorCommunitySqlite: a57c58e1c37f4bc250ef01e66b0055cb6ddd775e
-  CapacitorCordova: 5dc3912d25ef770a3fe0f431bb65c9fbfa2e92f9
-  CapacitorGeolocation: 8a405e707de9aff6ac9eca7f408966a370f7ca33
-  IONGeolocationLib: a5e40b54edc2ee9902036eda5aaa41ddf07bb68d
-  SQLCipher: 712e8416685e8e575b9b0706ffee71678b2fdcf8
-  ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
+  CapacitorCommunitySqlite: 4813d82ad33001e612a39d313cb5d28066cbafda
+  CapacitorCordova: c07921bdcfec6f691bae22274446b4d606ebf6a4
+  CapacitorGeolocation: b36f6287bfc9f2eefa04dc900496f2c8ae666136
+  IONCameraLib: f2349804460bd9e3f892e42109b8d996ab3fa19d
+  IONGeolocationLib: 6a7b6f76063fb1b01cfb14fae7d0f526e3c9b271
+  SQLCipher: eb79c64049cb002b4e9fcb30edb7979bf4706dfc
+  ZIPFoundation: dfd3d681c4053ff7e2f7350bc4e53b5dba3f5351
 
 PODFILE CHECKSUM: 69fc9b9b6f34dc46a2fca5e2bede775827aa2574
 

--- a/app/src/UI/Features/LegacyMap/Map.tsx
+++ b/app/src/UI/Features/LegacyMap/Map.tsx
@@ -37,6 +37,7 @@ import { DEMO_DOWNLOADED_FILENAME } from 'UI/Features/LegacyMap/helpers/function
 import LayerDataMarker from './helpers/components/LayerDataMarker/LayerDataMarker';
 import { useRecordSetControls } from 'utils/useRecordSetControls';
 import OfflineRecordsetLayer from './helpers/components/OfflineRecordsetLayer';
+import { useOfflineRecordSetLayers } from 'utils/useOfflineRecordSetLayers';
 
 const OfflineProtoMapsDebugModal = React.lazy(
   () => import('UI/Features/LegacyMap/helpers/components/OfflineProtomaps/Debug')
@@ -60,7 +61,7 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
   // Map position jump
   const map_center = useSelector((state) => state.Map.map_center);
   const map_zoom = useSelector((state) => state.Map.map_zoom);
-
+  const { recordsetLayers: offlineLayers, recordsetSources: offlineSources } = useOfflineRecordSetLayers();
   const [map, setMap] = useState<InvasivesMap>();
   const [mapLoaded, setMapLoaded] = useState<boolean>(false);
   const [mapReady, setMapReady] = useState<boolean>(false);
@@ -69,6 +70,7 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
 
   const { sources, layers, availableLayerDefinitions, setActiveBaseMap, setOverlayState } = useInvasivesMapLayers();
   const { recordsetLayers, recordsetSources } = useRecordSetControls();
+
   useEffect(() => {
     if (!mapContainer.current) {
       console.error('Mapinit invoked with invalid reference');
@@ -320,15 +322,17 @@ export const Map: React.FC<React.PropsWithChildren> = ({ children }) => {
 
           <ButtonContainer selectLayer={buttonContainerLayerSelect} layers={availableLayerDefinitions} />
 
-          {[...Object.entries(recordsetSources), ...Object.entries(sources)].map(([key, source]) => (
-            <SourceComponent mapReady={mapReady} key={key} id={key} source={source} />
-          ))}
+          {[...Object.entries(recordsetSources), ...Object.entries(sources), ...Object.entries(offlineSources)].map(
+            ([key, source]) => (
+              <SourceComponent mapReady={mapReady} key={key} id={key} source={source} />
+            )
+          )}
 
-          {[...layers, ...recordsetLayers].map((layer) => (
+          {[...layers, ...recordsetLayers, ...offlineLayers].map((layer) => (
             <LayerComponent mapReady={mapReady} key={layer.id} id={layer.id} layer={layer} />
           ))}
 
-          {[...Object.keys(sources), ...Object.keys(recordsetSources)].map((key) => (
+          {[...Object.keys(sources), ...Object.keys(recordsetSources), ...Object.keys(offlineSources)].map((key) => (
             <SourceCleanupComponent mapReady={mapReady} key={key} id={key} />
           ))}
 

--- a/app/src/UI/Features/LegacyMap/helpers/functional/layer-definitions/reusable-layer-specifications.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/layer-definitions/reusable-layer-specifications.ts
@@ -87,10 +87,9 @@ const createLabelLayer = (options: LabelOptions): LayerSpecificationWithStacking
   layout: {
     'text-field': [
       'format',
-      ['get', options.get_tag ?? 'short_id'],
-      { 'font-scale': 0.9 },
-      ['get', options.get_tag ?? 'site_id'],
-      { 'font-scale': 0.9 },
+      ...(options.get_tag
+        ? [['get', options.get_tag], { 'font-scale': 0.9 }]
+        : [['get', 'short_id'], { 'font-scale': 0.9 }, ['get', 'site_id'], { 'font-scale': 0.9 }]),
       '\n',
       {},
       ['get', 'map_symbol'],

--- a/app/src/utils/record-cache/localforage-cache.ts
+++ b/app/src/utils/record-cache/localforage-cache.ts
@@ -339,7 +339,7 @@ class LocalForageRecordCacheService extends RecordCacheService {
       const features = (data.geometry as Feature[]) ?? [];
       features.forEach((feature: Feature) => {
         feature.properties = {
-          name: label + '\n' + data.map_symbol,
+          name: label + '\n' + (data.map_symbol ?? ''),
           description: id,
           activity_subtype: data?.activity_subtype ?? null
         };

--- a/app/src/utils/useOfflineRecordSetLayers.tsx
+++ b/app/src/utils/useOfflineRecordSetLayers.tsx
@@ -1,0 +1,243 @@
+/**
+ * @desc Throwaway file to temporarily return the Offline Cached GeoJSON layers to the Application
+ *       while waiting for the more permanent solution to be implemented.
+ */
+import { useEffect, useState } from 'react';
+import { SourceSpecification } from 'maplibre-gl/dist/maplibre-gl-dev';
+import { shallowEqual } from 'react-redux';
+import { useDispatch, useSelector } from './use_selector';
+import {
+  InvasivesMapLayerDefinitionWithState,
+  LayerSpecificationWithStackingOrder
+} from 'UI/Features/LegacyMap/helpers/functional/layers-hook';
+import {
+  InvasivesMapLayerDefinition,
+  LAYER_Z_FOREGROUND,
+  MapDefinitionEligibilityPredicatesBuilder
+} from 'UI/Features/LegacyMap/helpers/functional/layer-definitions/types';
+import { selectGlobalRecordsetFilters } from 'state/reducers/map';
+import {
+  createBorderLayer,
+  createCircleLayer,
+  createFillLayer,
+  createLabelLayer,
+  getPaintBySchemeOrColor
+} from 'UI/Features/LegacyMap/helpers/functional/layer-definitions/reusable-layer-specifications';
+import { RecordSetId, UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
+import { RecordCacheServiceFactory } from './record-cache/context';
+import { Md5 } from 'ts-md5';
+import Alerts from 'state/actions/alerts/Alerts';
+import { AlertSeverity, AlertSubjects } from 'constants/alertEnums';
+import UserSettings from 'state/actions/userSettings/UserSettings';
+
+const useOfflineRecordSetLayers = () => {
+  const FEATURE_LIMIT = 50000;
+  const dispatch = useDispatch();
+  const buildCompleteRecordsetMapSpecificationFromRecordsets = async (
+    recordSets: Record<PropertyKey, UserRecordSet>
+  ) => {
+    const promises = Object.values(recordSets)
+      .filter(
+        (r) =>
+          r.id !== RecordSetId.OfflineActivities &&
+          r.cacheMetadataStatus === UserRecordCacheStatus.CACHED &&
+          r.mapToggle
+      )
+      .map(async (r) => await buildRecordsetLayerDefinitionsFromRecordset(r, globalMapFilters));
+
+    const resolvedPromises = await Promise.all(promises);
+
+    return resolvedPromises
+      .filter((r) => r != null)
+      .flat()
+      .reduce(
+        (previousValue, currentValue) => {
+          return {
+            sources: { ...previousValue.sources, ...currentValue.sources },
+            definitions: [...previousValue.definitions, ...currentValue.definitions]
+          };
+        },
+        { sources: {}, definitions: [] }
+      );
+  };
+
+  async function buildRecordsetLayerDefinitionsFromRecordset(
+    rec: UserRecordSet,
+    globalFilterObj
+  ): Promise<{
+    definitions: InvasivesMapLayerDefinition[];
+    sources: { [_: string]: SourceSpecification };
+  } | null> {
+    const color = getPaintBySchemeOrColor(rec.color);
+    const SOURCE_ID = 'offline-' + rec.id + rec.tableFiltersHash;
+    const service = await RecordCacheServiceFactory.getPlatformInstance();
+    if (!service) throw new Error('Service unavailable');
+    const r = await service.getRepository(rec.id);
+
+    if (!r?.cached_geojson || !r?.cached_centroid) {
+      console.warn(`[ABORTED] ${rec?.id} returned false positive for being cached.`);
+      return null;
+    }
+    /**
+     * Since this is meant as a temporary stopgap between features, Enable a limit of features that can be rendered per layer,
+     * this will help prevent users from making massive recordsets that crash their devices.
+     */
+    const OVERSIZED = r.cached_geojson.data.features.length >= FEATURE_LIMIT;
+    if (OVERSIZED && rec.mapToggle && !connected) {
+      dispatch(
+        Alerts.create({
+          content: `We can't load this layer offline because it contains too much information. Try checking it again once you're back online! (Contains over ${FEATURE_LIMIT.toLocaleString()} records!)`,
+          severity: AlertSeverity.Warning,
+          subject: AlertSubjects.Map,
+          autoClose: 10
+        })
+      );
+      dispatch(UserSettings.RecordSet.toggleVisibility(rec.id));
+      return null;
+    }
+    const layerID =
+      'offline-recordset-' +
+      rec.id +
+      Md5.hashStr(
+        SOURCE_ID +
+          rec.tableFiltersHash +
+          rec.mapToggle +
+          rec.labelToggle +
+          JSON.stringify(color) +
+          JSON.stringify(rec.tableFilters)
+      );
+
+    const layerConfiguration = {
+      layerId: layerID,
+      sourceId: SOURCE_ID,
+      color: color,
+      filters: globalFilterObj
+    };
+
+    const CENTROID_LAYER_ID = `centroid-${SOURCE_ID}`;
+    const centroidLayerConfiguration = {
+      layerId: CENTROID_LAYER_ID,
+      sourceId: `centroid-${SOURCE_ID}`,
+      color: color,
+      filters: globalFilterObj
+    };
+
+    return {
+      sources: {
+        [SOURCE_ID]: {
+          type: 'geojson',
+          data: r.cached_geojson.data
+        },
+        [CENTROID_LAYER_ID]: {
+          type: 'geojson',
+          data: r.cached_centroid.data
+        }
+      },
+      definitions: [
+        {
+          name: rec.id,
+          displayName: OVERSIZED ? 'DENY' : 'displayName',
+          icon: 'N/A',
+          mode: 'overlay',
+          selectionMode: null,
+          tooltip: '',
+          predicates: new MapDefinitionEligibilityPredicatesBuilder()
+            .requiresAuthentication(true)
+            .requiresNetwork(false)
+            .build(),
+          layers: [
+            createFillLayer({ ...layerConfiguration, minzoom: 12 }),
+            createCircleLayer({ ...layerConfiguration, minzoom: 12 }),
+            createBorderLayer({ ...layerConfiguration, minzoom: 12 }),
+            createLabelLayer({
+              ...layerConfiguration,
+              get_tag: 'name',
+              visibility: rec.labelToggle ? 'visible' : 'none',
+              minzoom: 12
+            }),
+            // Add slight overlap so layers don't disappear randomly while transitioning.
+            createFillLayer({ ...centroidLayerConfiguration, maxzoom: 12.5 }),
+            createCircleLayer({ ...centroidLayerConfiguration, maxzoom: 12.5 }),
+            createBorderLayer({ ...centroidLayerConfiguration, maxzoom: 12.5 })
+          ]
+        }
+      ]
+    };
+  }
+
+  const [recordsetLayers, setRecordsetLayers] = useState<LayerSpecificationWithStackingOrder[]>([]);
+  const [recordsetSources, setRecordsetSources] = useState<{ [_: string]: SourceSpecification }>({});
+  const recordsets = useSelector((state) => state.UserSettings.recordSets, shallowEqual);
+
+  const MOBILE = useSelector((state) => state.Configuration.current.build.MOBILE);
+  const DEBUG = useSelector((state) => state.Configuration.current.build.DEBUG);
+  const platform = useSelector((state) => state.Configuration.current.build.PLATFORM);
+  const features = useSelector((state) => state.Configuration.current.features);
+  const loggedInOrWorkingOffline = useSelector((state) => state.Auth.loggedInOrWorkingOffline);
+  const connected = useSelector((state) => state.Network.connected);
+  const globalMapFilters = useSelector(selectGlobalRecordsetFilters);
+
+  /**
+   * Rebuild Recordset layers when recordsets/auth/online status changes.
+   */
+
+  useEffect(() => {
+    (async () => {
+      const recordSetData = await buildCompleteRecordsetMapSpecificationFromRecordsets(recordsets);
+      const filteredRecordDefinitions: Array<InvasivesMapLayerDefinitionWithState> = [];
+
+      for (const l of recordSetData.definitions) {
+        const pass = (() => {
+          switch (true) {
+            case l.displayName == 'DENY': // Prevent Oversized records from rendering
+            case !l.predicates.directlySelectable:
+            case l.predicates.mobileOnly && !MOBILE:
+            case l.predicates.webOnly && MOBILE:
+            case l.predicates.requiresDebug && !DEBUG:
+            case l.predicates.requiresPlatform !== undefined && l.predicates.requiresPlatform !== platform:
+            case l.predicates.requiresFeature !== undefined && !features[l.predicates.requiresFeature].enabled:
+            case l.predicates.requiresAuthentication && !loggedInOrWorkingOffline:
+            case l.predicates.requiresAnonymous && loggedInOrWorkingOffline:
+            case l.predicates.requiresNetwork && !connected:
+            case l.predicates.requiresOffline && connected:
+              return false;
+            default:
+              return true;
+          }
+        })();
+
+        if (pass) {
+          filteredRecordDefinitions.push({
+            active: recordsets[l.name].mapToggle,
+            ...l
+          });
+        }
+      }
+      const newLayers: LayerSpecificationWithStackingOrder[] = [];
+      const requiredSources: Array<keyof typeof recordSetData.sources | string> = [];
+
+      filteredRecordDefinitions.forEach((l) => {
+        if (l.active) {
+          for (const subLayer of l.layers) {
+            newLayers.push({
+              stackLayer: LAYER_Z_FOREGROUND,
+              ...subLayer
+            });
+            if (subLayer.source && !requiredSources.includes(subLayer.source)) {
+              requiredSources.push(subLayer.source);
+            }
+          }
+        }
+      });
+      setRecordsetSources(recordSetData.sources);
+      setRecordsetLayers(newLayers);
+    })();
+  }, [recordsets, connected, loggedInOrWorkingOffline, globalMapFilters]);
+
+  return {
+    recordsetLayers,
+    recordsetSources
+  };
+};
+
+export { useOfflineRecordSetLayers };

--- a/app/src/utils/useOfflineRecordSetLayers.tsx
+++ b/app/src/utils/useOfflineRecordSetLayers.tsx
@@ -23,7 +23,7 @@ import {
   createLabelLayer,
   getPaintBySchemeOrColor
 } from 'UI/Features/LegacyMap/helpers/functional/layer-definitions/reusable-layer-specifications';
-import { RecordSetId, UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
+import { RecordSetId, RecordSetType, UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
 import { RecordCacheServiceFactory } from './record-cache/context';
 import { Md5 } from 'ts-md5';
 import Alerts from 'state/actions/alerts/Alerts';
@@ -73,8 +73,8 @@ const useOfflineRecordSetLayers = () => {
     const service = await RecordCacheServiceFactory.getPlatformInstance();
     if (!service) throw new Error('Service unavailable');
     const r = await service.getRepository(rec.id);
-
-    if (!r?.cached_geojson || !r?.cached_centroid) {
+    const IS_IBC_RECORD = rec.recordSetType === RecordSetType.Activity;
+    if (!r?.cached_geojson || (IS_IBC_RECORD && !r?.cached_centroid)) {
       console.warn(`[ABORTED] ${rec?.id} returned false positive for being cached.`);
       return null;
     }
@@ -121,48 +121,83 @@ const useOfflineRecordSetLayers = () => {
       color: color,
       filters: globalFilterObj
     };
-
-    return {
-      sources: {
-        [SOURCE_ID]: {
-          type: 'geojson',
-          data: r.cached_geojson.data
+    if (IS_IBC_RECORD) {
+      return {
+        sources: {
+          [SOURCE_ID]: {
+            type: 'geojson',
+            data: r.cached_geojson.data
+          },
+          [CENTROID_LAYER_ID]: {
+            type: 'geojson',
+            data: r.cached_centroid.data
+          }
         },
-        [CENTROID_LAYER_ID]: {
-          type: 'geojson',
-          data: r.cached_centroid.data
-        }
-      },
-      definitions: [
-        {
-          name: rec.id,
-          displayName: OVERSIZED ? 'DENY' : 'displayName',
-          icon: 'N/A',
-          mode: 'overlay',
-          selectionMode: null,
-          tooltip: '',
-          predicates: new MapDefinitionEligibilityPredicatesBuilder()
-            .requiresAuthentication(true)
-            .requiresNetwork(false)
-            .build(),
-          layers: [
-            createFillLayer({ ...layerConfiguration, minzoom: 12 }),
-            createCircleLayer({ ...layerConfiguration, minzoom: 12 }),
-            createBorderLayer({ ...layerConfiguration, minzoom: 12 }),
-            createLabelLayer({
-              ...layerConfiguration,
-              get_tag: 'name',
-              visibility: rec.labelToggle ? 'visible' : 'none',
-              minzoom: 12
-            }),
-            // Add slight overlap so layers don't disappear randomly while transitioning.
-            createFillLayer({ ...centroidLayerConfiguration, maxzoom: 12.5 }),
-            createCircleLayer({ ...centroidLayerConfiguration, maxzoom: 12.5 }),
-            createBorderLayer({ ...centroidLayerConfiguration, maxzoom: 12.5 })
-          ]
-        }
-      ]
-    };
+        definitions: [
+          {
+            name: rec.id,
+            displayName: OVERSIZED ? 'DENY' : 'displayName',
+            icon: 'N/A',
+            mode: 'overlay',
+            selectionMode: null,
+            tooltip: '',
+            predicates: new MapDefinitionEligibilityPredicatesBuilder()
+              .requiresAuthentication(true)
+              .requiresNetwork(false)
+              .build(),
+            layers: [
+              createFillLayer({ ...layerConfiguration, minzoom: 12 }),
+              createCircleLayer({ ...layerConfiguration, minzoom: 12 }),
+              createBorderLayer({ ...layerConfiguration, minzoom: 12 }),
+              createLabelLayer({
+                ...layerConfiguration,
+                get_tag: 'name',
+                visibility: rec.labelToggle ? 'visible' : 'none',
+                minzoom: 12
+              }),
+              // Add slight overlap so layers don't disappear randomly while transitioning.
+              createFillLayer({ ...centroidLayerConfiguration, maxzoom: 12.5 }),
+              createCircleLayer({ ...centroidLayerConfiguration, maxzoom: 12.5 }),
+              createBorderLayer({ ...centroidLayerConfiguration, maxzoom: 12.5 })
+            ]
+          }
+        ]
+      };
+    } else {
+      return {
+        sources: {
+          [SOURCE_ID]: {
+            type: 'geojson',
+            data: r.cached_geojson.data
+          }
+        },
+        definitions: [
+          {
+            name: rec.id,
+            displayName: OVERSIZED ? 'DENY' : 'displayName',
+            icon: 'N/A',
+            mode: 'overlay',
+            selectionMode: null,
+            tooltip: '',
+            predicates: new MapDefinitionEligibilityPredicatesBuilder()
+              .requiresAuthentication(true)
+              .requiresNetwork(false)
+              .build(),
+            layers: [
+              createFillLayer(layerConfiguration),
+              createCircleLayer(layerConfiguration),
+              createBorderLayer(layerConfiguration),
+              createLabelLayer({
+                ...layerConfiguration,
+                get_tag: 'name',
+                visibility: rec.labelToggle ? 'visible' : 'none',
+                minzoom: 12
+              })
+            ]
+          }
+        ]
+      };
+    }
   }
 
   const [recordsetLayers, setRecordsetLayers] = useState<LayerSpecificationWithStackingOrder[]>([]);


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):


- Add temporary file `useOfflineRecordSetLayers` to allow cached records to appear offline while replacement solution is in the works. 
    - Limit max number of features to 50,000, block viewing exceeding records while offline. Alert the user this is happening.
- Adjust label layer to not print the same label twice when `get_tag` used.
- Prevent map symbol from displaying 'null'
- Closes #3565