### PR TITLE
[INV-4670] User Feedback Loop

### DIFF
--- a/api-rework/invasives/api/models/activity/activity.py
+++ b/api-rework/invasives/api/models/activity/activity.py
@@ -116,6 +116,9 @@ class Activity(
             year = datetime.datetime.now().strftime("%y")
             self.short_id = f"{year}{subtype}{uuid_substr}"
 
+        plant_codes = super().get_invasive_plant_codes()
+        self.computed_map_symbol = ", ".join(plant_codes)
+
         super().save(*args, **kwargs)
 
         if self.form_status == "Submitted" and not self.computed_fields_generated:
@@ -233,6 +236,9 @@ class DraftActivity(DraftGeometry, BaseModel, models.Model):
             uuid_substr = str(self.id)[:UUID_SUBSTRING_LENGTH].upper()
             year = datetime.datetime.now().strftime("%y")
             self.short_id = f"{year}{subtype}{uuid_substr}"
+
+        plant_codes = super().get_invasive_plant_codes()
+        self.computed_map_symbol = ", ".join(plant_codes)
 
         super().save(*args, **kwargs)
 

--- a/api-rework/invasives/api/protocol/activity/plant_subtypes/base_form_schema.py
+++ b/api-rework/invasives/api/protocol/activity/plant_subtypes/base_form_schema.py
@@ -1,8 +1,11 @@
-from typing import List, Literal, Optional, Union
+import json
 from datetime import date
 from ninja import Schema
+from typing import Annotated, Dict, List, Literal, Optional, Union
+from django.contrib.gis.geos import GEOSGeometry
 from pydantic import Field, model_validator, field_validator, ConfigDict
-from api.models.activity import FormStatus
+from api.models.activity import FormStatus, Activity
+from api.models.activity.activity_subtypes import ActivitySubtypes, SubtypePrimary
 from api.protocol.activity.validators.no_repeat_key import no_repeat_key
 from api.protocol.activity.validators.check_sum import check_sum
 from api.protocol.activity.validators.no_future_date import no_future_date
@@ -11,10 +14,6 @@ from api.protocol.activity.validators.code_validation import (
     JurisdictionCodeType,
     FundingAgencyCodeType,
 )
-
-MAX_AREA_FOR_RECORD = 500000
-from typing import Annotated, Dict, List, Optional, Union
-from pydantic import Field
 from geojson_pydantic import Feature, FeatureCollection
 from geojson_pydantic.geometries import (
     Point,
@@ -26,6 +25,8 @@ from geojson_pydantic.geometries import (
     GeometryCollection as _GeometryCollection,
 )
 from geojson_pydantic.types import Position2D
+
+MAX_AREA_FOR_RECORD = 500000
 
 
 # Override base classes to use a 2D Coordinate system as we don't use z-indexes in app.
@@ -211,6 +212,44 @@ class BaseFormSchema(DraftBaseFormSchema):
 
     class Meta:
         abstract = True
+
+    @model_validator(mode="before")
+    def linked_activities_overlap(self):
+        """
+        For incoming records with Linked activities, check that the records match what is expected
+        - Shapes overlap in any way (intersecting, touching, fully contained within)
+        - ID is an appropriate type (A treatment is linked to an Observation)
+        """
+        # Early Return, no Linked Activities in Record
+        if self.linked_activities == None or len(self.linked_activities) == 0:
+            return self
+
+        def _map_incoming_subtype_to_linkable_type(subtype):
+            modelled_type: SubtypePrimary = ActivitySubtypes[subtype].typeOfActivity
+            match modelled_type:
+                case SubtypePrimary.Treatment:
+                    return SubtypePrimary.Observation
+                case SubtypePrimary.Monitoring:
+                    return SubtypePrimary.Treatment
+                case SubtypePrimary.Biocontrol:
+                    return SubtypePrimary.Observation
+                case _:
+                    pass
+
+        # Create small queryset of expected record
+        queryset = Activity.objects.filter(
+            type=_map_incoming_subtype_to_linkable_type(self.subtype),
+            id__in=[activity["full"] for activity in self.linked_activities],
+            shape__intersects=GEOSGeometry(json.dumps(self.shape["geometry"])),
+        ).values_list("id")
+
+        # Iterate Queryset to check id exists. Alert user if record not in shape
+        for activity in self.linked_activities:
+            if not queryset.filter(id=activity["full"]).exists():
+                short = activity["label"].split(" | ")[0]
+                error = f"Could not process Request. {short} does not sufficiently overlap with incoming record"
+                raise ValueError(error)
+        return self
 
     @field_validator("date")
     @classmethod

--- a/api-rework/invasives/api/protocol/activity/plant_subtypes/treatment_chemical_terrestrial.py
+++ b/api-rework/invasives/api/protocol/activity/plant_subtypes/treatment_chemical_terrestrial.py
@@ -116,7 +116,7 @@ class ProductApplicationRate(CleanSchema):
         application_rates = []
         for h in self.herbicide:
             app_rate = h.application_rate if h.application_rate else 0
-            if h.type.code == "granular":
+            if h.type.code == "G":
                 app_rate /= 1000
             application_rates.append(app_rate)
         MAX_RATE = max(application_rates, default=0)

--- a/api-rework/invasives/api/tests/mock_frontend_submissions/chem_treatment_terrestrial.py
+++ b/api-rework/invasives/api/tests/mock_frontend_submissions/chem_treatment_terrestrial.py
@@ -186,14 +186,14 @@ UPDATED_CHEM_TREATMENT_TERRESTRIAL = {
             "calculation_type": "PAR",
             "herbicide": [
                 {"type": "L", "name": "27634", "application_rate": 3.321},
-                {"type": "G", "name": "33128", "application_rate": 1.6544},
+                {"type": "G", "name": "33128", "application_rate": 31.6544},
             ],
             "plants_treated": [
                 {"invasive_plant": "AR", "percent_covered": 78},
                 {"invasive_plant": "JK", "percent_covered": 22},
             ],
             "amount_mix_used_l": 3.234,
-            "delivery_rate": 8085,
+            "delivery_rate": 4,
         },
     },
     "type": "Treatment",

--- a/api-rework/invasives/api/tests/test_linked_records.py
+++ b/api-rework/invasives/api/tests/test_linked_records.py
@@ -7,7 +7,7 @@ from api.tests.mock_frontend_submissions import (
 )
 
 
-class TerrestrialObservationTest(BaseActivitySubtypeTest):
+class LinkedActivityTests(BaseActivitySubtypeTest):
 
     fixtures = [
         "test/common/test_employer_codes",

--- a/api-rework/invasives/api/tests/test_linked_records.py
+++ b/api-rework/invasives/api/tests/test_linked_records.py
@@ -1,0 +1,94 @@
+import copy
+from .subtypes.base import BaseActivitySubtypeTest
+from api.tests.mock_frontend_submissions import (
+    UPDATED_TERRESTRIAL_OBSERVATION,
+    UPDATED_MECH_TREATMENT_TERRESTRIAL,
+    UPDATED_MONITORING_MECH_TREATMENT,
+)
+
+
+class TerrestrialObservationTest(BaseActivitySubtypeTest):
+
+    fixtures = [
+        "test/common/test_employer_codes",
+        "test/common/test_jurisdictions_codes",
+        "test/common/test_funding_agency_codes",
+        "test/common/test_invasive_plant_codes",
+        "test/common/test_jurisdictions",
+        "test/common/test_funding_agency",
+        "test/common/test_employer",
+        "test/common/test_participants",
+        "test/subtypes/observations/test_terrestrial_observation_codes",
+        "test/subtypes/observations/test_terrestrial_observation",
+        "test/subtypes/treatments/test_mechanical_treatment_codes",
+        "test/subtypes/treatments/test_terrestrial_mechanical_treatment",
+    ]
+
+    def _get_random_ocean_feature(self):
+        """
+        Random Feature for testing invalid Geojson in linking. Does not overlap any known record
+        """
+        return {
+            "type": "Feature",
+            "properties": {},
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [-123.8546835104566, 49.33264258114489],
+                        [-123.85470695780445, 49.3326337593165],
+                        [-123.85470695779607, 49.33261611566446],
+                        [-123.8546835104566, 49.3326072938408],
+                        [-123.85466006311715, 49.33261611566446],
+                        [-123.85466006310877, 49.3326337593165],
+                        [-123.8546835104566, 49.33264258114489],
+                    ]
+                ],
+            },
+        }
+
+    def test_linking_record_successful(self):
+        """
+        Expect:
+            - Submitting an appropriately linked record gets approved e.g.: Treatment -> Observation
+        """
+        init_record = UPDATED_TERRESTRIAL_OBSERVATION
+        self.submit_record(init_record)
+        linking_record = UPDATED_MECH_TREATMENT_TERRESTRIAL
+        linking_record["linked_activities"] = [
+            {"label": init_record["short_id"], "full": init_record["id"]}
+        ]
+        linking_record["shape"] = init_record["shape"]
+        response = self.submit_record(linking_record)
+        record = response.json()
+        self.assertEqual(len(record["linked_activities"]), 1)
+
+    def test_linking_record_failed_shape(self):
+        """
+        Expect:
+            - Submitting an Appropriate type of linked record, but with invalid shape, gets denies.
+        """
+        init_record = UPDATED_TERRESTRIAL_OBSERVATION
+        self.submit_record(init_record)
+        linking_record = UPDATED_MECH_TREATMENT_TERRESTRIAL
+        linking_record["linked_activities"] = [
+            {"label": init_record["short_id"], "full": init_record["id"]}
+        ]
+        linking_record["shape"] = self._get_random_ocean_feature()
+        response = self._post_record(payload=linking_record, type="submit")
+        self.assertEqual(response.status_code, 422)
+
+    def test_linking_record_failed_type(self):
+        """
+        Expect:
+            - Submitting an inappropriate type of linked record e.g.: Monitoring -> Observation gets denied
+        """
+        init_record = UPDATED_TERRESTRIAL_OBSERVATION
+        self.submit_record(init_record)
+        linking_record = UPDATED_MONITORING_MECH_TREATMENT
+        linking_record["linked_activities"] = [
+            {"label": init_record["short_id"], "full": init_record["id"]}
+        ]
+        linking_record["shape"] = init_record["shape"]
+        response = self._post_record(payload=linking_record, type="submit")
+        self.assertEqual(response.status_code, 422)

--- a/api-rework/invasives/api/tests/test_linked_records.py
+++ b/api-rework/invasives/api/tests/test_linked_records.py
@@ -1,4 +1,4 @@
-import copy
+from copy import copy
 from .subtypes.base import BaseActivitySubtypeTest
 from api.tests.mock_frontend_submissions import (
     UPDATED_TERRESTRIAL_OBSERVATION,
@@ -54,7 +54,7 @@ class LinkedActivityTests(BaseActivitySubtypeTest):
         """
         init_record = UPDATED_TERRESTRIAL_OBSERVATION
         self.submit_record(init_record)
-        linking_record = UPDATED_MECH_TREATMENT_TERRESTRIAL
+        linking_record = copy(UPDATED_MECH_TREATMENT_TERRESTRIAL)
         linking_record["linked_activities"] = [
             {"label": init_record["short_id"], "full": init_record["id"]}
         ]
@@ -70,7 +70,7 @@ class LinkedActivityTests(BaseActivitySubtypeTest):
         """
         init_record = UPDATED_TERRESTRIAL_OBSERVATION
         self.submit_record(init_record)
-        linking_record = UPDATED_MECH_TREATMENT_TERRESTRIAL
+        linking_record = copy(UPDATED_MECH_TREATMENT_TERRESTRIAL)
         linking_record["linked_activities"] = [
             {"label": init_record["short_id"], "full": init_record["id"]}
         ]
@@ -85,7 +85,7 @@ class LinkedActivityTests(BaseActivitySubtypeTest):
         """
         init_record = UPDATED_TERRESTRIAL_OBSERVATION
         self.submit_record(init_record)
-        linking_record = UPDATED_MONITORING_MECH_TREATMENT
+        linking_record = copy(UPDATED_MONITORING_MECH_TREATMENT)
         linking_record["linked_activities"] = [
             {"label": init_record["short_id"], "full": init_record["id"]}
         ]

--- a/api-rework/invasives/api/utils/filtered_activity_queryset.py
+++ b/api-rework/invasives/api/utils/filtered_activity_queryset.py
@@ -56,13 +56,13 @@ class FilteredActivityQueryset:
         meta = self.filter_objects[0]
 
         # Determine draft status up front
-        self.should_filter_drafts = any(
+        self.should_filter_drafts = draft_override or any(
             f.get("field") == "form_status" for f in meta.get("tableFilters", [])
         )
         self.prefix = "draft" if self.should_filter_drafts else ""
         self.root = self.prefix + "activitydatarecord"
 
-        if self.should_filter_drafts or draft_override:
+        if self.should_filter_drafts:
             # TODO: Pre-filter Draft Activities to only be by requesting user.
             self.model = DraftActivity
             self.queryset = DraftActivity.objects.all()

--- a/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarker.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/LayerDataMarker/LayerDataMarker.tsx
@@ -60,7 +60,7 @@ const LayerDataMarker = () => {
   const queryFeaturesAtTarget = useCallback(
     (e: MapMouseEvent | MapTouchEvent) => {
       const isUserUtilizingDraw = drawToolsActive.current || whatsHereEnabled || editModeActive.current;
-      if (!map || !connected || isUserUtilizingDraw || map.getZoom() < MINIMUM_ZOOM) return;
+      if (!map || isUserUtilizingDraw || map.getZoom() < MINIMUM_ZOOM) return;
       // Buffer target to avoid needing pinpoint accuracy
       const bbox: [PointLike, PointLike] = [
         new Point(e.point.x - BUFFER_IN_PX, e.point.y - BUFFER_IN_PX),

--- a/app/src/UI/Features/LegacyMap/helpers/components/OfflineRecordsetLayer.tsx
+++ b/app/src/UI/Features/LegacyMap/helpers/components/OfflineRecordsetLayer.tsx
@@ -62,9 +62,9 @@ const OfflineRecordsetLayer = ({ mapReady }: PropTypes) => {
           return Array.from(plants).filter(Boolean).join(', ');
         })();
 
-        if (parsedData?.geom) {
+        if (parsedData?.shape) {
           geometryList.push({
-            ...parsedData.geom,
+            ...parsedData.shape,
             properties: {
               short_id: parsedData.short_id,
               map_symbol: plantCodes,

--- a/app/src/UI/Features/OfflineDataSync/OfflineDataSyncTable.tsx
+++ b/app/src/UI/Features/OfflineDataSync/OfflineDataSyncTable.tsx
@@ -101,6 +101,13 @@ export const OfflineDataSyncTable = ({ handleClose }: PropTypes) => {
     return 'Unknown';
   };
 
+  // Present offline records in order of more recently saved.
+  const offlineRecords = useMemo(() => {
+    return Object.entries(serializedActivities as Record<PropertyKey, OfflineActivityRecord>).sort(
+      ([, a], [, b]) => b.saved_at - a.saved_at
+    );
+  }, [serializedActivities]);
+
   const disableOpeningRecord: boolean = useMemo(() => {
     if (!(workingOffline || authenticated)) {
       return true;
@@ -144,7 +151,7 @@ export const OfflineDataSyncTable = ({ handleClose }: PropTypes) => {
             </tr>
           </thead>
           <tbody>
-            {Object.entries(serializedActivities as Record<PropertyKey, OfflineActivityRecord>).map(([key, value]) => {
+            {offlineRecords.map(([key, value]) => {
               return (
                 <Fragment key={key}>
                   <tr>

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/CreateLinkedActivityButton.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/CreateLinkedActivityButton.tsx
@@ -1,0 +1,108 @@
+import { ActivitySubtypes } from 'sharedAPI';
+import FormActions from 'state/actions/activity/FormActions';
+import Button from 'UI/Reusable/Button/Button';
+import { useDispatch, useSelector } from 'utils/use_selector';
+import { FormSchema } from '../interfaces';
+
+/**
+  @desc Component for adding Form Control buttons to create related records. 
+        Results in New form of declared type, with current form as Linked Activity
+ */
+const CreateLinkedActivityButton = () => {
+  const CONFIG = {
+    [ActivitySubtypes.Observation_Plant_Aquatic]: [
+      {
+        label: 'Chemical Treatment',
+        links_to: ActivitySubtypes.Treatment_Chemical_Plant_Aquatic
+      },
+      {
+        label: 'Mechanical Treatment',
+        links_to: ActivitySubtypes.Treatment_Mechanical_Plant_Aquatic
+      }
+    ],
+    [ActivitySubtypes.Observation_Plant_Terrestrial]: [
+      {
+        label: 'Chemical Treatment',
+        links_to: ActivitySubtypes.Treatment_Chemical_Plant_Terrestrial
+      },
+      {
+        label: 'Mechanical Treatment',
+        links_to: ActivitySubtypes.Treatment_Mechanical_Plant_Terrestrial
+      }
+    ],
+    [ActivitySubtypes.Treatment_Chemical_Plant_Aquatic]: [
+      {
+        label: 'Chemical Treatment Monitoring',
+        links_to: ActivitySubtypes.Monitoring_Chemical_Plant_Terrestrial_Aquatic
+      }
+    ],
+    [ActivitySubtypes.Treatment_Chemical_Plant_Terrestrial]: [
+      {
+        label: 'Chemical Treatment Monitoring',
+        links_to: ActivitySubtypes.Monitoring_Chemical_Plant_Terrestrial_Aquatic
+      }
+    ],
+    [ActivitySubtypes.Treatment_Mechanical_Plant_Aquatic]: [
+      {
+        label: 'Mechanical Treatment Monitoring',
+        links_to: ActivitySubtypes.Monitoring_Mechanical_Plant_Terrestrial_Aquatic
+      }
+    ],
+    [ActivitySubtypes.Treatment_Mechanical_Plant_Terrestrial]: [
+      {
+        label: 'Mechanical Treatment Monitoring',
+        links_to: ActivitySubtypes.Monitoring_Mechanical_Plant_Terrestrial_Aquatic
+      }
+    ],
+    [ActivitySubtypes.Biocontrol_Release]: [
+      {
+        label: 'Biocontrol Collection',
+        links_to: ActivitySubtypes.Biocontrol_Collection
+      },
+      {
+        label: 'Dispersal Monitoring',
+        links_to: ActivitySubtypes.Monitoring_Biocontrol_Dispersal_Plant_Terrestrial
+      },
+      {
+        label: 'Release Monitoring',
+        links_to: ActivitySubtypes.Monitoring_Biocontrol_Release_Plant_Terrestrial
+      }
+    ]
+  };
+  const handleClick = (links_to: ActivitySubtypes) => {
+    if (!formState) return;
+    dispatch(
+      FormActions.duplicateForm({
+        subtype: links_to,
+        extraFields: {
+          shape: formState?.shape,
+          linked_activities: [
+            {
+              label: `${formState.short_id} | ${formState.date} | ${formState.created_by}`,
+              full: formState.id
+            }
+          ]
+        } as Partial<FormSchema>
+      })
+    );
+  };
+  const dispatch = useDispatch();
+  const currentSubtype = useSelector((state) => state.ActivityPage.formType);
+  const isRecordSubmitted = useSelector((state) => state.ActivityPage.formState?.form_status === 'Submitted');
+  const formActions = useSelector((state) => state.ActivityPage.recordActions);
+  const formState = useSelector((state) => state.ActivityPage?.formState);
+  const shouldHideFields =
+    !isRecordSubmitted || !currentSubtype || !CONFIG?.[currentSubtype] || !formActions?.includes('SUBMIT');
+
+  if (shouldHideFields) return;
+  return (
+    <>
+      {CONFIG[currentSubtype].map((o) => (
+        <Button onClick={() => handleClick(o.links_to)} className="control-button" key={o.links_to}>
+          Create {o.label} Entry
+        </Button>
+      ))}
+    </>
+  );
+};
+export default CreateLinkedActivityButton;

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/FormControl.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/FormControl.tsx
@@ -10,6 +10,7 @@ import getDefaultFormState from '../builders/getDefaultState';
 import { Debug } from 'UI/Reusable/Predicates/Debug';
 import Activity from 'state/actions/activity/Activity';
 import Button from 'UI/Reusable/Button/Button';
+import CreateLinkedActivityButton from './CreateLinkedActivityButton';
 
 /**
  * @desc Popover menu for form controls, handle Submit/Draft/Duplication fields.
@@ -147,6 +148,7 @@ const FormControl = () => {
           <Button className="control-button" onClick={handleDuplicateForm}>
             Duplicate Form
           </Button>
+          <CreateLinkedActivityButton />
           <Debug>
             <Button type="button" className="control-button" onClick={handleRefetchForm}>
               <BugReport /> Refetch Form

--- a/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/LinkedActivities.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/ActivityForm/LinkedActivities.tsx
@@ -88,7 +88,7 @@ const LinkedActivities = () => {
               <th>ID</th>
               <th>Activity Date</th>
               <th>Created By</th>
-              {!disabled && <th>{disabled ? 'Go to Record' : 'Copy Geometry'}</th>}
+              <th>{disabled ? 'Go to Record' : 'Copy Geometry'}</th>
             </tr>
           </thead>
           <tbody>

--- a/app/src/UI/Features/Records/Activity/forms/plant/hooks/useOfflineRecordsetEntries.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/hooks/useOfflineRecordsetEntries.tsx
@@ -74,7 +74,7 @@ const useOfflineRecordsetEntries = (options: Options) => {
             type: ActivitySubtypesToType[data?.subtype],
             subtype: ActivitySubtypesShortLabels[data?.subtype],
             date: data?.date,
-            geom: data?.geom,
+            geom: data?.shape,
             area_m: `${data?.area_m?.toLocaleString()}m²`,
             jurisdictions: jurisdictions,
             invasive_plants: plants,
@@ -83,7 +83,8 @@ const useOfflineRecordsetEntries = (options: Options) => {
             status: s?.sync_state
           };
         }) // TODO: remove null filter as part of Issue #4638 - 'Remove RJSF from frontend'.
-        .filter(Boolean) as Array<IOfflineActivityRow>,
+        .filter(Boolean)
+        .sort((a, b) => b?.date.localeCompare(a?.date)) as Array<IOfflineActivityRow>,
 
     [serializedActivities, serial, options?.filterUnsynced]
   );

--- a/app/src/UI/Features/Records/Activity/forms/plant/hooks/useOfflineRecordsetEntries.tsx
+++ b/app/src/UI/Features/Records/Activity/forms/plant/hooks/useOfflineRecordsetEntries.tsx
@@ -1,5 +1,6 @@
 import FormCode from 'interfaces/FormCode';
 import IOfflineActivityRow from 'interfaces/TableRows/IOfflineActivityRow';
+import moment from 'moment';
 import { useMemo } from 'react';
 import { ActivitySubtypesShortLabels, ActivitySubtypesToType } from 'sharedAPI';
 import { OfflineActivityRecord, OfflineActivitySyncState } from 'state/reducers/offlineActivity';
@@ -72,6 +73,8 @@ const useOfflineRecordsetEntries = (options: Options) => {
             activity_id: data?.id,
             short_id: data?.short_id,
             type: ActivitySubtypesToType[data?.subtype],
+            saved_at: moment(s.saved_at).fromNow(),
+            saved_stamp: s.saved_at,
             subtype: ActivitySubtypesShortLabels[data?.subtype],
             date: data?.date,
             geom: data?.shape,
@@ -84,7 +87,7 @@ const useOfflineRecordsetEntries = (options: Options) => {
           };
         }) // TODO: remove null filter as part of Issue #4638 - 'Remove RJSF from frontend'.
         .filter(Boolean)
-        .sort((a, b) => b?.date.localeCompare(a?.date)) as Array<IOfflineActivityRow>,
+        .sort((a, b) => b!.saved_stamp - a!.saved_stamp) as Array<IOfflineActivityRow>,
 
     [serializedActivities, serial, options?.filterUnsynced]
   );

--- a/app/src/UI/Features/Records/RecordSet/OfflineRecordSet.tsx
+++ b/app/src/UI/Features/Records/RecordSet/OfflineRecordSet.tsx
@@ -16,6 +16,8 @@ import CheckboxUI from '../Activity/forms/common/CheckboxUI/CheckboxUI';
 import StyledTable from 'UI/Reusable/StyledTable/StyledTable';
 import { ArrowBackIos } from '@mui/icons-material';
 import Button from 'UI/Reusable/Button/Button';
+import RecordSetControl from '../RecordSetControl';
+import { MobileOnly } from 'UI/Reusable/Predicates/MobileOnly';
 
 type PropTypes = { setID: string };
 
@@ -50,6 +52,7 @@ export const OfflineRecordSet = ({ setID }: PropTypes) => {
     navigate('/Records');
   };
 
+  const isCellPhoneWidth = useSelector((state) => state.AppMode.constraints.tinyScreen);
   const recordSet = useSelector((state) => state.UserSettings?.recordSets?.[setID]);
   const recordTable = useSelector((state) => state.Map.recordTables?.[setID]);
   const startIndex = recordTable?.page * recordTable?.limit;
@@ -79,6 +82,13 @@ export const OfflineRecordSet = ({ setID }: PropTypes) => {
             </Button>
           </div>
           <div className="recordSet_header_name">{recordSet?.recordSetName}</div>
+          {!isCellPhoneWidth && (
+            <MobileOnly>
+              <div className="recordset-control">
+                <RecordSetControl isDefaultRecordset={true} recordset={recordSet} hideCache hideColour />
+              </div>
+            </MobileOnly>
+          )}
         </div>
       </div>
       <div className="recordSet_container">

--- a/app/src/UI/Features/Records/RecordSet/OfflineRecordSet.tsx
+++ b/app/src/UI/Features/Records/RecordSet/OfflineRecordSet.tsx
@@ -76,7 +76,7 @@ export const OfflineRecordSet = ({ setID }: PropTypes) => {
       </CustomPopover>
       <div className="stickyHeader">
         <div className="recordSet_header" style={{ backgroundColor: recordSet?.color + `50` }}>
-          <div className="recordSet_back_button">
+          <div>
             <Button onClick={onClickBackButton} variant="contained">
               <ArrowBackIos /> Back
             </Button>

--- a/app/src/UI/Features/Records/RecordSet/RecordSet.css
+++ b/app/src/UI/Features/Records/RecordSet/RecordSet.css
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
   padding-bottom: var(--record-table-footer-height);
+
   .content-container {
     padding: 0 5pt;
     margin-top: var(--overlay-grip-height);
@@ -23,7 +24,7 @@
   justify-content: flex-start;
   border-bottom: 1px solid black;
 
-  .recordset-cache-control {
+  .recordset-control {
     margin-left: auto;
     margin-right: 5pt;
   }

--- a/app/src/UI/Features/Records/RecordSet/RecordSet.tsx
+++ b/app/src/UI/Features/Records/RecordSet/RecordSet.tsx
@@ -6,15 +6,14 @@ import RecordSetFooter from './RecordSetFooter';
 import { useSelector } from 'utils/use_selector';
 import { useEffect } from 'react';
 import { RecordSetId } from 'interfaces/UserRecordSet';
-import { RecordSetCacheButtons } from '../RecordSetCacheButtons';
 import { useNavigate } from 'react-router';
 import Activity from 'state/actions/activity/Activity';
 import Filters from './Filters/Filters';
 import { MobileOnly } from 'UI/Reusable/Predicates/MobileOnly';
-import { FeatureGated } from 'UI/Reusable/Predicates/FeatureGated';
 import GlobalFilterWarning from './GlobalFilterWarning/GlobalFilterWarning';
 import { ArrowBackIos } from '@mui/icons-material';
 import { Button } from '@mui/material';
+import RecordSetControl from '../RecordSetControl';
 
 type PropTypes = { setID: string };
 
@@ -50,16 +49,19 @@ export const RecordSet = ({ setID }: PropTypes) => {
           <div className="recordSet_header_name">
             {recordSet?.recordSetName || `New Recordset - ${recordSet?.recordSetType}`}
           </div>
+
           <GlobalFilterWarning />
-          <MobileOnly>
-            <FeatureGated requires="CACHE_RECORDSETS">
-              {canCacheRecordset && !isCellPhoneWidth && (
-                <div className="recordset-cache-control">
-                  <RecordSetCacheButtons recordSet={recordSet} setId={setID} onCacheStateChange={() => {}} />
-                </div>
-              )}
-            </FeatureGated>
-          </MobileOnly>
+          {!isCellPhoneWidth && (
+            <MobileOnly>
+              <div className="recordset-control">
+                <RecordSetControl
+                  hideCache={!canCacheRecordset}
+                  isDefaultRecordset={!canCacheRecordset}
+                  recordset={recordSet}
+                />
+              </div>
+            </MobileOnly>
+          )}
         </div>
       </div>
       <div className="recordSet_container">

--- a/app/src/UI/Features/Records/RecordSet/RecordSet.tsx
+++ b/app/src/UI/Features/Records/RecordSet/RecordSet.tsx
@@ -41,7 +41,7 @@ export const RecordSet = ({ setID }: PropTypes) => {
     <>
       <div className="stickyHeader">
         <div className="recordSet_header" style={{ backgroundColor: recordSet?.color + `50` }}>
-          <div className="recordSet_back_button">
+          <div>
             <Button onClick={onClickBackButton} variant="contained">
               <ArrowBackIos /> Back
             </Button>

--- a/app/src/UI/Features/Records/RecordSet/RecordTableHelpers.tsx
+++ b/app/src/UI/Features/Records/RecordSet/RecordTableHelpers.tsx
@@ -104,6 +104,7 @@ export const iappColumnsToDisplay = [
 export const offlineActivityColumnsToDisplay = [
   { key: 'short_id', name: 'Activity ID', displayWidget: 'div', hide: false },
   { key: 'type', name: 'Activity Type', hide: false },
+  { key: 'saved_at', name: 'Last Modified', hide: false },
   { key: 'subtype', name: 'Activity Sub Type', hide: false },
   { key: 'date', name: 'Activity Date', hide: false },
   { key: 'area_m', name: 'Area (m²)', hide: false },

--- a/app/src/UI/Features/Records/RecordSetControl.tsx
+++ b/app/src/UI/Features/Records/RecordSetControl.tsx
@@ -8,6 +8,7 @@ import { useSelector } from 'utils/use_selector';
 import { useRecordSetControls } from 'utils/useRecordSetControls';
 import './recordsetControl.css';
 import HoverTooltip from 'UI/Reusable/HoverTooltip/HoverTooltip';
+import { FeatureGated } from 'UI/Reusable/Predicates/FeatureGated';
 
 type PropTypes = {
   isDefaultRecordset: boolean;
@@ -51,13 +52,15 @@ const RecordSetControl = ({
     <div className={isProgressBar ? 'record-set-control record-set-progressbar' : 'record-set-control '}>
       {!isDefaultRecordset && !hideCache && (
         <MobileOnly>
-          <div>
-            <RecordSetCacheButtons
-              recordSet={recordset}
-              setId={RECORD_ID}
-              onCacheStateChange={handleProgressStateChange}
-            />
-          </div>
+          <FeatureGated requires="CACHE_RECORDSETS">
+            <div>
+              <RecordSetCacheButtons
+                recordSet={recordset}
+                setId={RECORD_ID}
+                onCacheStateChange={handleProgressStateChange}
+              />
+            </div>
+          </FeatureGated>
         </MobileOnly>
       )}
       <div className="record-set-buttons">

--- a/app/src/interfaces/TableRows/IOfflineActivityRow.ts
+++ b/app/src/interfaces/TableRows/IOfflineActivityRow.ts
@@ -4,6 +4,8 @@ import { ActivitySubtypes, ActivityType } from 'sharedAPI';
 interface IOfflineActivityRow {
   activity_id: string;
   short_id: string;
+  saved_at: string;
+  saved_stamp: number;
   geom: GeoJSON;
   type: ActivityType;
   subtype: ActivitySubtypes;

--- a/app/src/state/actions/activity/FormActions.ts
+++ b/app/src/state/actions/activity/FormActions.ts
@@ -23,6 +23,7 @@ interface FormSubmission {
 
 interface DuplicateForm {
   subtype: ActivitySubtypes;
+  extraFields?: Partial<FormSchema>;
 }
 interface VerifyLinkedActivity {
   id: string;
@@ -71,7 +72,7 @@ class FormActions {
 
   static readonly duplicateForm = createAsyncThunk(
     `${this.PREFIX}/duplicateForm`,
-    async ({ subtype }: DuplicateForm, { getState }) => {
+    async ({ subtype, extraFields }: DuplicateForm, { getState }) => {
       const {
         Auth,
         ActivityPage: { formState }
@@ -92,6 +93,7 @@ class FormActions {
         duplicatedForm.subtype = subtype;
         duplicatedForm.subtype_data = getDefaultFormState(subtype).subtype_data;
       }
+      if (extraFields) Object.assign(duplicatedForm, extraFields);
       return {
         data: duplicatedForm as FormSchema,
         available_actions: ['EDIT', 'DELETE', 'SUBMIT'] as Array<RecordAction>,


### PR DESCRIPTION
# Overview

This PR includes the following proposed change(s):

- Fix unsynced records layer
- Allow selecting records on map when offline (previously only online enabled)
- Set offline Sync table / Offline Recordset to display Records by most recently edited.
- Add Buttons to forms to create a new record that pre-links the existing record/reuses the shape 
   - Update duplicateForm action to allow specific fields to be added to the duplicate logic. 
- Closes #4670

# Additional Features
- Fix granular validation <sup><sub>again</sub></sup>
    - Add a test specifically for granular application rate validation
- Add backend validation for testing a linked record is valid at submission. (Overlaps and has proper type) 
 - Add recordset controls to sticky header inside recordsets. (does not display on cellphone width)
 - Fix Map symbol being populated when new activities submitted.
    - Fix related bug in Filtering Draft Querysets 

## Images

<img width="303" height="217" alt="image" src="https://github.com/user-attachments/assets/7b23e676-b843-42ba-8f37-73ded293f301" />

In this example, an open Terrestrial Observation allows a user with `SUBMIT` permissions to directly create a Terrestrial Treatment form. Doing so will follow the duplicateForm routine, but instead of selecting a form, it will open the chosen type and come prefilled with the geometry/activity already linked