### PR TITLE
[INV-N/A] BUGFIX** Refetching incorrect records

### DIFF
--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/ActivityForm.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/ActivityForm.tsx
@@ -15,6 +15,7 @@ import './activityForm.css';
 import Photos from './Photos';
 import FormControl from './FormControl';
 import RecordNotFound from './RecordNotFound/RecordNotFound';
+import UserSettings from 'state/actions/userSettings/UserSettings';
 
 const FORM_UPDATE_THROTTLE_DELAY = 1000; //ms
 const FORM_UPDATE_MAX_DELAY = 5000; //ms
@@ -27,7 +28,9 @@ const ActivityForm = () => {
   // TODO: Replace with Permission Logic
   const [isFormDisabled, setIsFormDisabled] = useState<boolean>(false);
   const { id, mode } = useParams<{ id: string; mode: Mode }>();
-
+  const handleCreateNewRecord = () => {
+    dispatch(UserSettings.openNewRecordDialogue());
+  };
   /**
    * Update Geometry related fields when Redux state of Geom changes
    */
@@ -136,6 +139,10 @@ const ActivityForm = () => {
     return (
       <div className="activity-page">
         <p>No active form found. Please create one or select an existing record to begin.</p>
+        <div className="alternate-options">
+          <button onClick={handleCreateNewRecord}>Create New Record</button>
+          <NavLink to="/Records">Go to Records</NavLink>
+        </div>
       </div>
     );
   }

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/RecordNotFound/RecordNotFound.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/RecordNotFound/RecordNotFound.tsx
@@ -1,9 +1,8 @@
-import { NavLink, useNavigate, useParams } from 'react-router';
+import { NavLink, useParams } from 'react-router';
 import './recordNotFound.css';
 
 const RecordNotFound = () => {
   const { id } = useParams<{ id: string }>();
-  const navigate = useNavigate();
 
   return (
     <div id="record-not-found">

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/activityForm.css
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/activityForm.css
@@ -25,6 +25,23 @@ input[type='button']:hover {
     }
   }
 
+  .alternate-options {
+    a,
+    button {
+      color: var(--blue-primary);
+      margin: 8px;
+      background-color: transparent;
+      outline: none;
+      border: none;
+      font-size: 1rem;
+      text-decoration: underline;
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
+  }
+
   nav {
     display: flex;
     flex-direction: 100%;

--- a/app/src/UI/Features/Records/RecordSet/RecordTablePopoverContent/RecordTablePopoverContent.tsx
+++ b/app/src/UI/Features/Records/RecordSet/RecordTablePopoverContent/RecordTablePopoverContent.tsx
@@ -7,6 +7,7 @@ import { GeoJSON } from 'geojson';
 import { MobileOnly } from 'UI/Reusable/Predicates/MobileOnly';
 import { useNavigate } from 'react-router';
 import { Debug } from 'UI/Reusable/Predicates/Debug';
+import { BugReport } from '@mui/icons-material';
 
 /**
  * @property { string } recordDisplayId Short ID / Site ID for a Record, displayed in the Popover
@@ -63,13 +64,13 @@ const RecordTablePopoverContent = ({ recordDisplayId: id, recordLookupId, record
       <p>
         {label}: {id}
       </p>
-      {/* // TODO: Remove RJSF Option */}
-      <Button onClick={handleOpenRecordInRJSF} variant="contained">
-        Open <Debug>- RJSF Form</Debug>
+      <Button onClick={handleOpenRecordInRHF} variant="contained">
+        Open
       </Button>
+      {/* // TODO: Remove RJSF Option */}
       <Debug>
-        <Button onClick={handleOpenRecordInRHF} variant="contained">
-          Open - RHF
+        <Button onClick={handleOpenRecordInRJSF} variant="contained">
+          <BugReport /> Open <Debug>- RJSF Form</Debug>
         </Button>
       </Debug>
       {!!geom && (

--- a/app/src/constants/offline_state_version.ts
+++ b/app/src/constants/offline_state_version.ts
@@ -1,5 +1,5 @@
 /*
   handle purging the offline storage on app version upgrade
 */
-export const CURRENT_MIGRATION_VERSION = 20260331;
+export const CURRENT_MIGRATION_VERSION = 20260804;
 export const MIGRATION_VERSION_KEY = '_persistedMigrationVersion';

--- a/app/src/state/actions/activity/FormActions.ts
+++ b/app/src/state/actions/activity/FormActions.ts
@@ -29,8 +29,16 @@ interface VerifyLinkedActivity {
 }
 class FormActions {
   private static readonly PREFIX = 'FormActions';
-
-  static readonly createNewForm = createAction<ActivitySubtypes>(`${this.PREFIX}/createNewForm`);
+  static readonly createNewForm = createAsyncThunk(
+    `${this.PREFIX}/createNewForm`,
+    async (subtype: ActivitySubtypes) => {
+      const newFormId = crypto.randomUUID();
+      return {
+        newFormId,
+        subtype
+      };
+    }
+  );
   static readonly startDuplicateForm = createAction(`${this.PREFIX}/startDuplicateForm`);
   static readonly delete = createAsyncThunk(
     `${this.PREFIX}/delete`,

--- a/app/src/state/reducers/activity.ts
+++ b/app/src/state/reducers/activity.ts
@@ -176,8 +176,6 @@ function createActivityReducer() {
       } else if (Activity.saveSuccess.match(action)) {
         draftState.pristine = true;
         draftState.activity = { ...action.payload };
-      } else if (Activity.createSuccess.match(action)) {
-        draftState.activeActivity = action.payload;
       } else if (Activity.deleteSuccess.match(action)) {
         Object.assign(draftState, {
           activity: null,
@@ -222,24 +220,26 @@ function createActivityReducer() {
         };
       } else if (Activity.refreshFormCodes.fulfilled.match(action)) {
         draftState.formCodes = action.payload;
-      } else if (FormActions.createNewForm.match(action)) {
+      } else if (FormActions.createNewForm.fulfilled.match(action)) {
         // Clear stale formstate if exists.
         delete draftState.formState;
         delete draftState.geometry_details;
         delete draftState.wellsInRecordArea;
         delete draftState.recordNotFound;
 
-        draftState.formId = crypto.randomUUID();
-        draftState.formType = action.payload;
+        draftState.formId = action.payload.newFormId;
+        draftState.formType = action.payload.subtype;
       } else if (FormActions.clearFormState.match(action) && draftState.formState) {
         delete draftState.geometry_details;
         delete draftState.wellsInRecordArea;
 
-        Object.assign(draftState.formState, {
-          ...getDefaultFormState(draftState.formType),
-          id: draftState.formId,
-          subtype: draftState.formType
-        });
+        if (draftState.formType) {
+          Object.assign(draftState.formState, {
+            ...getDefaultFormState(draftState.formType),
+            id: draftState.formId,
+            subtype: draftState.formType
+          });
+        }
       } else if (FormActions.duplicateForm.fulfilled.match(action)) {
         draftState.formType = action.payload.subtype;
         draftState.formId = action.payload.id;

--- a/app/src/state/reducers/rootReducer.ts
+++ b/app/src/state/reducers/rootReducer.ts
@@ -133,7 +133,6 @@ function createRootReducer(config: UnifiedConfig) {
         whitelist: [
           MIGRATION_VERSION_KEY,
           'activeActivity',
-          'activeActivityDescription',
           'activeIAPP',
           'recordSets',
           'recordsExpanded',

--- a/app/src/state/reducers/userSettings.ts
+++ b/app/src/state/reducers/userSettings.ts
@@ -339,10 +339,12 @@ function createUserSettingsReducer(_configuration: AppConfig) {
         draftState.newRecordDialogueState = { open: true, viewLayout: 'new' };
       } else if (
         UserSettings.closeNewRecordDialogue.match(action) ||
-        FormActions.createNewForm.match(action) ||
+        FormActions.createNewForm.pending.match(action) ||
         FormActions.duplicateForm.fulfilled.match(action)
       ) {
         draftState.newRecordDialogueState.open = false;
+      } else if (FormActions.createNewForm.fulfilled.match(action)) {
+        draftState.activeActivity = action.payload.newFormId;
       } else if (UserSettings.RecordSet.setSort.match(action)) {
         // if the sort column is the same as the current sort column, toggle the sort order
         // if its already desc, remove the sort column and order

--- a/app/src/state/reducers/userSettings.ts
+++ b/app/src/state/reducers/userSettings.ts
@@ -24,7 +24,6 @@ interface UserSettingsState {
   error: boolean;
 
   activeActivity: string | null;
-  activeActivityDescription: string | null;
   activeIAPP: string | null;
   apiDocsWithViewOptions: object | null;
   apiDocsWithSelectOptions: object | null;
@@ -55,7 +54,6 @@ const initialState: UserSettingsState = {
   [MIGRATION_VERSION_KEY]: CURRENT_MIGRATION_VERSION,
 
   activeActivity: null,
-  activeActivityDescription: null,
   activeIAPP: null,
 
   preferredBasemap: undefined,
@@ -90,7 +88,6 @@ function createUserSettingsReducer(_configuration: AppConfig) {
         draftState.recordsExpanded = !draftState.recordsExpanded;
       } else if (UserSettings.Activity.setActiveActivityIdSuccess.match(action)) {
         draftState.activeActivity = action.payload;
-        draftState.activeActivityDescription = action.payload;
       } else if (UserSettings.Boundaries.setSuccess.match(action)) {
         draftState.boundaries = action.payload;
       } else if (UserSettings.KML.deleteSuccess.match(action)) {
@@ -260,7 +257,6 @@ function createUserSettingsReducer(_configuration: AppConfig) {
         }
       } else if (Activity.deleteSuccess.match(action)) {
         draftState.activeActivity = null;
-        draftState.activeActivityDescription = null;
       } else if (Activity.get.match(action)) {
         draftState.activeActivity = action.payload;
       } else if (IappActions.getSuccess.match(action)) {

--- a/app/src/state/sagas/activity.ts
+++ b/app/src/state/sagas/activity.ts
@@ -63,6 +63,7 @@ import { isDrawing } from 'utils/geoTrackingHelpers';
 import AppActions from 'state/actions/appActions/appActions';
 import DrawToolActions from 'state/actions/drawtool/drawToolActions';
 import { selectConfiguration, selectRootConfiguration } from 'state/reducers/configuration';
+import { RootState } from 'state/reducers/rootReducer';
 
 function* handle_ACTIVITY_DELETE_SUCCESS() {
   yield put(UserSettings.RecordSet.setSelected(null));
@@ -79,12 +80,14 @@ function* handle_ACTIVITY_DELETE_SUCCESS() {
 function* handle_LOAD_ACTIVITY_IF_REQUIRED(action: PayloadAction<string>) {
   // this replaces an urlChange handler with more specific handling
   const id = action.payload;
-  const activityPageState = yield select(selectActivity);
-  const isValidIdMismatch =
-    id && id.length === 36 && (activityPageState?.activity?.activity_id !== id || id !== activityPageState.formId);
-  if (isValidIdMismatch) {
-    yield put(Activity.get(id));
+  const activityPageState: RootState['ActivityPage'] = yield select(selectActivity);
+  const appModeUrl: string = yield select((state: RootState) => state.AppMode.url);
+
+  if (!id || id.length !== 36) return;
+  if (appModeUrl.match(/\/Activity\//) && id !== activityPageState?.formId) {
     yield put(Activity.getActivity(id));
+  } else if (appModeUrl.match(/\/LegacyForm\//) && id !== activityPageState?.activity?.activity_id) {
+    yield put(Activity.get(id));
   }
 }
 


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):


- Refactor  `createNewForm` into Thunk
    - Removes need to chain another reducer in for consistency of 'formId' and 'currentActivity' 
    - Resolves bug where `currentActivity` was not updated when creating a new local record, causing tabbing to `current activity` to resolve to previous record.
- Tighten conditionals for fetching a `loadActivityIfNeeded` to be more strict about what its fetching.
- Add clear options for when no active record exists 
- Correct recordset popover context to show the RHF link when not in debug mode. 
- Remove unused `activeActivityDescription`
    - Bump version key
<img width="616" height="120" alt="image" src="https://github.com/user-attachments/assets/6c5fa02f-902e-43bf-8bdd-458313978958" />
