### PR TITLE
[INV-4667] Tank Mix Calculations

### DIFF
--- a/app/src/UI/Features/Records/Activity/forms/plant/interfaces/ChemicalTreatmentContext.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/interfaces/ChemicalTreatmentContext.ts
@@ -9,7 +9,7 @@ interface BaseChemicalContext {
 }
 
 interface BaseHerbicide {
-  type: 'granular' | 'liquid' | '';
+  type: 'L' | 'G' | '';
   name: string;
 }
 interface ApplicationRateHerbicide extends BaseHerbicide {
@@ -38,10 +38,7 @@ interface ChemicalContextApplicationRate extends BaseChemicalContext, ProductApp
 }
 
 type ChemicalTreatmentContext =
-  | BaseChemicalContext
-  | TankMixChemicalContext
-  | ChemicalContextDilution
-  | ChemicalContextApplicationRate;
+  BaseChemicalContext | TankMixChemicalContext | ChemicalContextDilution | ChemicalContextApplicationRate;
 
 export type {
   BaseChemicalContext,

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlantDetails.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlantDetails.tsx
@@ -57,7 +57,7 @@ const TreatmentChemicalPlantDetails = () => {
       ...(herbicides as Array<ApplicationRateHerbicide>).map((h: ApplicationRateHerbicide): number => {
         const rate = h?.application_rate ?? 0;
         if (!rate) return 0;
-        if (h.type === 'granular') return rate / 1000; // Convert all to same units (e.g.: 300g == 0.3L.
+        if (h.type === 'G') return rate / 1000; // Convert all to same units (e.g.: 300g == 0.3L.
         return rate;
       })
     );

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/calculations.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/calculations.ts
@@ -290,7 +290,7 @@ const mSpecie_mLGHerb_spray_usingProdAppRate = (
         herbicide_name: name,
         product_application_rate: application_rate,
         dilution: trunc(dilution),
-        area_treated_sqm: trunc(area_treated_sqm),
+        area_treated_sqm: trunc(area_treated_sqm) / herbicide.length,
         undiluted_herbicide_used_l: trunc(undiluted_herbicide_used_l),
         percentage_area_covered: trunc(area_covered_pct)
       } as CalculationResponseValues;

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/calculations.ts
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/calculations.ts
@@ -278,7 +278,9 @@ const mSpecie_mLGHerb_spray_usingProdAppRate = (
     const area_covered_pct = (area_treated_sqm / area_m) * 100;
     return herbicide.map(({ application_rate, type, name }) => {
       const dilution = (() => {
-        if (type === 'granular') return (application_rate / 1000 / delivery_rate) * 100;
+        if (type === 'G') {
+          return (application_rate / 1000 / delivery_rate) * 100;
+        }
         return (application_rate / delivery_rate) * 100;
       })();
       const undiluted_herbicide_used_l = ((dilution / 100) * amount_mix_used_l * percent_covered) / 100;


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Correct checks on herbicide type from `granular` | `liquid` to `G` | `L` in line with past changes. Fixes issue with granular conversion
- Divide the displayed Area of treatment for tank mixes by number of herbicides, as per request. 