### PR TITLE
[INV-N/A]BUGFIX** Adjust mechanical treatments default values

### DIFF
--- a/sharedAPI/src/openapi/api-doc/Components/Treatment_Sub_Forms.ts
+++ b/sharedAPI/src/openapi/api-doc/Components/Treatment_Sub_Forms.ts
@@ -252,7 +252,7 @@ export const Treatment_ChemicalPlant_Information = {
 export const Treatment_MechanicalPlant_Information = {
   type: 'array',
   title: 'Mechanical Treatments',
-  default: [{}],
+  default: [{ disposed_material: {} }],
   minItems: 1,
   items: {
     type: 'object',
@@ -362,7 +362,7 @@ export const Treatment_MechanicalPlant_Information = {
 export const Treatment_MechanicalPlant_Information_Aquiatic = {
   type: 'array',
   title: 'Mechanical Treatments',
-  default: [{}],
+  default: [{ disposed_material: {} }],
   minItems: 1,
   items: {
     type: 'object',


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

Sets the default values of mechanical treatment entries to include an empty disposed material format key.

The fields contained in disposed material are optional, but the parent object is not enclosed which *is* required.
To clear this error otherwise you would have to fill either field, then delete it.

Attempting to simply make this object not required just makes it fail in the backend

Tested by submitting both types of mechanical treatment records without touching the affected fields. Forms submitted as expected