### PR TITLE
Refactor ButtonContainer and tooltips

### DIFF
--- a/app/src/UI/Features/Admin/requests/PendingRequests.tsx
+++ b/app/src/UI/Features/Admin/requests/PendingRequests.tsx
@@ -1,4 +1,4 @@
-import { Button, Chip, Tooltip } from '@mui/material';
+import { Button, Chip } from '@mui/material';
 import { DataGrid, GridColDef, GridRowId, GridRowSelectionModel } from '@mui/x-data-grid';
 import React, { useState } from 'react';
 import { CustomNoRowsOverlay } from 'UI/Features/Admin/components/CustomNoRowsOverlay';
@@ -47,17 +47,15 @@ const PendingRequests: React.FC = () => {
 
   const renderRequestDetailsButton = (params) => {
     return (
-      <Tooltip title="View Details" classes={{ tooltip: 'toolTip' }}>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={() => {
-            openRequestDetailsDialog(params.row);
-          }}
-        >
-          Details
-        </Button>
-      </Tooltip>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={() => {
+          openRequestDetailsDialog(params.row);
+        }}
+      >
+        Details
+      </Button>
     );
   };
 

--- a/app/src/UI/Features/Admin/users/RoleAssignment.tsx
+++ b/app/src/UI/Features/Admin/users/RoleAssignment.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { Button, SelectChangeEvent, Tooltip } from '@mui/material';
+import { Button, SelectChangeEvent } from '@mui/material';
 import { DataGrid, GridColDef, GridRowId, GridRowSelectionModel } from '@mui/x-data-grid';
 import { CustomNoRowsOverlay } from 'UI/Features/Admin/components/CustomNoRowsOverlay';
 import Spinner from 'UI/Reusable/Spinner/Spinner';
@@ -44,17 +44,15 @@ const RoleAssignment: React.FC = () => {
 
   const renderDetailsButton = (params) => {
     return (
-      <Tooltip title="View Details" classes={{ tooltip: 'toolTip' }}>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={() => {
-            openDetailsDialog(params.row);
-          }}
-        >
-          Details
-        </Button>
-      </Tooltip>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={() => {
+          openDetailsDialog(params.row);
+        }}
+      >
+        Details
+      </Button>
     );
   };
 

--- a/app/src/UI/Features/LegacyMap/Controls/AccuracyToggle.tsx
+++ b/app/src/UI/Features/LegacyMap/Controls/AccuracyToggle.tsx
@@ -1,40 +1,19 @@
-import React, { useRef } from 'react';
-import { useDispatch } from 'react-redux';
-import { IconButton, Tooltip } from '@mui/material';
-import { useSelector } from 'utils/use_selector';
-import 'UI/Global.css';
-
+import { IconButton } from '@mui/material';
+import { useDispatch, useSelector } from 'utils/use_selector';
 import AttributionIcon from '@mui/icons-material/Attribution';
 import MapActions from 'state/actions/map';
+import HoverTooltip from 'UI/Reusable/HoverTooltip/HoverTooltip';
 
 export const AccuracyToggle = () => {
   const dispatch = useDispatch();
   const accuracyToggle = useSelector((state) => state.Map.accuracyToggle);
-
-  const [show, setShow] = React.useState(false);
-  const divRef = useRef<HTMLDivElement | null>(null);
-
   return (
-    <div ref={divRef} className={accuracyToggle ? 'map-btn-selected' : 'map-btn'}>
-      <Tooltip
-        open={show}
-        onMouseEnter={() => setShow(true)}
-        onMouseLeave={() => setShow(false)}
-        classes={{ tooltip: 'toolTip' }}
-        title={accuracyToggle ? 'Hide Accuracy' : 'Show Accuracy'}
-        placement="top-end"
-      >
-        <span>
-          <IconButton
-            className={'button'}
-            onClick={() => {
-              dispatch(MapActions.accuracyToggle());
-            }}
-          >
-            <AttributionIcon />
-          </IconButton>
-        </span>
-      </Tooltip>
+    <div className={accuracyToggle ? 'map-btn-selected' : 'map-btn'}>
+      <HoverTooltip tooltipText={accuracyToggle ? 'Hide Accuracy' : 'Show Accuracy'}>
+        <IconButton className={'button'} onClick={() => dispatch(MapActions.accuracyToggle())}>
+          <AttributionIcon />
+        </IconButton>
+      </HoverTooltip>
     </div>
   );
 };

--- a/app/src/UI/Features/LegacyMap/Controls/CenterCurrentRecord.tsx
+++ b/app/src/UI/Features/LegacyMap/Controls/CenterCurrentRecord.tsx
@@ -1,5 +1,4 @@
 import { IconButton } from '@mui/material';
-import 'UI/Global.css';
 import MapActions from 'state/actions/map';
 import { RecordSetType } from 'interfaces/UserRecordSet';
 import { useDispatch, useSelector } from 'utils/use_selector';

--- a/app/src/UI/Features/LegacyMap/Controls/FindMe.tsx
+++ b/app/src/UI/Features/LegacyMap/Controls/FindMe.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { IconButton, Tooltip } from '@mui/material';
+import { IconButton } from '@mui/material';
 import 'UI/Global.css';
 import { useSelector } from 'utils/use_selector';
 import MapActions from 'state/actions/map';
@@ -9,6 +9,7 @@ import { MapContext } from '../helpers/components/MapContext';
 import { MapLibreEvent } from 'maplibre-gl';
 import { isTracking } from 'utils/geoTrackingHelpers';
 import GeoTracking from 'state/actions/geotracking/GeoTracking';
+import HoverTooltip from 'UI/Reusable/HoverTooltip/HoverTooltip';
 
 export const FindMeToggle = () => {
   enum Mode {
@@ -16,6 +17,22 @@ export const FindMeToggle = () => {
     ON,
     FOLLOWING
   }
+
+  const CONFIG = {
+    [Mode.ON]: {
+      tooltip: 'Follow my Location',
+      icon: <GpsNotFixed />
+    },
+    [Mode.OFF]: {
+      tooltip: 'Turn on GPS Tracking',
+      icon: <GpsOff />
+    },
+    [Mode.FOLLOWING]: {
+      tooltip: 'Turn off GPS Tracking',
+      icon: <GpsFixed />
+    }
+  };
+
   const MIN_DRAG_IN_PX = 50;
 
   // Toggle Redux states on click
@@ -28,18 +45,15 @@ export const FindMeToggle = () => {
       }
       dispatch(MapActions.trackLocationToggle());
     }
-    setShow(false);
   };
 
   const map = useContext(MapContext);
   const dispatch = useDispatch();
-  const divRef = useRef<HTMLDivElement | null>(null);
 
   const positionTracking = useSelector((state) => state.Map?.positionTracking);
   const positionFollowing = useSelector((state) => state.Map?.panned);
   const userIsGeoTracking: boolean = useSelector((state) => isTracking(state.Map.track_me_draw_geo.status));
 
-  const [show, setShow] = useState<boolean>(false);
   const [mode, setMode] = useState<Mode>(Mode.OFF);
 
   const clientX = useRef<number>(0);
@@ -99,34 +113,14 @@ export const FindMeToggle = () => {
     };
   }, [map, handleDrag]);
 
+  const { tooltip, icon } = CONFIG[mode];
   return (
-    <div ref={divRef} className={positionTracking ? 'map-btn-selected' : 'map-btn'}>
-      <Tooltip
-        open={show}
-        classes={{ tooltip: 'toolTip' }}
-        onMouseEnter={() => setShow(true)}
-        onMouseLeave={() => setShow(false)}
-        title={
-          {
-            [Mode.ON]: 'Follow My Location',
-            [Mode.OFF]: 'Turn on GPS Tracking',
-            [Mode.FOLLOWING]: 'Turn off GPS Tracking'
-          }[mode]
-        }
-        placement="top-end"
-      >
-        <span>
-          <IconButton className={'button'} onClick={handleClick}>
-            {
-              {
-                [Mode.ON]: <GpsNotFixed />,
-                [Mode.OFF]: <GpsOff />,
-                [Mode.FOLLOWING]: <GpsFixed />
-              }[mode]
-            }
-          </IconButton>
-        </span>
-      </Tooltip>
+    <div className={positionTracking ? 'map-btn-selected' : 'map-btn'}>
+      <HoverTooltip tooltipText={tooltip}>
+        <IconButton className={'button'} onClick={handleClick}>
+          {icon}
+        </IconButton>
+      </HoverTooltip>
     </div>
   );
 };

--- a/app/src/UI/Features/LegacyMap/Controls/FindMe.tsx
+++ b/app/src/UI/Features/LegacyMap/Controls/FindMe.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { IconButton } from '@mui/material';
-import 'UI/Global.css';
 import { useSelector } from 'utils/use_selector';
 import MapActions from 'state/actions/map';
 import { GpsFixed, GpsNotFixed, GpsOff } from '@mui/icons-material';

--- a/app/src/UI/Features/LegacyMap/Controls/GeoTrackingButton.tsx
+++ b/app/src/UI/Features/LegacyMap/Controls/GeoTrackingButton.tsx
@@ -1,39 +1,21 @@
-import { IconButton, Tooltip } from '@mui/material';
+import { IconButton } from '@mui/material';
 import PolylineIcon from '@mui/icons-material/Polyline';
 import DirectionsWalkIcon from '@mui/icons-material/DirectionsWalk';
 import GeoShapes from 'constants/geoShapes';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { useSelector } from 'utils/use_selector';
 import GeoTracking from 'state/actions/geotracking/GeoTracking';
 import Prompt from 'state/actions/prompts/Prompt';
 import { isTracking } from 'utils/geoTrackingHelpers';
+import HoverTooltip from 'UI/Reusable/HoverTooltip/HoverTooltip';
 
-/**
- * TrackMeButton
- * @description Component to handle the functionality of the find me button
- * @returns {void}
- */
-export const GeoTrackingButton = () => {
-  const { status } = useSelector((state) => state.Map.track_me_draw_geo);
-
-  const dispatch = useDispatch();
-  const [show, setShow] = useState(false);
-  const divRef = useRef<HTMLDivElement | null>(null);
-  const tracking = isTracking(status);
-  const activityGeo = (useSelector((state) => state.ActivityPage.activity?.geometry) ?? [])[0] ?? {};
+const GeoTrackingButton = () => {
   const promptHandler = (input: string | number) => {
     dispatch(GeoTracking.start(input as GeoShapes));
   };
 
-  useEffect(() => {
-    if (activityGeo && activityGeo?.properties?.error == 'true') {
-      dispatch(GeoTracking.pause());
-    }
-  }, [activityGeo?.properties]);
-
   const clickHandler = () => {
-    setShow(false);
     if (tracking) {
       dispatch(GeoTracking.stop());
     } else {
@@ -51,23 +33,25 @@ export const GeoTrackingButton = () => {
       );
     }
   };
-  // this is to stop user from clicking it again while things are happening
+
+  const dispatch = useDispatch();
+  const status = useSelector((state) => state.Map.track_me_draw_geo.status);
+  const tracking = isTracking(status);
+  const activityGeo = useSelector((state) => state.ActivityPage.geometry_details?.shape);
+
+  useEffect(() => {
+    if (activityGeo && activityGeo?.properties?.error == 'true') {
+      dispatch(GeoTracking.pause());
+    }
+  }, [activityGeo?.properties]);
+
   return (
-    <div ref={divRef} className={tracking ? 'map-btn-selected' : 'map-btn'}>
-      <Tooltip
-        open={show}
-        classes={{ tooltip: 'toolTip' }}
-        onMouseEnter={() => setShow(true)}
-        onMouseLeave={() => setShow(false)}
-        title="Track My Path"
-        placement="top-end"
-      >
-        <span>
-          <IconButton className="button" onClick={clickHandler}>
-            <PolylineIcon /> <DirectionsWalkIcon />
-          </IconButton>
-        </span>
-      </Tooltip>
+    <div className={tracking ? 'map-btn-selected' : 'map-btn'}>
+      <HoverTooltip tooltipText="Track My Path">
+        <IconButton className="button" onClick={clickHandler}>
+          <PolylineIcon /> <DirectionsWalkIcon />
+        </IconButton>
+      </HoverTooltip>
     </div>
   );
 };

--- a/app/src/UI/Features/LegacyMap/Controls/LegendsButton.tsx
+++ b/app/src/UI/Features/LegacyMap/Controls/LegendsButton.tsx
@@ -1,40 +1,17 @@
-import { IconButton, Tooltip } from '@mui/material';
-import 'UI/Global.css';
+import { IconButton } from '@mui/material';
 import InfoIcon from '@mui/icons-material/Info';
-import { useState } from 'react';
 import { useNavigate } from 'react-router';
+import HoverTooltip from 'UI/Reusable/HoverTooltip/HoverTooltip';
 
 export const LegendsButton = () => {
   const navigate = useNavigate();
-
-  const [show, setShow] = useState(false);
-
-  const toggleLegend = () => navigate('/Legend');
-
   return (
     <div className={'map-btn'}>
-      <Tooltip
-        open={show}
-        classes={{ tooltip: 'toolTip' }}
-        onMouseEnter={() => {
-          setShow(true);
-          setTimeout(() => setShow(false), 3000);
-        }}
-        onMouseLeave={() => setShow(false)}
-        title="Map Legend"
-        placement="top-end"
-      >
-        <span>
-          <IconButton
-            className={'button'}
-            onClick={() => {
-              toggleLegend();
-            }}
-          >
-            <InfoIcon />
-          </IconButton>
-        </span>
-      </Tooltip>
+      <HoverTooltip tooltipText="Map Legend">
+        <IconButton className={'button'} onClick={() => navigate('/Legend')}>
+          <InfoIcon />
+        </IconButton>
+      </HoverTooltip>
     </div>
   );
 };

--- a/app/src/UI/Features/LegacyMap/Controls/NewRecord.tsx
+++ b/app/src/UI/Features/LegacyMap/Controls/NewRecord.tsx
@@ -1,37 +1,19 @@
-import { useRef, useState } from 'react';
-import { IconButton, Tooltip } from '@mui/material';
+import { IconButton } from '@mui/material';
 import FiberNewIcon from '@mui/icons-material/FiberNew';
-import 'UI/Global.css';
 import UserSettings from 'state/actions/userSettings/UserSettings';
 import { useDispatch } from 'utils/use_selector';
+import HoverTooltip from 'UI/Reusable/HoverTooltip/HoverTooltip';
 
 export const NewRecord = () => {
   const dispatch = useDispatch();
-  const divRef = useRef();
-
-  const [show, setShow] = useState(false);
 
   return (
-    <div ref={divRef} className="map-btn">
-      <Tooltip
-        open={show}
-        classes={{ tooltip: 'toolTip' }}
-        onMouseEnter={() => setShow(true)}
-        onMouseLeave={() => setShow(false)}
-        title={`New Record`}
-        placement="top-end"
-      >
-        <span>
-          <IconButton
-            className={'button'}
-            onClick={() => {
-              dispatch(UserSettings.openNewRecordDialogue());
-            }}
-          >
-            <FiberNewIcon />
-          </IconButton>
-        </span>
-      </Tooltip>
+    <div className="map-btn">
+      <HoverTooltip tooltipText="New Record">
+        <IconButton className={'button'} onClick={() => dispatch(UserSettings.openNewRecordDialogue())}>
+          <FiberNewIcon />
+        </IconButton>
+      </HoverTooltip>
     </div>
   );
 };

--- a/app/src/UI/Features/LegacyMap/Controls/PrimaryLayerSelect.tsx
+++ b/app/src/UI/Features/LegacyMap/Controls/PrimaryLayerSelect.tsx
@@ -1,5 +1,4 @@
 import { IconButton } from '@mui/material';
-import 'UI/Global.css';
 import { DeviceUnknown, Hd, Landscape, Map, SaveAlt, Sd, SignalCellularNodata } from '@mui/icons-material';
 import { InvasivesMapLayerDefinitionWithState } from 'UI/Features/LegacyMap/helpers/functional/layers-hook';
 import { useSelector } from 'utils/use_selector';

--- a/app/src/UI/Features/LegacyMap/Controls/PrimaryLayerSelect.tsx
+++ b/app/src/UI/Features/LegacyMap/Controls/PrimaryLayerSelect.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
-import { IconButton, Tooltip } from '@mui/material';
+import { IconButton } from '@mui/material';
 import 'UI/Global.css';
 import { DeviceUnknown, Hd, Landscape, Map, SaveAlt, Sd, SignalCellularNodata } from '@mui/icons-material';
 import { InvasivesMapLayerDefinitionWithState } from 'UI/Features/LegacyMap/helpers/functional/layers-hook';
 import { useSelector } from 'utils/use_selector';
+import HoverTooltip from 'UI/Reusable/HoverTooltip/HoverTooltip';
 
 type PrimaryLayerSelectProps = {
   layers: InvasivesMapLayerDefinitionWithState[];
@@ -11,8 +12,6 @@ type PrimaryLayerSelectProps = {
 };
 
 const PrimaryLayerSelect = ({ layers, selectLayer }: PrimaryLayerSelectProps) => {
-  const [toolTip, setToolTip] = useState('');
-
   const DEBUG = useSelector((state) => state.Configuration.current.build.DEBUG);
 
   function renderIcon(def: InvasivesMapLayerDefinitionWithState) {
@@ -43,30 +42,15 @@ const PrimaryLayerSelect = ({ layers, selectLayer }: PrimaryLayerSelectProps) =>
     <div className={'basemap-btn-group'}>
       {layers
         .filter((l) => (DEBUG || l.mode === 'basemap') && l.selectionMode === 'primary-selector')
-        .map((l) => {
-          return (
-            <div className={l.active ? 'selected' : ''} key={l.name}>
-              <Tooltip
-                open={toolTip == l.name}
-                onMouseEnter={() => setToolTip(l.name)}
-                onMouseLeave={() => setToolTip('')}
-                classes={{ tooltip: 'toolTip' }}
-                title={l.tooltip}
-                placement="top-end"
-              >
-                <IconButton
-                  className={'basemap-btn'}
-                  onClick={() => {
-                    setToolTip(l.name);
-                    selectLayer(l.name);
-                  }}
-                >
-                  {renderIcon(l)}
-                </IconButton>
-              </Tooltip>
-            </div>
-          );
-        })}
+        .map((l) => (
+          <div className={l.active ? 'selected' : ''} key={l.name}>
+            <HoverTooltip tooltipText={l.tooltip}>
+              <IconButton className={'basemap-btn'} onClick={() => selectLayer(l.name)}>
+                {renderIcon(l)}
+              </IconButton>
+            </HoverTooltip>
+          </div>
+        ))}
     </div>
   );
 };

--- a/app/src/UI/Features/LegacyMap/Controls/PrimaryLayerSelect.tsx
+++ b/app/src/UI/Features/LegacyMap/Controls/PrimaryLayerSelect.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { IconButton } from '@mui/material';
 import 'UI/Global.css';
 import { DeviceUnknown, Hd, Landscape, Map, SaveAlt, Sd, SignalCellularNodata } from '@mui/icons-material';

--- a/app/src/UI/Features/LegacyMap/Controls/WhatsHereButton.tsx
+++ b/app/src/UI/Features/LegacyMap/Controls/WhatsHereButton.tsx
@@ -1,6 +1,5 @@
 import { IconButton } from '@mui/material';
 import { useDispatch, useSelector } from 'utils/use_selector';
-import 'UI/Global.css';
 import { AlertSeverity, AlertSubjects } from 'constants/alertEnums';
 import Alerts from 'state/actions/alerts/Alerts';
 import WhatsHere from 'state/actions/whatsHere/WhatsHere';

--- a/app/src/UI/Features/LegacyMap/Controls/WhatsHereButton.tsx
+++ b/app/src/UI/Features/LegacyMap/Controls/WhatsHereButton.tsx
@@ -1,12 +1,12 @@
-import { IconButton, Tooltip } from '@mui/material';
+import { IconButton } from '@mui/material';
 import { useDispatch, useSelector } from 'utils/use_selector';
 import 'UI/Global.css';
 import { AlertSeverity, AlertSubjects } from 'constants/alertEnums';
 import Alerts from 'state/actions/alerts/Alerts';
 import WhatsHere from 'state/actions/whatsHere/WhatsHere';
 import { HourglassTop, TravelExplore } from '@mui/icons-material';
-import { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
+import HoverTooltip from 'UI/Reusable/HoverTooltip/HoverTooltip';
 
 export const WhatsHereButton = () => {
   const handleWhatsHere = () => {
@@ -29,24 +29,15 @@ export const WhatsHereButton = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const whatsHere = useSelector((state) => state.Map.whatsHere);
-  const [show, setShow] = useState(false);
+
   return (
     <div className={whatsHere.toggle ? 'map-btn-selected' : 'map-btn'}>
-      <Tooltip
-        open={show}
-        onMouseEnter={() => setShow(true)}
-        onMouseLeave={() => setShow(false)}
-        classes={{ tooltip: 'toolTip' }}
-        title={`What's here?`}
-        placement="top-end"
-      >
-        <span>
-          <IconButton className={'button'} onClick={handleWhatsHere}>
-            {(whatsHere.loadingActivities || whatsHere.loadingIAPP) && <HourglassTop />}
-            <TravelExplore />
-          </IconButton>
-        </span>
-      </Tooltip>
+      <HoverTooltip tooltipText={"What's Here?"}>
+        <IconButton className={'button'} onClick={handleWhatsHere}>
+          {(whatsHere.loadingActivities || whatsHere.loadingIAPP) && <HourglassTop />}
+          <TravelExplore />
+        </IconButton>
+      </HoverTooltip>
     </div>
   );
 };

--- a/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarkerContent.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarkerContent.tsx
@@ -1,5 +1,5 @@
 import LaunchIcon from '@mui/icons-material/Launch';
-import { IconButton, Tooltip } from '@mui/material';
+import { IconButton } from '@mui/material';
 import './layerDataMarkerContent.css';
 import { ArrowCircleLeftOutlined, ArrowCircleRightOutlined, CopyAll } from '@mui/icons-material';
 import { useState } from 'react';
@@ -7,6 +7,7 @@ import { NavigateFunction } from 'react-router';
 import { Dispatch } from 'redux';
 import Prompt from 'state/actions/prompts/Prompt';
 import Activity from 'state/actions/activity/Activity';
+import HoverTooltip from 'UI/Reusable/HoverTooltip/HoverTooltip';
 
 type PropTypes = {
   features: Array<{
@@ -64,13 +65,11 @@ const LayerDataMarkerContent = ({ features, navigate, dispatch, canCopyShape: ca
 
                 <td className="buttons">
                   {id && canCopyRecord && (
-                    <Tooltip classes={{ tooltip: 'toolTip' }} title={'Replace your current shape with this one'}>
-                      <span>
-                        <IconButton disabled={!canCopyRecord} onClick={handleCopy.bind(this, id)}>
-                          <CopyAll />
-                        </IconButton>
-                      </span>
-                    </Tooltip>
+                    <HoverTooltip tooltipText={'Replace your current shape with this one'}>
+                      <IconButton disabled={!canCopyRecord} onClick={handleCopy.bind(this, id)}>
+                        <CopyAll />
+                      </IconButton>
+                    </HoverTooltip>
                   )}
                   <IconButton onClick={handleGoTo.bind(this, url)}>
                     <LaunchIcon />

--- a/app/src/UI/Features/ManageTripsPage/subcomponents/ManageMyTrips/subcaches/MyTripAtAGlance.tsx
+++ b/app/src/UI/Features/ManageTripsPage/subcomponents/ManageMyTrips/subcaches/MyTripAtAGlance.tsx
@@ -1,10 +1,10 @@
-import { Tooltip } from '@mui/material';
 import {
   IappRecordsetIcon,
   InvasivesRecordsetIcon,
   OfflineMapIcon,
   WellIcon
 } from 'UI/Features/ManageTripsPage/iconography';
+import HoverTooltip from 'UI/Reusable/HoverTooltip/HoverTooltip';
 import { IPlanMyTripCacheStatus, IPlanMyTripCacheStatuses } from 'utils/plan-my-trip-cache';
 
 type PropTypes = {
@@ -32,18 +32,18 @@ const MyTripAtAGlance = ({ statuses }: PropTypes) => {
   const { activityRecordset, iappRecordset, mapTiles, wellData } = statuses;
   return (
     <>
-      <Tooltip classes={{ tooltip: 'toolTip' }} title={`InvasivesBC Recordest: ${activityRecordset}`}>
+      <HoverTooltip tooltipText={`InvasivesBC Recordest: ${activityRecordset}`}>
         <InvasivesRecordsetIcon color={getColor(activityRecordset)} />
-      </Tooltip>
-      <Tooltip classes={{ tooltip: 'toolTip' }} title={`IAPP Recordset: ${iappRecordset}`}>
+      </HoverTooltip>
+      <HoverTooltip tooltipText={`IAPP Recordset: ${iappRecordset}`}>
         <IappRecordsetIcon color={getColor(iappRecordset)} />
-      </Tooltip>
-      <Tooltip classes={{ tooltip: 'toolTip' }} title={`Well Data: ${wellData}`}>
+      </HoverTooltip>
+      <HoverTooltip tooltipText={`Well Data: ${wellData}`}>
         <WellIcon color={getColor(wellData)} />
-      </Tooltip>
-      <Tooltip classes={{ tooltip: 'toolTip' }} title={`Offline Map: ${mapTiles}`}>
+      </HoverTooltip>
+      <HoverTooltip tooltipText={`Offline Map: ${mapTiles}`}>
         <OfflineMapIcon color={getColor(mapTiles)} />
-      </Tooltip>
+      </HoverTooltip>
     </>
   );
 };

--- a/app/src/UI/Features/Records/ExcelExporter.tsx
+++ b/app/src/UI/Features/Records/ExcelExporter.tsx
@@ -1,4 +1,4 @@
-import { Accordion, Button, MenuItem, Select, Tooltip } from '@mui/material';
+import { Accordion, Button, MenuItem, Select } from '@mui/material';
 import { useMemo, useState } from 'react';
 import DownloadIcon from '@mui/icons-material/Download';
 import Spinner from 'UI/Reusable/Spinner/Spinner';
@@ -10,6 +10,7 @@ import ExportActions from 'state/actions/exports/exportActions';
 import { ActivitySubtypes } from 'sharedAPI';
 import Alerts from 'state/actions/alerts/Alerts';
 import downloadAlertMessages from 'constants/alerts/downloadAlerts';
+import HoverTooltip from 'UI/Reusable/HoverTooltip/HoverTooltip';
 
 const iappExportOptions = [
   { value: 'site_selection_extract', label: 'Site Selection Extract' },
@@ -116,7 +117,7 @@ const ExcelExporter = ({ setName }: PropTypes) => {
           Click here for CSV export
         </AccordionSummary>
         <AccordionDetails className="accordionDetails">
-          <Tooltip classes={{ tooltip: 'toolTip' }} title="CSV Export">
+          <HoverTooltip tooltipText="CSV Export">
             {linkToCSV && setName === recordSetForCSV ? (
               <a href={linkToCSV} download>
                 <Button
@@ -148,30 +149,26 @@ const ExcelExporter = ({ setName }: PropTypes) => {
                 )}
               </div>
             )}
-          </Tooltip>
-          <Tooltip classes={{ tooltip: 'toolTip' }} title="Choose report type" placement="right">
-            <>
-              CSV Summary Type:
-              <Select
-                className="excel-exporter-select"
-                value={selection}
-                onChange={(e) => {
-                  setSelection(e.target.value);
+          </HoverTooltip>
+          CSV Summary Type:
+          <Select
+            className="excel-exporter-select"
+            value={selection}
+            onChange={(e) => {
+              setSelection(e.target.value);
+            }}
+          >
+            {items.map((o, i) => (
+              <MenuItem
+                sx={{
+                  backgroundColor: i % 2 === 0 ? 'var(--even-list-item-bg-color)' : 'var(--odd-list-item-bg-color)'
                 }}
+                value={o.value}
               >
-                {items.map((o, i) => (
-                  <MenuItem
-                    sx={{
-                      backgroundColor: i % 2 === 0 ? 'var(--even-list-item-bg-color)' : 'var(--odd-list-item-bg-color)'
-                    }}
-                    value={o.value}
-                  >
-                    {o.label}
-                  </MenuItem>
-                ))}
-              </Select>
-            </>
-          </Tooltip>
+                {o.label}
+              </MenuItem>
+            ))}
+          </Select>
         </AccordionDetails>
       </Accordion>
     </div>

--- a/app/src/UI/Features/Records/RecordSet/Filters/Filter.tsx
+++ b/app/src/UI/Features/Records/RecordSet/Filters/Filter.tsx
@@ -1,4 +1,4 @@
-import { Button, Tooltip } from '@mui/material';
+import { Button } from '@mui/material';
 import { useCallback, useState } from 'react';
 import { activityColumnsToDisplay, iappColumnsToDisplay } from 'UI/Features/Records/RecordSet/RecordTableHelpers';
 import { useDispatch, useSelector } from 'utils/use_selector';
@@ -7,6 +7,7 @@ import UserSettings from 'state/actions/userSettings/UserSettings';
 import debounce from 'lodash.debounce';
 import EFilterType from 'constants/EFilterType';
 import { IFilter, IUpdateFilter } from 'state/actions/userSettings/RecordSet';
+import HoverTooltip from 'UI/Reusable/HoverTooltip/HoverTooltip';
 
 type PropTypes = {
   setID: string;
@@ -302,18 +303,16 @@ const Filter = ({ setID, disabled, filterSet, recordSetType }: PropTypes) => {
       </td>
       <td>{input}</td>
       <td className="deleteButtonCell">
-        <Tooltip classes={{ tooltip: 'toolTip' }} title="Delete the filter in this row, data will be refetched.">
-          <span>
-            <Button
-              className={'deleteButton'}
-              disabled={disabled}
-              onClick={() => removeFilter(EFilterType.Table)}
-              variant="contained"
-            >
-              Delete
-            </Button>
-          </span>
-        </Tooltip>
+        <HoverTooltip tooltipText="Delete the filter in this row, data will be refetched.">
+          <Button
+            className={'deleteButton'}
+            disabled={disabled}
+            onClick={() => removeFilter(EFilterType.Table)}
+            variant="contained"
+          >
+            Delete
+          </Button>
+        </HoverTooltip>
       </td>
     </tr>
   );

--- a/app/src/UI/Features/Records/RecordSetCacheButtons.tsx
+++ b/app/src/UI/Features/Records/RecordSetCacheButtons.tsx
@@ -1,5 +1,5 @@
 import { UserRecordCacheStatus, UserRecordSet } from 'interfaces/UserRecordSet';
-import { Button, Tooltip } from '@mui/material';
+import { Button } from '@mui/material';
 import SaveIcon from '@mui/icons-material/Save';
 import { MouseEvent, useEffect, useState } from 'react';
 import RecordCache from 'state/actions/cache/RecordCache';
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from 'utils/use_selector';
 import Prompt from 'state/actions/prompts/Prompt';
 import { shallowEqual } from 'react-redux';
 import ProgressControlPanel from 'UI/Features/Records/ProgressControlPanel';
+import HoverTooltip from 'UI/Reusable/HoverTooltip/HoverTooltip';
 
 interface PropTypes {
   recordSet: UserRecordSet;
@@ -140,7 +141,7 @@ const RecordSetCacheButtons = ({ recordSet, setId, onCacheStateChange }: PropTyp
   }, [recordSet.cacheMetadataStatus, connected, isLoadingRecords]);
 
   return (
-    <Tooltip classes={{ tooltip: 'toolTip' }} title="Click to save this layer and it's records">
+    <HoverTooltip tooltipText="Click to save this layer and it's records">
       <span>
         {activeDownloads ? (
           <ProgressControlPanel
@@ -161,7 +162,7 @@ const RecordSetCacheButtons = ({ recordSet, setId, onCacheStateChange }: PropTyp
           </Button>
         )}
       </span>
-    </Tooltip>
+    </HoverTooltip>
   );
 };
 

--- a/app/src/UI/Features/Records/RecordSetControl.tsx
+++ b/app/src/UI/Features/Records/RecordSetControl.tsx
@@ -1,12 +1,13 @@
 import { MobileOnly } from 'UI/Reusable/Predicates/MobileOnly';
 import { RecordSetCacheButtons } from 'UI/Features/Records/RecordSetCacheButtons';
-import { IconButton, Tooltip } from '@mui/material';
+import { IconButton } from '@mui/material';
 import { UserRecordSet } from 'interfaces/UserRecordSet';
 import { ColorLens, Delete, Label, LabelOff, Layers, LayersClear } from '@mui/icons-material';
 import { useState } from 'react';
 import { useSelector } from 'utils/use_selector';
 import { useRecordSetControls } from 'utils/useRecordSetControls';
 import './recordsetControl.css';
+import HoverTooltip from 'UI/Reusable/HoverTooltip/HoverTooltip';
 
 type PropTypes = {
   isDefaultRecordset: boolean;
@@ -61,59 +62,51 @@ const RecordSetControl = ({
       )}
       <div className="record-set-buttons">
         {!hideLabel && (
-          <Tooltip classes={{ tooltip: 'toolTip' }} title={LABEL_TOGGLE_TIP}>
-            <span>
-              <IconButton
-                disabled={!recordset?.mapToggle || !hasLayerIndex}
-                onClick={toggleRecordsetLabel}
-                color="primary"
-                data-testid="label-toggle"
-              >
-                {recordset?.labelToggle && recordset?.mapToggle ? <Label /> : <LabelOff />}
-              </IconButton>
-            </span>
-          </Tooltip>
+          <HoverTooltip tooltipText={LABEL_TOGGLE_TIP}>
+            <IconButton
+              disabled={!recordset?.mapToggle || !hasLayerIndex}
+              onClick={toggleRecordsetLabel}
+              color="primary"
+              data-testid="label-toggle"
+            >
+              {recordset?.labelToggle && recordset?.mapToggle ? <Label /> : <LabelOff />}
+            </IconButton>
+          </HoverTooltip>
         )}
 
         {!hideLayer && (
-          <Tooltip classes={{ tooltip: 'toolTip' }} title={LAYER_TOGGLE_TIP}>
-            <span>
-              <IconButton
-                data-testid="layer-toggle"
-                onClick={toggleRecordsetLayer}
-                color="primary"
-                disabled={!hasLayerIndex}
-              >
-                {recordset?.mapToggle ? <Layers /> : <LayersClear />}
-              </IconButton>
-            </span>
-          </Tooltip>
+          <HoverTooltip tooltipText={LAYER_TOGGLE_TIP}>
+            <IconButton
+              data-testid="layer-toggle"
+              onClick={toggleRecordsetLayer}
+              color="primary"
+              disabled={!hasLayerIndex}
+            >
+              {recordset?.mapToggle ? <Layers /> : <LayersClear />}
+            </IconButton>
+          </HoverTooltip>
         )}
 
         {!isDefaultRecordset && (
           <>
             {!hideColour && !isDefaultRecordset && (
-              <Tooltip placement="bottom-start" classes={{ tooltip: 'toolTip' }} title={COLOUR_CYCLE_TIP}>
-                <span>
-                  <IconButton
-                    data-testid="cycle-color"
-                    onClick={cycleRecordsetColour}
-                    color="primary"
-                    disabled={!hasLayerIndex}
-                  >
-                    <ColorLens />
-                  </IconButton>
-                </span>
-              </Tooltip>
+              <HoverTooltip tooltipText={COLOUR_CYCLE_TIP}>
+                <IconButton
+                  data-testid="cycle-color"
+                  onClick={cycleRecordsetColour}
+                  color="primary"
+                  disabled={!hasLayerIndex}
+                >
+                  <ColorLens />
+                </IconButton>
+              </HoverTooltip>
             )}
             {!hideDelete && (
-              <Tooltip classes={{ tooltip: 'toolTip' }} title={DELETE_TIP}>
-                <span>
-                  <IconButton data-testid="delete-recordset" onClick={deleteRecordSet} color="primary">
-                    <Delete />
-                  </IconButton>
-                </span>
-              </Tooltip>
+              <HoverTooltip tooltipText={DELETE_TIP}>
+                <IconButton data-testid="delete-recordset" onClick={deleteRecordSet} color="primary">
+                  <Delete />
+                </IconButton>
+              </HoverTooltip>
             )}
           </>
         )}

--- a/app/src/UI/Reusable/HoverTooltip/HoverTooltip.tsx
+++ b/app/src/UI/Reusable/HoverTooltip/HoverTooltip.tsx
@@ -1,23 +1,14 @@
 import { Tooltip } from '@mui/material';
-import { PropsWithChildren, ReactNode, useState } from 'react';
+import { PropsWithChildren, ReactNode } from 'react';
+import 'UI/Global.css';
 
 interface PropTypes extends PropsWithChildren {
   tooltipText: string | ReactNode;
 }
 
 const HoverTooltip = ({ tooltipText, children }: PropTypes) => {
-  const [showTooltip, setShowTooltip] = useState<boolean>(false);
   return (
-    <Tooltip
-      open={showTooltip}
-      classes={{ tooltip: 'toolTip' }}
-      onMouseEnter={setShowTooltip.bind(this, true)}
-      onMouseLeave={setShowTooltip.bind(this, false)}
-      onFocus={setShowTooltip.bind(this, true)}
-      onBlur={setShowTooltip.bind(this, false)}
-      title={tooltipText}
-      placement={'top-end'}
-    >
+    <Tooltip classes={{ tooltip: 'toolTip' }} title={tooltipText} placement={'top-end'}>
       <span>{children}</span>
     </Tooltip>
   );

--- a/app/src/UI/Reusable/HoverTooltip/HoverTooltip.tsx
+++ b/app/src/UI/Reusable/HoverTooltip/HoverTooltip.tsx
@@ -1,6 +1,6 @@
 import { Tooltip } from '@mui/material';
 import { PropsWithChildren, ReactNode } from 'react';
-import 'UI/Global.css';
+import './hoverTooltip.css';
 
 interface PropTypes extends PropsWithChildren {
   tooltipText: string | ReactNode;
@@ -8,7 +8,7 @@ interface PropTypes extends PropsWithChildren {
 
 const HoverTooltip = ({ tooltipText, children }: PropTypes) => {
   return (
-    <Tooltip classes={{ tooltip: 'toolTip' }} title={tooltipText} placement={'top-end'}>
+    <Tooltip classes={{ tooltip: 'tool-tip' }} title={tooltipText} placement={'top-end'}>
       <span>{children}</span>
     </Tooltip>
   );

--- a/app/src/UI/Reusable/HoverTooltip/hoverTooltip.css
+++ b/app/src/UI/Reusable/HoverTooltip/hoverTooltip.css
@@ -1,5 +1,5 @@
-.toolTip {
-  background-color: #003366 !important;
+.tool-tip {
+  background-color: var(--bc-blue) !important;
   color: white !important;
   border: none;
   width: 100%;
@@ -7,6 +7,6 @@
   font-size: 1rem !important;
 }
 
-.toolTip:hover {
+.tool-tip:hover {
   display: none;
 }

--- a/app/src/UI/Reusable/TooltipWithIcon/TooltipWithIcon.tsx
+++ b/app/src/UI/Reusable/TooltipWithIcon/TooltipWithIcon.tsx
@@ -1,6 +1,7 @@
 import { HelpOutline } from '@mui/icons-material';
 import { IconButton, SvgIconProps, Tooltip } from '@mui/material';
 import { ReactElement, ReactNode, useState } from 'react';
+import './tooltipWithIcon.css';
 
 type PropTypes = {
   tooltipText: string | ReactNode;
@@ -12,7 +13,7 @@ const TooltipWithIcon = ({ tooltipText, icon }: PropTypes) => {
   return (
     <Tooltip
       open={showTooltip}
-      classes={{ tooltip: 'toolTip' }}
+      classes={{ tooltip: 'tool-tip' }}
       onMouseEnter={setShowTooltip.bind(this, true)}
       onMouseLeave={setShowTooltip.bind(this, false)}
       onFocus={setShowTooltip.bind(this, true)}

--- a/app/src/UI/Reusable/TooltipWithIcon/tooltipWithIcon.css
+++ b/app/src/UI/Reusable/TooltipWithIcon/tooltipWithIcon.css
@@ -1,0 +1,12 @@
+.tool-tip {
+  background-color: var(--bc-blue) !important;
+  color: white !important;
+  border: none;
+  width: 100%;
+  height: 100%;
+  font-size: 1rem !important;
+}
+
+.tool-tip:hover {
+  display: none;
+}

--- a/app/src/rjsf/templates/ObjectFieldTemplate.tsx
+++ b/app/src/rjsf/templates/ObjectFieldTemplate.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import AddButton from 'rjsf/components/AddButton';
 import { Grid, Tooltip } from '@mui/material';
 import { canExpand, getTemplate, ObjectFieldTemplateProps } from '@rjsf/utils';
-import 'UI/Global.css';
 
 const ObjectFieldTemplate = (props: ObjectFieldTemplateProps) => {
   const DescriptionField = getTemplate('DescriptionFieldTemplate', props.registry, props.uiSchema);


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Refactors the usage of Tooltips individually, to a common component for
   - ease of later refactoring as part of MUI removal efforts.
   - less duplication of code/imports
   - consistent behaviour
- Remove Global.css as it only contained styling for tooltips
- Refactor ButtonContainer buttons to have less dead code / unneeded hooks
