### PR TITLE
[INV-4644] Show Referenced Records

### DIFF
--- a/api-rework/invasives/api/serializers/__init__.py
+++ b/api-rework/invasives/api/serializers/__init__.py
@@ -1,0 +1,1 @@
+from .activity_recordset_row import ActivityRecordsetRowSerializer

--- a/api-rework/invasives/api/serializers/activity.py
+++ b/api-rework/invasives/api/serializers/activity.py
@@ -68,6 +68,7 @@ class BaseSerializer(serializers.ModelSerializer):
     subtype_data = serializers.SerializerMethodField()
     participants = serializers.SerializerMethodField()
     linked_activities = serializers.SerializerMethodField()
+    linking_activities = serializers.SerializerMethodField()
 
     shape = serializers.SerializerMethodField()
     centroid = serializers.SerializerMethodField()
@@ -82,6 +83,7 @@ class BaseSerializer(serializers.ModelSerializer):
             "created_by",
             "form_status",
             "linked_activities",
+            "linking_activities",
             # Record type details
             "type",
             "subtype",
@@ -156,6 +158,13 @@ class ActivitySerializer(BaseSerializer):
                 }
             )
         return arr
+
+    def get_linking_activities(self, obj):
+        from api.serializers import ActivityRecordsetRowSerializer
+
+        return ActivityRecordsetRowSerializer(
+            obj.activity_set.all().order_by("-date"), many=True
+        ).data
 
     def get_shape(self, obj: Activity):
         geojson_py_object = json.loads(obj.shape.json)
@@ -260,6 +269,9 @@ class DraftActivitySerializer(BaseSerializer):
                 }
             )
         return arr
+
+    def get_linking_activities(self, obj):
+        return []
 
     def get_shape(self, obj: DraftActivity):
         if not obj.shape:  # Shouldn't happen outside of Draft Records.

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/ActivityForm.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/ActivityForm.tsx
@@ -160,7 +160,6 @@ const ActivityForm = () => {
       <FormProvider {...methods}>
         <form autoComplete={'off'} id="activity-form" onSubmit={handleSubmit(onSubmit)}>
           <RecordMetadata formState={getValues()} />
-          <LinkingActivities />
           {/* Use conditional Rendering so RHF Doesn't unmount fields in its validation step on submit */}
           <div className={`form-section ${mode === Mode.Form ? 'active' : ''}`}>
             <Form />
@@ -170,7 +169,7 @@ const ActivityForm = () => {
           </div>
 
           <FormControl />
-
+          <LinkingActivities />
           {/* Debug Information/Options */}
           <DebugButton
             label={`${isFormDisabled ? 'Enable' : 'Disable'} Form`}

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/ActivityForm.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/ActivityForm.tsx
@@ -16,6 +16,7 @@ import Photos from './Photos';
 import FormControl from './FormControl';
 import RecordNotFound from './RecordNotFound/RecordNotFound';
 import UserSettings from 'state/actions/userSettings/UserSettings';
+import LinkingActivities from './LinkingActivities/LinkingActivities';
 
 const FORM_UPDATE_THROTTLE_DELAY = 1000; //ms
 const FORM_UPDATE_MAX_DELAY = 5000; //ms
@@ -159,6 +160,7 @@ const ActivityForm = () => {
       <FormProvider {...methods}>
         <form autoComplete={'off'} id="activity-form" onSubmit={handleSubmit(onSubmit)}>
           <RecordMetadata formState={getValues()} />
+          <LinkingActivities />
           {/* Use conditional Rendering so RHF Doesn't unmount fields in its validation step on submit */}
           <div className={`form-section ${mode === Mode.Form ? 'active' : ''}`}>
             <Form />

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/LinkingActivities/LinkingActivities.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/LinkingActivities/LinkingActivities.tsx
@@ -27,7 +27,7 @@ const LinkingActivities = () => {
     return null;
   }
   return (
-    <Fieldset label={'Related Records'} tooltip={TOOLTIP}>
+    <Fieldset label={'Referenced By'} tooltip={TOOLTIP}>
       <CustomPopover buttonOverrideOptions={{ anchorEl, setAnchorEl }}>
         <RecordTablePopoverContent
           recordDisplayId={displayId}

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/LinkingActivities/LinkingActivities.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/LinkingActivities/LinkingActivities.tsx
@@ -1,0 +1,62 @@
+import StyledTable from 'UI/Reusable/StyledTable/StyledTable';
+import Fieldset from 'UI/Features/Records/Activity/forms/common/Fieldset/Fieldset';
+import { activityColumnsToDisplay } from 'UI/Features/Records/RecordSet/RecordTableHelpers';
+import { useSelector } from 'utils/use_selector';
+import CustomPopover from 'UI/Reusable/CustomPopover/CustomPopover';
+import { useState } from 'react';
+import RecordTablePopoverContent from 'UI/Features/Records/RecordSet/RecordTablePopoverContent/RecordTablePopoverContent';
+import { RecordSetType } from 'interfaces/UserRecordSet';
+
+/**
+ * @desc Display for Records that LINK TO this record.
+ */
+const LinkingActivities = () => {
+  const TOOLTIP = 'This list shows other activities that have added this record as a linked activity.';
+  const handleClick = (evt, a) => {
+    setRecordId(a.activity_id ?? '');
+    setDisplayId(a.short_id ?? '');
+    setAnchorEl(evt.currentTarget);
+  };
+  const linkingActivities = useSelector((state) => state.ActivityPage.formState?.linking_activities);
+
+  const [recordId, setRecordId] = useState<string>('');
+  const [displayId, setDisplayId] = useState<string>('');
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  if (!linkingActivities || linkingActivities.length === 0) {
+    return null;
+  }
+  return (
+    <Fieldset label={'Related Records'} tooltip={TOOLTIP}>
+      <CustomPopover buttonOverrideOptions={{ anchorEl, setAnchorEl }}>
+        <RecordTablePopoverContent
+          recordDisplayId={displayId}
+          recordLookupId={recordId}
+          recordType={RecordSetType.Activity}
+        />
+      </CustomPopover>
+      <StyledTable>
+        <thead>
+          <tr>
+            {activityColumnsToDisplay.map((c) => (
+              <th>{c.name}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {linkingActivities.map((a) => (
+            <tr key={a?.activity_id as string}>
+              {activityColumnsToDisplay.map((c) => (
+                <td onClick={(evt) => handleClick(evt, a)} key={c.key}>
+                  {(a?.[c.key] as string | number) || <span className="null-value" aria-hidden={true} />}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </StyledTable>
+    </Fieldset>
+  );
+};
+
+export default LinkingActivities;

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/LinkingActivities/LinkingActivities.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/LinkingActivities/LinkingActivities.tsx
@@ -3,7 +3,7 @@ import Fieldset from 'UI/Features/Records/Activity/forms/common/Fieldset/Fieldse
 import { activityColumnsToDisplay } from 'UI/Features/Records/RecordSet/RecordTableHelpers';
 import { useSelector } from 'utils/use_selector';
 import CustomPopover from 'UI/Reusable/CustomPopover/CustomPopover';
-import { useState } from 'react';
+import { MouseEvent, useState } from 'react';
 import RecordTablePopoverContent from 'UI/Features/Records/RecordSet/RecordTablePopoverContent/RecordTablePopoverContent';
 import { RecordSetType } from 'interfaces/UserRecordSet';
 
@@ -12,9 +12,9 @@ import { RecordSetType } from 'interfaces/UserRecordSet';
  */
 const LinkingActivities = () => {
   const TOOLTIP = 'This list shows other activities that have added this record as a linked activity.';
-  const handleClick = (evt, a) => {
-    setRecordId(a.activity_id ?? '');
-    setDisplayId(a.short_id ?? '');
+  const handleClick = (evt: MouseEvent<any>, a: Record<PropertyKey, unknown>) => {
+    setRecordId((a?.activity_id as string) ?? '');
+    setDisplayId((a?.short_id as string) ?? '');
     setAnchorEl(evt.currentTarget);
   };
   const linkingActivities = useSelector((state) => state.ActivityPage.formState?.linking_activities);

--- a/app/src/UI/Features/Records/Activity/forms/plant/builders/getDefaultState.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/builders/getDefaultState.ts
@@ -84,6 +84,7 @@ const getDefaultFormState = (subtype: ActivitySubtypes, created_by?: string): Fo
     utm_easting: 0,
     utm_northing: 0,
     linked_activities: [],
+    linking_activities: [], // Back-end supplied readonly field.
     participants: [{ name: '', pac_number: isChemical ? 0 : undefined }],
     subtype_data: subtype_data,
     type: ActivitySubtypesToType[subtype],

--- a/app/src/UI/Features/Records/Activity/forms/plant/interfaces/BaseForm.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/interfaces/BaseForm.ts
@@ -12,6 +12,7 @@ interface BaseForm {
     label: string;
     full: string;
   }>;
+  linking_activities: Record<PropertyKey, unknown>[];
   shape?: Feature;
   date: string;
   area_m: number;

--- a/app/src/UI/Reusable/StyledTable/StyledTable.tsx
+++ b/app/src/UI/Reusable/StyledTable/StyledTable.tsx
@@ -1,0 +1,11 @@
+import { PropsWithChildren } from 'react';
+import './styledTable.css';
+
+const StyledTable = ({ children }: PropsWithChildren) => {
+  return (
+    <div className="table-wrapper">
+      <table className="table-inner">{children}</table>
+    </div>
+  );
+};
+export default StyledTable;

--- a/app/src/UI/Reusable/StyledTable/styledTable.css
+++ b/app/src/UI/Reusable/StyledTable/styledTable.css
@@ -1,0 +1,80 @@
+.table-wrapper {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  font-size: 1rem;
+  margin-bottom: var(--record-table-footer-height);
+  max-height: 300pt;
+  overflow-x: scroll;
+  width: 100%;
+  text-size-adjust: 100%; /* Disables iOS Autoscaling text size */
+
+  .table-inner {
+    white-space: nowrap;
+    border-collapse: separate; /* Change from collapse to separate */
+    border-spacing: 0; /* Removes the gaps between cells */
+
+    thead {
+      top: 0;
+      overflow-x: scroll;
+      text-align: left;
+      padding-left: 5px;
+      background-color: lightgray;
+
+      th {
+        position: sticky;
+        top: 0;
+        padding: var(--td-padding);
+        font-size: 0.95rem;
+        border: 1px solid black;
+
+        /* Prevent Borders from doubling up due to border-collapse: separate */
+        &:not(:last-child) {
+          border-right: none;
+        }
+      }
+    }
+
+    tbody > tr,
+    thead > tr {
+      border-width: 2px;
+      border-spacing: 10px;
+      height: var(--tr-height);
+      background-color: var(--even-list-item-bg-color);
+    }
+
+    tbody tr:nth-child(odd) {
+      background-color: var(--odd-list-item-bg-color);
+    }
+
+    tbody tr:hover {
+      background-color: var(--hovered-list-item-bg-color);
+    }
+
+    td,
+    th {
+      padding: var(--td-padding);
+    }
+
+    td {
+      border-top: 1px solid lightgray;
+      border-left: 1px solid lightgray;
+      padding: 8px;
+      vertical-align: text-top;
+      text-align: left;
+
+      .null-value {
+        color: #ccc;
+        font-style: italic;
+
+        &::after {
+          content: 'None';
+        }
+      }
+
+      &:last-child {
+        border-right: 1px solid lightgray;
+      }
+    }
+  }
+}

--- a/app/src/state/reducers/userSettings.ts
+++ b/app/src/state/reducers/userSettings.ts
@@ -259,6 +259,8 @@ function createUserSettingsReducer(_configuration: AppConfig) {
         draftState.activeActivity = null;
       } else if (Activity.get.match(action)) {
         draftState.activeActivity = action.payload;
+      } else if (Activity.getActivity.fulfilled.match(action)) {
+        draftState.activeActivity = action.meta.arg;
       } else if (IappActions.getSuccess.match(action)) {
         draftState.activeIAPP = action.payload?.iapp?.site_id;
       } else if (


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Modified Activity serializer to add Records Linking to present record.
    - Reverse accessed relationships use the recordset row serializer for consistency.
    - Users can click through to the linked records if needed
- Added Common component `StyledTable` for better styling consistency cross app
    - Pending approval, will convert other tables to use it, reducing our code.
- Closes #4644 
- Updated userSettings reducer for a missed case in updating `activeActivity`
- 


<img width="845" height="195" alt="image" src="https://github.com/user-attachments/assets/33b3a066-5fe1-4847-b02c-cb7c2ef6c666" />
