### PR TITLE
[INV-4511][INV-4597] Draft Record Creation

### DIFF
--- a/api-rework/invasives/api/protocol/activity/api.py
+++ b/api-rework/invasives/api/protocol/activity/api.py
@@ -1,20 +1,19 @@
 from typing import List
 from django.http import JsonResponse
-from ninja import Router, Body
+from ninja import Router
 from ninja.errors import HttpError
-from datetime import datetime
-import uuid, json
+import json
+from django.shortcuts import get_object_or_404
 from django.contrib.gis.geos import GEOSGeometry
 from api.models.activity import Activity, ActivitySubtypes
 from api.serializers.activity import ActivitySerializer
-from api.schemas.plant_activity import ACTIVITY_PROCESSORS
+from api.schemas.plant_activity import ACTIVITY_PROCESSORS, DRAFT_ACTIVITY_PROCESSORS
 from api.ninja_authentication import NinjaKeycloakAuthentication
 from api.models.enums import FormStatus
-from api.models.activity import Activity
+from api.models.activity import Activity, DraftActivity
 from django.db import transaction
 from api.protocol.activity.activity import (
     ActivityMinimal,
-    ActivityOut,
     ActivitySearchParameters,
     ActivitySearchResult,
 )
@@ -24,19 +23,6 @@ from api.protocol.activity.plant_subtypes.union_definition import (
 )
 
 router = Router(auth=NinjaKeycloakAuthentication())
-
-
-# Helper
-def mock_record_id():
-    """Mock Function for generating short ID's"""
-    year_prefix = datetime.now().strftime("%y")
-    id = uuid.uuid4()
-    short_id = f"{year_prefix}PTO{id.hex[:8]}"
-
-    return {"short_id": short_id.upper(), "id": str(id)}
-
-
-# Routes
 
 
 @router.get("/", response=List[ActivityMinimal])
@@ -67,6 +53,11 @@ def activity_search(request, search: ActivitySearchParameters):
 
 @router.post("/submit", response={200: dict})
 def submit_record(request, data: PlantActivitySchema):
+    """
+    Handler for Incoming records with "Submitted" status.
+    Performs strict validation on payload to ensure data integrity.
+    - Adds record to the 'activity' schema
+    """
     with transaction.atomic():
         payload = data.model_dump(mode="python", exclude_unset=True)
         payload["form_status"] = FormStatus.Submitted.value
@@ -90,19 +81,55 @@ def submit_record(request, data: PlantActivitySchema):
 
         processed_activity = processor.process(payload=payload, instance=instance)
         serialized_data = ActivitySerializer(processed_activity).data
-        return JsonResponse(serialized_data, status=200, safe=False)
+
+        ## Delete Draft Version of record (if exists)
+        DraftActivity.objects.filter(id=activity_id).delete()
+
+        return JsonResponse(serialized_data, status=200)
 
 
 @router.post("/draft")
-def submit_draft_record(request, data: DraftPlantActivitySchema = Body(...)):
-    data = data.model_dump(mode="json")
-    return JsonResponse(data, status=200, safe=False)
+def submit_draft_record(request, data: DraftPlantActivitySchema):
+    """
+    Handler for Incoming records with "Draft" status.
+    Performs loose validation on incoming data to remove extraneous keys and ensure payload integrity
+    - Adds record to the 'draft_activity' schema
+    """
+    with transaction.atomic():
+        payload = data.model_dump(mode="python", exclude_unset=True)
+        shape_data = payload.get("shape", None)
+        if shape_data:
+            geometry_dict = shape_data.get("geometry", shape_data)
+            payload["shape"] = GEOSGeometry(json.dumps(geometry_dict))
+
+        # Determine if Create or Update
+        activity_id = payload.get("id")
+        instance = DraftActivity.objects.filter(id=activity_id).first()
+
+        if not instance:
+            payload["type"] = ActivitySubtypes[payload["subtype"]].typeOfActivity
+
+        subtype_key = payload.get("subtype")
+        processor = DRAFT_ACTIVITY_PROCESSORS.get(subtype_key)
+        if not processor:
+            raise HttpError(400, f"Unsupported activity subtype: {subtype_key}")
+
+        processed_activity = processor.process(payload=payload, instance=instance)
+        serialized_data = ActivitySerializer(processed_activity).data
+        return JsonResponse(serialized_data, status=200)
 
 
-@router.api_operation(["GET"], "/{id}", response=ActivityOut)
+@router.api_operation(["GET"], "/{id}")
 def get_activity_by_id(request, id: str):
-    activity = Activity.objects.get(id=id)
-    return activity
+    activity = Activity.objects.filter(id=id).first()
+    if activity:  # Submission found
+        serialized_data = ActivitySerializer(activity).data
+        return JsonResponse(serialized_data, status=200)
+    # Check if its a users draft record.
+    # TODO: Match user to Draft, to avoid pulling other users Draft records.
+    activity = get_object_or_404(DraftActivity, pk=id)
+    serialized_data = ActivitySerializer(activity).data
+    return JsonResponse(serialized_data, status=200)
 
 
 @router.api_operation(["DELETE"], "/{id}", response={204: None})

--- a/api-rework/invasives/api/schemas/plant_activity/__init__.py
+++ b/api-rework/invasives/api/schemas/plant_activity/__init__.py
@@ -1,17 +1,47 @@
 from api.models.activity import ActivitySubtypes
-from .base_activity import BaseActivityProcessor
-from .observation_terrestrial import PlantObservationTerrestrialIn
-from .observation_aquatic import PlantObservationAquaticIn
-from .treatment_mechanical_terrestrial import PlantTreatmentMechanicalTerrestrialIn
-from .treatment_mechanical_aquatic import PlantTreatmentMechanicalAquaticIn
-from .monitoring_mechanical import PlantMonitoringMechanicalIn
-from .monitoring_chemical import PlantMonitoringChemicalIn
-from .biocontrol_release import BiocontrolReleaseIn
-from .biocontrol_collection import BiocontrolCollectionIn
-from .monitoring_biocontrol_release import MonitoringBiocontrolReleaseIn
-from .monitoring_biocontrol_dispersal import MonitoringBiocontrolDispersalIn
-from .treatment_chemical_terrestrial import TreatmentChemicalTerrestrialIn
-from .treatment_chemical_aquatic import TreatmentChemicalAquaticIn
+from .base_activity import BaseActivityProcessor, DraftBaseActivityProcessor
+from .observation_terrestrial import (
+    PlantObservationTerrestrialIn,
+    DraftPlantObservationTerrestrialIn,
+)
+from .observation_aquatic import (
+    PlantObservationAquaticIn,
+    DraftPlantObservationAquaticIn,
+)
+from .treatment_mechanical_terrestrial import (
+    PlantTreatmentMechanicalTerrestrialIn,
+    DraftPlantTreatmentMechanicalTerrestrialIn,
+)
+from .treatment_mechanical_aquatic import (
+    PlantTreatmentMechanicalAquaticIn,
+    DraftPlantTreatmentMechanicalAquaticIn,
+)
+from .monitoring_mechanical import (
+    PlantMonitoringMechanicalIn,
+    DraftPlantMonitoringMechanicalIn,
+)
+from .monitoring_chemical import (
+    PlantMonitoringChemicalIn,
+    DraftPlantMonitoringChemicalIn,
+)
+from .biocontrol_release import BiocontrolReleaseIn, DraftBiocontrolReleaseIn
+from .biocontrol_collection import BiocontrolCollectionIn, DraftBiocontrolCollectionIn
+from .monitoring_biocontrol_release import (
+    MonitoringBiocontrolReleaseIn,
+    DraftMonitoringBiocontrolReleaseIn,
+)
+from .monitoring_biocontrol_dispersal import (
+    MonitoringBiocontrolDispersalIn,
+    DraftMonitoringBiocontrolDispersalIn,
+)
+from .treatment_chemical_terrestrial import (
+    TreatmentChemicalTerrestrialIn,
+    DraftTreatmentChemicalTerrestrialIn,
+)
+from .treatment_chemical_aquatic import (
+    TreatmentChemicalAquaticIn,
+    DraftTreatmentChemicalAquaticIn,
+)
 
 ACTIVITY_PROCESSORS = {
     ActivitySubtypes.Observation_Plant_Terrestrial.name: PlantObservationTerrestrialIn,
@@ -26,4 +56,19 @@ ACTIVITY_PROCESSORS = {
     ActivitySubtypes.Biocontrol_Collection.name: BiocontrolCollectionIn,
     ActivitySubtypes.Treatment_Chemical_Plant_Aquatic.name: TreatmentChemicalAquaticIn,
     ActivitySubtypes.Treatment_Chemical_Plant_Terrestrial.name: TreatmentChemicalTerrestrialIn,
+}
+
+DRAFT_ACTIVITY_PROCESSORS = {
+    ActivitySubtypes.Observation_Plant_Terrestrial.name: DraftPlantObservationTerrestrialIn,
+    ActivitySubtypes.Observation_Plant_Aquatic.name: DraftPlantObservationAquaticIn,
+    ActivitySubtypes.Treatment_Mechanical_Plant_Terrestrial.name: DraftPlantTreatmentMechanicalTerrestrialIn,
+    ActivitySubtypes.Treatment_Mechanical_Plant_Aquatic.name: DraftPlantTreatmentMechanicalAquaticIn,
+    ActivitySubtypes.Monitoring_Mechanical_Plant_Terrestrial_Aquatic.name: DraftPlantMonitoringMechanicalIn,
+    ActivitySubtypes.Monitoring_Chemical_Plant_Terrestrial_Aquatic.name: DraftPlantMonitoringChemicalIn,
+    ActivitySubtypes.Biocontrol_Release.name: DraftBiocontrolReleaseIn,
+    ActivitySubtypes.Monitoring_Biocontrol_Release_Plant_Terrestrial.name: DraftMonitoringBiocontrolReleaseIn,
+    ActivitySubtypes.Monitoring_Biocontrol_Dispersal_Plant_Terrestrial.name: DraftMonitoringBiocontrolDispersalIn,
+    ActivitySubtypes.Biocontrol_Collection.name: DraftBiocontrolCollectionIn,
+    ActivitySubtypes.Treatment_Chemical_Plant_Aquatic.name: DraftTreatmentChemicalAquaticIn,
+    ActivitySubtypes.Treatment_Chemical_Plant_Terrestrial.name: DraftTreatmentChemicalTerrestrialIn,
 }

--- a/api-rework/invasives/api/schemas/plant_activity/base_activity.py
+++ b/api-rework/invasives/api/schemas/plant_activity/base_activity.py
@@ -1,6 +1,6 @@
 from django.db import transaction
 from typing import Dict, Any, List
-from api.models.activity.activity import Activity
+from api.models.activity.activity import Activity, DraftActivity
 from api.models.activity import (
     ActivityDataRecord,
     Participant,
@@ -9,6 +9,13 @@ from api.models.activity import (
     ProjectCode,
     Jurisdiction,
     UploadedImage,
+    DraftActivityDataRecord,
+    DraftParticipant,
+    DraftEmployer,
+    DraftFundingAgency,
+    DraftProjectCode,
+    DraftJurisdiction,
+    DraftUploadedImage,
 )
 
 # Common Sub-Models
@@ -104,4 +111,100 @@ class BaseActivityProcessor:
 
     @classmethod
     def save_subtype_records(cls, subtype_data: Dict[str, Any], parent: Activity):
+        raise NotImplementedError("Subclasses must implement `save_subtype_records`.")
+
+
+DRAFT_MODEL_MAPPING = {
+    "participants": DraftParticipant,
+    "funding_agencies": DraftFundingAgency,
+    "employer": DraftEmployer,
+    "jurisdictions": DraftJurisdiction,
+    "projects": DraftProjectCode,
+}
+
+
+class DraftBaseActivityProcessor:
+    @classmethod
+    def process(
+        cls, payload: Dict[str, Any], instance: DraftActivity = None
+    ) -> DraftActivity:
+        """Determines pipeline path inside an atomic transaction."""
+        with transaction.atomic():
+            subtype_data = payload.pop("subtype_data", {})
+            linked_ids = payload.pop("linked_activities", [])
+
+            if instance:  # Update
+                activity = cls.update_activity(instance, payload, linked_ids)
+            else:  # Create
+                activity = cls.create_activity(payload, linked_ids)
+
+            # Route unique model properties to subclass
+            cls.save_subtype_records(subtype_data, activity)
+            return activity
+
+    @classmethod
+    def create_activity(
+        cls, payload: Dict[str, Any], linked_ids: List[int]
+    ) -> DraftActivity:
+        # Remove nested fields not directly attributed to Activity object
+        media_data = payload.pop("media", [])
+        nested_data = {
+            key: payload.pop(key, []) for key in DRAFT_MODEL_MAPPING if key in payload
+        }
+
+        # Instantiate parent
+        activity = DraftActivity.objects.create(**payload)
+
+        if linked_ids:
+            activity.linked_activities.set(linked_ids)
+        if media_data:
+            # Manually create each image, due to S3 upload/processing.
+            adr = DraftActivityDataRecord.objects.create(activity=activity)
+            for img in media_data:
+                DraftUploadedImage.objects.create(activity_data_record=adr, **img)
+
+        cls._bulk_create_nested_models(activity, nested_data)
+        return activity
+
+    @classmethod
+    def update_activity(
+        cls, instance: DraftActivity, payload: Dict[str, Any], linked_ids: List[int]
+    ) -> DraftActivity:
+        media_data = payload.pop("media", [])
+        nested_data = {
+            key: payload.pop(key, []) for key in DRAFT_MODEL_MAPPING if key in payload
+        }
+        # Update Top level Activity Object with new information.
+        for field, value in payload.items():
+            setattr(instance, field, value)
+        instance.save()
+
+        instance.linked_activities.set(linked_ids)
+        # Erase all nested items for an activity before recreating.
+        DraftActivityDataRecord.objects.filter(activity=instance).delete()
+        if media_data:
+            # Manually create each image, due to S3 upload/processing.
+            adr = DraftActivityDataRecord.objects.create(activity=instance)
+            for img in media_data:
+                DraftUploadedImage.objects.create(activity_data_record=adr, **img)
+        cls._bulk_create_nested_models(instance, nested_data)
+        return instance
+
+    @classmethod
+    def _bulk_create_nested_models(
+        cls, parent: DraftActivity, nested_data: Dict[str, Any]
+    ):
+        """
+        Iterate through nested fields and create the related model.
+        """
+        adr = DraftActivityDataRecord.objects.create(activity=parent)
+        for key, model_cls in DRAFT_MODEL_MAPPING.items():
+            entries = nested_data.get(key, [])
+            if entries:
+                model_cls.objects.bulk_create(
+                    model_cls(activity_data_record=adr, **values) for values in entries
+                )
+
+    @classmethod
+    def save_subtype_records(cls, subtype_data: Dict[str, Any], parent: DraftActivity):
         raise NotImplementedError("Subclasses must implement `save_subtype_records`.")

--- a/api-rework/invasives/api/schemas/plant_activity/biocontrol_collection.py
+++ b/api-rework/invasives/api/schemas/plant_activity/biocontrol_collection.py
@@ -1,4 +1,4 @@
-from . import BaseActivityProcessor
+from . import BaseActivityProcessor, DraftBaseActivityProcessor
 from api.models.activity import (
     TargetPlantHeights,
     TargetPlantPhenology,
@@ -8,16 +8,14 @@ from api.models.activity import (
     Activity,
     ActivityDataRecord,
     TerrestrialBiocontrolCollectionEntry,
-)
-
-from api.models.activity import (
-    Activity,
-    ActivityDataRecord,
-    TargetPlantHeights,
-    TargetPlantPhenology,
-    MicrositeCondition,
-    WeatherConditions,
-    TerrestrialBiocontrolAgentCount,
+    DraftTargetPlantHeights,
+    DraftTargetPlantPhenology,
+    DraftMicrositeCondition,
+    DraftWeatherConditions,
+    DraftTerrestrialBiocontrolAgentCount,
+    DraftActivity,
+    DraftActivityDataRecord,
+    DraftTerrestrialBiocontrolCollectionEntry,
 )
 
 
@@ -58,5 +56,50 @@ class BiocontrolCollectionIn(BaseActivityProcessor):
             )
             TerrestrialBiocontrolAgentCount.objects.bulk_create(
                 TerrestrialBiocontrolAgentCount(activity_data_record=adr, **count)
+                for count in estimated_agents
+            )
+
+
+class DraftBiocontrolCollectionIn(DraftBaseActivityProcessor):
+    @classmethod
+    def save_subtype_records(self, subtype_data: dict, parent: DraftActivity):
+        adr = DraftActivityDataRecord.objects.create(activity=parent)
+        phenology = subtype_data.get("target_plant_phenology")
+        if phenology:
+            plant_heights = phenology.pop("target_plant_heights")
+            DraftTargetPlantPhenology.objects.create(
+                activity_data_record=adr, **phenology
+            )
+
+            DraftTargetPlantHeights.objects.bulk_create(
+                DraftTargetPlantHeights(activity_data_record=adr, **tph)
+                for tph in plant_heights
+            )
+
+        microsite = subtype_data.get("microsite_conditions")
+        if microsite:
+            DraftMicrositeCondition.objects.create(
+                activity_data_record=adr, **microsite
+            )
+
+        weather_conditions = subtype_data.get("weather_conditions")
+        if weather_conditions:
+            DraftWeatherConditions.objects.create(
+                activity_data_record=adr, **weather_conditions
+            )
+
+        for entry in subtype_data.get("entries", []):
+            actual_agents = entry.pop("actual_biological_agents", [])
+            estimated_agents = entry.pop("estimated_biological_agents", [])
+            adr = DraftActivityDataRecord.objects.create(activity=parent)
+            DraftTerrestrialBiocontrolCollectionEntry.objects.create(
+                activity_data_record=adr, **entry
+            )
+            DraftTerrestrialBiocontrolAgentCount.objects.bulk_create(
+                DraftTerrestrialBiocontrolAgentCount(activity_data_record=adr, **count)
+                for count in actual_agents
+            )
+            DraftTerrestrialBiocontrolAgentCount.objects.bulk_create(
+                DraftTerrestrialBiocontrolAgentCount(activity_data_record=adr, **count)
                 for count in estimated_agents
             )

--- a/api-rework/invasives/api/schemas/plant_activity/biocontrol_release.py
+++ b/api-rework/invasives/api/schemas/plant_activity/biocontrol_release.py
@@ -1,4 +1,4 @@
-from . import BaseActivityProcessor
+from . import BaseActivityProcessor, DraftBaseActivityProcessor
 from api.models.activity import (
     TerrestrialBiocontrolReleaseEntry,
     TargetPlantHeights,
@@ -8,6 +8,14 @@ from api.models.activity import (
     TerrestrialBiocontrolAgentCount,
     Activity,
     ActivityDataRecord,
+    DraftTerrestrialBiocontrolReleaseEntry,
+    DraftTargetPlantHeights,
+    DraftTargetPlantPhenology,
+    DraftMicrositeCondition,
+    DraftWeatherConditions,
+    DraftTerrestrialBiocontrolAgentCount,
+    DraftActivity,
+    DraftActivityDataRecord,
 )
 
 
@@ -49,5 +57,51 @@ class BiocontrolReleaseIn(BaseActivityProcessor):
             )
             TerrestrialBiocontrolAgentCount.objects.bulk_create(
                 TerrestrialBiocontrolAgentCount(activity_data_record=adr, **count)
+                for count in estimated_agents
+            )
+
+
+class DraftBiocontrolReleaseIn(DraftBaseActivityProcessor):
+
+    @classmethod
+    def save_subtype_records(self, subtype_data: dict, parent: DraftActivity):
+        adr = DraftActivityDataRecord.objects.create(activity=parent)
+        phenology = subtype_data.get("target_plant_phenology")
+        if phenology:
+            plant_heights = phenology.pop("target_plant_heights")
+            DraftTargetPlantPhenology.objects.create(
+                activity_data_record=adr, **phenology
+            )
+
+            DraftTargetPlantHeights.objects.bulk_create(
+                DraftTargetPlantHeights(activity_data_record=adr, **tph)
+                for tph in plant_heights
+            )
+
+        microsite = subtype_data.get("microsite_conditions")
+        if microsite:
+            DraftMicrositeCondition.objects.create(
+                activity_data_record=adr, **microsite
+            )
+
+        weather_conditions = subtype_data.get("weather_conditions")
+        if weather_conditions:
+            DraftWeatherConditions.objects.create(
+                activity_data_record=adr, **weather_conditions
+            )
+
+        for entry in subtype_data.get("entries", []):
+            actual_agents = entry.pop("actual_biological_agents", [])
+            estimated_agents = entry.pop("estimated_biological_agents", [])
+            adr = DraftActivityDataRecord.objects.create(activity=parent)
+            DraftTerrestrialBiocontrolReleaseEntry.objects.create(
+                activity_data_record=adr, **entry
+            )
+            DraftTerrestrialBiocontrolAgentCount.objects.bulk_create(
+                DraftTerrestrialBiocontrolAgentCount(activity_data_record=adr, **count)
+                for count in actual_agents
+            )
+            DraftTerrestrialBiocontrolAgentCount.objects.bulk_create(
+                DraftTerrestrialBiocontrolAgentCount(activity_data_record=adr, **count)
                 for count in estimated_agents
             )

--- a/api-rework/invasives/api/schemas/plant_activity/monitoring_biocontrol_dispersal.py
+++ b/api-rework/invasives/api/schemas/plant_activity/monitoring_biocontrol_dispersal.py
@@ -1,4 +1,4 @@
-from . import BaseActivityProcessor
+from . import BaseActivityProcessor, DraftBaseActivityProcessor
 from api.models.activity import (
     TerrestrialBiocontrolDispersalMonitoringEntry,
     TargetPlantHeights,
@@ -10,6 +10,16 @@ from api.models.activity import (
     SignOfBiocontrolPresenceTerrestrial,
     Activity,
     ActivityDataRecord,
+    DraftTerrestrialBiocontrolDispersalMonitoringEntry,
+    DraftTargetPlantHeights,
+    DraftTargetPlantPhenology,
+    DraftMicrositeCondition,
+    DraftWeatherConditions,
+    DraftTerrestrialBiocontrolAgentCountExtended,
+    DraftLocationBiocontrolAgentsFoundTerrestrial,
+    DraftSignOfBiocontrolPresenceTerrestrial,
+    DraftActivity,
+    DraftActivityDataRecord,
 )
 
 
@@ -65,6 +75,68 @@ class MonitoringBiocontrolDispersalIn(BaseActivityProcessor):
             )
             SignOfBiocontrolPresenceTerrestrial.objects.bulk_create(
                 SignOfBiocontrolPresenceTerrestrial(
+                    activity_data_record=adr, sign_of_presence=sign
+                )
+                for sign in sign_of_presence
+            )
+
+
+class DraftMonitoringBiocontrolDispersalIn(DraftBaseActivityProcessor):
+
+    @classmethod
+    def save_subtype_records(self, subtype_data: dict, parent: DraftActivity):
+        adr = DraftActivityDataRecord.objects.create(activity=parent)
+        phenology = subtype_data.get("target_plant_phenology")
+        if phenology:
+            plant_heights = phenology.pop("target_plant_heights")
+            DraftTargetPlantPhenology.objects.create(
+                activity_data_record=adr, **phenology
+            )
+
+            DraftTargetPlantHeights.objects.bulk_create(
+                DraftTargetPlantHeights(activity_data_record=adr, **tph)
+                for tph in plant_heights
+            )
+
+        microsite = subtype_data.get("microsite_conditions")
+        if microsite:
+            DraftMicrositeCondition.objects.create(
+                activity_data_record=adr, **microsite
+            )
+
+        wc = subtype_data.get("weather_conditions")
+        if wc:
+            DraftWeatherConditions.objects.create(activity_data_record=adr, **wc)
+
+        for entry in subtype_data.get("entries", []):
+            actual_agents = entry.pop("actual_biological_agents", [])
+            estimated_agents = entry.pop("estimated_biological_agents", [])
+            location_found = entry.pop("location_agent_found", [])
+            sign_of_presence = entry.pop("sign_of_biocontrol_presence", [])
+            adr = DraftActivityDataRecord.objects.create(activity=parent)
+            DraftTerrestrialBiocontrolDispersalMonitoringEntry.objects.create(
+                activity_data_record=adr, **entry
+            )
+            DraftTerrestrialBiocontrolAgentCountExtended.objects.bulk_create(
+                DraftTerrestrialBiocontrolAgentCountExtended(
+                    activity_data_record=adr, **count
+                )
+                for count in actual_agents
+            )
+            DraftTerrestrialBiocontrolAgentCountExtended.objects.bulk_create(
+                DraftTerrestrialBiocontrolAgentCountExtended(
+                    activity_data_record=adr, **count
+                )
+                for count in estimated_agents
+            )
+            DraftLocationBiocontrolAgentsFoundTerrestrial.objects.bulk_create(
+                DraftLocationBiocontrolAgentsFoundTerrestrial(
+                    activity_data_record=adr, location_agent_found=loc
+                )
+                for loc in location_found
+            )
+            DraftSignOfBiocontrolPresenceTerrestrial.objects.bulk_create(
+                DraftSignOfBiocontrolPresenceTerrestrial(
                     activity_data_record=adr, sign_of_presence=sign
                 )
                 for sign in sign_of_presence

--- a/api-rework/invasives/api/schemas/plant_activity/monitoring_biocontrol_release.py
+++ b/api-rework/invasives/api/schemas/plant_activity/monitoring_biocontrol_release.py
@@ -1,4 +1,4 @@
-from . import BaseActivityProcessor
+from . import BaseActivityProcessor, DraftBaseActivityProcessor
 from api.models.activity import (
     TerrestrialBiocontrolDispersalMonitoringEntry,
     TargetPlantHeights,
@@ -11,6 +11,17 @@ from api.models.activity import (
     SignOfBiocontrolPresenceTerrestrial,
     Activity,
     ActivityDataRecord,
+    DraftTerrestrialBiocontrolDispersalMonitoringEntry,
+    DraftTargetPlantHeights,
+    DraftTargetPlantPhenology,
+    DraftMicrositeCondition,
+    DraftWeatherConditions,
+    DraftTerrestrialBiocontrolAgentCountExtended,
+    DraftLocationBiocontrolAgentsFoundTerrestrial,
+    DraftSpreadResults,
+    DraftSignOfBiocontrolPresenceTerrestrial,
+    DraftActivity,
+    DraftActivityDataRecord,
 )
 
 
@@ -72,6 +83,76 @@ class MonitoringBiocontrolReleaseIn(BaseActivityProcessor):
             )
             SignOfBiocontrolPresenceTerrestrial.objects.bulk_create(
                 SignOfBiocontrolPresenceTerrestrial(
+                    activity_data_record=adr, sign_of_presence=sign
+                )
+                for sign in sign_of_presence
+            )
+
+
+class DraftMonitoringBiocontrolReleaseIn(DraftBaseActivityProcessor):
+
+    @classmethod
+    def save_subtype_records(self, subtype_data: dict, parent: DraftActivity):
+        adr = DraftActivityDataRecord.objects.create(activity=parent)
+        phenology = subtype_data.get("target_plant_phenology")
+        if phenology:
+            plant_heights = phenology.pop("target_plant_heights")
+            DraftTargetPlantPhenology.objects.create(
+                activity_data_record=adr, **phenology
+            )
+
+            DraftTargetPlantHeights.objects.bulk_create(
+                DraftTargetPlantHeights(activity_data_record=adr, **tph)
+                for tph in plant_heights
+            )
+
+        spread_results = subtype_data.get("spread_results")
+        if spread_results:
+            DraftSpreadResults.objects.create(
+                activity_data_record=adr, **spread_results
+            )
+
+        microsite = subtype_data.get("microsite_conditions")
+        if microsite:
+            DraftMicrositeCondition.objects.create(
+                activity_data_record=adr, **microsite
+            )
+
+        weather_conditions = subtype_data.get("weather_conditions")
+        if weather_conditions:
+            DraftWeatherConditions.objects.create(
+                activity_data_record=adr, **weather_conditions
+            )
+
+        for entry in subtype_data.get("entries", []):
+            actual_agents = entry.pop("actual_biological_agents", [])
+            estimated_agents = entry.pop("estimated_biological_agents", [])
+            location_found = entry.pop("location_agent_found", [])
+            sign_of_presence = entry.pop("sign_of_biocontrol_presence", [])
+            adr = DraftActivityDataRecord.objects.create(activity=parent)
+            DraftTerrestrialBiocontrolDispersalMonitoringEntry.objects.create(
+                activity_data_record=adr, **entry
+            )
+            DraftTerrestrialBiocontrolAgentCountExtended.objects.bulk_create(
+                DraftTerrestrialBiocontrolAgentCountExtended(
+                    activity_data_record=adr, **count
+                )
+                for count in actual_agents
+            )
+            DraftTerrestrialBiocontrolAgentCountExtended.objects.bulk_create(
+                DraftTerrestrialBiocontrolAgentCountExtended(
+                    activity_data_record=adr, **count
+                )
+                for count in estimated_agents
+            )
+            DraftLocationBiocontrolAgentsFoundTerrestrial.objects.bulk_create(
+                DraftLocationBiocontrolAgentsFoundTerrestrial(
+                    activity_data_record=adr, location_agent_found=loc
+                )
+                for loc in location_found
+            )
+            DraftSignOfBiocontrolPresenceTerrestrial.objects.bulk_create(
+                DraftSignOfBiocontrolPresenceTerrestrial(
                     activity_data_record=adr, sign_of_presence=sign
                 )
                 for sign in sign_of_presence

--- a/api-rework/invasives/api/schemas/plant_activity/monitoring_chemical.py
+++ b/api-rework/invasives/api/schemas/plant_activity/monitoring_chemical.py
@@ -1,10 +1,15 @@
-from . import BaseActivityProcessor
+from . import BaseActivityProcessor, DraftBaseActivityProcessor
 from api.models.activity import (
     Activity,
     ActivityDataRecord,
     TerrestrialTreatmentMonitoringEntry,
     InvasivePlantsOnSite,
     AquaticTreatmentMonitoringEntry,
+    DraftActivity,
+    DraftActivityDataRecord,
+    DraftTerrestrialTreatmentMonitoringEntry,
+    DraftInvasivePlantsOnSite,
+    DraftAquaticTreatmentMonitoringEntry,
 )
 
 
@@ -35,5 +40,37 @@ class PlantMonitoringChemicalIn(BaseActivityProcessor):
 
             InvasivePlantsOnSite.objects.bulk_create(
                 InvasivePlantsOnSite(activity_data_record=adr, **plant)
+                for plant in plants_on_site
+            )
+
+
+class DraftPlantMonitoringChemicalIn(DraftBaseActivityProcessor):
+
+    @classmethod
+    def save_subtype_records(self, subtype_data: dict, parent: DraftActivity):
+        entries = subtype_data.get("entries", [])
+
+        adr = DraftActivityDataRecord.objects.create(activity=parent)
+
+        for entry in entries:
+            plants_on_site = entry.pop("invasive_plants_on_site", [])
+            adr = DraftActivityDataRecord.objects.create(activity=parent)
+
+            if entry["invasive_plant_aquatic"]:
+                entry["invasive_plant"] = entry.pop("invasive_plant_aquatic")
+                DraftAquaticTreatmentMonitoringEntry.objects.create(
+                    activity_data_record=adr,
+                    **entry,
+                )
+            else:
+                # Since this is a draft record and 'invasive_plant' may not even exist, just default to Terrestrial
+                # Because we at least know it's not aquatic.
+                entry.pop("invasive_plant_aquatic")
+                DraftTerrestrialTreatmentMonitoringEntry.objects.create(
+                    activity_data_record=adr, **entry
+                )
+
+            DraftInvasivePlantsOnSite.objects.bulk_create(
+                DraftInvasivePlantsOnSite(activity_data_record=adr, **plant)
                 for plant in plants_on_site
             )

--- a/api-rework/invasives/api/schemas/plant_activity/monitoring_mechanical.py
+++ b/api-rework/invasives/api/schemas/plant_activity/monitoring_mechanical.py
@@ -1,10 +1,15 @@
-from . import BaseActivityProcessor
+from . import BaseActivityProcessor, DraftBaseActivityProcessor
 from api.models.activity import (
     Activity,
     ActivityDataRecord,
     TerrestrialTreatmentMonitoringEntry,
     InvasivePlantsOnSite,
     AquaticTreatmentMonitoringEntry,
+    DraftActivity,
+    DraftActivityDataRecord,
+    DraftTerrestrialTreatmentMonitoringEntry,
+    DraftInvasivePlantsOnSite,
+    DraftAquaticTreatmentMonitoringEntry,
 )
 
 
@@ -35,5 +40,37 @@ class PlantMonitoringMechanicalIn(BaseActivityProcessor):
 
             InvasivePlantsOnSite.objects.bulk_create(
                 InvasivePlantsOnSite(activity_data_record=adr, **plant)
+                for plant in plants_on_site
+            )
+
+
+class DraftPlantMonitoringMechanicalIn(DraftBaseActivityProcessor):
+
+    @classmethod
+    def save_subtype_records(self, subtype_data: dict, parent: DraftActivity):
+        entries = subtype_data.get("entries", [])
+
+        adr = DraftActivityDataRecord.objects.create(activity=parent)
+
+        for entry in entries:
+            plants_on_site = entry.pop("invasive_plants_on_site", [])
+            adr = DraftActivityDataRecord.objects.create(activity=parent)
+
+            if entry["invasive_plant_aquatic"]:
+                entry["invasive_plant"] = entry.pop("invasive_plant_aquatic")
+                DraftAquaticTreatmentMonitoringEntry.objects.create(
+                    activity_data_record=adr,
+                    **entry,
+                )
+            else:
+                # Since this is a draft record and 'invasive_plant' may not even exist, just default to Terrestrial
+                # Because we at least know it's not aquatic.
+                entry.pop("invasive_plant_aquatic")
+                DraftTerrestrialTreatmentMonitoringEntry.objects.create(
+                    activity_data_record=adr, **entry
+                )
+
+            DraftInvasivePlantsOnSite.objects.bulk_create(
+                DraftInvasivePlantsOnSite(activity_data_record=adr, **plant)
                 for plant in plants_on_site
             )

--- a/api-rework/invasives/api/schemas/plant_activity/observation_aquatic.py
+++ b/api-rework/invasives/api/schemas/plant_activity/observation_aquatic.py
@@ -1,4 +1,3 @@
-from api.models.activity.activity import Activity
 from api.models.activity import (
     AquaticPlantObservationContext,
     AquaticPlantObservationEntry,
@@ -16,8 +15,24 @@ from api.models.activity import (
     WaterbodyOutflowPermanent,
     WaterbodyOutflowSeasonal,
     WaterbodyLevelManagement,
+    DraftAquaticPlantObservationContext,
+    DraftAquaticPlantObservationEntry,
+    DraftPretreatmentObservation,
+    DraftActivityDataRecord,
+    DraftAquaticVoucherSpecimen,
+    DraftActivity,
+    DraftWaterbodyAdjacentLandUse,
+    DraftShorelineTypes,
+    DraftWaterbodyUse,
+    DraftWaterbodySubstrateType,
+    DraftWaterbodyContext,
+    DraftWaterbodyInflowPermanent,
+    DraftWaterbodyInflowSeasonal,
+    DraftWaterbodyOutflowPermanent,
+    DraftWaterbodyOutflowSeasonal,
+    DraftWaterbodyLevelManagement,
 )
-from . import BaseActivityProcessor
+from . import BaseActivityProcessor, DraftBaseActivityProcessor
 
 
 class PlantObservationAquaticIn(BaseActivityProcessor):
@@ -95,5 +110,84 @@ class PlantObservationAquaticIn(BaseActivityProcessor):
                     **voucher_data
                 )
             AquaticPlantObservationEntry.objects.create(
+                activity_data_record=adr, **entry
+            )
+
+
+class DraftPlantObservationAquaticIn(DraftBaseActivityProcessor):
+    @classmethod
+    def save_subtype_records(self, subtype_data: dict, parent: DraftActivity):
+        adr = DraftActivityDataRecord.objects.create(activity=parent)
+
+        DraftAquaticPlantObservationContext.objects.create(
+            activity_data_record=adr, **subtype_data.get("context", None)
+        )
+
+        DraftPretreatmentObservation.objects.create(
+            activity_data_record=adr,
+            pre_treatment_observation=subtype_data.get(
+                "pretreatment_observation", None
+            ),
+        )
+
+        wb_context: dict = subtype_data.get("waterbody_context", None)
+
+        DraftWaterbodyInflowPermanent.objects.bulk_create(
+            DraftWaterbodyInflowPermanent(activity_data_record=adr, flow_code=flow)
+            for flow in wb_context.pop("inflow_permanent", [])
+        )
+        DraftWaterbodyInflowSeasonal.objects.bulk_create(
+            DraftWaterbodyInflowSeasonal(activity_data_record=adr, flow_code=flow)
+            for flow in wb_context.pop("inflow_seasonal", [])
+        )
+        DraftWaterbodyOutflowPermanent.objects.bulk_create(
+            DraftWaterbodyOutflowPermanent(activity_data_record=adr, flow_code=flow)
+            for flow in wb_context.pop("outflow_permanent", [])
+        )
+        DraftWaterbodyOutflowSeasonal.objects.bulk_create(
+            DraftWaterbodyOutflowSeasonal(activity_data_record=adr, flow_code=flow)
+            for flow in wb_context.pop("outflow_seasonal", [])
+        )
+        DraftWaterbodyContext.objects.create(activity_data_record=adr, **wb_context)
+
+        # Populate 1:M Arrays of strings
+        DraftShorelineTypes.objects.bulk_create(
+            DraftShorelineTypes(activity_data_record=adr, **shoreline_type)
+            for shoreline_type in subtype_data.get("shoreline_types", [])
+        )
+
+        DraftWaterbodyUse.objects.bulk_create(
+            DraftWaterbodyUse(activity_data_record=adr, waterbody_use=code)
+            for code in subtype_data.get("water_use", [])
+        )
+        DraftWaterbodySubstrateType.objects.bulk_create(
+            DraftWaterbodySubstrateType(activity_data_record=adr, substrate_type=code)
+            for code in subtype_data.get("substrate_type", [])
+        )
+        DraftWaterbodyAdjacentLandUse.objects.bulk_create(
+            DraftWaterbodyAdjacentLandUse(
+                activity_data_record=adr, waterbody_adjacent_land_use=code
+            )
+            for code in subtype_data.get("adjacent_land_use", [])
+        )
+        DraftWaterbodyLevelManagement.objects.bulk_create(
+            DraftWaterbodyLevelManagement(
+                activity_data_record=adr, waterlevel_management=code
+            )
+            for code in subtype_data.get("waterlevel_management", [])
+        )
+
+        # Aquatic Entries
+        for entry in subtype_data.get("entries", []):
+            adr = DraftActivityDataRecord.objects.create(activity=parent)
+
+            voucher_data = entry.pop("voucher_specimen", None)
+            if voucher_data:
+                DraftAquaticVoucherSpecimen.objects.create(
+                    activity_data_record=adr,
+                    invasive_plant=entry["invasive_plant"],
+                    **voucher_data
+                )
+            DraftAquaticPlantObservationEntry.objects.create(
                 activity_data_record=adr, **entry
             )

--- a/api-rework/invasives/api/schemas/plant_activity/observation_terrestrial.py
+++ b/api-rework/invasives/api/schemas/plant_activity/observation_terrestrial.py
@@ -1,5 +1,5 @@
 from typing import Dict, Any
-from api.models.activity.activity import Activity
+from api.models.activity.activity import Activity, DraftActivity
 from api.models.activity import (
     ActivityDataRecord,
     SpecificUse,
@@ -7,8 +7,14 @@ from api.models.activity import (
     TerrestrialVoucherSpecimen,
     TerrestrialPlantObservationContext,
     TerrestrialPlantObservationEntries,
+    DraftActivityDataRecord,
+    DraftSpecificUse,
+    DraftPretreatmentObservation,
+    DraftTerrestrialVoucherSpecimen,
+    DraftTerrestrialPlantObservationContext,
+    DraftTerrestrialPlantObservationEntries,
 )
-from . import BaseActivityProcessor
+from . import BaseActivityProcessor, DraftBaseActivityProcessor
 
 
 class PlantObservationTerrestrialIn(BaseActivityProcessor):
@@ -50,5 +56,49 @@ class PlantObservationTerrestrialIn(BaseActivityProcessor):
                     **voucher_data
                 )
             TerrestrialPlantObservationEntries.objects.create(
+                activity_data_record=adr, **entry
+            )
+
+
+class DraftPlantObservationTerrestrialIn(DraftBaseActivityProcessor):
+
+    @classmethod
+    def save_subtype_records(cls, subtype_data: Dict[str, Any], parent: DraftActivity):
+        """
+        Processes a pre-validated dictionary structure.
+        Pydantic has already cast empty strings to None and verified all types.
+        """
+        adr = DraftActivityDataRecord.objects.create(activity=parent)
+
+        context_data = subtype_data.get("context")
+        if context_data:
+
+            specific_uses = context_data.pop("specific_uses", [])
+            if specific_uses:
+                DraftSpecificUse.objects.bulk_create(
+                    DraftSpecificUse(activity_data_record=adr, **su)
+                    for su in specific_uses
+                )
+            DraftTerrestrialPlantObservationContext.objects.create(
+                activity_data_record=adr, **context_data
+            )
+
+        pretreat_data = subtype_data.get("pretreatment_observation")
+        if pretreat_data:
+            DraftPretreatmentObservation.objects.create(
+                activity_data_record=adr, pre_treatment_observation=pretreat_data
+            )
+
+        for entry in subtype_data.get("entries", []):
+            # Create ADR per entry so nested items attach properly
+            adr = DraftActivityDataRecord.objects.create(activity=parent)
+            voucher_data = entry.pop("voucher_specimen", None)
+            if voucher_data:
+                DraftTerrestrialVoucherSpecimen.objects.create(
+                    activity_data_record=adr,
+                    invasive_plant_id=entry["invasive_plant"],
+                    **voucher_data
+                )
+            DraftTerrestrialPlantObservationEntries.objects.create(
                 activity_data_record=adr, **entry
             )

--- a/api-rework/invasives/api/schemas/plant_activity/treatment_chemical_aquatic.py
+++ b/api-rework/invasives/api/schemas/plant_activity/treatment_chemical_aquatic.py
@@ -1,10 +1,13 @@
-from . import BaseActivityProcessor
+from . import BaseActivityProcessor, DraftBaseActivityProcessor
 import logging
 from api.models.activity import (
     Activity,
     ActivityDataRecord,
     WellEntry,
     ChemicalTreatmentContext,
+    DraftActivity,
+    DraftActivityDataRecord,
+    DraftWellEntry,
 )
 
 log = logging.getLogger(__name__)
@@ -24,4 +27,21 @@ class TreatmentChemicalAquaticIn(BaseActivityProcessor):
         )
         log.error(
             f"[{parent.short_id}] And attempt was made to create a {parent.subtype} activity. This has not been fully implemented, data loss will occur."
+        )
+
+
+class DraftTreatmentChemicalAquaticIn(DraftBaseActivityProcessor):
+
+    @classmethod
+    def save_subtype_records(self, subtype_data: dict, parent: DraftActivity):
+        adr = DraftActivityDataRecord.objects.create(activity=parent)
+        # DraftChemicalTreatmentContext.objects.create(
+        #     activity_data_record=adr, **subtype_data.get("context")
+        # )
+        DraftWellEntry.objects.bulk_create(
+            DraftWellEntry(activity_data_record=adr, **well)
+            for well in subtype_data.get("well_entries", [])
+        )
+        log.error(
+            f"[{parent.short_id}] And attempt was made to create a Draft {parent.subtype} activity. This has not been fully implemented, data loss will occur."
         )

--- a/api-rework/invasives/api/schemas/plant_activity/treatment_chemical_terrestrial.py
+++ b/api-rework/invasives/api/schemas/plant_activity/treatment_chemical_terrestrial.py
@@ -1,10 +1,13 @@
-from . import BaseActivityProcessor
+from . import BaseActivityProcessor, DraftBaseActivityProcessor
 import logging
 from api.models.activity import (
     Activity,
     ActivityDataRecord,
     WellEntry,
     ChemicalTreatmentContext,
+    DraftActivity,
+    DraftActivityDataRecord,
+    DraftWellEntry,
 )
 
 log = logging.getLogger(__name__)
@@ -25,4 +28,22 @@ class TreatmentChemicalTerrestrialIn(BaseActivityProcessor):
 
         log.error(
             f"[{parent.short_id}] And attempt was made to create a {parent.subtype} activity. This has not been fully implemented, data loss will occur."
+        )
+
+
+class DraftTreatmentChemicalTerrestrialIn(DraftBaseActivityProcessor):
+
+    @classmethod
+    def save_subtype_records(self, subtype_data: dict, parent: DraftActivity):
+        adr = DraftActivityDataRecord.objects.create(activity=parent)
+        # DraftChemicalTreatmentContext.objects.create(
+        #     activity_data_record=adr, **subtype_data.get("context")
+        # )
+        DraftWellEntry.objects.bulk_create(
+            DraftWellEntry(activity_data_record=adr, **well)
+            for well in subtype_data.get("well_entries", [])
+        )
+
+        log.error(
+            f"[{parent.short_id}] And attempt was made to create a Draft {parent.subtype} activity. This has not been fully implemented, data loss will occur."
         )

--- a/api-rework/invasives/api/schemas/plant_activity/treatment_mechanical_aquatic.py
+++ b/api-rework/invasives/api/schemas/plant_activity/treatment_mechanical_aquatic.py
@@ -1,10 +1,15 @@
-from . import BaseActivityProcessor
+from . import BaseActivityProcessor, DraftBaseActivityProcessor
 from api.models.activity import (
     Activity,
     ActivityDataRecord,
     ShorelineTypes,
     AquaticPlantMechanicalTreatmentEntry,
     AquaticMechanicalAuthorization,
+    DraftActivity,
+    DraftActivityDataRecord,
+    DraftShorelineTypes,
+    DraftAquaticPlantMechanicalTreatmentEntry,
+    DraftAquaticMechanicalAuthorization,
 )
 
 
@@ -25,5 +30,26 @@ class PlantTreatmentMechanicalAquaticIn(BaseActivityProcessor):
         auth_info = subtype_data.get("authorization_information")
         if auth_info:
             AquaticMechanicalAuthorization.objects.create(
+                activity_data_record=adr, authorization_information=auth_info
+            )
+
+
+class DraftPlantTreatmentMechanicalAquaticIn(DraftBaseActivityProcessor):
+
+    @classmethod
+    def save_subtype_records(self, subtype_data: dict, parent: DraftActivity):
+        adr = DraftActivityDataRecord.objects.create(activity=parent)
+
+        DraftShorelineTypes.objects.bulk_create(
+            DraftShorelineTypes(activity_data_record=adr, **shoreline_type)
+            for shoreline_type in subtype_data.get("shoreline_types", [])
+        )
+        DraftAquaticPlantMechanicalTreatmentEntry.objects.bulk_create(
+            DraftAquaticPlantMechanicalTreatmentEntry(activity_data_record=adr, **entry)
+            for entry in subtype_data.get("entries", [])
+        )
+        auth_info = subtype_data.get("authorization_information")
+        if auth_info:
+            DraftAquaticMechanicalAuthorization.objects.create(
                 activity_data_record=adr, authorization_information=auth_info
             )

--- a/api-rework/invasives/api/schemas/plant_activity/treatment_mechanical_terrestrial.py
+++ b/api-rework/invasives/api/schemas/plant_activity/treatment_mechanical_terrestrial.py
@@ -1,8 +1,11 @@
-from . import BaseActivityProcessor
+from . import BaseActivityProcessor, DraftBaseActivityProcessor
 from api.models.activity import (
     Activity,
     ActivityDataRecord,
     TerrestrialPlantMechanicalTreatmentEntry,
+    DraftActivity,
+    DraftActivityDataRecord,
+    DraftTerrestrialPlantMechanicalTreatmentEntry,
 )
 
 
@@ -12,5 +15,17 @@ class PlantTreatmentMechanicalTerrestrialIn(BaseActivityProcessor):
         adr = ActivityDataRecord.objects.create(activity=parent)
         TerrestrialPlantMechanicalTreatmentEntry.objects.bulk_create(
             TerrestrialPlantMechanicalTreatmentEntry(activity_data_record=adr, **entry)
+            for entry in subtype_data.get("entries", [])
+        )
+
+
+class DraftPlantTreatmentMechanicalTerrestrialIn(DraftBaseActivityProcessor):
+    @classmethod
+    def save_subtype_records(self, subtype_data: dict, parent: DraftActivity):
+        adr = DraftActivityDataRecord.objects.create(activity=parent)
+        DraftTerrestrialPlantMechanicalTreatmentEntry.objects.bulk_create(
+            DraftTerrestrialPlantMechanicalTreatmentEntry(
+                activity_data_record=adr, **entry
+            )
             for entry in subtype_data.get("entries", [])
         )

--- a/api-rework/invasives/api/tests/subtypes/test_observation_terrestrial.py
+++ b/api-rework/invasives/api/tests/subtypes/test_observation_terrestrial.py
@@ -1,6 +1,5 @@
 from .base import BaseActivitySubtypeTest
-from api.models.activity import Activity
-from api.serializers.activity import ActivitySerializer
+from api.models.activity import Activity, DraftActivity
 from api.tests.mock_frontend_submissions import (
     EMPTY_TERRESTRIAL_OBSERVATION,
     MINIMAL_TERRESTRIAL_OBSERVATION,
@@ -96,24 +95,64 @@ class TerrestrialObservationTest(BaseActivitySubtypeTest):
 
         self.assertCountEqual(obs_detail, sd["entries"])
 
-    def test_draft_submissions(self):
-        self.draft_pydantic_protocol_test(
-            empty_record=EMPTY_TERRESTRIAL_OBSERVATION,
-            minimal_record=MINIMAL_TERRESTRIAL_OBSERVATION,
-            full_record=UPDATED_TERRESTRIAL_OBSERVATION,
-        )
+    def test_initial_draft_submissions(self):
+        """
+        Expect:
+            - Submitting Draft returns 200
+            - Record is created in DB
+        """
+        payload = EMPTY_TERRESTRIAL_OBSERVATION
+        res = self.draft_record(payload)
+        self.assertEqual(res.status_code, 200)
+        record = res.json()
+
+        self.assertEqual(record["id"], payload["id"])
+        self.assertEqual(record["short_id"], payload["short_id"])
+        # Needs Serializers before can expand tests.
+        # self.assertGreater(len(record["subtype_data"]["entries"]), 0)
+        # self.assertEqual(
+        #     record["subtype_data"]["entries"][0]["observation_type"],
+        #     payload["subtype_data"]["entries"][0]["observation_type"],
+        # )
+
+    def test_update_draft_submission(self):
+        """
+        Expect:
+            - Submitting Draft returns 200
+            - Record is updated in DB
+        """
+        payload = MINIMAL_TERRESTRIAL_OBSERVATION
+        res = self.draft_record(payload)
+        self.assertEqual(res.status_code, 200)
+        record = res.json()
+
+        self.assertEqual(record["id"], payload["id"])
+        self.assertEqual(record["short_id"], payload["short_id"])
+        self.assertEqual(record["form_status"], payload["form_status"])
+        rec = DraftActivity.objects.get(id=payload["id"])
+        self.assertIsNotNone(rec)
+        # Needs Serializers before can expand tests.
+        # self.assertEqual(len(record["subtype_data"]["entries"]), 1)
+        # self.assertEqual(
+        #     record["subtype_data"]["entries"][0]["observation_type"],
+        #     payload["subtype_data"]["entries"][0]["observation_type"],
+        # )
 
     def test_submit_record(self):
         """
         Expect:
             - Submitting Record returns 200
             - Record is created in DB
+            - Draft Record is deleted when submitted record instantiated
         """
         payload = MINIMAL_TERRESTRIAL_OBSERVATION
         self.submit_record(payload).json()
         record = self.fetch(id=payload["id"]).json()
 
         self.assertIsNotNone(record)
+        draft_record_exists = DraftActivity.objects.filter(id=payload["id"]).exists()
+        self.assertFalse(draft_record_exists)
+        # self.assertIsNone()
 
     def test_update_record(self):
         """

--- a/api-rework/invasives/api/viewsets/activity.py
+++ b/api-rework/invasives/api/viewsets/activity.py
@@ -2,7 +2,7 @@ import json
 import logging
 
 import psycopg
-from django.contrib.gis.db.models.functions import Centroid, AsGeoJSON
+from django.contrib.gis.db.models.functions import PointOnSurface, AsGeoJSON
 from django.db.models import Q
 from django.http.response import HttpResponse
 from psycopg.rows import dict_row
@@ -29,7 +29,9 @@ class ActivityViewSet(ReadOnlyModelViewSet):
         )
         .values("id", "type", "subtype", "date", "has_migration_remarks")
         .all(),
-        "default": Activity.objects.annotate(centroid=AsGeoJSON(Centroid("shape")))
+        "default": Activity.objects.annotate(
+            centroid=AsGeoJSON(PointOnSurface("shape"))
+        )
         .prefetch_related()
         .all(),
     }

--- a/app/src/state/actions/activity/Activity.ts
+++ b/app/src/state/actions/activity/Activity.ts
@@ -124,7 +124,7 @@ class Activity {
           return rejectWithValue(404);
         }
       }
-      const req = await fetch(`${Configuration.current.runtime.API_V2_BASE}/activities/${id}`, {
+      const req = await fetch(`${Configuration.current.runtime.API_V2_BASE}/ninja/activities/${id}`, {
         headers: { Authorization: await getCurrentJWT() }
       });
       if (req.status === 404) return rejectWithValue(404);


### PR DESCRIPTION
# Overview

>[!IMPORTANT]
> Targets Previous PR, #4510

This PR includes the following proposed change(s):

- Adds protocols for Draft Record creation. 
- Submitting a record now hard deletes draft version of record (if exists)
    - Updates `test_terrestrial_observation` to test deletion occurs when record is submitted. 
- Change centroid serializer to PointInArea for consistency (`api-rework/invasives/api/viewsets/activity.py`)
- Change frontend Fetch target to ninja API
- Add stubbed functionality to fetch Draft records from ninja api
- Closes #4511 
- Closes #4597

>[!IMPORTANT]
> Will expand tests when serializers broken down and split between Draft/Submission.
