### PR TITLE
Verify keycloak adapter state on wakeup

### DIFF
--- a/app/src/state/sagas/auth/keycloak.ts
+++ b/app/src/state/sagas/auth/keycloak.ts
@@ -81,6 +81,13 @@ function* keepTokenFresh() {
         continue;
       }
 
+      if (authenticated && !keycloakInstance.authenticated) {
+        // we think we are authenticated but keycloak disagrees (possible after a tab is restored from background after a long time, for example)
+
+        // update our state to match
+        put(AuthActions.signoutRequest());
+      }
+
       try {
         if (keycloakInstance.isTokenExpired(MIN_TOKEN_FRESHNESS)) {
           const refreshed = yield keycloakInstance.updateToken(MIN_TOKEN_FRESHNESS);


### PR DESCRIPTION
Verify that the keycloak adapter remains in `authenticated` state on wakeup. Log the user out if not.

# Overview

This PR includes the following proposed change(s):

- {List all the changes, if possible add the linked issue/ticket #}

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Screenshots

Please add any relevant UI screenshots if applicable.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
