### PR TITLE
[INV-4607] BUGFIX** Photo Uploads

### DIFF
--- a/api/src/utils/file-utils.ts
+++ b/api/src/utils/file-utils.ts
@@ -27,7 +27,7 @@ const S3 = getS3Client();
  * @param {string} key the unique key assigned to the file in S3 when it was originally uploaded
  * @returns {Promise<GetObjectCommandOutput>} the response from S3 or null if required parameters are null
  */
-export async function getFileFromS3(key: string): Promise<GetObjectCommandOutput> {
+async function getFileFromS3(key: string): Promise<GetObjectCommandOutput> {
   if (!key) {
     return null;
   }
@@ -35,7 +35,7 @@ export async function getFileFromS3(key: string): Promise<GetObjectCommandOutput
   return S3.send(new GetObjectCommand({ Bucket: OBJECT_STORE_BUCKET_NAME, Key: key }));
 }
 
-export type UploadFileResult = {
+type UploadFileResult = {
   key: string;
   result: PutObjectCommandOutput;
 };
@@ -50,10 +50,7 @@ export type UploadFileResult = {
  * @param {Metadata} [metadata={}] A metadata object to store additional information with the file
  * @returns {Promise<PutObjectCommandOutput>} the response from S3 or null if required parameters are null
  */
-export async function uploadFileToS3(
-  media: MediaBase64,
-  metadata: Record<string, string> = {}
-): Promise<UploadFileResult> {
+async function uploadFileToS3(media: MediaBase64, metadata: Record<string, string> = {}): Promise<UploadFileResult> {
   if (!media) {
     return null;
   }
@@ -82,7 +79,7 @@ export async function uploadFileToS3(
  * @param {string} key of object to delete from s3 bucket
  * @returns {Promise<DeleteObjectOutput>}
  */
-export async function deleteFileFromS3(key: string): Promise<DeleteObjectOutput> {
+async function deleteFileFromS3(key: string): Promise<DeleteObjectOutput> {
   if (!key) {
     return null;
   }
@@ -109,7 +106,7 @@ export async function deleteFileFromS3(key: string): Promise<DeleteObjectOutput>
  * @param {string} key S3 object key
  * @returns {Promise<string>} the response from S3 or null if required parameters are null
  */
-export async function getS3SignedURL(key: string): Promise<string> {
+async function getS3SignedURL(key: string): Promise<string> {
   if (!key) {
     return null;
   }
@@ -136,7 +133,7 @@ const base64DataURLRegex = new RegExp(/^data:(\w+\/\w+);base64,(.*)/);
  * @return {{ contentType: string; contentString: string }} returns an object with the Data URL encoded strings
  * contentType and contentString, or null if string is invalid or encoded incorrectly.
  */
-export function parseBase64DataURLString(base64String: string): { contentType: string; contentString: string } {
+function parseBase64DataURLString(base64String: string): { contentType: string; contentString: string } {
   if (!base64String) {
     return null;
   }
@@ -149,3 +146,6 @@ export function parseBase64DataURLString(base64String: string): { contentType: s
 
   return { contentType: matches[1], contentString: matches[2] };
 }
+
+export { getFileFromS3, parseBase64DataURLString, getS3SignedURL, deleteFileFromS3, uploadFileToS3 };
+export type { UploadFileResult };

--- a/app/src/UI/Features/Landing/Landing.tsx
+++ b/app/src/UI/Features/Landing/Landing.tsx
@@ -135,7 +135,7 @@ export const LandingComponent = () => {
                         <strong>Roles:</strong>
                       </p>
                       {roles.map((role) => (
-                        <p key={role.role_id}>{role.role_name}</p>
+                        <p key={role.role_id}>{role.role_description}</p>
                       ))}
                     </Box>
                   </Grid>

--- a/app/src/UI/Features/Records/Activity/Photo.tsx
+++ b/app/src/UI/Features/Records/Activity/Photo.tsx
@@ -1,0 +1,71 @@
+import { DeleteForever } from '@mui/icons-material';
+import {
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardMedia,
+  FormControl,
+  Grid,
+  IconButton,
+  TextField,
+  Typography
+} from '@mui/material';
+import UploadedPhoto from 'interfaces/UploadedPhoto';
+import EditIcon from '@mui/icons-material/Edit';
+import { useState } from 'react';
+import Activity from 'state/actions/activity/Activity';
+import { useDispatch } from 'utils/use_selector';
+
+type PropTypes = {
+  photo: UploadedPhoto;
+  isDisabled?: boolean;
+};
+const Photo = ({ photo, isDisabled }: PropTypes) => {
+  const handleDelete = () => dispatch(Activity.Photo.delete(photo));
+  const handleEditDescription = () => {
+    dispatch(Activity.Photo.edit({ ...photo, description }));
+    setIsEditing(false);
+  };
+
+  const dispatch = useDispatch();
+  const [description, setDescription] = useState<string>('');
+  const [isEditing, setIsEditing] = useState<boolean>(false);
+
+  return (
+    <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+      <Card>
+        <CardMedia src={photo.encoded_file} component="img" />
+        <Typography style={{ marginTop: '15px' }} textAlign={'center'} variant="h5">
+          {photo.description}
+        </Typography>
+        {!isDisabled && (
+          <CardActions style={{ width: '100%', display: 'flex', justifyContent: 'space-around' }}>
+            <IconButton onClick={handleDelete}>
+              <DeleteForever color="error" />
+            </IconButton>
+            <IconButton disabled={isDisabled} onClick={() => setIsEditing((prev) => !prev)}>
+              <EditIcon color={isEditing ? 'primary' : 'inherit'} />
+            </IconButton>
+          </CardActions>
+        )}
+        {isEditing && (
+          <FormControl>
+            <Box mb={2}>
+              <TextField
+                label="Change Description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+              />
+              <Button onClick={handleEditDescription} disabled={description === photo.description}>
+                Save
+              </Button>
+            </Box>
+          </FormControl>
+        )}
+      </Card>
+    </Grid>
+  );
+};
+
+export default Photo;

--- a/app/src/UI/Features/Records/Activity/PhotoContainer.tsx
+++ b/app/src/UI/Features/Records/Activity/PhotoContainer.tsx
@@ -1,43 +1,24 @@
 import { Camera, MediaResult, MediaTypeSelection } from '@capacitor/camera';
-import {
-  Box,
-  Button,
-  Card,
-  CardActions,
-  CardMedia,
-  CircularProgress,
-  FormControl,
-  Grid,
-  IconButton,
-  TextField,
-  Typography
-} from '@mui/material';
-import EditIcon from '@mui/icons-material/Edit';
-import { PhotoCamera, PhotoLibrary, DeleteForever } from '@mui/icons-material';
-import React, { useState } from 'react';
+import { Box, Button, CircularProgress, Grid } from '@mui/material';
+import { PhotoCamera, PhotoLibrary } from '@mui/icons-material';
 import Activity from 'state/actions/activity/Activity';
 import UploadedPhoto from 'interfaces/UploadedPhoto';
 import { useDispatch, useSelector } from 'utils/use_selector';
 import 'UI/Features/Records/Activity/PhotoContainer.css';
 import Alerts from 'state/actions/alerts/Alerts';
 import { AlertSeverity, AlertSubjects } from 'constants/alertEnums';
-export interface IPhoto {
-  file_name: string;
-  webviewPath?: string;
-  base64?: string;
-  dataUrl?: string;
-  description?: string;
-  editing?: boolean;
-}
+import { Md5 } from 'ts-md5';
+import Photo from './Photo';
+import { MobileOnly } from 'UI/Reusable/Predicates/MobileOnly';
 
 export interface IPhotoContainerProps {
   classes?: any;
   isDisabled?: boolean;
 }
 
-const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
+const PhotoContainer = (props: IPhotoContainerProps) => {
   const dispatch = useDispatch();
-  const media = useSelector((state) => state.ActivityPage.activity?.media || []);
+  const media = useSelector((state) => state.ActivityPage.activity?.media) ?? [];
 
   const checkPermissionsAndAlert = async (permission: 'Photo Gallery' | 'Camera'): Promise<void> => {
     const { camera, photos } = await Camera.checkPermissions();
@@ -89,99 +70,54 @@ const PhotoContainer: React.FC<IPhotoContainerProps> = (props) => {
         quality: 75
       });
       const processedPhotos = results.map(transformImageToFormData);
-      // filter out failed photo conversions
-      processedPhotos.filter(Boolean).forEach((p) => dispatch(Activity.Photo.add(p)));
+      // filter out failed photo conversions / twice-uploaded images
+      processedPhotos.filter(Boolean).forEach((p) => {
+        const hashed = Md5.hashStr(p.encoded_file ?? '');
+        const isPhotoAlreadyUploaded = media.some((m) => Md5.hashStr(m.encoded_file) === hashed);
+        if (isPhotoAlreadyUploaded) {
+          dispatch(
+            Alerts.create({
+              content: `Uploaded image "${p.file_name}" Already in record. Image was removed.`,
+              severity: AlertSeverity.Error,
+              subject: AlertSubjects.Photo,
+              autoClose: 8
+            })
+          );
+        } else {
+          dispatch(Activity.Photo.add(p));
+        }
+      });
     } catch (e) {
       console.error(e);
     }
   };
 
-  const deletePhoto = async (photo: UploadedPhoto) => {
-    dispatch(Activity.Photo.delete(photo));
-  };
-
-  const [newPhotoDesc, setNewPhotoDesc] = useState('untitled');
-
   if (!media) {
     return <CircularProgress />;
   }
-
   return (
     <Box width={1}>
       <Box mb={3}>
         <Grid container>
           <Grid container>
-            {media.map((photo, index) => (
-              <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }} key={index}>
-                <Card>
-                  <CardMedia src={photo.encoded_file} component="img" />
-                  <Typography style={{ marginTop: '15px' }} textAlign={'center'} variant="h5">
-                    {photo.description}
-                  </Typography>
-                  {!props.isDisabled && (
-                    <CardActions style={{ width: '100%', display: 'flex', justifyContent: 'space-around' }}>
-                      <IconButton onClick={() => deletePhoto(photo)}>
-                        <DeleteForever />
-                      </IconButton>
-                      <IconButton
-                        disabled={photo.editing}
-                        onClick={() => {
-                          dispatch(Activity.Photo.edit({ ...photo, editing: true }));
-                        }}
-                      >
-                        <EditIcon />
-                      </IconButton>
-                    </CardActions>
-                  )}
-
-                  <FormControl>
-                    {photo.editing && (
-                      <>
-                        <TextField
-                          label="Change Description"
-                          onChange={(e) => {
-                            setNewPhotoDesc(e.target.value);
-                          }}
-                        />
-                        <Button
-                          onClick={() => {
-                            dispatch(Activity.Photo.edit({ ...photo, description: newPhotoDesc, editing: false }));
-                            setNewPhotoDesc('untitled');
-                          }}
-                        >
-                          Save
-                        </Button>
-                      </>
-                    )}
-                  </FormControl>
-                </Card>
-              </Grid>
+            {media.map((photo) => (
+              <Photo key={Md5.hashStr(photo.encoded_file)} photo={photo} isDisabled={props?.isDisabled} />
             ))}
           </Grid>
         </Grid>
       </Box>
       {!props.isDisabled && (
-        <Box>
-          <Grid container>
-            <Grid container spacing={3} justifyContent="center">
-              <Grid>
-                <Button variant="contained" color="primary" startIcon={<PhotoCamera />} onClick={takePhotoFromCamera}>
-                  Capture Photo
-                </Button>
-              </Grid>
-              <Grid>
-                <Button
-                  variant="contained"
-                  color="primary"
-                  startIcon={<PhotoLibrary />}
-                  onClick={choosePhotosFromLibrary}
-                >
-                  Choose from Gallery
-                </Button>
-              </Grid>
-            </Grid>
-          </Grid>
-        </Box>
+        <div>
+          <MobileOnly>
+            <Button variant="contained" color="primary" startIcon={<PhotoCamera />} onClick={takePhotoFromCamera}>
+              Capture Photo
+            </Button>
+          </MobileOnly>
+
+          <Button variant="contained" color="primary" startIcon={<PhotoLibrary />} onClick={choosePhotosFromLibrary}>
+            Choose from Gallery
+          </Button>
+        </div>
       )}
     </Box>
   );

--- a/app/src/UI/Features/Records/Activity/PhotoContainer.tsx
+++ b/app/src/UI/Features/Records/Activity/PhotoContainer.tsx
@@ -10,6 +10,7 @@ import { AlertSeverity, AlertSubjects } from 'constants/alertEnums';
 import { Md5 } from 'ts-md5';
 import Photo from './Photo';
 import { MobileOnly } from 'UI/Reusable/Predicates/MobileOnly';
+import { nanoid } from '@reduxjs/toolkit';
 
 export interface IPhotoContainerProps {
   classes?: any;
@@ -34,8 +35,8 @@ const PhotoContainer = (props: IPhotoContainerProps) => {
     }
   };
 
-  const transformImageToFormData = (photo: MediaResult, index = 0): UploadedPhoto => {
-    const fileName = `${new Date().toISOString().slice(0, 10)}-${index}.${photo.metadata?.format}`;
+  const transformImageToFormData = (photo: MediaResult): UploadedPhoto => {
+    const fileName = `${new Date().toISOString().slice(0, 10)}-${nanoid()}.${photo.metadata?.format}`;
     const dataUrl = `data:image/${photo.metadata?.format};base64,${photo.thumbnail}`;
     return {
       file_name: fileName,
@@ -77,7 +78,7 @@ const PhotoContainer = (props: IPhotoContainerProps) => {
         if (isPhotoAlreadyUploaded) {
           dispatch(
             Alerts.create({
-              content: `Uploaded image "${p.file_name}" Already in record. Image was removed.`,
+              content: `Selected image already in record. Image was removed.`,
               severity: AlertSeverity.Error,
               subject: AlertSubjects.Photo,
               autoClose: 8

--- a/app/src/UI/Features/Records/FormMenuButtons/FormMenuButtons.tsx
+++ b/app/src/UI/Features/Records/FormMenuButtons/FormMenuButtons.tsx
@@ -28,7 +28,7 @@ const FormMenuButtons = () => {
 
   const recordIsSerializedActivity = !!serializedActivities[activity_id];
   // Users must have write permission and be online to delete, or record is users offline record
-  console.log(activityErrors);
+
   useEffect(() => {
     setSaveDisabled(!can_edit || pristine || activityErrors?.length > 0);
     setDraftDisabled(pristine || status === 'Submitted' || !can_edit);

--- a/app/src/interfaces/UploadedPhoto.ts
+++ b/app/src/interfaces/UploadedPhoto.ts
@@ -1,9 +1,8 @@
 interface UploadedPhoto {
   file_name: string;
   media_key?: string;
-  encoded_file: string | undefined;
+  encoded_file: string;
   description: string;
-  editing: boolean;
 }
 
 export default UploadedPhoto;

--- a/app/src/state/actions/activity/Photos.ts
+++ b/app/src/state/actions/activity/Photos.ts
@@ -14,7 +14,7 @@ class Photos {
   static readonly addSuccess = createAction(`${this.PREFIX}/addSuccess`);
   static readonly addFailure = createAction(`${this.PREFIX}/addFailure`);
 
-  static readonly edit = createAction(`${this.PREFIX}/edit`);
+  static readonly edit = createAction<UploadedPhoto>(`${this.PREFIX}/edit`);
   static readonly editSuccess = createAction<UploadedPhoto[]>(`${this.PREFIX}/editSuccess`);
 
   static readonly delete = createAction<UploadedPhoto>(`${this.PREFIX}/delete`);

--- a/app/src/state/reducers/activity.ts
+++ b/app/src/state/reducers/activity.ts
@@ -112,10 +112,13 @@ function createActivityReducer() {
           draftState.activity.media = [];
         }
         draftState.activity.media.push(action.payload);
+        draftState.pristine = false;
       } else if (Activity.Photo.editSuccess.match(action)) {
         draftState.activity.media = action.payload;
+        draftState.pristine = false;
       } else if (Activity.Photo.deleteSuccess.match(action)) {
         draftState.activity = action.payload;
+        draftState.pristine = false;
       } else if (Activity.Suggestions.jurisdictionsSuccess.match(action)) {
         draftState.suggestedJurisdictions = [...action.payload];
       } else if (Activity.Suggestions.biocontrolOnlineSuccess.match(action)) {

--- a/app/src/state/reducers/auth.ts
+++ b/app/src/state/reducers/auth.ts
@@ -17,7 +17,7 @@ interface IUserExtendedInfo {
   pac_service_number_2: string | null;
 }
 interface OfflineUserState {
-  roles: { role_id: number; role_name: string }[];
+  roles: { role_id: number; role_name: string; role_description: string }[];
   writePrivilege: Array<ActivitySubtype>;
   extendedInfo: IUserExtendedInfo;
 
@@ -61,7 +61,7 @@ interface AuthState {
 
   roles: { role_id: number; role_name: string }[];
   writePrivilege: Array<ActivitySubtype>;
-  accessRoles: { role_id: number; role_name: string }[];
+  accessRoles: { role_id: number; role_name: string; role_description: string }[];
   rolesInitialized: boolean;
 
   extendedInfo: {

--- a/app/src/state/reducers/auth.ts
+++ b/app/src/state/reducers/auth.ts
@@ -59,7 +59,11 @@ interface AuthState {
   loggedInOrWorkingOffline: boolean;
   loginInProgress: boolean;
 
-  roles: { role_id: number; role_name: string }[];
+  roles: {
+    role_description: string;
+    role_id: number;
+    role_name: string;
+  }[];
   writePrivilege: Array<ActivitySubtype>;
   accessRoles: { role_id: number; role_name: string; role_description: string }[];
   rolesInitialized: boolean;

--- a/app/src/state/sagas/activity/dataAccess.ts
+++ b/app/src/state/sagas/activity/dataAccess.ts
@@ -15,6 +15,7 @@ import { Feature, FeatureCollection } from 'geojson';
 
 import { PayloadAction } from '@reduxjs/toolkit';
 import cloneDeep from 'lodash.clonedeep';
+import { Md5 } from 'ts-md5';
 import {
   autoFillNameByPAC,
   autoFillTotalBioAgentQuantity,
@@ -652,60 +653,54 @@ export function* handle_ACTIVITY_ADD_PHOTO_REQUEST(action) {
 }
 
 export function* handle_ACTIVITY_DELETE_PHOTO_REQUEST(action) {
-  try {
-    if (action.payload) {
-      const beforeState = yield select(selectActivity);
-      const beforeActivity = beforeState.activity;
-
-      const media = beforeActivity.media.filter((photo: UploadedPhoto) => {
-        if (photo.media_key) {
-          return photo.media_key !== action.payload.media_key;
-        } else {
-          return photo.file_name !== action.payload.file_name;
-        }
-      });
-
-      let media_keys = [];
-      if (beforeActivity.media_keys) {
-        media_keys = beforeActivity.media_keys.filter((key) => {
-          if (action.payload.media_key) {
-            return key !== action.payload.media_key;
-          }
-        });
-      }
-
-      let delete_keys: string[] = [];
-      if (beforeActivity.media_delete_keys?.length) {
-        delete_keys = [...beforeActivity.media_delete_keys];
-      }
-      if (action.payload.media_key) {
-        delete_keys.push(action.payload.media_key);
-      }
-      yield put(
-        Activity.Photo.deleteSuccess({
-          ...beforeActivity,
-          media: media ?? [],
-          media_keys: media_keys ?? [],
-          media_delete_keys: delete_keys
-        })
-      );
+  const beforeState = yield select(selectActivity);
+  const beforeActivity = beforeState.activity;
+  const incomingHash = Md5.hashStr(action.payload.encoded_file);
+  const media = beforeActivity.media.filter((photo: UploadedPhoto) => {
+    if (photo.media_key) {
+      return photo.media_key !== action.payload.media_key;
     }
-  } catch (e) {
-    console.error(e);
-    yield put(Activity.Photo.deleteFailure());
+    return incomingHash !== Md5.hashStr(photo.encoded_file);
+  });
+
+  const media_keys: Array<unknown> = [];
+  if (beforeActivity.media_keys) {
+    media_keys.push(
+      ...beforeActivity.media_keys.filter((key) => {
+        if (action.payload.media_key) {
+          return key !== action.payload.media_key;
+        }
+      })
+    );
   }
+
+  const delete_keys: string[] = [];
+  delete_keys.push(...beforeActivity.media_delete_keys);
+
+  if (action.payload.media_key) {
+    delete_keys.push(action.payload.media_key);
+  }
+  yield put(
+    Activity.Photo.deleteSuccess({
+      ...beforeActivity,
+      media: media ?? [],
+      media_keys: media_keys ?? [],
+      media_delete_keys: delete_keys
+    })
+  );
 }
 
 export function* handle_ACTIVITY_EDIT_PHOTO_REQUEST(action) {
   try {
     const beforeState = yield select(selectActivity);
-    const beforeActivityMedia: UploadedPhoto[] = JSON.parse(JSON.stringify(beforeState.activity.media));
-    const photoIndex = beforeActivityMedia.findIndex((photo) => photo.file_name === action.payload.file_name);
+    const beforeActivityMedia: UploadedPhoto[] = structuredClone(beforeState.activity.media);
+    const incomingHash = Md5.hashStr(action.payload.encoded_file);
+    const idx = beforeActivityMedia.findIndex((photo) => Md5.hashStr(photo.encoded_file) === incomingHash);
 
-    if (photoIndex >= 0) {
-      beforeActivityMedia[photoIndex] = action.payload;
+    if (idx !== -1) {
+      beforeActivityMedia[idx] = action.payload;
+      yield put(Activity.Photo.editSuccess(beforeActivityMedia));
     }
-    yield put(Activity.Photo.editSuccess(beforeActivityMedia));
   } catch (e) {
     console.error(e);
   }


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Editing photos triggers pristine, allowing submission when no other changes
- Separated Photos from Photo Container, and refactor `description` editing to local state. 
    - Less redux calls as a result, cleaner transition. 
- Change key from index (causes errors) to hashed encoded_file. 
- Update Editing/Deletion/Methods to find files based on hashed encoded file instead of file name
    - Its not impossible for two users to upload a file with the same name, given their use
- Prevent uploading the same image to a record twice, via hash comparison.
- Hide `Capture Image` button from Web, as functionality behaves same as `Choose from Gallery` in this context.
- Move exports to bottom of `api/src/utils/file-utils.ts` to remove sea of intellisense warnings.
- Edit Landing page to display `role_description` over `role_name`
- Closes #4607 