### PR TITLE
Check subtype before assigning PAC to record

### DIFF
--- a/api-rework/invasives/api/legacy_db/mappings/participants.py
+++ b/api-rework/invasives/api/legacy_db/mappings/participants.py
@@ -1,5 +1,10 @@
 from api.legacy_db.model_serializer import LegacyActivity
-from api.models.activity import Activity, Participant, ActivityDataRecord
+from api.models.activity import (
+    Activity,
+    Participant,
+    ActivityDataRecord,
+    ActivitySubtypes,
+)
 
 
 def add_persons(
@@ -9,8 +14,12 @@ def add_persons(
     adr = ActivityDataRecord.objects.create(activity=new)
 
     for person in old.activity_payload.form_data.activity_type_data.activity_persons:
+        is_chem_treatment = old.activity_subtype in [
+            ActivitySubtypes.Treatment_Chemical_Plant_Terrestrial,
+            ActivitySubtypes.Treatment_Chemical_Plant_Aquatic,
+        ]
         Participant.objects.create(
             activity_data_record=adr,
             name=person.person_name,
-            pac_number=str(person.applicator_license),
+            pac_number=str(person.applicator_license) if is_chem_treatment else None,
         )


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Add check for chemical treatments before assigning PAC in ETL
    - Items incorrectly received PAC numbers from old "copy/paste" logic 
- Closes #4643
