### PR TITLE
[INV-4601] Add alerts for 422 errors

### DIFF
--- a/app/src/UI/Features/LegacyMap/LayerPicker/LayerPicker.css
+++ b/app/src/UI/Features/LegacyMap/LayerPicker/LayerPicker.css
@@ -46,6 +46,7 @@ ul > hr {
   z-index: 500;
   box-sizing: border-box;
   border-left: 1pt solid var(--eigengrau);
+  animation: slide-in 0.2s ease-in;
 
   .lp-content {
     height: 100%;
@@ -135,4 +136,16 @@ ul > hr {
   justify-content: flex-start;
   align-items: flex-start;
   text-align: left;
+}
+
+@keyframes slide-in {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateX(0);
+    opacity: 0.85;
+  }
 }

--- a/app/src/UI/Features/OfflineDataSync/OfflineDataSync.css
+++ b/app/src/UI/Features/OfflineDataSync/OfflineDataSync.css
@@ -37,12 +37,24 @@
           min-height: var(--tr-height);
         }
 
+        tbody tr.warn:not(:hover) {
+          background-color: var(--bc-yellow);
+        }
+
         tbody tr td {
           vertical-align: top;
           font-size: 0.95rem;
 
           &:first-child {
             padding-left: 8px;
+          }
+
+          pre {
+            vertical-align: top;
+            text-align: left;
+            margin: 0;
+            padding: 0.25em 0;
+            background-color: inherit;
           }
         }
 

--- a/app/src/UI/Features/OfflineDataSync/OfflineDataSyncTable.tsx
+++ b/app/src/UI/Features/OfflineDataSync/OfflineDataSyncTable.tsx
@@ -138,8 +138,8 @@ export const OfflineDataSyncTable = ({ handleClose }: PropTypes) => {
                       </td>
                     </tr>
                     {(value as OfflineActivityRecord).sync_state == 'Error' && (
-                      <tr>
-                        <td></td>
+                      <tr className="warn">
+                        <td />
                         <td>
                           {(value as OfflineActivityRecord).error_detail
                             ? (value as OfflineActivityRecord).error_detail

--- a/app/src/UI/Layout/AlertsContainer/AlertsContainer.css
+++ b/app/src/UI/Layout/AlertsContainer/AlertsContainer.css
@@ -1,4 +1,4 @@
-.alertsContainer {
+.alerts-container {
   position: absolute;
   display: flex;
   flex-direction: column;
@@ -9,11 +9,24 @@
   right: 4%;
 }
 
-.alertsContainerAlert {
+.alerts-container-alert {
   width: calc(max(30vw, min(375px, 90vw)));
   box-sizing: border-box;
   text-align: left;
   align-items: center;
   margin: 2pt;
-  opacity: 0.8;
+  opacity: 0.85;
+  animation: slide-in 0.35s ease-out forwards;
+}
+
+@keyframes slide-in {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateX(0);
+    opacity: 0.85;
+  }
 }

--- a/app/src/UI/Layout/AlertsContainer/AlertsContainer.tsx
+++ b/app/src/UI/Layout/AlertsContainer/AlertsContainer.tsx
@@ -78,7 +78,7 @@ const AlertsContainer = () => {
   }, [alerts]);
 
   return (
-    <div className="alertsContainer">
+    <div className="alerts-container">
       {alerts.length > 0 && (
         <Button
           variant="contained"
@@ -95,7 +95,7 @@ const AlertsContainer = () => {
           key={id}
           severity={severity}
           onClose={() => handleClose(id!)}
-          className="alertsContainerAlert"
+          className="alerts-container-alert"
           icon={<Icon color={severity}>{getImageFromSubject(subject)}</Icon>}
         >
           {title && <AlertTitle>{title}</AlertTitle>}

--- a/app/src/state/actions/activity/FormActions.ts
+++ b/app/src/state/actions/activity/FormActions.ts
@@ -14,6 +14,7 @@ import EFilterType from 'constants/EFilterType';
 import { getCurrentJWT } from 'state/sagas/auth/auth';
 import formAlerts from 'constants/alerts/formAlerts';
 import { Role } from 'constants/roles';
+import transformPydanticErrors from 'utils/transformPydanticErrors';
 
 interface FormSubmission {
   data: FormSchema;
@@ -183,8 +184,16 @@ class FormActions {
         });
         if (!res?.ok) {
           // Request failed, alert user.
-          dispatch(Alerts.create(formAlerts.recordSubmittedFailure));
-          return rejectWithValue(await res.json());
+          if (res.status === 422) {
+            const rawErrors = await res.json();
+            const errors = transformPydanticErrors(rawErrors.detail);
+            for (const e of errors) {
+              dispatch(Alerts.create(e));
+            }
+          } else {
+            dispatch(Alerts.create(formAlerts.recordSubmittedFailure));
+            return rejectWithValue(await res.json());
+          }
         }
         dispatch(Alerts.create(formAlerts.recordSubmittedSuccess));
         return await res.json();

--- a/app/src/state/sagas/activity/offline.ts
+++ b/app/src/state/sagas/activity/offline.ts
@@ -17,6 +17,8 @@ import WhatsHere from 'state/actions/whatsHere/WhatsHere';
 import FormActions, { FormSubmission } from 'state/actions/activity/FormActions';
 import { selectConfiguration } from 'state/reducers/configuration';
 import { AppConfig } from 'state/configuration/runtime-config';
+import transformPydanticErrors from 'utils/transformPydanticErrors';
+import formAlerts from 'constants/alerts/formAlerts';
 
 function* handle_ACTIVITY_SAVE_OFFLINE(action: PayloadAction<FormSubmission>) {
   const connected = yield select(selectNetworkConnected);
@@ -102,7 +104,7 @@ function* handle_ACTIVITY_GET_LOCAL_REQUEST(action: PayloadAction<string>) {
 function* handle_ACTIVITY_RUN_OFFLINE_SYNC() {
   const config: AppConfig = yield select(selectConfiguration);
   const { serializedActivities } = yield select(selectOfflineActivity);
-  const { activeActivity, activeActivityPermissions } = yield select(selectActivity);
+  const { formId, activeActivityPermissions } = yield select(selectActivity);
   const toSync: OfflineActivityRecord[] = Object.values(serializedActivities).filter(
     (s) =>
       typeof s === 'object' &&
@@ -137,7 +139,7 @@ function* handle_ACTIVITY_RUN_OFFLINE_SYNC() {
           })
         );
 
-        if (hydrated.id === activeActivity) {
+        if (hydrated.id === formId) {
           yield put(
             Activity.getSuccess({
               activity: {
@@ -151,16 +153,30 @@ function* handle_ACTIVITY_RUN_OFFLINE_SYNC() {
         // Refetch Draft Records now that we're synced
         yield put(WhatsHere.getIdsForRecordset({ recordSetID: RecordSetId.Drafts, tableFiltersHash: 'init' }));
       } else {
+        let errorDetail = networkReturn.data;
+        if (networkReturn.status === 422) {
+          const parsedError = yield networkReturn.json();
+          errorDetail = `Form contains ${parsedError?.detail?.length} error(s).`;
+          // If this record is the active record, alert the errors.
+          if (formId === hydrated['id']) {
+            const errors = transformPydanticErrors(parsedError.detail);
+            for (const e of errors) {
+              yield put(Alerts.create(e));
+            }
+          }
+        } else if (networkReturn.status === 500) {
+          errorDetail = 'There was an internal error. Please try again in a few moments.';
+        }
+        // Request failed, alert user.
+        yield put(Alerts.create(formAlerts.recordSubmittedFailure));
+
         yield put(
           Activity.Offline.updateSyncState({
-            id: hydrated.activity_id,
+            id: hydrated.id,
             data: { ...hydrated, sync_status: ActivitySyncStatus.SAVE_FAILED },
             sync_state: OfflineActivitySyncState.ERROR,
             error_detail: `HTTP response code ${networkReturn.status}`,
-            error_object:
-              networkReturn.status < 500
-                ? networkReturn.data
-                : 'There was an internal error. Please try again in a few moments.'
+            error_object: errorDetail
           })
         );
       }

--- a/app/src/utils/transformPydanticErrors.ts
+++ b/app/src/utils/transformPydanticErrors.ts
@@ -1,0 +1,57 @@
+import { AlertSeverity, AlertSubjects } from 'constants/alertEnums';
+import AlertMessage from 'interfaces/AlertMessage';
+
+type PydanticError = {
+  type: string;
+  loc: Array<string>;
+  ctx?: object;
+  msg: string;
+};
+
+const capitalize = (text) => text.charAt(0).toUpperCase() + text.slice(1);
+
+/**
+ * @desc Parser for Pydantic validation errors.
+ * @returns {string} formatted error message
+ */
+const formatMessage = (msg: string, type: string) => {
+  const required = 'Field is required';
+  if (msg === 'Value error, Invalid type for code: None') {
+    return 'Should be valid option from dropdown.';
+  }
+  const typeMap = {
+    too_short: msg,
+    string_too_short: msg,
+    greater_than: msg,
+    enum: msg,
+    value_error: msg,
+    string_type: required,
+    missing: required
+  };
+  return typeMap?.[type] ?? msg;
+};
+
+const transformPydanticErrors = (rawErrors: Array<PydanticError>): Array<AlertMessage> =>
+  rawErrors.map(({ type, loc, msg }) => {
+    /* 
+    If the error is on an array itself, we'll get a meaningless index, so if that's the case, iterate to the next one
+    e.g.: ["subtype_data", "entries", 0]
+    */
+    const field: string = (() => {
+      for (const entry of loc.reverse()) {
+        if (typeof entry === 'string') {
+          return capitalize(entry.replaceAll('_', ' '));
+        }
+      }
+      return loc[0];
+    })();
+
+    return {
+      content: `[${field}]: ${formatMessage(msg, type)}`,
+      severity: AlertSeverity.Error,
+      subject: AlertSubjects.Form,
+      autoClose: 5
+    };
+  });
+
+export default transformPydanticErrors;


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

## Styling
- Add slide animation to LayerPicker
- Add slide animation to Alerts
- Adjust Alert Opacity +5% 
- Update SyncStatusTable to highlight errors, clean formatting for display

## Functionality

Adds parser for Pydantic validation errors and displays to the user via Alerts.
These alerts are only displayed for a user's active form.
Number of errors will appear in Sync Status menu for user clarity

Given the forms already block submissions when errors are present, a user should generally not see these errors. But if an error gets through and is caught by the backend, it will display. 

For ease of replication, adjust the `/draft` endpoint to use the `/submit` validator to see.

- Closes #4601 