### PR TITLE
[INV-4526] S3 Photo Upload / Fetching

### DIFF
--- a/api-rework/invasives/api/models/activity/uploaded_image.py
+++ b/api-rework/invasives/api/models/activity/uploaded_image.py
@@ -1,12 +1,36 @@
+import uuid
 from django.db import models
+from api.utils.fetch_s3_activity_photos import FetchS3MediaFiles
 
 from api.models.activity import RepeatedFormData
+
+
+class UploadedImageManager(models.Manager):
+    def create(self, **kwargs):
+        encoded_file = kwargs.pop("encoded_file", None)
+        if not encoded_file:
+            raise ValueError({"encoded_file": "No Encoded File Provided"})
+
+        instance = self.model(**kwargs)
+
+        instance.file_name = instance._create_file_name(instance.file_name)
+        success = FetchS3MediaFiles().upload_b64_encoded_image(
+            b64_image=encoded_file, file_name=instance.file_name
+        )
+
+        if not success:
+            raise ValueError({"encoded_file": "An Error occurred during S3 upload."})
+
+        instance.save(using=self._db)
+        return instance
 
 
 class UploadedImage(RepeatedFormData):
     """
     Details for User Uploaded Photos
     """
+
+    objects = UploadedImageManager()
 
     file_name = models.CharField(
         max_length=256, db_comment="Image file name, required for S3 fetching"
@@ -19,3 +43,10 @@ class UploadedImage(RepeatedFormData):
     class Meta:
         db_table = '"activity"."uploaded_image"'
         db_table_comment = "Image uploads for IBC Records"
+
+    def _create_file_name(self, provided_name) -> str:
+        """Convert users supplied file's name to provided name"""
+        ext = provided_name.split(".")[-1]
+        id = uuid.uuid4().hex
+        prescribed_name = f"IBC-{id}.{ext}"
+        return prescribed_name

--- a/api-rework/invasives/api/models/activity/uploaded_image.py
+++ b/api-rework/invasives/api/models/activity/uploaded_image.py
@@ -1,4 +1,3 @@
-import uuid
 import hashlib
 from django.db import models
 from api.utils.fetch_s3_activity_photos import FetchS3MediaFiles

--- a/api-rework/invasives/api/models/activity/uploaded_image.py
+++ b/api-rework/invasives/api/models/activity/uploaded_image.py
@@ -1,4 +1,5 @@
 import uuid
+import hashlib
 from django.db import models
 from api.utils.fetch_s3_activity_photos import FetchS3MediaFiles
 
@@ -6,14 +7,37 @@ from api.models.activity import RepeatedFormData
 
 
 class UploadedImageManager(models.Manager):
-    def create(self, **kwargs):
-        encoded_file = kwargs.pop("encoded_file", None)
+    def get_or_create(self, **kwargs):
+        """
+        Idempotently gets or creates an image record.
+        Hashes file content and activity ID to block duplicate S3 uploads.
+        """
+
+        # Remove encoded_file, as is not property.
+        encoded_file: str = kwargs.pop("encoded_file", None)
         if not encoded_file:
             raise ValueError({"encoded_file": "No Encoded File Provided"})
 
         instance = self.model(**kwargs)
 
-        instance.file_name = instance._create_file_name(instance.file_name)
+        # Create a filename based on the hashed activity id + b64 image
+        activity_id = str(instance.activity_data_record.activity_id)
+        extension = instance.file_name.split(".")[-1]
+
+        hasher = hashlib.md5()
+        hasher.update(activity_id.encode("utf-8"))
+        hasher.update(encoded_file.encode("utf-8"))
+        hashed_string = hasher.hexdigest()
+
+        generated_file_name = f"IBC-{hashed_string}.{extension}"
+
+        # Check if this file already exists
+        existing_image = self.filter(file_name=generated_file_name).first()
+        if existing_image:
+            return existing_image, False
+
+        instance.file_name = generated_file_name
+
         success = FetchS3MediaFiles().upload_b64_encoded_image(
             b64_image=encoded_file, file_name=instance.file_name
         )
@@ -22,6 +46,11 @@ class UploadedImageManager(models.Manager):
             raise ValueError({"encoded_file": "An Error occurred during S3 upload."})
 
         instance.save(using=self._db)
+        return instance, True
+
+    def create(self, **kwargs):
+        """Use Deduplication logic in get_or_create, but only return the instance"""
+        instance, created = self.get_or_create(**kwargs)
         return instance
 
 
@@ -43,10 +72,3 @@ class UploadedImage(RepeatedFormData):
     class Meta:
         db_table = '"activity"."uploaded_image"'
         db_table_comment = "Image uploads for IBC Records"
-
-    def _create_file_name(self, provided_name) -> str:
-        """Convert users supplied file's name to provided name"""
-        ext = provided_name.split(".")[-1]
-        id = uuid.uuid4().hex
-        prescribed_name = f"IBC-{id}.{ext}"
-        return prescribed_name

--- a/api-rework/invasives/api/models/activity/uploaded_image.py
+++ b/api-rework/invasives/api/models/activity/uploaded_image.py
@@ -1,6 +1,6 @@
 import hashlib
 from django.db import models
-from api.utils.fetch_s3_activity_photos import FetchS3MediaFiles
+from api.utils.s3_media_files import S3MediaFiles
 
 from api.models.activity import RepeatedFormData
 
@@ -37,7 +37,7 @@ class UploadedImageManager(models.Manager):
 
         instance.file_name = generated_file_name
 
-        success = FetchS3MediaFiles().upload_b64_encoded_image(
+        success = S3MediaFiles().upload_b64_encoded_image(
             b64_image=encoded_file, file_name=instance.file_name
         )
 

--- a/api-rework/invasives/api/protocol/activity/api.py
+++ b/api-rework/invasives/api/protocol/activity/api.py
@@ -7,6 +7,8 @@ import uuid
 from api.models.activity import Activity
 from api.ninja_authentication import NinjaKeycloakAuthentication
 from api.models.enums import FormStatus
+from api.models.activity import UploadedImage, ActivityDataRecord, Activity
+from django.db import transaction
 from api.protocol.activity.activity import (
     ActivityMinimal,
     ActivityOut,
@@ -60,10 +62,28 @@ def activity_search(request, search: ActivitySearchParameters):
 @router.post("/submit")
 def submit_record(request, data: PlantActivitySchema = Body(...)):
     data = data.model_dump()
-    val = mock_record_id()
-    data["id"] = val["id"]
-    data["short_id"] = val["short_id"]
     data["type"] = "Submitted"
+    if not Activity.objects.filter(id=data["id"]).exists():
+        val = mock_record_id()
+        data["id"] = val["id"]
+        data["short_id"] = val["short_id"]
+        return data  # Creation not implemented
+
+    with transaction.atomic():
+        rec = Activity.objects.filter(id=data["id"]).first()
+        if not rec:
+            return data
+        for image in data["media"]:
+            adr = ActivityDataRecord.objects.create(activity=rec)
+            instance, created = UploadedImage.objects.get_or_create(
+                activity_data_record=adr,
+                file_name=image["file_name"],
+                description=image["description"],
+                encoded_file=image["encoded_file"],
+            )
+            if not created:
+                adr.delete()
+
     return data
 
 

--- a/api-rework/invasives/api/serializers/activity.py
+++ b/api-rework/invasives/api/serializers/activity.py
@@ -35,8 +35,8 @@ Serializers for all Common models in an Activity
 
 
 class UploadedImageSerializer(serializers.ModelSerializer):
-    file_name = serializers.CharField(source="file_name")
-    description = serializers.CharField(source="description")
+    file_name = serializers.CharField()
+    description = serializers.CharField()
     encoded_file = serializers.SerializerMethodField()
 
     class Meta:

--- a/api-rework/invasives/api/serializers/activity.py
+++ b/api-rework/invasives/api/serializers/activity.py
@@ -14,7 +14,7 @@ from api.models.activity import (
 from api.models.activity.activity import Activity
 from api.models.activity import UploadedImage
 from api.models.mixins.geometry import Geometry
-from api.utils.fetch_s3_activity_photos import FetchS3MediaFiles
+from api.utils.s3_media_files import S3MediaFiles
 from api.serializers.type.subtype import (
     AquaticChemicalTreatmentSerializer,
     AquaticObservationSerializer,
@@ -49,7 +49,7 @@ class UploadedImageSerializer(serializers.ModelSerializer):
         )
 
     def get_encoded_file(self, obj):
-        encoded_image = FetchS3MediaFiles().get_b64_encoded_image(obj.file_name)
+        encoded_image = S3MediaFiles().get_b64_encoded_image(obj.file_name)
         return encoded_image
 
 

--- a/api-rework/invasives/api/serializers/activity.py
+++ b/api-rework/invasives/api/serializers/activity.py
@@ -14,6 +14,7 @@ from api.models.activity import (
 from api.models.activity.activity import Activity
 from api.models.activity import UploadedImage
 from api.models.mixins.geometry import Geometry
+from api.utils.fetch_s3_activity_photos import FetchS3MediaFiles
 from api.serializers.type.subtype import (
     AquaticChemicalTreatmentSerializer,
     AquaticObservationSerializer,
@@ -48,7 +49,8 @@ class UploadedImageSerializer(serializers.ModelSerializer):
         )
 
     def get_encoded_file(self, obj):
-        return "TODO"
+        encoded_image = FetchS3MediaFiles().get_b64_encoded_image(obj.file_name)
+        return encoded_image
 
 
 class EmployerSerializer(serializers.ModelSerializer):

--- a/api-rework/invasives/api/utils/s3_media_files.py
+++ b/api-rework/invasives/api/utils/s3_media_files.py
@@ -1,0 +1,78 @@
+import boto3, base64, io, logging
+from botocore.exceptions import ClientError
+from invasivesbc.settings import (
+    OBJECT_STORE_SECRET_ACCESS_KEY,
+    OBJECT_STORE_ACCESS_KEY_ID,
+    OBJECT_STORE_ENDPOINT_URL,
+    OBJECT_STORE_PHOTO_UPLOAD_BUCKET,
+    OBJECT_STORE_REGION,
+)
+
+log = logging.getLogger(__name__)
+
+
+class S3MediaFiles:
+
+    def __init__(self):
+        self.s3_client = boto3.client(
+            "s3",
+            endpoint_url=OBJECT_STORE_ENDPOINT_URL,
+            aws_access_key_id=OBJECT_STORE_ACCESS_KEY_ID,
+            aws_secret_access_key=OBJECT_STORE_SECRET_ACCESS_KEY,
+            region_name=OBJECT_STORE_REGION,
+            aws_session_token=None,
+            config=boto3.session.Config(
+                signature_version="s3v4",
+                request_checksum_calculation="when_required",
+                response_checksum_validation="when_required",
+            ),
+        )
+
+    def get_image(self, file_name):
+        """
+        Fetch Image from S3 bucket
+        """
+        response = self.s3_client.get_object(
+            Key=file_name, Bucket=OBJECT_STORE_PHOTO_UPLOAD_BUCKET
+        )
+        return response["Body"]
+
+    def get_b64_encoded_image(self, file_name) -> str:
+        """
+        Take Raw image obtained from S3 and convert into Base64 encoded image
+        """
+        ext = file_name.split(".")[-1].lower()
+        if ext == "jpg":
+            ext = "jpeg"
+
+        raw_image = self.get_image(file_name)
+        bytes = base64.b64encode(raw_image.read())
+        b64_string = bytes.decode("utf-8")
+        return f"data:image/{ext};base64,{b64_string}"
+
+    def _parse_b64_encoded_image_to_binary(self, b64_string: str) -> str:
+        if "base64," in b64_string:
+            b64_string = b64_string.split("base64,")[-1]
+        return base64.b64decode(b64_string)  # binary
+
+    def upload_b64_encoded_image(self, b64_image: str, file_name: str) -> bool:
+        """Take User submitted URI Image and upload to S3"""
+        try:
+            binary = self._parse_b64_encoded_image_to_binary(b64_string=b64_image)
+            image_buffer = io.BytesIO(binary)
+            content_type = "image/jpeg"
+            if file_name.lower().endswith(".png"):
+                content_type = "image/png"
+            self.s3_client.upload_fileobj(
+                Fileobj=image_buffer,
+                Bucket=OBJECT_STORE_PHOTO_UPLOAD_BUCKET,
+                Key=file_name,
+                ExtraArgs={"ContentType": content_type},
+            )
+            return True
+        except ClientError as e:
+            log.error(f"Error Uploading Image to S3: {e}")
+            return False
+        except Exception as e:
+            log.error(e)
+            return False

--- a/api-rework/invasives/api/utils/s3_media_files.py
+++ b/api-rework/invasives/api/utils/s3_media_files.py
@@ -37,18 +37,23 @@ class S3MediaFiles:
         )
         return response["Body"]
 
-    def get_b64_encoded_image(self, file_name) -> str:
+    def get_b64_encoded_image(self, file_name):
         """
         Take Raw image obtained from S3 and convert into Base64 encoded image
         """
-        ext = file_name.split(".")[-1].lower()
-        if ext == "jpg":
-            ext = "jpeg"
+        try:
 
-        raw_image = self.get_image(file_name)
-        bytes = base64.b64encode(raw_image.read())
-        b64_string = bytes.decode("utf-8")
-        return f"data:image/{ext};base64,{b64_string}"
+            ext = file_name.split(".")[-1].lower()
+            if ext == "jpg":
+                ext = "jpeg"
+
+            raw_image = self.get_image(file_name)
+            bytes = base64.b64encode(raw_image.read())
+            b64_string = bytes.decode("utf-8")
+
+            return f"data:image/{ext};base64,{b64_string}"
+        except Exception:
+            return None
 
     def _parse_b64_encoded_image_to_binary(self, b64_string: str) -> str:
         if "base64," in b64_string:

--- a/api-rework/invasives/invasivesbc/settings.py
+++ b/api-rework/invasives/invasivesbc/settings.py
@@ -86,7 +86,7 @@ CELERY_TIMEZONE = "America/Vancouver"
 CELERY_TASK_TRACK_STARTED = True
 CELERY_ACCEPT_CONTENT = ["pickle", "json"]
 CELERY_TASK_SERIALIZER = "pickle"  # by default - more efficient than json, less compatible with other platforms though
-CELERY_TASK_ACKS_LATE = True # enable re-queuing on worker loss
+CELERY_TASK_ACKS_LATE = True  # enable re-queuing on worker loss
 
 """
 Settings related to map generation and tile caching
@@ -175,7 +175,7 @@ CORS_ALLOWED_ORIGINS = [
     "https://normalization-fe-dev-invasivesbci.apps.silver.devops.gov.bc.ca",
     "https://normalization-fe-prod-invasivesbci.apps.silver.devops.gov.bc.ca",
     "https://invasivesbc.gov.bc.ca",
-    "invasivesbc://localhost"
+    "invasivesbc://localhost",
 ]
 
 CORS_EXPOSE_HEADERS = ["Content-Disposition"]
@@ -186,6 +186,9 @@ OBJECT_STORE_ENDPOINT_URL = os.getenv(
 OBJECT_STORE_ACCESS_KEY_ID = os.getenv("OBJECT_STORE_ACCESS_KEY_ID", "unset")
 OBJECT_STORE_SECRET_ACCESS_KEY = os.getenv("OBJECT_STORE_SECRET_ACCESS_KEY", "unset")
 OBJECT_STORE_MAP_UPLOAD_BUCKET = os.getenv("OBJECT_STORE_MAP_UPLOAD_BUCKET", "maps")
+OBJECT_STORE_PHOTO_UPLOAD_BUCKET = os.getenv(
+    "OBJECT_STORE_PHOTO_UPLOAD_BUCKET", "photos"
+)
 OBJECT_STORE_REGION = os.getenv(
     "OBJECT_STORE_REGION", "unset"
 )  # certain operations, like generating pre-signed URLS, require this to match the service expectation
@@ -225,9 +228,9 @@ LOGGING = {
             "propagate": False,
         },
         "psycopg.pool": {
-          "handlers": ["timestamped"],
-          "level": "WARNING",
-          "propagate": False,
+            "handlers": ["timestamped"],
+            "level": "WARNING",
+            "propagate": False,
         },
         "invasives": {
             "handlers": ["timestamped"],

--- a/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarker.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarker.tsx
@@ -71,7 +71,6 @@ const LayerDataMarker = () => {
           map
             .queryRenderedFeatures(bbox, { layers: recordsetLayers })
             .map((feature) => {
-              console.log(feature);
               const isInvasivesRecord = 'short_id' in feature.properties;
               return isInvasivesRecord
                 ? {

--- a/app/src/UI/Features/Records/Activity/forms/debug/DebugFormData.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/debug/DebugFormData.tsx
@@ -33,7 +33,7 @@ const DebugFormData = () => {
           {JSON.stringify(
             formData,
             (key, value) => {
-              if (key === 'encoded_file') {
+              if (key === 'encoded_file' && value) {
                 return value.slice(0, 25) + '... [Truncated]';
               }
               return value;

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/FormControl.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/FormControl.tsx
@@ -8,6 +8,8 @@ import { useDispatch, useSelector } from 'utils/use_selector';
 import Prompt from 'state/actions/prompts/Prompt';
 import getDefaultFormState from '../builders/getDefaultState';
 import { Role } from 'constants/roles';
+import { Debug } from 'UI/Reusable/Predicates/Debug';
+import Activity from 'state/actions/activity/Activity';
 
 /**
  * @desc Popover menu for form controls, handle Submit/Draft/Duplication fields.
@@ -17,6 +19,9 @@ const FormControl = () => {
     setAnchorEl(evt.currentTarget);
   };
 
+  const handleRefetchForm = () => {
+    if (currId) dispatch(Activity.getActivity(currId));
+  };
   const handleDelete = () => {
     dispatch(
       Prompt.confirmation({
@@ -81,7 +86,7 @@ const FormControl = () => {
   const created_by = useSelector((state) => state.ActivityPage?.formState?.created_by);
   const subtype = useSelector((state) => state.ActivityPage.formType);
   const isFormSubmitted = useSelector((state) => state.ActivityPage.formState?.form_status === 'Submitted');
-
+  const currId = useSelector((state) => state.ActivityPage.formId);
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
   const isRecordCreator: boolean = useMemo(() => {
@@ -134,6 +139,9 @@ const FormControl = () => {
             <input className="control-button" disabled={disabled} onClick={handleDelete} type="button" value="Delete" />
           )}
           <input type="button" className="control-button" onClick={handleDuplicateForm} value="Duplicate Form" />
+          <Debug>
+            <input type="button" className="control-button" onClick={handleRefetchForm} value="[Debug] Refetch Form" />
+          </Debug>
         </div>
       </CustomPopover>
     </>

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/Photo.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/Photo.tsx
@@ -3,6 +3,7 @@ import { useFieldArray, useFormContext } from 'react-hook-form';
 import { FormSchema } from '../interfaces';
 import StyledModal from 'UI/Reusable/StyledModal/StyledModal';
 import { WebOnly } from 'UI/Reusable/Predicates/WebOnly';
+import { BrokenImage } from '@mui/icons-material';
 
 const Photo = ({ photo, index, remove }) => {
   const handleClose = () => setIsModalOpen(false);
@@ -35,8 +36,9 @@ const Photo = ({ photo, index, remove }) => {
    * Primarily intended as a safe guard from SVG images.
    * @param {string} dataUri - The full string (e.g., "data:image/svg+xml;base64,...")
    */
-  const createSafeLink = (dataUri) => {
+  const createSafeLink = (dataUri: string | undefined) => {
     try {
+      if (!dataUri) return;
       const parts = dataUri.split(',');
       if (parts.length < 2) throw new Error('Invalid Data URI format');
 
@@ -86,7 +88,14 @@ const Photo = ({ photo, index, remove }) => {
         </div>
       </StyledModal>
       <div className="photo">
-        <img src={photo.encoded_file} onClick={handleOpen} alt={photo.description} />
+        {photo?.encoded_file ? (
+          <img src={photo.encoded_file} onClick={handleOpen} alt={photo.description} />
+        ) : (
+          <div className="missing-image">
+            <BrokenImage />
+            Image not found
+          </div>
+        )}
       </div>
       <div className="description">
         <p>{photo.description}</p>

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/activityForm.css
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/activityForm.css
@@ -207,15 +207,21 @@ input[type='button']:hover {
         width: 100%;
         display: flex;
 
+        .missing-image {
+          display: flex;
+          color: gray;
+          align-items: center;
+        }
+
         img {
           object-fit: contain;
           width: 100%;
           height: 100%;
           max-height: 350px;
-        }
 
-        &:hover {
-          cursor: zoom-in;
+          &:hover {
+            cursor: zoom-in;
+          }
         }
       }
 

--- a/app/src/UI/Features/Records/Record.tsx
+++ b/app/src/UI/Features/Records/Record.tsx
@@ -64,14 +64,14 @@ export const Activity = () => {
             <Button
               variant="contained"
               className={'records__activity__photos_button ' + (mode === 'form' ? ' selectedFormTab' : '')}
-              onClick={() => navigate(`/Records/Activity/${id}/photos`)}
+              onClick={() => navigate(`/Records/LegacyForm/${id}/photos`)}
             >
               Photos
             </Button>
             <Button
               variant="contained"
               className={'records__activity__form_button ' + (mode === 'form' ? ' selectedFormTab' : '')}
-              onClick={() => navigate(`/Records/Activity/${id}/form`)}
+              onClick={() => navigate(`/Records/LegacyForm/${id}/form`)}
             >
               Form
             </Button>


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

Add Necessary work for Uploading/Fetching S3 images for Activities. 
Prevents Photos from being re-uploaded to a record using idempotent hash for naming scheme. 

- Create Util for handling S3 images.
- UploadedPhoto:
    - Add Serializer
    - Add Manager for overriding create/get_or_create logic.
- Modify stubbed Submit endpoint to handle image uploads for existing activity (no creation, yet)
- Modify frontend to handle when UploadedPhoto missing (File not found)
- Add ENV for Photo bucket
- Add Debug button for refetching the active form
- Closes #4526


>[!IMPORTANT]
> Adds new env `OBJECT_STORE_PHOTO_UPLOAD_BUCKET`

<img width="467" height="388" alt="image" src="https://github.com/user-attachments/assets/b2037d9a-8982-4f60-a1f8-728f47ebdc4c" />
