### PR TITLE
Change Validation on Mechanical Treatments

### DIFF
--- a/api-rework/invasives/api/protocol/activity/plant_subtypes/treatment_mechanical_aquatic.py
+++ b/api-rework/invasives/api/protocol/activity/plant_subtypes/treatment_mechanical_aquatic.py
@@ -1,5 +1,6 @@
 from typing import List, Literal, Optional
 from pydantic import Field, model_validator, field_validator
+from api.protocol.activity.validators.distinct_entries import distinct_entries
 from api.protocol.activity.validators.no_repeat_key import no_repeat_key
 from api.protocol.activity.validators.check_sum import check_sum
 from api.protocol.activity.plant_subtypes.base_form_schema import (
@@ -67,8 +68,12 @@ class SubtypeData(DraftSubtypeData):
 
     @field_validator("entries")
     @classmethod
-    def unique_plants(cls, v):
-        return no_repeat_key(v, key="invasive_plant", key_label="Invasive Plant")
+    def unique_entries(cls, v):
+        return distinct_entries(
+            v,
+            unique_keys=["invasive_plant", "mechanical_method"],
+            error_message="Entries must contain a unique Invasive Plant / Mechanical Method combination",
+        )
 
     @field_validator("shoreline_types")
     @classmethod

--- a/api-rework/invasives/api/protocol/activity/plant_subtypes/treatment_mechanical_terrestrial.py
+++ b/api-rework/invasives/api/protocol/activity/plant_subtypes/treatment_mechanical_terrestrial.py
@@ -1,6 +1,6 @@
 from typing import List, Literal, Optional
 from pydantic import Field, field_validator
-from api.protocol.activity.validators.no_repeat_key import no_repeat_key
+from api.protocol.activity.validators.distinct_entries import distinct_entries
 from api.protocol.activity.plant_subtypes.base_form_schema import (
     BaseFormSchema,
     CleanSchema,
@@ -40,8 +40,12 @@ class SubtypeData(DraftSubtypeData):
 
     @field_validator("entries")
     @classmethod
-    def unique_plants(cls, v):
-        return no_repeat_key(v, key="invasive_plant", key_label="Invasive Plant")
+    def unique_entries(cls, v):
+        return distinct_entries(
+            v,
+            unique_keys=["invasive_plant", "mechanical_method"],
+            error_message="Entries must contain a unique Invasive Plant / Mechanical Method combination",
+        )
 
 
 class DraftTreatmentMechanicalTerrestrial(DraftBaseFormSchema):

--- a/api-rework/invasives/api/protocol/activity/validators/distinct_entries.py
+++ b/api-rework/invasives/api/protocol/activity/validators/distinct_entries.py
@@ -1,0 +1,37 @@
+from typing import Any, Dict, List, Union
+
+
+def distinct_entries(
+    arr: List[Dict[str, Any]], unique_keys: List[str], error_message: str
+) -> Union[bool, str]:
+    """
+    Checks for uniqueness based on a specific set of keys.
+
+    :param arr: The list of dictionaries to validate.
+    :param unique_keys: The specific keys that, when combined, must be
+    unique.
+    :param error_message: Human-readable name for the error message.
+    :return: True if all non-empty entries are unique; error_message otherwise.
+    """
+    seen: set[str] = set()
+
+    for entry in arr:
+        # Build composite string based on unique keys
+        parts: list[str] = []
+        for key in unique_keys:
+            val = entry.get(key) if isinstance(entry, dict) else None
+            # Normalize values to strings, handling None
+            parts.append(str(val).strip() if val is not None else "")
+
+        composite_id = "-".join(parts)
+
+        # Skip validation on empty entries
+        if composite_id.replace("-", "") == "":
+            continue
+
+        if composite_id in seen:
+            return error_message
+
+        seen.add(composite_id)
+
+    return True

--- a/api-rework/invasives/api/protocol/activity/validators/distinct_entries.py
+++ b/api-rework/invasives/api/protocol/activity/validators/distinct_entries.py
@@ -19,7 +19,7 @@ def distinct_entries(
         # Build composite string based on unique keys
         parts: list[str] = []
         for key in unique_keys:
-            val = entry.get(key) if isinstance(entry, dict) else None
+            val = getattr(entry, key, None)
             # Normalize values to strings, handling None
             parts.append(str(val).strip() if val is not None else "")
 
@@ -28,10 +28,8 @@ def distinct_entries(
         # Skip validation on empty entries
         if composite_id.replace("-", "") == "":
             continue
-
         if composite_id in seen:
             raise ValueError(error_message)
 
         seen.add(composite_id)
-
     return arr

--- a/api-rework/invasives/api/protocol/activity/validators/distinct_entries.py
+++ b/api-rework/invasives/api/protocol/activity/validators/distinct_entries.py
@@ -30,8 +30,8 @@ def distinct_entries(
             continue
 
         if composite_id in seen:
-            return error_message
+            raise ValueError(error_message)
 
         seen.add(composite_id)
 
-    return True
+    return arr

--- a/app/src/UI/Features/LegacyMap/Controls/ButtonContainer.css
+++ b/app/src/UI/Features/LegacyMap/Controls/ButtonContainer.css
@@ -85,8 +85,12 @@
     .button {
       background-color: white;
       color: var(--bc-blue);
+      max-height: var(--map-button-bar-height);
+      max-width: var(--map-button-bar-height);
 
       & > img {
+        height: 100%;
+        width: 100%;
         object-fit: scale-down;
       }
 

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlant.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlant.tsx
@@ -95,19 +95,19 @@ const TreatmentChemicalPlant = () => {
   useEffect(() => {
     // Refire Temperature validation when confirmation changes
     if (!isDirty) return;
-    trigger(getPath('temperature_c'));
+    trigger(getContextPath('temperature_c'));
   }, [userVerifiedTemperatureAccurate]);
 
   useEffect(() => {
     // Refire Temperature validation when confirmation changes
     if (!isDirty) return;
-    trigger(getPath('wind_speed_kmh'));
+    trigger(getContextPath('wind_speed_kmh'));
   }, [userVerifiedWindspeedAccurate]);
 
   // Cleanup NTZ Reduction Rationale if Reduction is changed to False
   useEffect(() => {
     if (isDirty && !ntz_bool) {
-      setValue(getPath('rationale_for_ntz_reduction'), '');
+      setValue(getContextPath('rationale_for_ntz_reduction'), '');
     }
   }, [ntz_bool]);
 

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-mech-plant-aquatic/TreatmentMechPlantAquatic.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-mech-plant-aquatic/TreatmentMechPlantAquatic.tsx
@@ -9,7 +9,8 @@ import {
   lessThanEqual,
   minArrayLength,
   noRepeatKey,
-  greaterThan
+  greaterThan,
+  distinctEntries
 } from 'UI/Features/Records/Activity/forms/common/validators';
 import SingleSelect from 'UI/Features/Records/Activity/forms/common/SingleSelect/SingleSelect';
 import tooltips from 'UI/Features/Records/Activity/forms/plant/content/tooltips';
@@ -95,7 +96,12 @@ const TreatmentMechPlantAquatic = () => {
         rules={{
           validate: {
             minLength: (val) => minArrayLength(val, 1),
-            noRepeatPlants: (val) => noRepeatKey(val, 'invasive_plant', 'Invasive Plant')
+            noRepeatMethodsOnPlants: (val) =>
+              distinctEntries(
+                val,
+                ['invasive_plant', 'mechanical_method'],
+                'Entries must contain a unique Invasive Plant / Mechanical Method combination'
+              )
           }
         }}
         renderRow={(index) => {

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-mech-plant-terrestrial/TreatmentMechPlantTerrestrial.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-mech-plant-terrestrial/TreatmentMechPlantTerrestrial.tsx
@@ -3,7 +3,7 @@ import ArrayField from 'UI/Features/Records/Activity/forms/common/ArrayField/Arr
 import Fieldset from 'UI/Features/Records/Activity/forms/common/Fieldset/Fieldset';
 import getDefaultFormState from 'UI/Features/Records/Activity/forms/plant/builders/getDefaultState';
 import { EntryBasePath, TerrestrialMechTreatment } from 'UI/Features/Records/Activity/forms/plant/interfaces';
-import { minArrayLength, noRepeatKey } from 'UI/Features/Records/Activity/forms/common/validators';
+import { distinctEntries, minArrayLength } from 'UI/Features/Records/Activity/forms/common/validators';
 import { useSelector } from 'utils/use_selector';
 import tooltips from 'UI/Features/Records/Activity/forms/plant/content/tooltips';
 import { Width } from 'UI/Features/Records/Activity/forms/common/utils';
@@ -30,7 +30,12 @@ const TreatmentMechPlantTerrestrial = () => {
       rules={{
         validate: {
           minLength: (val) => minArrayLength(val, 1),
-          noRepeatPlants: (val) => noRepeatKey(val, 'invasive_plant', 'Invasive Plant')
+          noRepeatMethodsOnPlants: (val) =>
+            distinctEntries(
+              val,
+              ['invasive_plant', 'mechanical_method'],
+              'Entries must contain a unique Invasive Plant / Mechanical Method combination'
+            )
         }
       }}
       renderRow={(index) => {

--- a/app/src/UI/Layout/AlertsContainer/AlertsContainer.css
+++ b/app/src/UI/Layout/AlertsContainer/AlertsContainer.css
@@ -16,7 +16,7 @@
   align-items: center;
   margin: 2pt;
   opacity: 0.85;
-  animation: slide-in 0.35s ease-out forwards;
+  animation: slide-in 0.35s linear forwards;
 }
 
 @keyframes slide-in {

--- a/app/src/state/actions/activity/FormActions.ts
+++ b/app/src/state/actions/activity/FormActions.ts
@@ -212,8 +212,9 @@ class FormActions {
             dispatch(Alerts.create(formAlerts.recordSubmittedFailure));
             return rejectWithValue(await res.json());
           }
+        } else {
+          dispatch(Alerts.create(formAlerts.recordSubmittedSuccess));
         }
-        dispatch(Alerts.create(formAlerts.recordSubmittedSuccess));
         return await res.json();
       }
     }


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Implement `distinct_entries` in backend
- Change validation of Mech Entries to unique combination of `plant+method`. Previously just `plant`
- Fix small bug where a submitted form that has a 422 error still emits a success alert.