### PR TITLE
[INV-N/A] Clear metadata on duplicate

### DIFF
--- a/app/src/state/actions/activity/FormActions.ts
+++ b/app/src/state/actions/activity/FormActions.ts
@@ -2,7 +2,7 @@ import { createAction, createAsyncThunk } from '@reduxjs/toolkit';
 import { Feature, GeoJSON } from 'geojson';
 import { ActivityStatus, ActivitySubtypes } from 'sharedAPI';
 import Alerts from 'state/actions/alerts/Alerts';
-import { RecordAction } from 'api/api-schema';
+import { RecordAction, RecordMetadata } from 'api/api-schema';
 import { RecordSetType } from 'interfaces/UserRecordSet';
 import { RootState } from 'state/reducers/rootReducer';
 import getDefaultFormState from 'UI/Features/Records/Activity/forms/plant/builders/getDefaultState';
@@ -94,7 +94,8 @@ class FormActions {
       }
       return {
         data: duplicatedForm as FormSchema,
-        available_actions: ['EDIT', 'DELETE', 'SUBMIT'] as Array<RecordAction>
+        available_actions: ['EDIT', 'DELETE', 'SUBMIT'] as Array<RecordAction>,
+        metadata: {} as RecordMetadata
       };
     }
   );

--- a/app/src/state/reducers/activity.ts
+++ b/app/src/state/reducers/activity.ts
@@ -256,11 +256,12 @@ function createActivityReducer() {
           });
         }
       } else if (FormActions.duplicateForm.fulfilled.match(action)) {
-        const { data, available_actions } = action.payload;
+        const { data, available_actions, metadata } = action.payload;
         draftState.formType = data.subtype;
         draftState.formId = data.id;
         draftState.formState = data;
         draftState.recordActions = available_actions;
+        draftState.formMetadata = metadata;
       } else if (FormActions.updateState.match(action)) {
         draftState.formState = structuredClone(action.payload);
       } else if (FormActions.sendForm.fulfilled.match(action)) {


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):
- When duplicating form ,clear metadata to not confuse user with unrelated linked records / revision history 
    - This is purely a local state issue. Metadata has no bearing on submit logic.  