### PR TITLE
[INV-4648] Viewable Revision History

### DIFF
--- a/api-rework/invasives/api/protocol/activity/api.py
+++ b/api-rework/invasives/api/protocol/activity/api.py
@@ -29,6 +29,7 @@ from api.protocol.activity.plant_subtypes.union_definition import (
     PlantActivitySchema,
     DraftPlantActivitySchema,
 )
+from api.utils.deepdiff import AtomicFieldOperator
 
 router = Router(auth=NinjaKeycloakAuthentication())
 
@@ -103,7 +104,13 @@ def submit_record(request, data: PlantActivitySchema):
         new_record = ActivitySerializer(processed_activity, read_only=True).data
 
         if existing_record:
-            diff = DeepDiff(old_activity, new_record)
+            diff = DeepDiff(
+                old_activity,
+                new_record,
+                custom_operators=[
+                    AtomicFieldOperator(regex_paths=[r"root\['shape'\]"])
+                ],
+            )
             if diff:
                 ActivityModificationRecord.objects.create(
                     user=request.auth,

--- a/api-rework/invasives/api/utils/deepdiff/__init__.py
+++ b/api-rework/invasives/api/utils/deepdiff/__init__.py
@@ -1,0 +1,1 @@
+from .atomic_field_operator import AtomicFieldOperator

--- a/api-rework/invasives/api/utils/deepdiff/atomic_field_operator.py
+++ b/api-rework/invasives/api/utils/deepdiff/atomic_field_operator.py
@@ -1,0 +1,20 @@
+from deepdiff.operator import BaseOperator
+
+
+class AtomicFieldOperator(BaseOperator):
+    """
+    Custom Operator for DeepDiff to treat a declared Object as one item, instead of comparing nested properties
+    e.g.: GeoJSON objects.
+    """
+
+    def give_up_diffing(self, level, diff_instance):
+        if level.t1 != level.t2:
+            diff_instance.custom_report_result(
+                "values_changed",
+                level,
+                {
+                    "old_value": level.t1,
+                    "new_value": level.t2,
+                },
+            )
+        return True

--- a/app/src/UI/App.css
+++ b/app/src/UI/App.css
@@ -132,6 +132,11 @@ body {
   --hovered-list-item-bg-color: #d1cfcd;
   --tr-height: 40px;
   --td-padding: 5px 8px;
+
+  /* Button Styles */
+  --sm-button-text: 0.85rem;
+  --med-button-text: 1rem;
+  --lg-button-text: 1.15rem;
 }
 
 /* Color Classes */

--- a/app/src/UI/Features/Records/Activity/forms/common/ChangeHistory/ChangeHistory.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/common/ChangeHistory/ChangeHistory.tsx
@@ -1,0 +1,218 @@
+import './changeHistory.css';
+import { useSelector } from 'utils/use_selector';
+import { ReactNode, useState } from 'react';
+import { ArrowForward } from '@mui/icons-material';
+import StyledModal from 'UI/Reusable/StyledModal/StyledModal';
+import Button from 'UI/Reusable/Button/Button';
+
+enum ChangeType {
+  ItemAdded = 'iterable_item_added',
+  ItemRemoved = 'iterable_item_removed',
+  ValueChanged = 'values_changed',
+  TypeChanges = 'type_changes'
+}
+
+/**
+ * @property {string} activity Record Identifier (UUID format)
+ * @property {string} date Date of change
+ * @property {string} platform - Platform change was initiated from e.g.: Batch, Web, iOS, Android
+ * @property {string} user - Readable name of User who initiated the record change.
+ * @property {number} version - Version of change created. e.g.: 1, 2, 3
+ */
+type History = {
+  activity: string;
+  date: string;
+  diff: Record<ChangeType, Record<PropertyKey, unknown>>;
+  platform: string;
+  user: string;
+  version: string;
+};
+
+/**
+ * @desc Format Diff Labels to a smaller readable format, skips indices
+ * @param { string } l supplied diff, e.g.: root['subtype_data']['context']['pest_management_plan']
+ * @returns { string } formatted string, e.g.: "pest management plan"
+ */
+const formatLabel = (l: string): string => {
+  const partial = l.match(/'([^']+)'(?=[^']*$)/);
+  if (!partial) return l;
+  return partial[1].replace(/_/g, ' ');
+};
+const parseObject = (entry: unknown) => {
+  // Explicit to not block 'False' from boolean switches
+  if (entry == null || entry == undefined) return '';
+  if (typeof entry === 'object' && entry !== null) {
+    const keys = Object.keys(entry);
+    const isMultiKey = keys.length > 1;
+    if (isMultiKey && 'full' in entry && 'label' in entry) {
+      // Edge case for Linked Id's
+      return (entry.label as string).split(' | ')[0];
+    } else if (isMultiKey) {
+      return JSON.stringify(entry, null, 2);
+    } else {
+      return entry[keys[0]].toString();
+    }
+  }
+  return entry.toString();
+};
+
+/**
+ * Format incoming values
+ * @param vc Values Changed -- DeepDiff object values_changed key. contains a { PropertyKey: { old_value, new_value }}
+ * @returns {ReactNode} Formatted Input element for comparing before and after. e.g.: "Old -> New"
+ */
+const _formattedValuesChanges = (vc: Record<PropertyKey, any> = {}): Array<ReactNode> => {
+  const entries: Array<ReactNode> = Object.entries(vc).map(([key, v]) => {
+    const MAX_SIZE_BEFORE_HIDDEN = 400;
+
+    const { old_value, new_value } = v;
+    const previous = parseObject(old_value);
+    const current = parseObject(new_value);
+
+    const IS_LARGE_DIFF = previous.length + current.length > MAX_SIZE_BEFORE_HIDDEN;
+    const [showDiff, setShowDiff] = useState<boolean>(!IS_LARGE_DIFF);
+
+    return (
+      <li className="diff-entry">
+        <dt className="label">{formatLabel(key)}</dt>
+        <dd className="italic">Value Modified</dd>
+        {IS_LARGE_DIFF && (
+          <dd>
+            <Button onClick={() => setShowDiff((prev) => !prev)}>See Change</Button>
+          </dd>
+        )}
+        {showDiff && (
+          <dd>
+            <span className="deep-red strike-through">{previous}</span>
+            &nbsp;
+            <ArrowForward />
+            &nbsp;
+            <span className="green">{current}</span>
+          </dd>
+        )}
+      </li>
+    );
+  });
+  return entries;
+};
+
+/**
+ * Format incoming values.
+ * The only time items should change type in the forms is when they go from Something to Null or vice-versa, so these are treated as additions/subtractions
+ * @param vc Values Changed -- DeepDiff object type_changes key. contains a { PropertyKey: { olt_type, old_value, new_type, new_value }}
+ * @returns {ReactNode} Formatted Input element for comparing before and after. e.g.: "Old -> New"
+ */
+const _formattedTypeChanges = (va: Record<PropertyKey, any> = {}): Array<ReactNode> => {
+  const additions = {};
+  const removals = {};
+  Object.entries(va).forEach(([key, value]) => {
+    if (value?.new_type === 'NoneType') {
+      removals[key] = value.old_value;
+    } else if (value?.old_type === 'NoneType') {
+      additions[key] = value.new_value;
+    }
+  });
+  return [..._formattedValuesAdded(additions), ..._formattedValuesRemoved(removals)];
+};
+
+/**
+ *
+ * @param va Values Added -- DeepDiff object iterated_values_added key. contains a { PropertyKey: value }
+ * @returns {ReactNode} Formatted Input element for comparing before and after. e.g.: "BCGOV"
+ */
+const _formattedValuesAdded = (va: Record<PropertyKey, any> = {}): Array<ReactNode> => {
+  const entries: Array<ReactNode> = Object.entries(va).map(([key, value]) => {
+    return (
+      <li className="diff-entry">
+        <dt>{formatLabel(key)}</dt>
+        <dd className="italic">Value Added</dd>
+        <dd className="green">{parseObject(value)}</dd>
+      </li>
+    );
+  });
+
+  return entries;
+};
+
+/**
+ *
+ * @param vr Values Removed -- DeepDiff object iterated_values_removed key. contains a { PropertyKey: value }
+ * @returns {ReactNode} Formatted Input element for comparing before and after. e.g.: "-BCGOV-"
+ */
+const _formattedValuesRemoved = (vr: Record<PropertyKey, any> = {}): Array<ReactNode> => {
+  const entries: Array<ReactNode> = Object.entries(vr).map(([key, value]) => {
+    return (
+      <li className="diff-entry">
+        <dt>{formatLabel(key)}</dt>
+        <dd className="italic">Value Removed</dd>
+        <dd className="deep-red strike-through">{parseObject(value)}</dd>
+      </li>
+    );
+  });
+
+  return entries;
+};
+
+/**
+ * @desc Subcomponent for rendering a list of individual diffs in a history object.
+ */
+const AllChanges = ({ diff }) => {
+  const entries: Array<ReactNode> = [
+    ..._formattedValuesChanges(diff?.[ChangeType.ValueChanged]),
+    ..._formattedValuesAdded(diff?.[ChangeType.ItemAdded]),
+    ..._formattedTypeChanges(diff?.[ChangeType.TypeChanges]),
+    ..._formattedValuesRemoved(diff?.[ChangeType.ItemRemoved])
+  ];
+  return (
+    <>
+      <dt>Changes</dt>
+      <dd>
+        <ul className="changes">{entries.map((r) => r)}</ul>
+      </dd>
+    </>
+  );
+};
+
+const ChangeHistory = () => {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+  const history = useSelector((state) => state.ActivityPage.formMetadata?.history) as Array<History>;
+  const short_id = useSelector((state) => state.ActivityPage.formState?.short_id);
+  console.log(history[0]);
+  return (
+    <>
+      <Button onClick={() => setIsModalOpen(true)} disabled={!history?.length}>
+        {history?.length ?? 0} Revisions
+      </Button>
+      <StyledModal open={isModalOpen} onClose={() => setIsModalOpen(false)}>
+        <div className="header">Revision History For {short_id}</div>
+        <div className="content">
+          <div className="history-wrapper">
+            {history && history.length > 0 ? (
+              <ul id="activity-history">
+                {history.map((h) => (
+                  <li className="entry" key={h.version}>
+                    <dl className="details">
+                      <dt>Updated By</dt>
+                      <dd>{h.user}</dd>
+                      <dt>Date of Change</dt>
+                      <dd>{new Date(h.date).toDateString()}</dd>
+
+                      <AllChanges diff={h.diff} />
+                    </dl>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p>There have been no revisions made to record {short_id}</p>
+            )}
+          </div>
+        </div>
+        <div className="control">
+          <Button onClick={() => setIsModalOpen((prev) => !prev)}>Close</Button>
+        </div>
+      </StyledModal>
+    </>
+  );
+};
+export default ChangeHistory;

--- a/app/src/UI/Features/Records/Activity/forms/common/ChangeHistory/ChangeHistory.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/common/ChangeHistory/ChangeHistory.tsx
@@ -83,11 +83,11 @@ const _formattedValuesChanges = (vc: Record<PropertyKey, any> = {}): Array<React
         )}
         {showDiff && (
           <dd>
-            <span className="deep-red strike-through">{previous}</span>
+            <del className="deep-red">{previous}</del>
             &nbsp;
             <ArrowForward />
             &nbsp;
-            <span className="green">{current}</span>
+            <ins className="green">{current}</ins>
           </dd>
         )}
       </li>
@@ -126,7 +126,9 @@ const _formattedValuesAdded = (va: Record<PropertyKey, any> = {}): Array<ReactNo
       <li className="diff-entry">
         <dt>{formatLabel(key)}</dt>
         <dd className="italic">Value Added</dd>
-        <dd className="green">{parseObject(value)}</dd>
+        <dd className="green">
+          <ins>{parseObject(value)}</ins>
+        </dd>
       </li>
     );
   });
@@ -145,7 +147,9 @@ const _formattedValuesRemoved = (vr: Record<PropertyKey, any> = {}): Array<React
       <li className="diff-entry">
         <dt>{formatLabel(key)}</dt>
         <dd className="italic">Value Removed</dd>
-        <dd className="deep-red strike-through">{parseObject(value)}</dd>
+        <dd className="deep-red">
+          <del>{parseObject(value)}</del>
+        </dd>
       </li>
     );
   });
@@ -177,18 +181,16 @@ const ChangeHistory = () => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   const history = useSelector((state) => state.ActivityPage.formMetadata?.history) as Array<History>;
-  const short_id = useSelector((state) => state.ActivityPage.formState?.short_id);
-  console.log(history[0]);
   return (
     <>
       <Button onClick={() => setIsModalOpen(true)} disabled={!history?.length}>
         {history?.length ?? 0} Revisions
       </Button>
       <StyledModal open={isModalOpen} onClose={() => setIsModalOpen(false)}>
-        <div className="header">Revision History For {short_id}</div>
+        <div className="header">Revision History</div>
         <div className="content">
           <div className="history-wrapper">
-            {history && history.length > 0 ? (
+            {history && history.length > 0 && (
               <ul id="activity-history">
                 {history.map((h) => (
                   <li className="entry" key={h.version}>
@@ -203,8 +205,6 @@ const ChangeHistory = () => {
                   </li>
                 ))}
               </ul>
-            ) : (
-              <p>There have been no revisions made to record {short_id}</p>
             )}
           </div>
         </div>

--- a/app/src/UI/Features/Records/Activity/forms/common/ChangeHistory/changeHistory.css
+++ b/app/src/UI/Features/Records/Activity/forms/common/ChangeHistory/changeHistory.css
@@ -1,0 +1,69 @@
+.history-wrapper {
+  display: flex;
+  flex-direction: column;
+  width: 800px;
+  max-width: 100%;
+}
+
+#activity-history {
+  list-style: none;
+  background-color: var(--odd-list-item-bg-color);
+  box-sizing: border-box;
+  max-height: 70vh;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  overflow-wrap: break-word;
+  margin: 1rem 0;
+  padding: 0;
+}
+
+/* Complete History Object entry */
+#activity-history .entry {
+  background-color: var(--odd-list-item-bg-color);
+
+  &:nth-of-type(even) {
+    background-color: var(--even-list-item-bg-color);
+  }
+}
+
+#activity-history .entry .details {
+  padding: 8px;
+}
+
+/* Individual row of a history object, e.g.: Created by, Diffs, etc */
+#activity-history .entry .details li {
+  padding: 5px;
+
+  .label {
+    text-transform: capitalize;
+  }
+}
+
+#activity-history .entry .details .diff-entry {
+  div {
+    display: flex;
+    flex-direction: column;
+  }
+
+  dt {
+    text-transform: capitalize;
+  }
+
+  dd {
+    display: flex;
+    align-items: center;
+    padding-top: 2px;
+    padding-left: 1rem;
+
+    &.italic {
+      font-style: italic;
+      font-size: 0.95rem;
+    }
+  }
+
+  .strike-through {
+    text-decoration: line-through;
+  }
+}

--- a/app/src/UI/Features/Records/Activity/forms/common/ChangeHistory/changeHistory.css
+++ b/app/src/UI/Features/Records/Activity/forms/common/ChangeHistory/changeHistory.css
@@ -62,8 +62,4 @@
       font-size: 0.95rem;
     }
   }
-
-  .strike-through {
-    text-decoration: line-through;
-  }
 }

--- a/app/src/UI/Features/Records/Activity/forms/common/RecordMetadata/RecordMetadata.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/common/RecordMetadata/RecordMetadata.tsx
@@ -2,6 +2,7 @@ import './recordMetadata.css';
 import Fieldset from '../Fieldset/Fieldset';
 import { FormSchema } from '../../plant/interfaces';
 import { ActivitySubtypesShortLabels } from 'sharedAPI';
+import ChangeHistory from '../ChangeHistory/ChangeHistory';
 
 type InfoProps = {
   term: string;
@@ -31,6 +32,12 @@ const RecordMetadata = ({ formState }: PropTypes) => {
           <Info term={'Activity Subtype'} definition={ActivitySubtypesShortLabels[formState?.subtype]} />
           <Info term={'Date of Activity'} definition={new Date(formState?.date)?.toLocaleDateString() ?? ''} />
           <Info term={'Created By'} definition={formState?.created_by} />
+          <div className="list-item">
+            <dt>Record History</dt>
+            <dd>
+              <ChangeHistory />
+            </dd>
+          </div>
         </dl>
       </div>
     </Fieldset>

--- a/app/src/UI/Reusable/Button/Button.tsx
+++ b/app/src/UI/Reusable/Button/Button.tsx
@@ -1,0 +1,12 @@
+import { ComponentPropsWithoutRef } from 'react';
+import './button.css';
+
+interface InputButtonProps extends ComponentPropsWithoutRef<'button'> {
+  size?: 'sm' | 'med' | 'lg';
+}
+
+const Button = ({ size = 'med', className = '', ...props }: InputButtonProps) => (
+  <button type="button" className={`invasives-button ${className} ${size}`} {...props} />
+);
+
+export default Button;

--- a/app/src/UI/Reusable/Button/button.css
+++ b/app/src/UI/Reusable/Button/button.css
@@ -1,0 +1,28 @@
+.invasives-button {
+  color: var(--blue-primary);
+  border: 1pt solid var(--blue-primary);
+  background-color: white;
+  padding: 5px 8px;
+  border-radius: 4px;
+
+  &.small {
+    font-size: var(--sm-button-text);
+  }
+
+  &.med {
+    font-size: var(--med-button-text);
+  }
+
+  &.lg {
+    font-size: var(--lg-button-text);
+  }
+
+  &:disabled {
+    color: gray;
+    border: 1pt solid gray;
+
+    &:hover {
+      cursor: not-allowed;
+    }
+  }
+}

--- a/app/src/UI/Reusable/StyledModal/StyledModal.css
+++ b/app/src/UI/Reusable/StyledModal/StyledModal.css
@@ -13,7 +13,7 @@
   overflow: auto;
 
   .styled-modal {
-    --title-control-height: 45px;
+    --title-control-height: 55px;
 
     max-width: 100%;
     background-color: white;
@@ -41,7 +41,7 @@
       align-items: center;
       display: flex;
       padding-left: 0.5rem;
-      font-size: 1.25rem;
+      font-size: 1.35rem;
       box-sizing: border-box;
       text-transform: capitalize;
     }


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Add `AtomicFieldOperator` to DeepDiff to prevent GeoJSON from being parsed key by key 
- Implement component `ChangeHistory` to display Diff history to users on a form
    - Parse various DeepDiff fields and initially hide oversized ones 
- Add pre-styled common button component for use across the application. Will extend as future use dictates
- Adjust height of `StyledModal` heading
- Closes #4648


# Images

<img width="155" height="74" alt="image" src="https://github.com/user-attachments/assets/7097c7d8-86da-4097-88a0-ea13b2c243e4" />
 
> [History button, number of changes pre-displayed]

<img width="764" height="602" alt="image" src="https://github.com/user-attachments/assets/cd9f6d44-6604-430d-9d70-320d927c78a2" />
<img width="789" height="441" alt="image" src="https://github.com/user-attachments/assets/aeade9fb-3db9-4a04-9414-de85ba889aa2" />

> [Example Revision View]

<img width="241" height="116" alt="image" src="https://github.com/user-attachments/assets/54c82bb8-cbec-4a14-a10e-7e51970cfca5" />
<img width="769" height="270" alt="image" src="https://github.com/user-attachments/assets/f374e10e-2fe3-402b-8929-43ce0ae5546b" />

> [Example of very-large-diff display toggle]