### PR TITLE
[INV-4583] Split Project Codes

### DIFF
--- a/api-rework/invasives/api/configs/exports/base_activity_annotation.py
+++ b/api-rework/invasives/api/configs/exports/base_activity_annotation.py
@@ -1,12 +1,29 @@
-from django.db.models import F, Value, CharField, Case, When, Exists, OuterRef, Q, Func
+from django.db.models import (
+    F,
+    Value,
+    CharField,
+    Case,
+    When,
+    Exists,
+    OuterRef,
+    Q,
+    Func,
+    Subquery,
+)
 from django.contrib.postgres.aggregates import StringAgg
 from django.db.models.functions import Concat, Cast
-from api.models.activity import (
-    UploadedImage,
-)
+from api.models.activity import UploadedImage, ProjectCode
 
 SRC = "root_activity"
 ADR_PATH = f"{SRC}__activitydatarecord"
+
+base_project_code_subquery = (
+    ProjectCode.objects.filter(activity_data_record__activity_id=OuterRef(f"{SRC}__id"))
+    .exclude(description__isnull=True)
+    .exclude(description="")
+    .order_by("id")
+    .values("description")
+)
 
 
 def get_BASE_ANNOTATION_CONFIGURATION_LEADING(is_chemical_treatment: bool):
@@ -17,13 +34,20 @@ def get_BASE_ANNOTATION_CONFIGURATION_LEADING(is_chemical_treatment: bool):
             "annotation": F(f"{SRC}__short_id"),
         },
         {
-            "header": "Project Codes",
-            "key": "project_code_display",
-            "annotation": StringAgg(
-                f"{ADR_PATH}__projectcode__description", delimiter=", ", distinct=True
-            ),
+            "header": "Project Code - 1",
+            "key": "project_code_display_one",
+            "annotation": Subquery(base_project_code_subquery[:1]),
         },
-        {"header": "Date", "key": "date_display", "annotation": F(f"{SRC}__date")},
+        {
+            "header": "Project Code - 2",
+            "key": "project_code_display_two",
+            "annotation": Subquery(base_project_code_subquery[1:2]),
+        },
+        {
+            "header": "Date",
+            "key": "date_display",
+            "annotation": F(f"{SRC}__date"),
+        },
         {
             "header": "Area (m)",
             "key": "area_display",

--- a/app/src/UI/Features/Records/ExcelExporter.tsx
+++ b/app/src/UI/Features/Records/ExcelExporter.tsx
@@ -8,6 +8,9 @@ import AccordionSummary from '@mui/material/AccordionSummary';
 import { useDispatch, useSelector } from 'utils/use_selector';
 import ExportActions from 'state/actions/exports/exportActions';
 import { ActivitySubtypes } from 'sharedAPI';
+import Alerts from 'state/actions/alerts/Alerts';
+import downloadAlertMessages from 'constants/alerts/downloadAlerts';
+
 const iappExportOptions = [
   { value: 'site_selection_extract', label: 'Site Selection Extract' },
   { value: 'survey_extract', label: 'Survey Extract' },
@@ -75,19 +78,26 @@ const ibcExportOptions = [
     label: 'Biocontrol – Collection'
   }
 ];
-const ExcelExporter = (props) => {
+
+type PropTypes = {
+  setName: string;
+};
+
+const ExcelExporter = ({ setName }: PropTypes) => {
   const handleRequest = () => {
     if (setType === 'IAPP') {
-      dispatch(ExportActions.requestExcel({ setId: props.setName, csvType: selection }));
+      dispatch(ExportActions.requestExcel({ setId: setName, csvType: selection }));
     } else if (setType === 'Activity') {
-      dispatch(ExportActions.requestActivityCSV({ setId: props.setName, csvType: selection }));
+      dispatch(ExportActions.requestActivityCSV({ setId: setName, csvType: selection }));
     }
+    dispatch(Alerts.create(downloadAlertMessages.csvDownloadStarted));
   };
+
   const dispatch = useDispatch();
   const linkToCSV = useSelector((state) => state.Map.linkToCSV);
   const recordSetForCSV = useSelector((state) => state.Map.recordSetForCSV);
   const CanTriggerCSV = useSelector((state) => state.Map.CanTriggerCSV);
-  const setType = useSelector((state) => state.UserSettings.recordSets[props.setName]?.recordSetType);
+  const setType = useSelector((state) => state.UserSettings.recordSets[setName]?.recordSetType);
   const [selection, setSelection] = useState(
     setType === 'IAPP' ? 'site_selection_extract' : ActivitySubtypes.Observation_Plant_Terrestrial
   );
@@ -107,7 +117,7 @@ const ExcelExporter = (props) => {
         </AccordionSummary>
         <AccordionDetails className="accordionDetails">
           <Tooltip classes={{ tooltip: 'toolTip' }} title="CSV Export">
-            {linkToCSV && props.setName === recordSetForCSV ? (
+            {linkToCSV && setName === recordSetForCSV ? (
               <a href={linkToCSV} download>
                 <Button
                   onClick={() => dispatch(ExportActions.resetCsvUrl())}
@@ -134,7 +144,7 @@ const ExcelExporter = (props) => {
                     <DownloadIcon />
                   </Button>
                 ) : (
-                  <Spinner></Spinner>
+                  <Spinner />
                 )}
               </div>
             )}

--- a/app/src/UI/Layout/AlertsContainer/AlertsContainer.tsx
+++ b/app/src/UI/Layout/AlertsContainer/AlertsContainer.tsx
@@ -3,7 +3,7 @@
  * @external {@link https://github.com/bcgov/invasivesbc/wiki/User-Alert-System }
  */
 import { Alert, AlertTitle, Button, Icon } from '@mui/material';
-import { Assignment, InsertPhoto, Lock, Luggage, MapOutlined, Save, Wifi } from '@mui/icons-material';
+import { Assignment, Downloading, InsertPhoto, Lock, Luggage, MapOutlined, Save, Wifi } from '@mui/icons-material';
 import { useDispatch } from 'react-redux';
 import 'UI/Layout/AlertsContainer/AlertsContainer.css';
 import AlertMessage from 'interfaces/AlertMessage';
@@ -36,6 +36,8 @@ const AlertsContainer = () => {
         return <Lock />;
       case AlertSubjects.PlanMyTrip:
         return <Luggage />;
+      case AlertSubjects.Download:
+        return <Downloading />;
       default:
         break;
     }

--- a/app/src/constants/alertEnums.ts
+++ b/app/src/constants/alertEnums.ts
@@ -6,7 +6,8 @@ export enum AlertSubjects {
   Network = 'network',
   Authentication = 'authentication',
   Cache = 'cache',
-  PlanMyTrip = 'plan my trip'
+  PlanMyTrip = 'plan my trip',
+  Download = 'download'
 }
 
 export enum AlertSeverity {

--- a/app/src/constants/alerts/downloadAlerts.ts
+++ b/app/src/constants/alerts/downloadAlerts.ts
@@ -1,0 +1,25 @@
+import { AlertSeverity, AlertSubjects } from 'constants/alertEnums';
+import AlertMessage from 'interfaces/AlertMessage';
+
+const downloadAlertMessages: Record<string, AlertMessage> = {
+  csvDownloadStarted: {
+    severity: AlertSeverity.Info,
+    subject: AlertSubjects.Download,
+    content: 'Recordset CSV export started.',
+    autoClose: 5
+  },
+  csvDownloadComplete: {
+    severity: AlertSeverity.Success,
+    subject: AlertSubjects.Download,
+    content: 'Recordset CSV Export downloaded.',
+    autoClose: 5
+  },
+  csvDownloadReady: {
+    severity: AlertSeverity.Info,
+    subject: AlertSubjects.Download,
+    content: 'Recordset CSV Export is ready. You may now start the download button.',
+    autoClose: 5
+  }
+};
+
+export default downloadAlertMessages;

--- a/app/src/state/actions/exports/exportActions.ts
+++ b/app/src/state/actions/exports/exportActions.ts
@@ -3,13 +3,15 @@ import { RecordSetType } from 'interfaces/UserRecordSet';
 import { RootState } from 'state/reducers/rootReducer';
 import { getCurrentJWT } from 'state/sagas/auth/auth';
 import { getRecordFilterObjectFromStateForAPI } from 'state/sagas/map/dataAccess';
+import Alerts from 'state/actions/alerts/Alerts';
+import downloadAlertMessages from 'constants/alerts/downloadAlerts';
 
 class ExportActions {
   private static readonly PREFIX = 'ExportActions';
 
   public static readonly requestActivityCSV = createAsyncThunk(
     `${this.PREFIX}/requestActivityCSV`,
-    async (spec: { setId: string; csvType: string }, { getState, rejectWithValue }) => {
+    async (spec: { setId: string; csvType: string }, { getState, rejectWithValue, dispatch }) => {
       const state = (await getState()) as RootState;
       const API_V2_BASE = state.Configuration.current.runtime.API_V2_BASE;
       const filterObject = getRecordFilterObjectFromStateForAPI(spec.setId, state.UserSettings);
@@ -48,12 +50,13 @@ class ExportActions {
       a.click();
       window.URL.revokeObjectURL('url');
       document.body.removeChild(a);
+      dispatch(Alerts.create(downloadAlertMessages.csvDownloadComplete));
     }
   );
 
   public static readonly requestExcel = createAsyncThunk(
     `${this.PREFIX}/requestExcel`,
-    async (spec: { setId: string; csvType: string }, { getState, rejectWithValue }) => {
+    async (spec: { setId: string; csvType: string }, { getState, rejectWithValue, dispatch }) => {
       const state = (await getState()) as RootState;
       const { API_BASE, API_V2_BASE } = state.Configuration.current.runtime;
       const set = state.UserSettings?.recordSets[spec.setId];
@@ -77,6 +80,7 @@ class ExportActions {
       if (!res?.ok) return rejectWithValue('HTTP Request failed to resolve');
 
       const url = await res.text();
+      dispatch(Alerts.create(downloadAlertMessages.csvDownloadReady));
       return { link: url, setId: spec.setId };
     }
   );


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Splits Project codes from Array Aggregate into two columns for First entry and second. any further project codes are not part of the exports.
- Adds alerts for the export process to provide users with feedback.
- Closes #4583 