### PR TITLE
[INV-4602] Refactor centroids to pointOnSurface/Feature

### DIFF
--- a/api-rework/invasives/api/serializers/activity.py
+++ b/api-rework/invasives/api/serializers/activity.py
@@ -177,8 +177,7 @@ class ActivitySerializer(BaseSerializer):
     def get_centroid(self, obj):
         if not obj.shape:
             return None
-        centroid = obj.shape.centroid
-        return json.loads(centroid.json)
+        return json.loads(obj.shape.point_on_surface.json)
 
     def get_subtype_data(self, obj: Activity):
         """Maps the Activity to the proper Subtype Serializer, populating the form specific information"""
@@ -284,8 +283,7 @@ class DraftActivitySerializer(BaseSerializer):
     def get_centroid(self, obj):
         if not obj.shape:
             return None
-        centroid = obj.shape.centroid
-        return json.loads(centroid.json)
+        return json.loads(obj.shape.point_on_surface.json)
 
     def get_subtype_data(self, obj: DraftActivity):
         """Maps the Activity to the proper Subtype Serializer, populating the form specific information"""

--- a/api-rework/invasives/api/serializers/activity_recordset_row.py
+++ b/api-rework/invasives/api/serializers/activity_recordset_row.py
@@ -1,6 +1,6 @@
 import json
 from rest_framework import serializers
-from django.contrib.gis.db.models.functions import Centroid, AsGeoJSON
+from django.contrib.gis.db.models.functions import PointOnSurface, AsGeoJSON
 from api.models.activity.activity import Activity
 from api.models.activity import ActivitySubtypes, RisoArea, ProjectCode, FundingAgency
 from api.serializers.activity import ActivitySerializer
@@ -289,7 +289,7 @@ class CachedActivityRecordsetRowSerializer(ActivityRecordsetRowSerializer):
     def get_data(self, obj):
         # Refetch the object and annotate the centroid value.
         annotated_obj = Activity.objects.annotate(
-            centroid=AsGeoJSON(Centroid("shape"))
+            centroid=AsGeoJSON(PointOnSurface("shape"))
         ).get(pk=obj.pk)
 
         return ActivitySerializer(annotated_obj, context=self.context).data

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -42,6 +42,7 @@
         "@turf/distance": "^7.3.5",
         "@turf/helpers": "^7.3.5",
         "@turf/line-to-polygon": "^7.3.5",
+        "@turf/point-on-feature": "7.3.5",
         "@turf/turf": "^7.3.5",
         "dayjs": "^1.11.20",
         "immer": "^11.1.4",

--- a/app/package.json
+++ b/app/package.json
@@ -46,6 +46,7 @@
     "@turf/distance": "^7.3.5",
     "@turf/helpers": "^7.3.5",
     "@turf/line-to-polygon": "^7.3.5",
+    "@turf/point-on-feature": "7.3.5",
     "@turf/turf": "^7.3.5",
     "dayjs": "^1.11.20",
     "immer": "^11.1.4",

--- a/app/src/UI/Features/LegacyMap/helpers/components/PositionMarkers.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/PositionMarkers.tsx
@@ -4,7 +4,7 @@ import {
   refreshCurrentRecMakers,
   refreshHighlightedRecord
 } from 'UI/Features/LegacyMap/helpers/functional/current-record';
-import centroid from '@turf/centroid';
+import pointOnFeature from '@turf/point-on-feature';
 import maplibregl, { LngLatLike } from 'maplibre-gl';
 import { useSelector } from 'utils/use_selector';
 import circle from '@turf/circle';
@@ -126,7 +126,7 @@ const PositionMarkers = ({ mapReady }) => {
 
     refreshHighlightedRecord(map, { userRecordOnHoverRecordGeometry, userRecordOnHoverRecordType });
     if (quickPanToRecord && userRecordOnHoverRecordGeometry) {
-      const c = centroid(userRecordOnHoverRecordGeometry).geometry.coordinates as LngLatLike;
+      const c = pointOnFeature(userRecordOnHoverRecordGeometry).geometry.coordinates as LngLatLike;
       if (c) {
         map.easeTo({
           center: c,

--- a/app/src/UI/Features/LegacyMap/helpers/functional/current-record.ts
+++ b/app/src/UI/Features/LegacyMap/helpers/functional/current-record.ts
@@ -1,4 +1,4 @@
-import centroid from '@turf/centroid';
+import pointOnFeature from '@turf/point-on-feature';
 import { RecordSetType } from 'interfaces/UserRecordSet';
 import { LAYER_Z_FOREGROUND } from 'UI/Features/LegacyMap/helpers/functional/layer-definitions/types';
 
@@ -8,7 +8,7 @@ export const refreshCurrentRecMakers = (map, options: any) => {
     options.IAPPMarker.addTo(map);
   }
   if (options.activityMarker && options.activityGeo?.[0]?.geometry && options.currentActivityShortID) {
-    options.activityMarker.setLngLat(centroid(options.activityGeo[0]).geometry.coordinates);
+    options.activityMarker.setLngLat(pointOnFeature(options.activityGeo[0]).geometry.coordinates);
     options.activityMarker.addTo(map);
   }
 
@@ -17,7 +17,7 @@ export const refreshCurrentRecMakers = (map, options: any) => {
     (options.userRecordOnHoverRecordGeometry?.geometry?.[0] || options.userRecordOnHoverRecordGeometry?.geometry)
   ) {
     options.whatsHereMarker.setLngLat(
-      centroid(
+      pointOnFeature(
         options.userRecordOnHoverRecordGeometry?.geometry?.[0] || options.userRecordOnHoverRecordGeometry?.geometry
       ).geometry?.coordinates
     );

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -1,6 +1,6 @@
 import { all, call, put, select, take } from 'redux-saga/effects';
 import center from '@turf/center';
-import centroid from '@turf/centroid';
+import pointOnFeature from '@turf/point-on-feature';
 import {
   activity_create_function,
   ActivityStatus,
@@ -121,7 +121,7 @@ export function* handle_ACTIVITY_UPDATE_GEO_REQUEST(action: PayloadAction<Featur
             max: 10,
             callback: (userEnteredArea: number) => {
               // For a Hexagon (6 steps) to have exactly 'finalArea'
-              const STEPS = 8;
+              const STEPS = 6;
               const adjustedRadius = Math.sqrt((2 * userEnteredArea) / (STEPS * Math.sin((2 * Math.PI) / STEPS)));
               const buffered = circle(modifiedPayload[0], adjustedRadius, { units: 'meters', steps: STEPS }) as Feature;
               modifiedPayload[0] = buffered;
@@ -578,7 +578,7 @@ export function* handle_PAN_AND_ZOOM_TO_ACTIVITY() {
     if (isPoint) {
       target = geometry.geometry;
     } else {
-      const acentroid = centroid(geometry);
+      const acentroid = pointOnFeature(geometry);
 
       target = acentroid.geometry;
     }

--- a/app/src/state/sagas/iappsite/dataAccess.ts
+++ b/app/src/state/sagas/iappsite/dataAccess.ts
@@ -1,5 +1,5 @@
 import { put, select } from 'redux-saga/effects';
-import centroid from '@turf/centroid';
+import pointOnFeature from '@turf/point-on-feature';
 import { PayloadAction } from '@reduxjs/toolkit';
 import { selectIAPPSite } from 'state/reducers/iappsite';
 import { selectUserSettings } from 'state/reducers/userSettings';
@@ -52,7 +52,7 @@ export function* handle_IAPP_PAN_AND_ZOOM() {
     if (isPoint) {
       target = geometry.geometry;
     } else {
-      const acentroid = centroid(geometry);
+      const acentroid = pointOnFeature(geometry);
 
       target = acentroid.geometry;
     }

--- a/app/src/utils/geometryHelpers.ts
+++ b/app/src/utils/geometryHelpers.ts
@@ -1,5 +1,5 @@
 import area from '@turf/area';
-import centroid from '@turf/centroid';
+import pointOnFeature from '@turf/point-on-feature';
 import * as turf from '@turf/helpers';
 import { Feature, Position } from 'geojson';
 import GeoShapes from 'constants/geoShapes';
@@ -57,40 +57,17 @@ export function calculateGeometryArea(geometry: Feature[]) {
  *
  * @param {Feature[]} geom The geometry in GeoJSON format
  */
-export function calculateLatLng(geom: Feature[]) {
-  if (!geom || !geom[geom.length - 1] || !geom[geom.length - 1].geometry) return;
+export function calculateLatLng(geom: Feature[] | Feature) {
+  if (!geom) return;
 
-  const geo = geom[geom.length - 1].geometry;
-  const firstCoord = geo['coordinates'][0];
-
-  let latitude: number | null = null;
-  let longitude: number | null = null;
-
-  /*
-    Calculations based on business rules as to how anchor points need to be calculated
-    for different geometry types
-  */
-  if (geo.type === GeoShapes.Point) {
-    latitude = geo.coordinates[1];
-    longitude = firstCoord;
-  } else if (geo.type === GeoShapes.LineString && geo.coordinates.length > 1) {
-    latitude = firstCoord[1];
-    longitude = firstCoord[0];
-  } else if (geom[0]?.properties?.isRectangle) {
-    latitude = firstCoord[0][1];
-    longitude = firstCoord[0][0];
-  } else {
-    const centerPoint = centroid(geom[0] as any) || centroid(geom as any); //center(turf.polygon(geo['coordinates'])).geometry;
-    latitude = centerPoint.geometry.coordinates[1];
-    longitude = centerPoint.geometry.coordinates[0];
+  if (Array.isArray(geom)) {
+    if (geom.length === 0) return;
+    geom = geom[0];
   }
-
-  if (!latitude || !longitude) {
-    return null;
-  }
+  const pointFromGeom = pointOnFeature(geom);
   return {
-    latitude: parseFloat(latitude.toFixed(6)),
-    longitude: parseFloat(longitude.toFixed(6))
+    longitude: parseFloat(pointFromGeom.geometry.coordinates[0].toFixed(6)),
+    latitude: parseFloat(pointFromGeom.geometry.coordinates[1].toFixed(6))
   };
 }
 


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Add `@turf/point-on-feature` to app
- Convert instances of `centroid` to `pointOnFeature` 
- Correct Hex conversion to 6 points
- Refactor `calculateLatLng`, as all roads lead to the same result (polygon conversion). Also handles geom not being an array (future implementation)

Remedies issues with oblong shapes where a centroid may not necessarily be on the given feature, falsely flagging a location that may not be part of the record. Given a record contains a Multipolygon (future implementation), this will ensure point appears on a sub-polygon as well.