### PR TITLE
Set different colors for Layer visibility buttons

### DIFF
--- a/app/src/UI/Features/LegacyMap/LayerPicker/LayerIcon.tsx
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LayerIcon.tsx
@@ -1,0 +1,10 @@
+import { Visibility, VisibilityOff } from '@mui/icons-material';
+import { SvgIconProps } from '@mui/material';
+
+interface PropTypes extends SvgIconProps {
+  active: boolean;
+}
+const LayerIcon = ({ active, ...props }: PropTypes) =>
+  active ? <Visibility color="primary" {...props} /> : <VisibilityOff color="action" {...props} />;
+
+export default LayerIcon;

--- a/app/src/UI/Features/LegacyMap/LayerPicker/LpLayers/LpLayers.tsx
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LpLayers/LpLayers.tsx
@@ -1,5 +1,5 @@
 import { useDispatch, useSelector } from 'utils/use_selector';
-import { Layers, Settings, Visibility, VisibilityOff } from '@mui/icons-material';
+import { Layers, Settings } from '@mui/icons-material';
 import TooltipWithIcon from 'UI/Reusable/TooltipWithIcon/TooltipWithIcon';
 import LpLayersOption from './LpLayersOption';
 import { nanoid } from '@reduxjs/toolkit';
@@ -9,6 +9,7 @@ import './LpLayers.css';
 import UserSettings from 'state/actions/userSettings/UserSettings';
 import EmptyCollection from '../EmptyCollection/EmptyCollection';
 import AppActions from 'state/actions/appActions/appActions';
+import LayerIcon from '../LayerIcon';
 
 type PropTypes = {
   layers: InvasivesMapLayerDefinitionWithState[];
@@ -53,7 +54,7 @@ const LpLayers = ({ layers, setOverlayState }: PropTypes) => {
                       setOverlayState(layer.name);
                     }}
                   >
-                    {layer.active ? <Visibility /> : <VisibilityOff />}
+                    {<LayerIcon active={layer.active} />}
                   </button>
                   <p>{layer.displayName}</p>
                 </li>

--- a/app/src/UI/Features/LegacyMap/LayerPicker/LpLayers/LpLayersOption.tsx
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LpLayers/LpLayersOption.tsx
@@ -1,4 +1,4 @@
-import { Visibility, VisibilityOff } from '@mui/icons-material';
+import LayerIcon from '../LayerIcon';
 
 type Layer = {
   id: string;
@@ -14,7 +14,7 @@ const LpLayersOption = ({ onClick, layer }: PropTypes) => {
     <>
       <li className="lp-layers-item">
         <button data-testid="lp-layers-option-button" onClick={() => onClick(layer)}>
-          {layer?.toggle ? <Visibility /> : <VisibilityOff />}
+          {<LayerIcon active={layer.toggle} />}
         </button>
         <p>{layer.title ?? 'Layer name is null'}</p>
       </li>

--- a/app/src/UI/Features/LegacyMap/LayerPicker/LpOfflineMaps/LpOfflineMapsOption.tsx
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LpOfflineMaps/LpOfflineMapsOption.tsx
@@ -1,4 +1,4 @@
-import { Visibility, VisibilityOff } from '@mui/icons-material';
+import LayerIcon from '../LayerIcon';
 
 type PropTypes = {
   id: string;
@@ -11,7 +11,7 @@ const LpOfflineMapsOptions = ({ description, id, layerVisible, onClick }: PropTy
   return (
     <>
       <li className="lp-offline-map-option">
-        <button onClick={onClick.bind(this, id)}>{layerVisible ? <Visibility /> : <VisibilityOff />}</button>
+        <button onClick={onClick.bind(this, id)}>{<LayerIcon active={layerVisible} />}</button>
         <p>{description || id}</p>
       </li>
     </>

--- a/app/src/UI/Reusable/OfflineMapControls/OfflineMapControls.tsx
+++ b/app/src/UI/Reusable/OfflineMapControls/OfflineMapControls.tsx
@@ -1,9 +1,10 @@
-import { Delete, Visibility, VisibilityOff } from '@mui/icons-material';
+import { Delete } from '@mui/icons-material';
 import { IconButton } from '@mui/material';
 import { useInvasivesMapLayers } from 'UI/Features/LegacyMap/helpers/functional/layers-hook';
 import './offlineMapControls.css';
 import PlanMyTrip from 'state/actions/planMyTrip/PlanMyTrip';
 import { useDispatch } from 'utils/use_selector';
+import LayerIcon from 'UI/Features/LegacyMap/LayerPicker/LayerIcon';
 
 type PropTypes = {
   id: string;
@@ -21,7 +22,7 @@ const OfflineMapControls = ({ id, hideLayerToggle = false, hideDelete = false }:
   return (
     <div className="offline-map-controls">
       {!hideLayerToggle && (
-        <IconButton onClick={() => setOverlayState(id)}>{isEnabled ? <Visibility /> : <VisibilityOff />}</IconButton>
+        <IconButton onClick={() => setOverlayState(id)}>{<LayerIcon active={isEnabled} />}</IconButton>
       )}
       {!hideDelete && (
         <IconButton onClick={removeSubCache}>


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):
- Refactor LayerPicker visibility icons to single named export
- Set different colors for on/off state. 
 
<img width="57" height="99" alt="image" src="https://github.com/user-attachments/assets/f10411fd-d166-4e4f-b654-660669b8495a" />
