### PR TITLE
[INV-N/A] Feedback loop fixes

### DIFF
--- a/api-rework/invasives/api/fixtures/test/subtypes/treatments/test_aquatic_mechanical_treatment.json
+++ b/api-rework/invasives/api/fixtures/test/subtypes/treatments/test_aquatic_mechanical_treatment.json
@@ -64,7 +64,7 @@
     "fields": {
       "activity_data_record_id": 1000,
       "disposed_material_amount": 544,
-      "disposed_material_format": "kg",
+      "disposed_material_format": "weight",
       "disposal_method": "II",
       "invasive_plant": "CT",
       "mechanical_method": "DIG",
@@ -77,7 +77,7 @@
     "fields": {
       "activity_data_record_id": 1001,
       "disposed_material_amount": 544,
-      "disposed_material_format": "m^3",
+      "disposed_material_format": "volume (m3)",
       "disposal_method": "II",
       "invasive_plant": "JK",
       "mechanical_method": "DIG",
@@ -91,7 +91,7 @@
       "activity_data_record_id": 1001,
       "invasive_plant": "JK",
       "disposed_material_amount": 544,
-      "disposed_material_format": "plants",
+      "disposed_material_format": "number of plants",
       "disposal_method": "LDB",
       "mechanical_method": "CNV",
       "treated_area_msq": 512

--- a/api-rework/invasives/api/fixtures/test/subtypes/treatments/test_terrestrial_mechanical_treatment.json
+++ b/api-rework/invasives/api/fixtures/test/subtypes/treatments/test_terrestrial_mechanical_treatment.json
@@ -64,7 +64,7 @@
     "fields": {
       "activity_data_record_id": 1000,
       "disposed_material_amount": 544,
-      "disposed_material_format": "kg",
+      "disposed_material_format": "weight",
       "disposal_method": "II",
       "invasive_plant": "CT",
       "mechanical_method": "DIG",
@@ -77,7 +77,7 @@
     "fields": {
       "activity_data_record_id": 1001,
       "disposed_material_amount": 544,
-      "disposed_material_format": "m^3",
+      "disposed_material_format": "volume (m3)",
       "disposal_method": "II",
       "invasive_plant": "JK",
       "mechanical_method": "DIG",
@@ -91,7 +91,7 @@
       "activity_data_record_id": 1001,
       "invasive_plant": "JK",
       "disposed_material_amount": 544,
-      "disposed_material_format": "plants",
+      "disposed_material_format": "number of plants",
       "disposal_method": "LDB",
       "mechanical_method": "CNV",
       "treated_area_msq": 512

--- a/api-rework/invasives/api/models/enums/plant_disposal_format.py
+++ b/api-rework/invasives/api/models/enums/plant_disposal_format.py
@@ -2,6 +2,6 @@ from django.db import models
 
 
 class PlantDisposalFormat(models.TextChoices):
-    Each = "plants", "Number of plants"
-    Volume = "m^3", "Volume (Cubic Meters)"
-    Weight = "kg", "Weight (kg)"
+    Each = "number of plants", "Number of plants"
+    Volume = "volume (m3)", "Volume (Cubic Meters)"
+    Weight = "weight", "Weight (kg)"

--- a/api-rework/invasives/api/protocol/activity/plant_subtypes/biocontrol_collection.py
+++ b/api-rework/invasives/api/protocol/activity/plant_subtypes/biocontrol_collection.py
@@ -66,17 +66,10 @@ class Entry(DraftEntry):
 
     @model_validator(mode="after")
     def validate_collection_type_followup(self) -> "Entry":
-        if (
-            self.collection_type == "Timed"
-            and self.time_collection_duration_minutes is None
-        ):
-            raise ValueError(
-                '"Count duration (Minutes)" is required when Collection type is "Timed"'
-            )
-        elif self.collection_type == "Count" and self.plant_count_collection is None:
-            raise ValueError(
-                '"Plant Count" is required when Collection type is "Count"'
-            )
+        if self.collection_type == "Timed":
+            self.plant_count_collection = None
+        elif self.collection_type == "Count":
+            self.time_collection_duration_minutes = None
         return self
 
     @model_validator(mode="after")

--- a/api-rework/invasives/api/protocol/activity/plant_subtypes/biocontrol_dispersal_monitoring.py
+++ b/api-rework/invasives/api/protocol/activity/plant_subtypes/biocontrol_dispersal_monitoring.py
@@ -75,6 +75,14 @@ class Entry(DraftEntry):
     estimated_biological_agents: List[BiocontrolCountExtended] = []
 
     @model_validator(mode="after")
+    def collection_type_cleanup(self) -> "Entry":
+        if self.monitoring_type == "Timed":
+            self.plant_count = None
+        elif self.monitoring_type == "Count":
+            self.count_duration_minutes = None
+        return self
+
+    @model_validator(mode="after")
     def validate_number_of_sweeps(self) -> "Entry":
         if self.monitoring_method == "Cs" and self.number_of_sweeps is None:
             raise ValueError(

--- a/api-rework/invasives/api/protocol/activity/plant_subtypes/monitoring_biocontrol_release.py
+++ b/api-rework/invasives/api/protocol/activity/plant_subtypes/monitoring_biocontrol_release.py
@@ -82,6 +82,14 @@ class Entry(DraftEntry):
         return self
 
     @model_validator(mode="after")
+    def collection_type_cleanup(self) -> "Entry":
+        if self.monitoring_type == "Timed":
+            self.plant_count = None
+        elif self.monitoring_type == "Count":
+            self.count_duration_minutes = None
+        return self
+
+    @model_validator(mode="after")
     def validate_monitoring_method(self) -> "Entry":
         if self.monitoring_method == "Cs" and self.number_of_sweeps is None:
             raise ValueError("Number of sweeps is a required field")

--- a/api-rework/invasives/api/serializers/activity_invasive_plants.py
+++ b/api-rework/invasives/api/serializers/activity_invasive_plants.py
@@ -37,11 +37,11 @@ class BaseSerializer(serializers.ModelSerializer):
         return getattr(obj, self.record_set_attr).all()
 
     def get_invasive_plant(self, obj):
-        plants = [
+        plants = {
             e.invasive_plant.full
             for e in self._get_plant_entries(obj)
             if e.invasive_plant
-        ]
+        }
         return ", ".join(filter(None, plants)) or None
 
 

--- a/api-rework/invasives/api/serializers/activity_recordset_row.py
+++ b/api-rework/invasives/api/serializers/activity_recordset_row.py
@@ -160,11 +160,11 @@ class BaseSerializer(serializers.ModelSerializer):
                     yield from getattr(record, destination).all()
 
     def get_invasive_plant(self, obj):
-        plants = [
+        plants = {
             e.invasive_plant.full
             for e in self._get_plant_entries(obj)
             if e.invasive_plant
-        ]
+        }
         return self.build_response_value(plants)
 
     def _get_species_observation(self, obj, observation_type):
@@ -173,12 +173,12 @@ class BaseSerializer(serializers.ModelSerializer):
         if not is_observation:
             return None
 
-        plants = [
+        plants = {
             e.invasive_plant.full
             for e in self._get_plant_entries(obj)
             if getattr(e, "observation_type", None) == observation_type
             and e.invasive_plant
-        ]
+        }
         return self.build_response_value(plants)
 
     def get_species_positive_full(self, obj):
@@ -192,11 +192,11 @@ class BaseSerializer(serializers.ModelSerializer):
         if activity_type not in ["Treatment", "Biocontrol", "Monitoring"]:
             return None
 
-        plants = [
+        plants = {
             e.invasive_plant.full
             for e in self._get_plant_entries(obj)
             if e.invasive_plant
-        ]
+        }
         return self.build_response_value(plants)
 
     def get_species_biocontrol_full(self, obj):

--- a/api-rework/invasives/api/tests/mock_frontend_submissions/mech_treatment_aquatic.py
+++ b/api-rework/invasives/api/tests/mock_frontend_submissions/mech_treatment_aquatic.py
@@ -123,7 +123,7 @@ UPDATED_MECH_TREATMENT_AQUATIC = {
         "entries": [
             {
                 "disposed_material_amount": 22,
-                "disposed_material_format": "plants",
+                "disposed_material_format": "number of plants",
                 "disposal_method": "II",
                 "invasive_plant": "JK",
                 "mechanical_method": "BRY",

--- a/api-rework/invasives/api/tests/mock_frontend_submissions/mech_treatment_terrestrial.py
+++ b/api-rework/invasives/api/tests/mock_frontend_submissions/mech_treatment_terrestrial.py
@@ -119,7 +119,7 @@ UPDATED_MECH_TREATMENT_TERRESTRIAL = {
         "entries": [
             {
                 "disposed_material_amount": 42,
-                "disposed_material_format": "m^3",
+                "disposed_material_format": "volume (m3)",
                 "disposal_method": "II",
                 "invasive_plant": "JK",
                 "mechanical_method": "BUR",

--- a/api-rework/invasives/api/tests/subtypes/test_treatment_mechanical_aquatic.py
+++ b/api-rework/invasives/api/tests/subtypes/test_treatment_mechanical_aquatic.py
@@ -33,7 +33,7 @@ class AquaticMechanicalTreatmentTest(BaseActivitySubtypeTest):
         mt = sd["entries"][0]
 
         self.assertEqual(mt["disposed_material_amount"], 544)
-        self.assertEqual(mt["disposed_material_format"], "kg")
+        self.assertEqual(mt["disposed_material_format"], "weight")
         self.assertEqual(mt["disposal_method"], "II")
         self.assertEqual(mt["invasive_plant"], "CT")
         self.assertEqual(mt["mechanical_method"], "DIG")
@@ -64,7 +64,7 @@ class AquaticMechanicalTreatmentTest(BaseActivitySubtypeTest):
         expected = [
             {
                 "disposed_material_amount": 544,
-                "disposed_material_format": "m^3",
+                "disposed_material_format": "volume (m3)",
                 "disposal_method": "II",
                 "invasive_plant": "JK",
                 "mechanical_method": "DIG",
@@ -73,7 +73,7 @@ class AquaticMechanicalTreatmentTest(BaseActivitySubtypeTest):
             {
                 "invasive_plant": "JK",
                 "disposed_material_amount": 544,
-                "disposed_material_format": "plants",
+                "disposed_material_format": "number of plants",
                 "disposal_method": "LDB",
                 "mechanical_method": "CNV",
                 "treated_area_msq": 512,

--- a/api-rework/invasives/api/tests/subtypes/test_treatment_mechanical_terrestrial.py
+++ b/api-rework/invasives/api/tests/subtypes/test_treatment_mechanical_terrestrial.py
@@ -30,7 +30,7 @@ class TerrestrialMechanicalTreatmentTest(BaseActivitySubtypeTest):
 
         mt = response_object["subtype_data"]["entries"][0]
         self.assertEqual(mt["disposed_material_amount"], 544)
-        self.assertEqual(mt["disposed_material_format"], "kg")
+        self.assertEqual(mt["disposed_material_format"], "weight")
         self.assertEqual(mt["disposal_method"], "II")
         self.assertEqual(mt["invasive_plant"], "CT")
         self.assertEqual(mt["mechanical_method"], "DIG")
@@ -45,7 +45,7 @@ class TerrestrialMechanicalTreatmentTest(BaseActivitySubtypeTest):
         expected = [
             {
                 "disposed_material_amount": 544,
-                "disposed_material_format": "m^3",
+                "disposed_material_format": "volume (m3)",
                 "disposal_method": "II",
                 "invasive_plant": "JK",
                 "mechanical_method": "DIG",
@@ -54,7 +54,7 @@ class TerrestrialMechanicalTreatmentTest(BaseActivitySubtypeTest):
             {
                 "invasive_plant": "JK",
                 "disposed_material_amount": 544,
-                "disposed_material_format": "plants",
+                "disposed_material_format": "number of plants",
                 "disposal_method": "LDB",
                 "mechanical_method": "CNV",
                 "treated_area_msq": 512,

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/biocontrol-release-monitoring/BiocontrolReleaseMonitoringEntry.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/biocontrol-release-monitoring/BiocontrolReleaseMonitoringEntry.tsx
@@ -36,7 +36,7 @@ const BiocontrolReleaseMonitoringEntry = ({ index }: PropTypes) => {
     return 'Start time must be before stop time.';
   };
 
-  const SWEEP_COUNT_CODES = ['Cs', 'S'];
+  const SWEEP_COUNT_CODES = new Set(['Cs', 'S']);
   const codes = useSelector((state) => state.ActivityPage.formCodes);
 
   const selectedPlant = watch(getPath('invasive_plant'));
@@ -73,7 +73,7 @@ const BiocontrolReleaseMonitoringEntry = ({ index }: PropTypes) => {
 
   useEffect(() => {
     // Delete number_of_sweeps if no longer needed
-    if (isDirty && !SWEEP_COUNT_CODES.includes(monitoringMethod)) {
+    if (isDirty && !SWEEP_COUNT_CODES.has(monitoringMethod)) {
       setValue(getPath('number_of_sweeps'), undefined);
     }
   }, [monitoringMethod]);
@@ -168,7 +168,7 @@ const BiocontrolReleaseMonitoringEntry = ({ index }: PropTypes) => {
         rules={{ required: true }}
         width={Width.Half}
       />
-      {SWEEP_COUNT_CODES.includes(monitoringMethod) ? (
+      {SWEEP_COUNT_CODES.has(monitoringMethod) ? (
         <NumberInput
           error={get(errors, getPath('number_of_sweeps'))}
           label={'Number of Sweeps'}

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/common/WeatherConditions.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/common/WeatherConditions.tsx
@@ -11,11 +11,19 @@ import useFieldPath from 'UI/Features/Records/Activity/forms/plant/hooks/useFiel
 import { greaterThanEqual } from 'UI/Features/Records/Activity/forms/common/validators';
 
 const BiocontrolWeatherConditions = () => {
-  const validateWindDirectionAndSpeed = (wind_direction: string, formValues) => {
+  const validateWindDirectionAndSpeedPositive = (wind_direction: string, formValues) => {
     const wind_speed = formValues.subtype_data.weather_conditions?.wind_speed_kmh;
     if (wind_speed === undefined || wind_direction === undefined) return true;
     if (wind_speed > 0 && wind_direction === 'No Wind') {
       return 'Must specify a wind direction when wind speed is > 0';
+    }
+    return true;
+  };
+  const validateWindDirectionAndSpeedNegative = (wind_direction: string, formValues) => {
+    const wind_speed = formValues.subtype_data.weather_conditions?.wind_speed_kmh;
+    if (wind_speed === undefined || wind_direction === undefined) return true;
+    if (wind_speed === 0 && wind_direction !== 'No Wind') {
+      return 'Cannot specify a wind direction when wind speed is 0';
     }
     return true;
   };
@@ -79,7 +87,8 @@ const BiocontrolWeatherConditions = () => {
         rules={{
           required: true,
           validate: {
-            checkSpeedAndDirection: (v, formValues) => validateWindDirectionAndSpeed(v, formValues)
+            checkSpeedAndDirectionPos: (v, formValues) => validateWindDirectionAndSpeedPositive(v, formValues),
+            checkSpeedAndDirectionNeg: (v, formValues) => validateWindDirectionAndSpeedNegative(v, formValues)
           }
         }}
         tooltip={tooltips.plant.biocontrol.weather.wind_direction}

--- a/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlant.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/subtype-component/treatment-chemical-plant/TreatmentChemicalPlant.tsx
@@ -32,6 +32,22 @@ const TreatmentChemicalPlant = () => {
   const MIN_ALLOWED_TEMP = 10;
   const MAX_WIND_SPEED = 9;
 
+  const validateWindDirectionAndSpeedPositive = (wind_direction: string, formValues) => {
+    const wind_speed = formValues.subtype_data.context?.wind_speed_kmh;
+    if (wind_speed === undefined || wind_direction === undefined) return true;
+    if (wind_speed > 0 && wind_direction === 'No Wind') {
+      return 'Must specify a wind direction when wind speed is > 0';
+    }
+    return true;
+  };
+  const validateWindDirectionAndSpeedNegative = (wind_direction: string, formValues) => {
+    const wind_speed = formValues.subtype_data.context?.wind_speed_kmh;
+    if (wind_speed === undefined || wind_direction === undefined) return true;
+    if (wind_speed === 0 && wind_direction !== 'No Wind') {
+      return 'Cannot specify a wind direction when wind speed is 0';
+    }
+    return true;
+  };
   /**
    * @desc Validate only PMP or Manual PMP are filled in, not both.
    */
@@ -197,12 +213,9 @@ const TreatmentChemicalPlant = () => {
           rules={{
             required: true,
             deps: [getContextPath('wind_speed_kmh')],
-            validate: (direction, formValues) => {
-              const windSpeed = formValues.subtype_data?.context?.wind_speed_kmh;
-              if (direction === 'No Wind' && windSpeed > 0) {
-                return 'Must specify a wind direction when wind speed > 0';
-              }
-              return true;
+            validate: {
+              checkSpeedAndDirectionPos: (v, formValues) => validateWindDirectionAndSpeedPositive(v, formValues),
+              checkSpeedAndDirectionNeg: (v, formValues) => validateWindDirectionAndSpeedNegative(v, formValues)
             }
           }}
         />


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Fix backend validation of disposal enums
- Add validation to weather for wind direction claimed when no wind speed.
- convert arrays to sets for serializers to skip duplicate values for invasive plants.
- make biocontrol monitoring/collection codes clear the opposing fields in the backend.
- Update tests values